### PR TITLE
v0.0.5: Type checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.5] - 2026-02-23
+
+### Added
+- **Type checker**: Tier 1 decidable type checking — validates expression types, slot reference resolution, effect annotations, and contract well-formedness
+  - Two-pass architecture: pass 1 registers all declarations (handles forward references and mutual recursion), pass 2 checks bodies
+  - Expression type synthesis for all AST node types (literals, operators, calls, constructors, match/if, handlers, anonymous functions, quantifiers)
+  - De Bruijn slot reference resolution with alias opacity
+  - Function call type checking with generic type argument inference
+  - ADT constructor validation and pattern type checking
+  - Basic effect checking (pure functions can't call effectful operations)
+  - Handler effect discharge (handlers eliminate their effect from the enclosing function's requirements)
+  - Contract well-formedness (predicates must be Bool, `@T.result` only in ensures, `old`/`new` only in ensures)
+  - Error accumulation — all type errors collected, never stops at first error
+  - Unresolved name graceful handling (warning, not failure) with `UnknownType` propagation
+  - LLM-oriented `TypeError` diagnostics with description, location, rationale, fix, and spec reference
+- **Internal type representation** (`vera/types.py`): semantic `Type` objects separate from syntactic AST `TypeExpr` nodes — `PrimitiveType`, `AdtType`, `FunctionType`, `RefinedType`, `TypeVar`, `UnknownType`, effect row types
+- **Type environment** (`vera/environment.py`): scope stack, slot resolution, built-in type/effect/function registrations (Option, Result, State with get/put, IO, length)
+- **CLI command**: `vera typecheck <file>` as explicit alias for `vera check`
+- **Convenience API**: `typecheck_file(path)` in `vera/parser.py`
+- **Type checker tests**: 91 new tests — round-trip tests for all 13 examples, literal types, slot references, operators, function calls, generics, constructors, patterns, control flow, effects, contracts, higher-order functions, refinement types, error accumulation, where blocks, arrays, return types (284 total, up from 193)
+
+### Changed
+- `vera check` now runs the full pipeline: parse → AST → type check (previously parse only)
+- README: updated status table (Type checker: Working), added type checker to project structure, documented `vera typecheck` alias
+- SKILLS.md: added `vera typecheck` to toolchain section
+
 ## [0.0.4] - 2026-02-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ This principle applies at every stage: parse errors, type errors, effect mismatc
 
 ## Project Status
 
-Vera is in **active development**. The language specification and parser are functional. Type checking, verification, and code generation are not yet implemented.
+Vera is in **active development**. The language specification, parser, AST, and type checker are functional. Verification and code generation are not yet implemented.
 
 | Component | Status |
 |-----------|--------|
@@ -113,7 +113,7 @@ Vera is in **active development**. The language specification and parser are fun
 | Language specification (Chapters 8-9, 11-12) | Not started |
 | Parser (Lark LALR(1)) | Working |
 | AST (typed syntax tree) | Working |
-| Type checker | Not started |
+| Type checker | Working |
 | Contract verifier (Z3) | Not started |
 | WASM code generation | Not started |
 
@@ -142,6 +142,8 @@ vera check examples/absolute_value.vera
 ```
 OK: examples/absolute_value.vera
 ```
+
+`vera check` parses the file, builds the AST, and runs the type checker. `vera typecheck` is an explicit alias for the same command.
 
 ### Parse a program
 
@@ -288,6 +290,9 @@ vera/
 │   ├── parser.py                  # Parser module
 │   ├── ast.py                     # Typed AST node definitions
 │   ├── transform.py               # Lark parse tree → AST transformer
+│   ├── types.py                   # Internal type representation
+│   ├── environment.py             # Type environment and slot resolution
+│   ├── checker.py                 # Type checker
 │   ├── errors.py                  # LLM-oriented diagnostics
 │   └── cli.py                     # Command-line interface
 ├── examples/                      # Example Vera programs

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -10,11 +10,12 @@ Vera is a programming language designed for LLMs to write. It uses typed slot re
 ## Toolchain
 
 ```bash
-vera check file.vera    # Parse and report errors (or "OK")
-vera parse file.vera    # Print the parse tree
-vera ast file.vera      # Print the typed AST
+vera check file.vera       # Parse and type-check (or "OK")
+vera typecheck file.vera   # Same as check (explicit alias)
+vera parse file.vera       # Print the parse tree
+vera ast file.vera         # Print the typed AST
 vera ast --json file.vera  # Print the AST as JSON
-pytest tests/ -v        # Run the test suite
+pytest tests/ -v           # Run the test suite
 ```
 
 Errors are natural language instructions explaining what went wrong and how to fix it. Feed them back into your context to correct the code.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.4"
+version = "0.0.5"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -1,0 +1,950 @@
+"""Tests for the Vera type checker (Phase C3).
+
+Follows the same patterns as test_ast.py: helper functions, parametrised
+round-trip tests, then node-specific test classes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from vera.checker import typecheck
+from vera.errors import Diagnostic
+from vera.parser import parse_to_ast
+
+# =====================================================================
+# Helpers
+# =====================================================================
+
+EXAMPLES_DIR = Path(__file__).parent.parent / "examples"
+EXAMPLE_FILES = sorted(f.name for f in EXAMPLES_DIR.glob("*.vera"))
+
+# Self-contained examples (no unresolved external references)
+CLEAN_EXAMPLES = [
+    "absolute_value.vera",
+    "factorial.vera",
+    "generics.vera",
+    "increment.vera",
+    "list_ops.vera",
+    "modules.vera",
+    "mutual_recursion.vera",
+    "pattern_matching.vera",
+    "quantifiers.vera",
+    "refinement_types.vera",
+    "safe_divide.vera",
+]
+
+# Examples with unresolved external references (warnings expected)
+WARN_EXAMPLES = [
+    "closures.vera",
+    "effect_handler.vera",
+]
+
+
+def _check(source: str) -> list[Diagnostic]:
+    """Parse and type-check, return diagnostics."""
+    prog = parse_to_ast(source)
+    return typecheck(prog, source=source)
+
+
+def _errors(source: str) -> list[Diagnostic]:
+    """Parse and type-check, return only errors (not warnings)."""
+    return [d for d in _check(source) if d.severity == "error"]
+
+
+def _warnings(source: str) -> list[Diagnostic]:
+    """Parse and type-check, return only warnings."""
+    return [d for d in _check(source) if d.severity != "error"]
+
+
+def _check_ok(source: str) -> None:
+    """Assert the source type-checks with no errors."""
+    errs = _errors(source)
+    assert errs == [], \
+        f"Expected no errors, got: {[e.description for e in errs]}"
+
+
+def _check_err(source: str, match: str) -> list[Diagnostic]:
+    """Assert the source has at least one error matching the substring."""
+    errs = _errors(source)
+    assert any(match.lower() in e.description.lower() for e in errs), \
+        f"Expected error matching '{match}', got: " \
+        f"{[e.description for e in errs]}"
+    return errs
+
+
+# =====================================================================
+# Round-trip example tests
+# =====================================================================
+
+class TestExampleRoundTrips:
+    """All self-contained examples must type-check cleanly."""
+
+    @pytest.mark.parametrize("filename", CLEAN_EXAMPLES)
+    def test_clean_example(self, filename: str) -> None:
+        source = (EXAMPLES_DIR / filename).read_text()
+        prog = parse_to_ast(source, file=filename)
+        errors = typecheck(prog, source=source, file=filename)
+        real_errors = [e for e in errors if e.severity == "error"]
+        assert real_errors == [], \
+            f"{filename}: {[e.description for e in real_errors]}"
+
+    @pytest.mark.parametrize("filename", WARN_EXAMPLES)
+    def test_warn_example(self, filename: str) -> None:
+        """Examples with unresolved names: only warnings, no errors."""
+        source = (EXAMPLES_DIR / filename).read_text()
+        prog = parse_to_ast(source, file=filename)
+        errors = typecheck(prog, source=source, file=filename)
+        real_errors = [e for e in errors if e.severity == "error"]
+        assert real_errors == [], \
+            f"{filename}: {[e.description for e in real_errors]}"
+
+
+# =====================================================================
+# Literals
+# =====================================================================
+
+class TestLiterals:
+
+    def test_int_lit(self) -> None:
+        _check_ok("""
+fn foo(@Unit -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ 42 }
+""")
+
+    def test_negative_int_lit(self) -> None:
+        _check_ok("""
+fn foo(@Unit -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ 0 - 1 }
+""")
+
+    def test_float_lit(self) -> None:
+        _check_ok("""
+fn foo(@Unit -> @Float64)
+  requires(true) ensures(true) effects(pure)
+{ 3.14 }
+""")
+
+    def test_string_lit(self) -> None:
+        _check_ok("""
+fn foo(@Unit -> @String)
+  requires(true) ensures(true) effects(pure)
+{ "hello" }
+""")
+
+    def test_bool_lit(self) -> None:
+        _check_ok("""
+fn foo(@Unit -> @Bool)
+  requires(true) ensures(true) effects(pure)
+{ true }
+""")
+
+    def test_unit_lit(self) -> None:
+        _check_ok("""
+fn foo(@Unit -> @Unit)
+  requires(true) ensures(true) effects(pure)
+{ () }
+""")
+
+
+# =====================================================================
+# Slot references
+# =====================================================================
+
+class TestSlotRefs:
+
+    def test_simple_ref(self) -> None:
+        _check_ok("""
+fn id(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 }
+""")
+
+    def test_multiple_same_type(self) -> None:
+        _check_ok("""
+fn add(@Int, @Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 + @Int.1 }
+""")
+
+    def test_different_types(self) -> None:
+        _check_ok("""
+fn pick(@Int, @String -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 }
+""")
+
+    def test_out_of_bounds(self) -> None:
+        _check_err("""
+fn bad(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.1 }
+""", "Cannot resolve @Int.1")
+
+    def test_no_bindings(self) -> None:
+        _check_err("""
+fn bad(@Unit -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 }
+""", "Cannot resolve @Int.0")
+
+    def test_let_introduces_binding(self) -> None:
+        _check_ok("""
+fn foo(@Unit -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  let @Int = 42;
+  @Int.0
+}
+""")
+
+    def test_let_shadowing(self) -> None:
+        _check_ok("""
+fn foo(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  let @Int = 99;
+  @Int.0 + @Int.1
+}
+""")
+
+    def test_alias_opacity(self) -> None:
+        """Type aliases are opaque for slot reference resolution."""
+        _check_ok("""
+type PosInt = { @Int | @Int.0 > 0 };
+
+fn foo(@PosInt, @Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @PosInt.0 + @Int.0 }
+""")
+
+    def test_parameterised_slot(self) -> None:
+        _check_ok("""
+data Option<T> { None, Some(T) }
+
+fn foo(@Option<Int> -> @Bool)
+  requires(true) ensures(true) effects(pure)
+{ true }
+""")
+
+
+# =====================================================================
+# Result references
+# =====================================================================
+
+class TestResultRefs:
+
+    def test_result_in_ensures(self) -> None:
+        _check_ok("""
+fn foo(@Int -> @Int)
+  requires(true)
+  ensures(@Int.result == @Int.0)
+  effects(pure)
+{ @Int.0 }
+""")
+
+    def test_result_outside_ensures(self) -> None:
+        _check_err("""
+fn foo(@Int -> @Int)
+  requires(@Int.result > 0)
+  ensures(true)
+  effects(pure)
+{ @Int.0 }
+""", "@Int.result is only valid inside ensures")
+
+    def test_result_in_body(self) -> None:
+        _check_err("""
+fn foo(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.result }
+""", "only valid inside ensures")
+
+
+# =====================================================================
+# Binary operators
+# =====================================================================
+
+class TestBinaryOps:
+
+    def test_add_int(self) -> None:
+        _check_ok("""
+fn foo(@Int, @Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 + @Int.1 }
+""")
+
+    def test_add_float(self) -> None:
+        _check_ok("""
+fn foo(@Float64, @Float64 -> @Float64)
+  requires(true) ensures(true) effects(pure)
+{ @Float64.0 + @Float64.1 }
+""")
+
+    def test_add_mixed_error(self) -> None:
+        _check_err("""
+fn bad(@Int, @String -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 + @String.0 }
+""", "requires numeric operands")
+
+    def test_comparison(self) -> None:
+        _check_ok("""
+fn foo(@Int, @Int -> @Bool)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 < @Int.1 }
+""")
+
+    def test_equality(self) -> None:
+        _check_ok("""
+fn foo(@Int, @Int -> @Bool)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 == @Int.1 }
+""")
+
+    def test_logical_and(self) -> None:
+        _check_ok("""
+fn foo(@Bool, @Bool -> @Bool)
+  requires(true) ensures(true) effects(pure)
+{ @Bool.0 && @Bool.1 }
+""")
+
+    def test_logical_implies(self) -> None:
+        _check_ok("""
+fn foo(@Bool, @Bool -> @Bool)
+  requires(true) ensures(true) effects(pure)
+{ @Bool.0 ==> @Bool.1 }
+""")
+
+    def test_logical_not_bool_error(self) -> None:
+        _check_err("""
+fn bad(@Int, @Bool -> @Bool)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 && @Bool.0 }
+""", "must be Bool")
+
+    def test_modulo(self) -> None:
+        _check_ok("""
+fn foo(@Int, @Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 % @Int.1 }
+""")
+
+
+# =====================================================================
+# Unary operators
+# =====================================================================
+
+class TestUnaryOps:
+
+    def test_not(self) -> None:
+        _check_ok("""
+fn foo(@Bool -> @Bool)
+  requires(true) ensures(true) effects(pure)
+{ !@Bool.0 }
+""")
+
+    def test_neg(self) -> None:
+        _check_ok("""
+fn foo(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ 0 - @Int.0 }
+""")
+
+    def test_not_non_bool_error(self) -> None:
+        _check_err("""
+fn bad(@Int -> @Bool)
+  requires(true) ensures(true) effects(pure)
+{ !@Int.0 }
+""", "requires Bool operand")
+
+
+# =====================================================================
+# Function calls
+# =====================================================================
+
+class TestFnCalls:
+
+    def test_simple_call(self) -> None:
+        _check_ok("""
+fn double(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 + @Int.0 }
+
+fn main(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ double(@Int.0) }
+""")
+
+    def test_arity_mismatch(self) -> None:
+        _check_err("""
+fn double(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 + @Int.0 }
+
+fn main(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ double(@Int.0, @Int.0) }
+""", "expects 1 argument")
+
+    def test_type_mismatch_arg(self) -> None:
+        _check_err("""
+fn double(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 + @Int.0 }
+
+fn main(@String -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ double(@String.0) }
+""", "has type String, expected Int")
+
+    def test_recursive_call(self) -> None:
+        _check_ok("""
+fn factorial(@Nat -> @Nat)
+  requires(true)
+  ensures(@Nat.result >= 1)
+  decreases(@Nat.0)
+  effects(pure)
+{
+  if @Nat.0 == 0 then { 1 }
+  else { @Nat.0 * factorial(@Nat.0 - 1) }
+}
+""")
+
+    def test_unresolved_function_warning(self) -> None:
+        """Unresolved functions emit warnings, not errors."""
+        diags = _check("""
+fn foo(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ unknown_fn(@Int.0) }
+""")
+        warnings = [d for d in diags if d.severity == "warning"]
+        errors = [d for d in diags if d.severity == "error"]
+        assert len(warnings) >= 1
+        assert any("Unresolved" in w.description for w in warnings)
+        assert errors == []
+
+
+# =====================================================================
+# Generic functions
+# =====================================================================
+
+class TestGenerics:
+
+    def test_identity(self) -> None:
+        _check_ok("""
+forall<T> fn identity(@T -> @T)
+  requires(true) ensures(true) effects(pure)
+{ @T.0 }
+""")
+
+    def test_generic_call(self) -> None:
+        _check_ok("""
+forall<T> fn identity(@T -> @T)
+  requires(true) ensures(true) effects(pure)
+{ @T.0 }
+
+fn main(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ identity(@Int.0) }
+""")
+
+
+# =====================================================================
+# ADTs and constructors
+# =====================================================================
+
+class TestConstructors:
+
+    def test_nullary_constructor(self) -> None:
+        _check_ok("""
+data Color { Red, Green, Blue }
+
+fn foo(@Unit -> @Color)
+  requires(true) ensures(true) effects(pure)
+{ Red }
+""")
+
+    def test_constructor_with_fields(self) -> None:
+        _check_ok("""
+data Pair { MkPair(Int, String) }
+
+fn foo(@Int, @String -> @Pair)
+  requires(true) ensures(true) effects(pure)
+{ MkPair(@Int.0, @String.0) }
+""")
+
+    def test_constructor_arity_mismatch(self) -> None:
+        _check_err("""
+data Pair { MkPair(Int, String) }
+
+fn foo(@Int -> @Pair)
+  requires(true) ensures(true) effects(pure)
+{ MkPair(@Int.0) }
+""", "expects 2 field")
+
+    def test_parameterised_adt(self) -> None:
+        _check_ok("""
+data Box<T> { MkBox(T) }
+
+fn foo(@Int -> @Box<Int>)
+  requires(true) ensures(true) effects(pure)
+{ MkBox(@Int.0) }
+""")
+
+
+# =====================================================================
+# Pattern matching
+# =====================================================================
+
+class TestPatterns:
+
+    def test_constructor_pattern(self) -> None:
+        _check_ok("""
+data Option<T> { None, Some(T) }
+
+fn unwrap(@Option<Int> -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  match @Option<Int>.0 {
+    None -> 0,
+    Some(@Int) -> @Int.0
+  }
+}
+""")
+
+    def test_wildcard_pattern(self) -> None:
+        _check_ok("""
+fn classify(@Int -> @String)
+  requires(true) ensures(true) effects(pure)
+{
+  match @Int.0 {
+    0 -> "zero",
+    1 -> "one",
+    _ -> "other"
+  }
+}
+""")
+
+    def test_bool_pattern(self) -> None:
+        _check_ok("""
+fn to_str(@Bool -> @String)
+  requires(true) ensures(true) effects(pure)
+{
+  match @Bool.0 {
+    true -> "yes",
+    false -> "no"
+  }
+}
+""")
+
+    def test_nested_pattern(self) -> None:
+        _check_ok("""
+data Option<T> { None, Some(T) }
+data List<T> { Nil, Cons(T, List<T>) }
+
+fn first(@List<Option<Int>> -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  match @List<Option<Int>>.0 {
+    Cons(Some(@Int), @List<Option<Int>>) -> @Int.0,
+    Cons(None, @List<Option<Int>>) -> first(@List<Option<Int>>.0),
+    Nil -> 0
+  }
+}
+""")
+
+
+# =====================================================================
+# Control flow
+# =====================================================================
+
+class TestControlFlow:
+
+    def test_if_then_else(self) -> None:
+        _check_ok("""
+fn abs(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  if @Int.0 >= 0 then { @Int.0 }
+  else { 0 - @Int.0 }
+}
+""")
+
+    def test_if_condition_not_bool(self) -> None:
+        _check_err("""
+fn bad(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  if @Int.0 then { 1 } else { 2 }
+}
+""", "condition must be Bool")
+
+    def test_if_branch_mismatch(self) -> None:
+        _check_err("""
+fn bad(@Bool -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  if @Bool.0 then { 42 } else { "hello" }
+}
+""", "incompatible types")
+
+    def test_block_with_let(self) -> None:
+        _check_ok("""
+fn foo(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  let @Int = @Int.0 + 1;
+  let @Int = @Int.0 * 2;
+  @Int.0
+}
+""")
+
+
+# =====================================================================
+# Effects
+# =====================================================================
+
+class TestEffects:
+
+    def test_pure_function(self) -> None:
+        _check_ok("""
+fn pure_fn(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 }
+""")
+
+    def test_effect_declaration(self) -> None:
+        _check_ok("""
+effect Logger {
+  op log(String -> Unit);
+}
+
+fn greet(@String -> @Unit)
+  requires(true) ensures(true) effects(<Logger>)
+{
+  Logger.log(@String.0)
+}
+""")
+
+    def test_pure_calling_effectful_error(self) -> None:
+        _check_err("""
+effect Logger {
+  op log(String -> Unit);
+}
+
+fn bad(@String -> @Unit)
+  requires(true) ensures(true) effects(pure)
+{
+  Logger.log(@String.0)
+}
+""", "Pure function")
+
+    def test_handler_basic(self) -> None:
+        _check_ok("""
+fn foo(@Unit -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  handle[State<Int>](@Int = 0) {
+    get(@Unit) -> { resume(@Int.0) },
+    put(@Int) -> { resume(()) }
+  } in {
+    get(())
+  }
+}
+""")
+
+    def test_state_effect_builtin(self) -> None:
+        """The built-in State<T> effect is available."""
+        _check_ok("""
+fn incr(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<State<Int>>)
+{
+  let @Int = get(());
+  put(@Int.0 + 1);
+  ()
+}
+""")
+
+    def test_qualified_effect_call(self) -> None:
+        _check_ok("""
+effect Counter {
+  op get_count(Unit -> Int);
+  op increment(Unit -> Unit);
+}
+
+fn use_counter(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<Counter>)
+{
+  Counter.increment(())
+}
+""")
+
+
+# =====================================================================
+# Contracts
+# =====================================================================
+
+class TestContracts:
+
+    def test_requires_bool(self) -> None:
+        _check_ok("""
+fn foo(@Int -> @Int)
+  requires(@Int.0 > 0) ensures(true) effects(pure)
+{ @Int.0 }
+""")
+
+    def test_requires_non_bool_error(self) -> None:
+        _check_err("""
+fn bad(@Int -> @Int)
+  requires(@Int.0) ensures(true) effects(pure)
+{ @Int.0 }
+""", "requires() predicate must be Bool")
+
+    def test_ensures_bool(self) -> None:
+        _check_ok("""
+fn foo(@Int -> @Int)
+  requires(true) ensures(@Int.result >= 0) effects(pure)
+{ @Int.0 }
+""")
+
+    def test_ensures_non_bool_error(self) -> None:
+        _check_err("""
+fn bad(@Int -> @Int)
+  requires(true) ensures(@Int.result) effects(pure)
+{ @Int.0 }
+""", "ensures() predicate must be Bool")
+
+    def test_decreases(self) -> None:
+        _check_ok("""
+fn count(@Nat -> @Nat)
+  requires(true) ensures(true)
+  decreases(@Nat.0)
+  effects(pure)
+{
+  if @Nat.0 == 0 then { 0 }
+  else { 1 + count(@Nat.0 - 1) }
+}
+""")
+
+    def test_multiple_contracts(self) -> None:
+        _check_ok("""
+fn clamp(@Int, @Int, @Int -> @Int)
+  requires(@Int.1 <= @Int.2)
+  ensures(@Int.result >= @Int.1)
+  ensures(@Int.result <= @Int.2)
+  effects(pure)
+{
+  if @Int.0 < @Int.1 then { @Int.1 }
+  else {
+    if @Int.0 > @Int.2 then { @Int.2 }
+    else { @Int.0 }
+  }
+}
+""")
+
+    def test_old_new_in_ensures(self) -> None:
+        _check_ok("""
+fn incr(@Unit -> @Unit)
+  requires(true)
+  ensures(new(State<Int>) == old(State<Int>) + 1)
+  effects(<State<Int>>)
+{
+  let @Int = get(());
+  put(@Int.0 + 1);
+  ()
+}
+""")
+
+    def test_old_outside_ensures_error(self) -> None:
+        _check_err("""
+fn bad(@Unit -> @Unit)
+  requires(old(State<Int>) > 0)
+  ensures(true)
+  effects(<State<Int>>)
+{ () }
+""", "old() is only valid inside ensures")
+
+
+# =====================================================================
+# Higher-order functions
+# =====================================================================
+
+class TestHigherOrder:
+
+    def test_anon_fn(self) -> None:
+        _check_ok("""
+fn foo(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  let @Int = 5;
+  @Int.0
+}
+""")
+
+    def test_fn_type_alias(self) -> None:
+        _check_ok("""
+type IntToInt = fn(Int -> Int) effects(pure);
+
+fn apply(@IntToInt, @Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 }
+""")
+
+
+# =====================================================================
+# Refinement types
+# =====================================================================
+
+class TestRefinementTypes:
+
+    def test_refinement_alias(self) -> None:
+        _check_ok("""
+type PosInt = { @Int | @Int.0 > 0 };
+
+fn foo(@PosInt -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @PosInt.0 }
+""")
+
+    def test_refinement_subtype_to_base(self) -> None:
+        """Refinement type is subtype of its base type."""
+        _check_ok("""
+type PosInt = { @Int | @Int.0 > 0 };
+
+fn foo(@PosInt -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @PosInt.0 + 1 }
+""")
+
+    def test_int_to_nat_allowed(self) -> None:
+        """Int -> Nat is allowed in C3 (deferred to C4)."""
+        _check_ok("""
+fn foo(@Int -> @Nat)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 }
+""")
+
+
+# =====================================================================
+# Error accumulation and edge cases
+# =====================================================================
+
+class TestErrorAccumulation:
+
+    def test_multiple_errors(self) -> None:
+        """Multiple type errors in one file are all reported."""
+        errs = _errors("""
+fn bad(@Unit -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  let @String = 42;
+  @Int.0
+}
+""")
+        # At least one error expected (let type mismatch or unresolved slot)
+        assert len(errs) >= 1
+
+    def test_empty_program(self) -> None:
+        """An empty program type-checks cleanly."""
+        _check_ok("")
+
+    def test_data_only_program(self) -> None:
+        """A program with only data declarations type-checks cleanly."""
+        _check_ok("""
+data Color { Red, Green, Blue }
+data Option<T> { None, Some(T) }
+""")
+
+    def test_type_error_has_location(self) -> None:
+        """Type errors include source location."""
+        errs = _errors("""
+fn bad(@Int -> @Bool)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 }
+""")
+        assert len(errs) >= 1
+        assert errs[0].location.line > 0
+
+
+# =====================================================================
+# Where blocks (mutual recursion)
+# =====================================================================
+
+class TestWhereBlocks:
+
+    def test_mutual_recursion(self) -> None:
+        _check_ok("""
+fn is_even(@Nat -> @Bool)
+  requires(true) ensures(true)
+  decreases(@Nat.0)
+  effects(pure)
+{
+  if @Nat.0 == 0 then { true }
+  else { is_odd(@Nat.0 - 1) }
+}
+where {
+  fn is_odd(@Nat -> @Bool)
+    requires(true) ensures(true)
+    decreases(@Nat.0)
+    effects(pure)
+  {
+    if @Nat.0 == 0 then { false }
+    else { is_even(@Nat.0 - 1) }
+  }
+}
+""")
+
+
+# =====================================================================
+# Array operations
+# =====================================================================
+
+class TestArrays:
+
+    def test_array_index(self) -> None:
+        _check_ok("""
+fn first(@Array<Int> -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Array<Int>.0[0] }
+""")
+
+    def test_array_index_non_array_error(self) -> None:
+        _check_err("""
+fn bad(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0[0] }
+""", "Cannot index")
+
+
+# =====================================================================
+# Return type checking
+# =====================================================================
+
+class TestReturnTypes:
+
+    def test_return_type_mismatch(self) -> None:
+        _check_err("""
+fn bad(@Int -> @Bool)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 }
+""", "body has type")
+
+    def test_nat_return_from_int_body(self) -> None:
+        """Int body with Nat return: allowed in C3."""
+        _check_ok("""
+fn foo(@Int -> @Nat)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 }
+""")
+
+    def test_if_nat_literal_return(self) -> None:
+        """Non-negative literal should satisfy Nat return."""
+        _check_ok("""
+fn foo(@Unit -> @Nat)
+  requires(true) ensures(true) effects(pure)
+{ 42 }
+""")

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.4"
+__version__ = "0.0.5"

--- a/vera/checker.py
+++ b/vera/checker.py
@@ -1,0 +1,1588 @@
+"""Vera type checker — Tier 1 decidable type checking.
+
+Validates expression types, slot reference resolution, effect annotations,
+and contract well-formedness.  Consumes Program AST nodes from parse_to_ast()
+and produces a list of Diagnostic errors (empty = success).
+
+Refinement predicate verification and contract satisfiability are deferred
+to C4 (Z3 solver).
+"""
+
+from __future__ import annotations
+
+from vera import ast
+from vera.errors import Diagnostic, SourceLocation
+from vera.environment import (
+    AdtInfo,
+    Binding,
+    ConstructorInfo,
+    EffectInfo,
+    FunctionInfo,
+    OpInfo,
+    TypeAliasInfo,
+    TypeEnv,
+)
+from vera.types import (
+    BOOL,
+    FLOAT64,
+    INT,
+    NAT,
+    NEVER,
+    NUMERIC_TYPES,
+    ORDERABLE_TYPES,
+    PRIMITIVES,
+    STRING,
+    UNIT,
+    AdtType,
+    ConcreteEffectRow,
+    EffectInstance,
+    EffectRowType,
+    FunctionType,
+    PureEffectRow,
+    RefinedType,
+    Type,
+    TypeVar,
+    UnknownType,
+    base_type,
+    canonical_type_name,
+    is_subtype,
+    pretty_effect,
+    pretty_type,
+    substitute,
+    substitute_effect,
+    types_equal,
+)
+
+
+# =====================================================================
+# Public API
+# =====================================================================
+
+def typecheck(program: ast.Program,
+              source: str = "",
+              file: str | None = None) -> list[Diagnostic]:
+    """Type-check a Vera Program AST.
+
+    Returns a list of Diagnostics (empty = no errors).
+    """
+    checker = TypeChecker(source=source, file=file)
+    checker.check_program(program)
+    return checker.errors
+
+
+# =====================================================================
+# Type checker
+# =====================================================================
+
+class TypeChecker:
+    """Top-down type checker with error accumulation."""
+
+    def __init__(self, source: str = "", file: str | None = None) -> None:
+        self.env = TypeEnv()
+        self.errors: list[Diagnostic] = []
+        self.source = source
+        self.file = file
+        self._effect_ops_used: set[str] = set()
+
+    # -----------------------------------------------------------------
+    # Diagnostics
+    # -----------------------------------------------------------------
+
+    def _error(self, node: ast.Node, description: str, *,
+               rationale: str = "", fix: str = "",
+               spec_ref: str = "", severity: str = "error") -> None:
+        """Record a type error diagnostic."""
+        loc = SourceLocation(file=self.file)
+        if node.span:
+            loc.line = node.span.line
+            loc.column = node.span.column
+        self.errors.append(Diagnostic(
+            description=description,
+            location=loc,
+            source_line=self._source_line(node),
+            rationale=rationale,
+            fix=fix,
+            spec_ref=spec_ref,
+            severity=severity,
+        ))
+
+    def _source_line(self, node: ast.Node) -> str:
+        """Extract source line for a node."""
+        if not node.span or not self.source:
+            return ""
+        lines = self.source.splitlines()
+        idx = node.span.line - 1
+        if 0 <= idx < len(lines):
+            return lines[idx]
+        return ""
+
+    # -----------------------------------------------------------------
+    # Type resolution: AST TypeExpr -> semantic Type
+    # -----------------------------------------------------------------
+
+    def _resolve_type(self, te: ast.TypeExpr) -> Type:
+        """Convert an AST TypeExpr into a resolved semantic Type."""
+        if isinstance(te, ast.NamedType):
+            return self._resolve_named_type(te)
+        if isinstance(te, ast.FnType):
+            params = tuple(self._resolve_type(p) for p in te.params)
+            ret = self._resolve_type(te.return_type)
+            eff = self._resolve_effect_row(te.effect)
+            return FunctionType(params, ret, eff)
+        if isinstance(te, ast.RefinementType):
+            base = self._resolve_type(te.base_type)
+            return RefinedType(base, te.predicate)
+        return UnknownType()
+
+    def _resolve_named_type(self, te: ast.NamedType) -> Type:
+        """Resolve a named type (possibly parameterised)."""
+        name = te.name
+
+        # Type variable?
+        if name in self.env.type_params:
+            return self.env.type_params[name]
+
+        # Primitive?
+        if name in PRIMITIVES and not te.type_args:
+            return PRIMITIVES[name]
+
+        # Type alias?
+        alias = self.env.type_aliases.get(name)
+        if alias:
+            if te.type_args and alias.type_params:
+                args = tuple(self._resolve_type(a) for a in te.type_args)
+                mapping = dict(zip(alias.type_params, args))
+                return substitute(alias.resolved_type, mapping)
+            return alias.resolved_type
+
+        # ADT or parameterised built-in?
+        adt = self.env.data_types.get(name)
+        if adt is not None:
+            if te.type_args:
+                args = tuple(self._resolve_type(a) for a in te.type_args)
+                return AdtType(name, args)
+            return AdtType(name, ())
+
+        # Array, Tuple (always parameterised)
+        if name in ("Array", "Tuple"):
+            if te.type_args:
+                args = tuple(self._resolve_type(a) for a in te.type_args)
+                return AdtType(name, args)
+            return AdtType(name, ())
+
+        # Unknown — might be a type from an unresolved import
+        return AdtType(name, tuple(
+            self._resolve_type(a) for a in te.type_args
+        ) if te.type_args else ())
+
+    def _resolve_effect_row(self, er: ast.EffectRow) -> EffectRowType:
+        """Convert an AST EffectRow into a semantic EffectRowType."""
+        if isinstance(er, ast.PureEffect):
+            return PureEffectRow()
+        if isinstance(er, ast.EffectSet):
+            instances = []
+            row_var = None
+            for ref in er.effects:
+                if isinstance(ref, ast.EffectRef):
+                    # Check if it's a type variable (effect polymorphism)
+                    if ref.name in self.env.type_params:
+                        row_var = ref.name
+                        continue
+                    args = tuple(
+                        self._resolve_type(a) for a in ref.type_args
+                    ) if ref.type_args else ()
+                    instances.append(EffectInstance(ref.name, args))
+                elif isinstance(ref, ast.QualifiedEffectRef):
+                    args = tuple(
+                        self._resolve_type(a) for a in ref.type_args
+                    ) if ref.type_args else ()
+                    instances.append(
+                        EffectInstance(f"{ref.module}.{ref.name}", args))
+            return ConcreteEffectRow(frozenset(instances), row_var)
+        return PureEffectRow()
+
+    def _resolve_effect_ref(self, ref: ast.EffectRefNode) -> EffectInstance | None:
+        """Resolve a single effect reference."""
+        if isinstance(ref, ast.EffectRef):
+            args = tuple(
+                self._resolve_type(a) for a in ref.type_args
+            ) if ref.type_args else ()
+            return EffectInstance(ref.name, args)
+        if isinstance(ref, ast.QualifiedEffectRef):
+            args = tuple(
+                self._resolve_type(a) for a in ref.type_args
+            ) if ref.type_args else ()
+            return EffectInstance(f"{ref.module}.{ref.name}", args)
+        return None
+
+    # -----------------------------------------------------------------
+    # Canonical type name for slot references
+    # -----------------------------------------------------------------
+
+    def _slot_type_name(self, type_name: str,
+                        type_args: tuple[ast.TypeExpr, ...] | None) -> str:
+        """Form the canonical type name for slot reference matching."""
+        if not type_args:
+            return type_name
+        resolved = tuple(self._resolve_type(a) for a in type_args)
+        return canonical_type_name(type_name, resolved)
+
+    # -----------------------------------------------------------------
+    # Pass 1: Registration
+    # -----------------------------------------------------------------
+
+    def _register_all(self, program: ast.Program) -> None:
+        """Register all top-level declarations (forward reference support)."""
+        for tld in program.declarations:
+            self._register_decl(tld.decl)
+
+    def _register_decl(self, decl: ast.Decl) -> None:
+        """Register a single declaration's signature."""
+        if isinstance(decl, ast.DataDecl):
+            self._register_data(decl)
+        elif isinstance(decl, ast.TypeAliasDecl):
+            self._register_alias(decl)
+        elif isinstance(decl, ast.EffectDecl):
+            self._register_effect(decl)
+        elif isinstance(decl, ast.FnDecl):
+            self._register_fn(decl)
+
+    def _register_data(self, decl: ast.DataDecl) -> None:
+        """Register an ADT and its constructors."""
+        # Set up type params for resolving constructor field types
+        saved_params = dict(self.env.type_params)
+        if decl.type_params:
+            for tv in decl.type_params:
+                self.env.type_params[tv] = TypeVar(tv)
+
+        ctors: dict[str, ConstructorInfo] = {}
+        for ctor in decl.constructors:
+            field_types = None
+            if ctor.fields is not None:
+                field_types = tuple(
+                    self._resolve_type(f) for f in ctor.fields)
+            ci = ConstructorInfo(
+                name=ctor.name,
+                parent_type=decl.name,
+                parent_type_params=decl.type_params,
+                field_types=field_types,
+            )
+            ctors[ctor.name] = ci
+            self.env.constructors[ctor.name] = ci
+
+        self.env.data_types[decl.name] = AdtInfo(
+            name=decl.name,
+            type_params=decl.type_params,
+            constructors=ctors,
+        )
+
+        self.env.type_params = saved_params
+
+    def _register_alias(self, decl: ast.TypeAliasDecl) -> None:
+        """Register a type alias."""
+        saved_params = dict(self.env.type_params)
+        if decl.type_params:
+            for tv in decl.type_params:
+                self.env.type_params[tv] = TypeVar(tv)
+
+        resolved = self._resolve_type(decl.type_expr)
+        self.env.type_aliases[decl.name] = TypeAliasInfo(
+            name=decl.name,
+            type_params=decl.type_params,
+            resolved_type=resolved,
+        )
+
+        self.env.type_params = saved_params
+
+    def _register_effect(self, decl: ast.EffectDecl) -> None:
+        """Register an effect and its operations."""
+        saved_params = dict(self.env.type_params)
+        if decl.type_params:
+            for tv in decl.type_params:
+                self.env.type_params[tv] = TypeVar(tv)
+
+        ops: dict[str, OpInfo] = {}
+        for op in decl.operations:
+            param_types = tuple(self._resolve_type(p) for p in op.param_types)
+            ret_type = self._resolve_type(op.return_type)
+            ops[op.name] = OpInfo(
+                name=op.name,
+                param_types=param_types,
+                return_type=ret_type,
+                parent_effect=decl.name,
+            )
+
+        self.env.effects[decl.name] = EffectInfo(
+            name=decl.name,
+            type_params=decl.type_params,
+            operations=ops,
+        )
+
+        self.env.type_params = saved_params
+
+    def _register_fn(self, decl: ast.FnDecl) -> None:
+        """Register a function signature."""
+        saved_params = dict(self.env.type_params)
+        if decl.forall_vars:
+            for tv in decl.forall_vars:
+                self.env.type_params[tv] = TypeVar(tv)
+
+        param_types = tuple(self._resolve_type(p) for p in decl.params)
+        ret_type = self._resolve_type(decl.return_type)
+        eff = self._resolve_effect_row(decl.effect)
+
+        self.env.functions[decl.name] = FunctionInfo(
+            name=decl.name,
+            forall_vars=decl.forall_vars,
+            param_types=param_types,
+            return_type=ret_type,
+            effect=eff,
+            span=decl.span,
+        )
+
+        # Register where-block functions
+        if decl.where_fns:
+            for wfn in decl.where_fns:
+                self._register_fn(wfn)
+
+        self.env.type_params = saved_params
+
+    # -----------------------------------------------------------------
+    # Pass 2: Checking
+    # -----------------------------------------------------------------
+
+    def check_program(self, program: ast.Program) -> None:
+        """Entry point: register all declarations, then check each."""
+        self._register_all(program)
+        for tld in program.declarations:
+            self._check_decl(tld.decl)
+
+    def _check_decl(self, decl: ast.Decl) -> None:
+        """Check a single declaration."""
+        if isinstance(decl, ast.FnDecl):
+            self._check_fn(decl)
+        elif isinstance(decl, ast.DataDecl):
+            self._check_data(decl)
+        # TypeAliasDecl and EffectDecl are validated during registration
+
+    def _check_data(self, decl: ast.DataDecl) -> None:
+        """Check an ADT declaration (invariant well-formedness)."""
+        if decl.invariant is not None:
+            # Push scope with constructor bindings for invariant checking
+            self.env.push_scope()
+            saved_params = dict(self.env.type_params)
+            if decl.type_params:
+                for tv in decl.type_params:
+                    self.env.type_params[tv] = TypeVar(tv)
+
+            inv_type = self._synth_expr(decl.invariant)
+            if inv_type and not is_subtype(inv_type, BOOL):
+                self._error(
+                    decl.invariant,
+                    f"Invariant must be Bool, found {pretty_type(inv_type)}.",
+                    rationale="Data type invariants are predicates that must "
+                              "evaluate to Bool.",
+                    spec_ref='Chapter 2, Section 2.5 "Algebraic Data Types"',
+                )
+
+            self.env.type_params = saved_params
+            self.env.pop_scope()
+
+    def _check_fn(self, decl: ast.FnDecl) -> None:
+        """Check a function declaration."""
+        saved_params = dict(self.env.type_params)
+        saved_return = self.env.current_return_type
+        saved_effect = self.env.current_effect_row
+
+        # 1. Bind forall type parameters
+        if decl.forall_vars:
+            for tv in decl.forall_vars:
+                self.env.type_params[tv] = TypeVar(tv)
+
+        # 2. Resolve parameter and return types
+        param_types = tuple(self._resolve_type(p) for p in decl.params)
+        return_type = self._resolve_type(decl.return_type)
+        effect_row = self._resolve_effect_row(decl.effect)
+
+        # 3. Set context
+        self.env.current_return_type = return_type
+        self.env.current_effect_row = effect_row
+        self._effect_ops_used = set()
+
+        # 4. Push scope and bind parameters
+        self.env.push_scope()
+        for i, (param_te, param_ty) in enumerate(
+                zip(decl.params, param_types)):
+            tname = self._type_expr_to_slot_name(param_te)
+            self.env.bind(tname, param_ty, "param")
+
+        # 5. Check contracts
+        for contract in decl.contracts:
+            self._check_contract(contract, decl)
+
+        # 6. Check body
+        body_type = self._synth_expr(decl.body)
+        if body_type and not isinstance(body_type, UnknownType):
+            if not is_subtype(body_type, return_type):
+                self._error(
+                    decl.body,
+                    f"Function '{decl.name}' body has type "
+                    f"{pretty_type(body_type)}, expected "
+                    f"{pretty_type(return_type)}.",
+                    rationale="The function body's type must match the "
+                              "declared return type.",
+                    fix=f"Change the return type or adjust the body "
+                        f"expression.",
+                    spec_ref='Chapter 5, Section 5.1 "Function Declarations"',
+                )
+
+        # 7. Check effect compliance (basic)
+        if isinstance(effect_row, PureEffectRow) and self._effect_ops_used:
+            ops_str = ", ".join(sorted(self._effect_ops_used))
+            self._error(
+                decl,
+                f"Pure function '{decl.name}' performs effect operations: "
+                f"{ops_str}.",
+                rationale="Functions declared with effects(pure) cannot "
+                          "call effect operations.",
+                fix=f"Declare the appropriate effects, e.g. "
+                    f"effects(<{next(iter(self._effect_ops_used), '...')}>).",
+                spec_ref='Chapter 7, Section 7.4 "Performing Effects"',
+            )
+
+        # 8. Check where-block functions
+        if decl.where_fns:
+            for wfn in decl.where_fns:
+                self._check_fn(wfn)
+
+        # 9. Restore context
+        self.env.pop_scope()
+        self.env.type_params = saved_params
+        self.env.current_return_type = saved_return
+        self.env.current_effect_row = saved_effect
+
+    def _type_expr_to_slot_name(self, te: ast.TypeExpr) -> str:
+        """Extract the canonical slot name from a type expression used as a
+        parameter binding.  This is the syntactic name — aliases are opaque."""
+        if isinstance(te, ast.NamedType):
+            if te.type_args:
+                resolved_args = tuple(
+                    self._resolve_type(a) for a in te.type_args)
+                return canonical_type_name(te.name, resolved_args)
+            return te.name
+        if isinstance(te, ast.RefinementType):
+            return self._type_expr_to_slot_name(te.base_type)
+        if isinstance(te, ast.FnType):
+            # Function-typed parameters: use a synthetic name
+            return "Fn"
+        return "?"
+
+    # -----------------------------------------------------------------
+    # Contracts
+    # -----------------------------------------------------------------
+
+    def _check_contract(self, contract: ast.Contract,
+                        fn: ast.FnDecl) -> None:
+        """Check a contract clause for well-formedness."""
+        if isinstance(contract, ast.Requires):
+            self.env.in_contract = True
+            ty = self._synth_expr(contract.expr)
+            self.env.in_contract = False
+            if ty and not is_subtype(ty, BOOL):
+                self._error(
+                    contract.expr,
+                    f"requires() predicate must be Bool, found "
+                    f"{pretty_type(ty)}.",
+                    rationale="Contract predicates must evaluate to Bool.",
+                    spec_ref='Chapter 6, Section 6.2 "Preconditions"',
+                )
+
+        elif isinstance(contract, ast.Ensures):
+            self.env.in_ensures = True
+            self.env.in_contract = True
+            ty = self._synth_expr(contract.expr)
+            self.env.in_ensures = False
+            self.env.in_contract = False
+            if ty and not is_subtype(ty, BOOL):
+                self._error(
+                    contract.expr,
+                    f"ensures() predicate must be Bool, found "
+                    f"{pretty_type(ty)}.",
+                    rationale="Contract predicates must evaluate to Bool.",
+                    spec_ref='Chapter 6, Section 6.3 "Postconditions"',
+                )
+
+        elif isinstance(contract, ast.Decreases):
+            self.env.in_contract = True
+            for expr in contract.exprs:
+                ty = self._synth_expr(expr)
+                # Type is checked but verification deferred to C4
+            self.env.in_contract = False
+
+    # -----------------------------------------------------------------
+    # Expression type synthesis
+    # -----------------------------------------------------------------
+
+    def _synth_expr(self, expr: ast.Expr) -> Type | None:
+        """Synthesise the type of an expression.  Returns None on error."""
+        if isinstance(expr, ast.IntLit):
+            # Non-negative integer literals are Nat (which is a subtype of
+            # Int).  This lets literals like 0, 1, 42 satisfy Nat parameters
+            # without refinement verification.
+            return NAT if expr.value >= 0 else INT
+        if isinstance(expr, ast.FloatLit):
+            return FLOAT64
+        if isinstance(expr, ast.StringLit):
+            return STRING
+        if isinstance(expr, ast.BoolLit):
+            return BOOL
+        if isinstance(expr, ast.UnitLit):
+            return UNIT
+        if isinstance(expr, ast.SlotRef):
+            return self._check_slot_ref(expr)
+        if isinstance(expr, ast.ResultRef):
+            return self._check_result_ref(expr)
+        if isinstance(expr, ast.BinaryExpr):
+            return self._check_binary(expr)
+        if isinstance(expr, ast.UnaryExpr):
+            return self._check_unary(expr)
+        if isinstance(expr, ast.IndexExpr):
+            return self._check_index(expr)
+        if isinstance(expr, ast.FnCall):
+            return self._check_fn_call(expr)
+        if isinstance(expr, ast.ConstructorCall):
+            return self._check_constructor_call(expr)
+        if isinstance(expr, ast.NullaryConstructor):
+            return self._check_nullary_constructor(expr)
+        if isinstance(expr, ast.QualifiedCall):
+            return self._check_qualified_call(expr)
+        if isinstance(expr, ast.ModuleCall):
+            return self._check_module_call(expr)
+        if isinstance(expr, ast.IfExpr):
+            return self._check_if(expr)
+        if isinstance(expr, ast.MatchExpr):
+            return self._check_match(expr)
+        if isinstance(expr, ast.Block):
+            return self._check_block(expr)
+        if isinstance(expr, ast.AnonFn):
+            return self._check_anon_fn(expr)
+        if isinstance(expr, ast.HandleExpr):
+            return self._check_handle(expr)
+        if isinstance(expr, ast.ArrayLit):
+            return self._check_array_lit(expr)
+        if isinstance(expr, ast.AssertExpr):
+            return self._check_assert(expr)
+        if isinstance(expr, ast.AssumeExpr):
+            return self._check_assume(expr)
+        if isinstance(expr, ast.ForallExpr):
+            return self._check_forall_expr(expr)
+        if isinstance(expr, ast.ExistsExpr):
+            return self._check_exists_expr(expr)
+        if isinstance(expr, ast.OldExpr):
+            return self._check_old_expr(expr)
+        if isinstance(expr, ast.NewExpr):
+            return self._check_new_expr(expr)
+        self._error(expr, f"Unknown expression type: {type(expr).__name__}")
+        return None
+
+    # -----------------------------------------------------------------
+    # Slot references
+    # -----------------------------------------------------------------
+
+    def _check_slot_ref(self, ref: ast.SlotRef) -> Type | None:
+        """Type-check @T.n slot reference."""
+        tname = self._slot_type_name(ref.type_name, ref.type_args)
+        resolved = self.env.resolve_slot(tname, ref.index)
+        if resolved is None:
+            count = self.env.count_bindings(tname)
+            self._error(
+                ref,
+                f"Cannot resolve @{tname}.{ref.index}: "
+                f"only {count} {tname} binding(s) in scope "
+                f"(valid indices: 0..{count - 1})."
+                if count > 0
+                else f"Cannot resolve @{tname}.{ref.index}: "
+                     f"no {tname} bindings in scope.",
+                rationale=f"Slot reference @{tname}.{ref.index} requires at "
+                          f"least {ref.index + 1} binding(s) of type {tname}.",
+                fix=f"Ensure enough {tname} bindings are in scope, or use a "
+                    f"lower index.",
+                spec_ref='Chapter 3, Section 3.4 "Reference Resolution"',
+            )
+            return UnknownType()
+        return resolved
+
+    def _check_result_ref(self, ref: ast.ResultRef) -> Type | None:
+        """Type-check @T.result reference."""
+        if not self.env.in_ensures:
+            self._error(
+                ref,
+                f"@{ref.type_name}.result is only valid inside ensures() "
+                f"clauses.",
+                rationale="The @T.result reference refers to a function's "
+                          "return value, which is only meaningful in "
+                          "postcondition context.",
+                fix="Move the @T.result reference inside an ensures() clause.",
+                spec_ref='Chapter 3, Section 3.6 "The @result Reference"',
+            )
+            return UnknownType()
+
+        ret = self.env.current_return_type
+        if ret is None:
+            return UnknownType()
+        return ret
+
+    # -----------------------------------------------------------------
+    # Binary operators
+    # -----------------------------------------------------------------
+
+    def _check_binary(self, expr: ast.BinaryExpr) -> Type | None:
+        """Type-check a binary operator expression."""
+        # Pipe is special
+        if expr.op == ast.BinOp.PIPE:
+            return self._check_pipe(expr)
+
+        left_ty = self._synth_expr(expr.left)
+        right_ty = self._synth_expr(expr.right)
+        if left_ty is None or right_ty is None:
+            return None
+        if isinstance(left_ty, UnknownType) or isinstance(right_ty, UnknownType):
+            return UnknownType()
+
+        op = expr.op
+
+        # Arithmetic: +, -, *, /, %
+        if op in (ast.BinOp.ADD, ast.BinOp.SUB, ast.BinOp.MUL,
+                  ast.BinOp.DIV, ast.BinOp.MOD):
+            left_base = base_type(left_ty)
+            right_base = base_type(right_ty)
+            if left_base not in NUMERIC_TYPES or right_base not in NUMERIC_TYPES:
+                self._error(
+                    expr,
+                    f"Operator '{op.value}' requires numeric operands, found "
+                    f"{pretty_type(left_ty)} and {pretty_type(right_ty)}.",
+                    rationale="Arithmetic operators work on Int, Nat, or "
+                              "Float64.",
+                    spec_ref='Chapter 4, Section 4.3 "Operators"',
+                )
+                return UnknownType()
+            # Allow Nat+Int => Int, etc. Result is the more general type.
+            if is_subtype(left_base, right_base):
+                return right_base
+            if is_subtype(right_base, left_base):
+                return left_base
+            self._error(
+                expr,
+                f"Operator '{op.value}' requires matching numeric types, "
+                f"found {pretty_type(left_ty)} and {pretty_type(right_ty)}.",
+                rationale="Both operands must be the same numeric type "
+                          "(or Nat where Int is expected).",
+                spec_ref='Chapter 4, Section 4.3 "Operators"',
+            )
+            return UnknownType()
+
+        # Comparison: ==, !=, <, >, <=, >=
+        if op in (ast.BinOp.EQ, ast.BinOp.NEQ):
+            left_base = base_type(left_ty)
+            right_base = base_type(right_ty)
+            if not (is_subtype(left_base, right_base)
+                    or is_subtype(right_base, left_base)):
+                self._error(
+                    expr,
+                    f"Cannot compare {pretty_type(left_ty)} with "
+                    f"{pretty_type(right_ty)}.",
+                    rationale="Equality comparison requires compatible types.",
+                    spec_ref='Chapter 4, Section 4.3 "Operators"',
+                )
+            return BOOL
+
+        if op in (ast.BinOp.LT, ast.BinOp.GT, ast.BinOp.LE, ast.BinOp.GE):
+            left_base = base_type(left_ty)
+            right_base = base_type(right_ty)
+            if (left_base not in ORDERABLE_TYPES
+                    or right_base not in ORDERABLE_TYPES):
+                self._error(
+                    expr,
+                    f"Operator '{op.value}' requires orderable operands, "
+                    f"found {pretty_type(left_ty)} and "
+                    f"{pretty_type(right_ty)}.",
+                    spec_ref='Chapter 4, Section 4.3 "Operators"',
+                )
+            return BOOL
+
+        # Logical: &&, ||, ==>
+        if op in (ast.BinOp.AND, ast.BinOp.OR, ast.BinOp.IMPLIES):
+            left_base = base_type(left_ty)
+            right_base = base_type(right_ty)
+            if not is_subtype(left_base, BOOL):
+                self._error(
+                    expr,
+                    f"Left operand of '{op.value}' must be Bool, found "
+                    f"{pretty_type(left_ty)}.",
+                    spec_ref='Chapter 4, Section 4.3 "Operators"',
+                )
+            if not is_subtype(right_base, BOOL):
+                self._error(
+                    expr,
+                    f"Right operand of '{op.value}' must be Bool, found "
+                    f"{pretty_type(right_ty)}.",
+                    spec_ref='Chapter 4, Section 4.3 "Operators"',
+                )
+            return BOOL
+
+        return UnknownType()
+
+    def _check_pipe(self, expr: ast.BinaryExpr) -> Type | None:
+        """Type-check pipe: left |> right (right must be a FnCall)."""
+        left_ty = self._synth_expr(expr.left)
+        if left_ty is None:
+            return None
+
+        # The right side should be a FnCall — prepend left as first arg
+        if isinstance(expr.right, ast.FnCall):
+            # Create a virtual call with left prepended
+            all_args = (expr.left,) + expr.right.args
+            return self._check_call_with_args(
+                expr.right.name, all_args, expr.right)
+        # Fallback: just synth the right side
+        return self._synth_expr(expr.right)
+
+    # -----------------------------------------------------------------
+    # Unary operators
+    # -----------------------------------------------------------------
+
+    def _check_unary(self, expr: ast.UnaryExpr) -> Type | None:
+        """Type-check a unary operator expression."""
+        operand_ty = self._synth_expr(expr.operand)
+        if operand_ty is None:
+            return None
+        if isinstance(operand_ty, UnknownType):
+            return UnknownType()
+
+        operand_base = base_type(operand_ty)
+
+        if expr.op == ast.UnaryOp.NOT:
+            if not is_subtype(operand_base, BOOL):
+                self._error(
+                    expr,
+                    f"Operator '!' requires Bool operand, found "
+                    f"{pretty_type(operand_ty)}.",
+                    spec_ref='Chapter 4, Section 4.3 "Operators"',
+                )
+            return BOOL
+
+        if expr.op == ast.UnaryOp.NEG:
+            if operand_base not in NUMERIC_TYPES:
+                self._error(
+                    expr,
+                    f"Operator '-' requires numeric operand, found "
+                    f"{pretty_type(operand_ty)}.",
+                    spec_ref='Chapter 4, Section 4.3 "Operators"',
+                )
+                return UnknownType()
+            # Negating Nat produces Int (may go negative)
+            if types_equal(operand_base, NAT):
+                return INT
+            return operand_base
+
+        return UnknownType()
+
+    # -----------------------------------------------------------------
+    # Index
+    # -----------------------------------------------------------------
+
+    def _check_index(self, expr: ast.IndexExpr) -> Type | None:
+        """Type-check array index: collection[index]."""
+        coll_ty = self._synth_expr(expr.collection)
+        idx_ty = self._synth_expr(expr.index)
+        if coll_ty is None or idx_ty is None:
+            return None
+        if isinstance(coll_ty, UnknownType):
+            return UnknownType()
+
+        coll_base = base_type(coll_ty)
+
+        # Must be Array<T>
+        if isinstance(coll_base, AdtType) and coll_base.name == "Array":
+            if coll_base.type_args:
+                elem_type = coll_base.type_args[0]
+            else:
+                elem_type = UnknownType()
+
+            # Index must be Int or Nat
+            if idx_ty and not isinstance(idx_ty, UnknownType):
+                idx_base = base_type(idx_ty)
+                if not is_subtype(idx_base, INT):
+                    self._error(
+                        expr.index,
+                        f"Array index must be Int or Nat, found "
+                        f"{pretty_type(idx_ty)}.",
+                        spec_ref='Chapter 4, Section 4.4 "Array Access"',
+                    )
+            return elem_type
+
+        self._error(
+            expr.collection,
+            f"Cannot index {pretty_type(coll_ty)}: indexing requires "
+            f"Array<T>.",
+            spec_ref='Chapter 4, Section 4.4 "Array Access"',
+        )
+        return UnknownType()
+
+    # -----------------------------------------------------------------
+    # Function calls
+    # -----------------------------------------------------------------
+
+    def _check_fn_call(self, expr: ast.FnCall) -> Type | None:
+        """Type-check a function call."""
+        return self._check_call_with_args(expr.name, expr.args, expr)
+
+    def _check_call_with_args(self, name: str, args: tuple[ast.Expr, ...],
+                              node: ast.Node) -> Type | None:
+        """Check a call to function `name` with given arguments."""
+        # Look up function
+        fn_info = self.env.lookup_function(name)
+        if fn_info:
+            return self._check_fn_call_with_info(fn_info, args, node)
+
+        # Maybe it's an effect operation
+        op_info = self.env.lookup_effect_op(name)
+        if op_info:
+            self._effect_ops_used.add(op_info.parent_effect)
+            return self._check_op_call(op_info, args, node)
+
+        # Unresolved — emit warning and continue
+        self._error(
+            node,
+            f"Unresolved function '{name}'.",
+            rationale="The function is not defined in this file and may come "
+                      "from an unresolved import.",
+            severity="warning",
+        )
+        # Still synth arg types to find errors within them
+        for arg in args:
+            self._synth_expr(arg)
+        return UnknownType()
+
+    def _check_fn_call_with_info(self, fn_info: FunctionInfo,
+                                 args: tuple[ast.Expr, ...],
+                                 node: ast.Node) -> Type | None:
+        """Check a call against a known function signature."""
+        # Synth arg types
+        arg_types: list[Type | None] = []
+        for arg in args:
+            arg_types.append(self._synth_expr(arg))
+
+        # Arity check
+        if len(args) != len(fn_info.param_types):
+            self._error(
+                node,
+                f"Function '{fn_info.name}' expects {len(fn_info.param_types)}"
+                f" argument(s), got {len(args)}.",
+                spec_ref='Chapter 5, Section 5.1 "Function Declarations"',
+            )
+            return fn_info.return_type
+
+        # Generic inference
+        param_types = fn_info.param_types
+        return_type = fn_info.return_type
+        if fn_info.forall_vars:
+            mapping = self._infer_type_args(
+                fn_info.forall_vars, fn_info.param_types, arg_types)
+            if mapping:
+                param_types = tuple(
+                    substitute(p, mapping) for p in param_types)
+                return_type = substitute(return_type, mapping)
+
+        # Check each argument
+        for i, (arg_ty, param_ty) in enumerate(zip(arg_types, param_types)):
+            if arg_ty is None or isinstance(arg_ty, UnknownType):
+                continue
+            if isinstance(param_ty, (TypeVar, UnknownType)):
+                continue
+            if not is_subtype(arg_ty, param_ty):
+                self._error(
+                    args[i],
+                    f"Argument {i} of '{fn_info.name}' has type "
+                    f"{pretty_type(arg_ty)}, expected "
+                    f"{pretty_type(param_ty)}.",
+                    spec_ref='Chapter 5, Section 5.1 "Function Declarations"',
+                )
+
+        # Track effects
+        if not isinstance(fn_info.effect, PureEffectRow):
+            if isinstance(fn_info.effect, ConcreteEffectRow):
+                for ei in fn_info.effect.effects:
+                    self._effect_ops_used.add(ei.name)
+
+        return return_type
+
+    def _check_op_call(self, op_info: OpInfo,
+                       args: tuple[ast.Expr, ...],
+                       node: ast.Node) -> Type | None:
+        """Check a call to an effect operation."""
+        arg_types: list[Type | None] = []
+        for arg in args:
+            arg_types.append(self._synth_expr(arg))
+
+        # Resolve type params from current effect context
+        mapping = self._effect_type_mapping(op_info.parent_effect)
+        param_types = tuple(substitute(p, mapping) for p in op_info.param_types)
+        return_type = substitute(op_info.return_type, mapping)
+
+        if len(args) != len(param_types):
+            self._error(
+                node,
+                f"Effect operation '{op_info.name}' expects "
+                f"{len(param_types)} argument(s), got {len(args)}.",
+            )
+            return return_type
+
+        for i, (arg_ty, param_ty) in enumerate(zip(arg_types, param_types)):
+            if arg_ty is None or isinstance(arg_ty, UnknownType):
+                continue
+            if isinstance(param_ty, (TypeVar, UnknownType)):
+                continue
+            if not is_subtype(arg_ty, param_ty):
+                self._error(
+                    args[i],
+                    f"Argument {i} of '{op_info.name}' has type "
+                    f"{pretty_type(arg_ty)}, expected "
+                    f"{pretty_type(param_ty)}.",
+                )
+
+        return return_type
+
+    def _effect_type_mapping(self, effect_name: str) -> dict[str, Type]:
+        """Get the type argument mapping for an effect from the current
+        effect row context."""
+        if not isinstance(self.env.current_effect_row, ConcreteEffectRow):
+            return {}
+        for ei in self.env.current_effect_row.effects:
+            if ei.name == effect_name:
+                eff_info = self.env.lookup_effect(effect_name)
+                if eff_info and eff_info.type_params and ei.type_args:
+                    return dict(zip(eff_info.type_params, ei.type_args))
+        return {}
+
+    # -----------------------------------------------------------------
+    # Constructors
+    # -----------------------------------------------------------------
+
+    def _check_constructor_call(self, expr: ast.ConstructorCall) -> Type | None:
+        """Type-check a constructor call: Ctor(args)."""
+        ci = self.env.lookup_constructor(expr.name)
+        if ci is None:
+            self._error(
+                expr,
+                f"Unknown constructor '{expr.name}'.",
+                severity="warning",
+            )
+            for arg in expr.args:
+                self._synth_expr(arg)
+            return UnknownType()
+
+        # Synth arg types
+        arg_types: list[Type | None] = []
+        for arg in expr.args:
+            arg_types.append(self._synth_expr(arg))
+
+        if ci.field_types is None:
+            if expr.args:
+                self._error(
+                    expr,
+                    f"Constructor '{expr.name}' is nullary but was given "
+                    f"{len(expr.args)} argument(s).",
+                )
+            return self._ctor_result_type(ci, arg_types)
+
+        if len(expr.args) != len(ci.field_types):
+            self._error(
+                expr,
+                f"Constructor '{expr.name}' expects "
+                f"{len(ci.field_types)} field(s), got {len(expr.args)}.",
+            )
+            return self._ctor_result_type(ci, arg_types)
+
+        # Infer type args for parameterised ADTs
+        mapping = self._infer_ctor_type_args(ci, arg_types)
+        field_types = ci.field_types
+        if mapping:
+            field_types = tuple(substitute(ft, mapping) for ft in field_types)
+
+        for i, (arg_ty, field_ty) in enumerate(zip(arg_types, field_types)):
+            if arg_ty is None or isinstance(arg_ty, UnknownType):
+                continue
+            if isinstance(field_ty, (TypeVar, UnknownType)):
+                continue
+            if not is_subtype(arg_ty, field_ty):
+                self._error(
+                    expr.args[i],
+                    f"Constructor '{expr.name}' field {i} has type "
+                    f"{pretty_type(arg_ty)}, expected "
+                    f"{pretty_type(field_ty)}.",
+                )
+
+        return self._ctor_result_type(ci, arg_types)
+
+    def _check_nullary_constructor(self, expr: ast.NullaryConstructor) -> Type | None:
+        """Type-check a nullary constructor: None, Nil, etc."""
+        ci = self.env.lookup_constructor(expr.name)
+        if ci is None:
+            self._error(expr, f"Unknown constructor '{expr.name}'.",
+                        severity="warning")
+            return UnknownType()
+
+        if ci.field_types is not None:
+            self._error(
+                expr,
+                f"Constructor '{expr.name}' requires "
+                f"{len(ci.field_types)} field(s) but was used as nullary.",
+            )
+
+        return self._ctor_result_type(ci, [])
+
+    def _ctor_result_type(self, ci: ConstructorInfo,
+                          arg_types: list[Type | None]) -> Type:
+        """Compute the result type of a constructor call."""
+        if ci.parent_type_params:
+            # Try to infer type args from argument types
+            mapping = self._infer_ctor_type_args(ci, arg_types)
+            if mapping:
+                args = tuple(
+                    mapping.get(tv, TypeVar(tv))
+                    for tv in ci.parent_type_params
+                )
+                return AdtType(ci.parent_type, args)
+            # Leave as type vars
+            return AdtType(ci.parent_type, tuple(
+                TypeVar(tv) for tv in ci.parent_type_params))
+        return AdtType(ci.parent_type, ())
+
+    def _infer_ctor_type_args(self, ci: ConstructorInfo,
+                              arg_types: list[Type | None]) -> dict[str, Type]:
+        """Infer type arguments for a parameterised constructor."""
+        if not ci.parent_type_params or not ci.field_types:
+            return {}
+        mapping: dict[str, Type] = {}
+        for field_ty, arg_ty in zip(ci.field_types, arg_types):
+            if arg_ty is None or isinstance(arg_ty, UnknownType):
+                continue
+            self._unify_for_inference(field_ty, arg_ty, mapping)
+        return mapping
+
+    # -----------------------------------------------------------------
+    # Qualified / module calls
+    # -----------------------------------------------------------------
+
+    def _check_qualified_call(self, expr: ast.QualifiedCall) -> Type | None:
+        """Type-check a qualified call: Effect.op(args)."""
+        # Try as effect operation
+        op_info = self.env.lookup_effect_op(expr.name, expr.qualifier)
+        if op_info:
+            self._effect_ops_used.add(op_info.parent_effect)
+            return self._check_op_call(op_info, expr.args, expr)
+
+        # Try as module-qualified function
+        self._error(
+            expr,
+            f"Unresolved qualified call '{expr.qualifier}.{expr.name}'.",
+            severity="warning",
+        )
+        for arg in expr.args:
+            self._synth_expr(arg)
+        return UnknownType()
+
+    def _check_module_call(self, expr: ast.ModuleCall) -> Type | None:
+        """Type-check a module call: path.to.fn(args)."""
+        self._error(
+            expr,
+            f"Module call '{'.'.join(expr.path)}.{expr.name}' cannot be "
+            f"resolved (cross-module resolution not yet implemented).",
+            severity="warning",
+        )
+        for arg in expr.args:
+            self._synth_expr(arg)
+        return UnknownType()
+
+    # -----------------------------------------------------------------
+    # Control flow
+    # -----------------------------------------------------------------
+
+    def _check_if(self, expr: ast.IfExpr) -> Type | None:
+        """Type-check if-then-else."""
+        cond_ty = self._synth_expr(expr.condition)
+        if cond_ty and not isinstance(cond_ty, UnknownType):
+            if not is_subtype(base_type(cond_ty), BOOL):
+                self._error(
+                    expr.condition,
+                    f"If condition must be Bool, found "
+                    f"{pretty_type(cond_ty)}.",
+                    spec_ref='Chapter 4, Section 4.8 "Conditional Expressions"',
+                )
+
+        then_ty = self._synth_expr(expr.then_branch)
+        else_ty = self._synth_expr(expr.else_branch)
+
+        if then_ty is None or else_ty is None:
+            return then_ty or else_ty
+        if isinstance(then_ty, UnknownType):
+            return else_ty
+        if isinstance(else_ty, UnknownType):
+            return then_ty
+
+        # Never propagation
+        if types_equal(then_ty, NEVER):
+            return else_ty
+        if types_equal(else_ty, NEVER):
+            return then_ty
+
+        # Branches must have compatible types
+        if is_subtype(then_ty, else_ty):
+            return else_ty
+        if is_subtype(else_ty, then_ty):
+            return then_ty
+
+        self._error(
+            expr,
+            f"If branches have incompatible types: then-branch is "
+            f"{pretty_type(then_ty)}, else-branch is "
+            f"{pretty_type(else_ty)}.",
+            rationale="Both branches of an if-expression must have "
+                      "the same type.",
+            spec_ref='Chapter 4, Section 4.8 "Conditional Expressions"',
+        )
+        return then_ty  # use then-branch type as best guess
+
+    def _check_match(self, expr: ast.MatchExpr) -> Type | None:
+        """Type-check a match expression."""
+        scrutinee_ty = self._synth_expr(expr.scrutinee)
+        if scrutinee_ty is None:
+            return None
+
+        result_type: Type | None = None
+        for arm in expr.arms:
+            # Check pattern and collect bindings
+            bindings = self._check_pattern(arm.pattern, scrutinee_ty)
+
+            # Push scope with pattern bindings
+            self.env.push_scope()
+            for b in bindings:
+                self.env.bind(b.type_name, b.resolved_type, "match")
+
+            # Synth arm body type
+            arm_ty = self._synth_expr(arm.body)
+            self.env.pop_scope()
+
+            if arm_ty is None or isinstance(arm_ty, UnknownType):
+                continue
+
+            if result_type is None or isinstance(result_type, UnknownType):
+                result_type = arm_ty
+            elif types_equal(result_type, NEVER):
+                result_type = arm_ty
+            elif not types_equal(arm_ty, NEVER):
+                if not (is_subtype(arm_ty, result_type)
+                        or is_subtype(result_type, arm_ty)):
+                    self._error(
+                        arm.body if hasattr(arm, 'body') else expr,
+                        f"Match arm type {pretty_type(arm_ty)} is "
+                        f"incompatible with previous arm type "
+                        f"{pretty_type(result_type)}.",
+                        rationale="All match arms must have the same type.",
+                        spec_ref='Chapter 4, Section 4.9 "Pattern Matching"',
+                    )
+
+        return result_type or UnknownType()
+
+    # -----------------------------------------------------------------
+    # Patterns
+    # -----------------------------------------------------------------
+
+    def _check_pattern(self, pat: ast.Pattern,
+                       expected: Type | None) -> list[Binding]:
+        """Check a pattern against an expected type, return bindings."""
+        if isinstance(pat, ast.ConstructorPattern):
+            return self._check_ctor_pattern(pat, expected)
+        if isinstance(pat, ast.NullaryPattern):
+            return self._check_nullary_pattern(pat, expected)
+        if isinstance(pat, ast.BindingPattern):
+            return self._check_binding_pattern(pat, expected)
+        if isinstance(pat, ast.WildcardPattern):
+            return []
+        if isinstance(pat, ast.IntPattern):
+            return []
+        if isinstance(pat, ast.StringPattern):
+            return []
+        if isinstance(pat, ast.BoolPattern):
+            return []
+        return []
+
+    def _check_ctor_pattern(self, pat: ast.ConstructorPattern,
+                            expected: Type | None) -> list[Binding]:
+        """Check a constructor pattern."""
+        ci = self.env.lookup_constructor(pat.name)
+        if ci is None:
+            self._error(pat, f"Unknown constructor '{pat.name}' in pattern.",
+                        severity="warning")
+            return []
+
+        # Infer type args from expected type
+        mapping: dict[str, Type] = {}
+        if (isinstance(expected, AdtType) and ci.parent_type_params
+                and expected.type_args):
+            for tv, arg in zip(ci.parent_type_params, expected.type_args):
+                mapping[tv] = arg
+
+        field_types = ci.field_types or ()
+        if mapping:
+            field_types = tuple(substitute(ft, mapping) for ft in field_types)
+
+        if len(pat.sub_patterns) != len(field_types):
+            self._error(
+                pat,
+                f"Constructor '{pat.name}' has {len(field_types)} field(s), "
+                f"pattern has {len(pat.sub_patterns)} sub-pattern(s).",
+            )
+            return []
+
+        bindings: list[Binding] = []
+        for sub_pat, field_ty in zip(pat.sub_patterns, field_types):
+            bindings.extend(self._check_pattern(sub_pat, field_ty))
+        return bindings
+
+    def _check_nullary_pattern(self, pat: ast.NullaryPattern,
+                               expected: Type | None) -> list[Binding]:
+        """Check a nullary constructor pattern."""
+        ci = self.env.lookup_constructor(pat.name)
+        if ci is None:
+            self._error(pat, f"Unknown constructor '{pat.name}' in pattern.",
+                        severity="warning")
+        return []
+
+    def _check_binding_pattern(self, pat: ast.BindingPattern,
+                               expected: Type | None) -> list[Binding]:
+        """Check a binding pattern (@Type)."""
+        resolved = self._resolve_type(pat.type_expr)
+        tname = self._type_expr_to_slot_name(pat.type_expr)
+        return [Binding(tname, resolved, "match")]
+
+    # -----------------------------------------------------------------
+    # Blocks and statements
+    # -----------------------------------------------------------------
+
+    def _check_block(self, block: ast.Block) -> Type | None:
+        """Type-check a block expression."""
+        self.env.push_scope()
+        for stmt in block.statements:
+            self._check_stmt(stmt)
+        result = self._synth_expr(block.expr)
+        self.env.pop_scope()
+        return result
+
+    def _check_stmt(self, stmt: ast.Stmt) -> None:
+        """Type-check a statement."""
+        if isinstance(stmt, ast.LetStmt):
+            self._check_let(stmt)
+        elif isinstance(stmt, ast.LetDestruct):
+            self._check_let_destruct(stmt)
+        elif isinstance(stmt, ast.ExprStmt):
+            self._synth_expr(stmt.expr)
+
+    def _check_let(self, stmt: ast.LetStmt) -> None:
+        """Type-check a let binding."""
+        declared_type = self._resolve_type(stmt.type_expr)
+        val_type = self._synth_expr(stmt.value)
+
+        if val_type and not isinstance(val_type, UnknownType):
+            if not isinstance(declared_type, UnknownType):
+                if not is_subtype(val_type, declared_type):
+                    self._error(
+                        stmt.value,
+                        f"Let binding expects {pretty_type(declared_type)}, "
+                        f"value has type {pretty_type(val_type)}.",
+                        spec_ref='Chapter 4, Section 4.5 "Let Bindings"',
+                    )
+
+        tname = self._type_expr_to_slot_name(stmt.type_expr)
+        self.env.bind(tname, declared_type, "let")
+
+    def _check_let_destruct(self, stmt: ast.LetDestruct) -> None:
+        """Type-check a destructuring let."""
+        val_type = self._synth_expr(stmt.value)
+
+        for te in stmt.type_bindings:
+            resolved = self._resolve_type(te)
+            tname = self._type_expr_to_slot_name(te)
+            self.env.bind(tname, resolved, "destruct")
+
+    # -----------------------------------------------------------------
+    # Anonymous functions
+    # -----------------------------------------------------------------
+
+    def _check_anon_fn(self, expr: ast.AnonFn) -> Type | None:
+        """Type-check an anonymous function."""
+        param_types = tuple(self._resolve_type(p) for p in expr.params)
+        ret_type = self._resolve_type(expr.return_type)
+        eff = self._resolve_effect_row(expr.effect)
+
+        self.env.push_scope()
+        for param_te, param_ty in zip(expr.params, param_types):
+            tname = self._type_expr_to_slot_name(param_te)
+            self.env.bind(tname, param_ty, "param")
+
+        body_type = self._synth_expr(expr.body)
+        self.env.pop_scope()
+
+        if body_type and not isinstance(body_type, UnknownType):
+            if not is_subtype(body_type, ret_type):
+                self._error(
+                    expr.body,
+                    f"Anonymous function body has type "
+                    f"{pretty_type(body_type)}, expected "
+                    f"{pretty_type(ret_type)}.",
+                    spec_ref='Chapter 5, Section 5.7 "Anonymous Functions"',
+                )
+
+        return FunctionType(param_types, ret_type, eff)
+
+    # -----------------------------------------------------------------
+    # Handlers
+    # -----------------------------------------------------------------
+
+    def _check_handle(self, expr: ast.HandleExpr) -> Type | None:
+        """Type-check a handler expression."""
+        # Resolve the handled effect
+        effect_inst = self._resolve_effect_ref(expr.effect)
+        if effect_inst is None:
+            return UnknownType()
+
+        eff_info = self.env.lookup_effect(effect_inst.name)
+        if eff_info is None:
+            self._error(
+                expr.effect,
+                f"Unknown effect '{effect_inst.name}' in handler.",
+            )
+            return UnknownType()
+
+        # Build type mapping for effect type params
+        mapping: dict[str, Type] = {}
+        if eff_info.type_params and effect_inst.type_args:
+            mapping = dict(zip(eff_info.type_params, effect_inst.type_args))
+
+        # Check handler state
+        state_type: Type | None = None
+        if expr.state:
+            state_type = self._resolve_type(expr.state.type_expr)
+            init_type = self._synth_expr(expr.state.init_expr)
+            if init_type and not isinstance(init_type, UnknownType):
+                if not is_subtype(init_type, state_type):
+                    self._error(
+                        expr.state.init_expr,
+                        f"Handler state initial value has type "
+                        f"{pretty_type(init_type)}, expected "
+                        f"{pretty_type(state_type)}.",
+                    )
+
+        # Check handler clauses
+        for clause in expr.clauses:
+            op_info = eff_info.operations.get(clause.op_name)
+            if op_info is None:
+                self._error(
+                    clause if hasattr(clause, 'span') else expr,
+                    f"Effect '{eff_info.name}' has no operation "
+                    f"'{clause.op_name}'.",
+                )
+                continue
+
+            self.env.push_scope()
+            # Bind operation parameters
+            op_param_types = tuple(
+                substitute(p, mapping) for p in op_info.param_types)
+            for param_te, param_ty in zip(clause.params, op_param_types):
+                tname = self._type_expr_to_slot_name(param_te)
+                self.env.bind(tname, param_ty, "handler")
+
+            # Bind handler state if present
+            if state_type:
+                state_tname = self._type_expr_to_slot_name(
+                    expr.state.type_expr) if expr.state else "?"
+                self.env.bind(state_tname, state_type, "handler")
+
+            self._synth_expr(clause.body)
+            self.env.pop_scope()
+
+        # Check handler body — temporarily add handled effect to context
+        # so effect operations resolve correctly inside the body
+        saved_effect = self.env.current_effect_row
+        saved_ops = self._effect_ops_used
+
+        # Add the handled effect to the current effect row
+        handler_effects = frozenset({effect_inst})
+        if isinstance(self.env.current_effect_row, ConcreteEffectRow):
+            handler_effects = handler_effects | self.env.current_effect_row.effects
+            self.env.current_effect_row = ConcreteEffectRow(
+                handler_effects, self.env.current_effect_row.row_var)
+        else:
+            self.env.current_effect_row = ConcreteEffectRow(handler_effects)
+
+        # Track ops used inside handler body separately (they're discharged)
+        self._effect_ops_used = set()
+
+        # Bind handler state in handler body scope too
+        if state_type and expr.state:
+            self.env.push_scope()
+            state_tname = self._type_expr_to_slot_name(expr.state.type_expr)
+            self.env.bind(state_tname, state_type, "handler")
+
+        body_type = self._synth_expr(expr.body)
+
+        if state_type and expr.state:
+            self.env.pop_scope()
+
+        # Restore — the handler discharges its effect
+        self.env.current_effect_row = saved_effect
+        self._effect_ops_used = saved_ops
+
+        return body_type
+
+    # -----------------------------------------------------------------
+    # Arrays
+    # -----------------------------------------------------------------
+
+    def _check_array_lit(self, expr: ast.ArrayLit) -> Type | None:
+        """Type-check an array literal."""
+        if not expr.elements:
+            return AdtType("Array", (UnknownType(),))
+
+        elem_types: list[Type | None] = []
+        for elem in expr.elements:
+            elem_types.append(self._synth_expr(elem))
+
+        first = None
+        for et in elem_types:
+            if et and not isinstance(et, UnknownType):
+                first = et
+                break
+
+        if first is None:
+            return AdtType("Array", (UnknownType(),))
+
+        return AdtType("Array", (first,))
+
+    # -----------------------------------------------------------------
+    # Assert / Assume
+    # -----------------------------------------------------------------
+
+    def _check_assert(self, expr: ast.AssertExpr) -> Type | None:
+        """Type-check assert(expr)."""
+        ty = self._synth_expr(expr.expr)
+        if ty and not isinstance(ty, UnknownType):
+            if not is_subtype(base_type(ty), BOOL):
+                self._error(
+                    expr.expr,
+                    f"assert() requires Bool, found {pretty_type(ty)}.",
+                    spec_ref='Chapter 6, Section 6.6 "Assertions"',
+                )
+        return UNIT
+
+    def _check_assume(self, expr: ast.AssumeExpr) -> Type | None:
+        """Type-check assume(expr)."""
+        ty = self._synth_expr(expr.expr)
+        if ty and not isinstance(ty, UnknownType):
+            if not is_subtype(base_type(ty), BOOL):
+                self._error(
+                    expr.expr,
+                    f"assume() requires Bool, found {pretty_type(ty)}.",
+                    spec_ref='Chapter 6, Section 6.7 "Assumptions"',
+                )
+        return UNIT
+
+    # -----------------------------------------------------------------
+    # Quantifiers
+    # -----------------------------------------------------------------
+
+    def _check_forall_expr(self, expr: ast.ForallExpr) -> Type | None:
+        """Type-check forall(type, domain, predicate)."""
+        self._resolve_type(expr.binding_type)
+        self._synth_expr(expr.domain)
+        self._synth_expr(expr.predicate)
+        return BOOL
+
+    def _check_exists_expr(self, expr: ast.ExistsExpr) -> Type | None:
+        """Type-check exists(type, domain, predicate)."""
+        self._resolve_type(expr.binding_type)
+        self._synth_expr(expr.domain)
+        self._synth_expr(expr.predicate)
+        return BOOL
+
+    # -----------------------------------------------------------------
+    # Old / New (contract expressions)
+    # -----------------------------------------------------------------
+
+    def _check_old_expr(self, expr: ast.OldExpr) -> Type | None:
+        """Type-check old(EffectRef) — state before effect execution."""
+        if not self.env.in_ensures:
+            self._error(
+                expr,
+                "old() is only valid inside ensures() clauses.",
+                spec_ref='Chapter 7, Section 7.9 "Effect-Contract Interaction"',
+            )
+        ei = self._resolve_effect_ref(expr.effect_ref)
+        if ei:
+            return self._effect_state_type(ei)
+        return UnknownType()
+
+    def _check_new_expr(self, expr: ast.NewExpr) -> Type | None:
+        """Type-check new(EffectRef) — state after effect execution."""
+        if not self.env.in_ensures:
+            self._error(
+                expr,
+                "new() is only valid inside ensures() clauses.",
+                spec_ref='Chapter 7, Section 7.9 "Effect-Contract Interaction"',
+            )
+        ei = self._resolve_effect_ref(expr.effect_ref)
+        if ei:
+            return self._effect_state_type(ei)
+        return UnknownType()
+
+    def _effect_state_type(self, ei: EffectInstance) -> Type:
+        """Get the state type of a State-like effect."""
+        if ei.name == "State" and ei.type_args:
+            return ei.type_args[0]
+        # For other effects, return Unknown
+        return UnknownType()
+
+    # -----------------------------------------------------------------
+    # Type inference helpers
+    # -----------------------------------------------------------------
+
+    def _infer_type_args(self, forall_vars: tuple[str, ...],
+                         param_types: tuple[Type, ...],
+                         arg_types: list[Type | None]) -> dict[str, Type]:
+        """Infer type variable bindings by matching args against params."""
+        mapping: dict[str, Type] = {}
+        for param_ty, arg_ty in zip(param_types, arg_types):
+            if arg_ty is None or isinstance(arg_ty, UnknownType):
+                continue
+            self._unify_for_inference(param_ty, arg_ty, mapping)
+        return mapping
+
+    def _unify_for_inference(self, pattern: Type, concrete: Type,
+                             mapping: dict[str, Type]) -> None:
+        """Simple unification for type argument inference."""
+        if isinstance(pattern, TypeVar):
+            if pattern.name not in mapping:
+                mapping[pattern.name] = concrete
+            return
+
+        if isinstance(pattern, AdtType) and isinstance(concrete, AdtType):
+            if pattern.name == concrete.name:
+                for p_arg, c_arg in zip(pattern.type_args, concrete.type_args):
+                    self._unify_for_inference(p_arg, c_arg, mapping)
+
+        if isinstance(pattern, FunctionType) and isinstance(concrete, FunctionType):
+            for p_param, c_param in zip(pattern.params, concrete.params):
+                self._unify_for_inference(p_param, c_param, mapping)
+            self._unify_for_inference(
+                pattern.return_type, concrete.return_type, mapping)

--- a/vera/cli.py
+++ b/vera/cli.py
@@ -1,10 +1,11 @@
 """Vera command-line interface.
 
 Usage:
-    vera parse <file.vera>         Parse a file and print the tree
-    vera check <file.vera>         Parse and report any errors
-    vera ast   <file.vera>         Parse and print the AST
-    vera ast   --json <file.vera>  Parse and print the AST as JSON
+    vera parse     <file.vera>         Parse a file and print the tree
+    vera check     <file.vera>         Parse and type-check a file
+    vera typecheck <file.vera>         Same as check (explicit alias)
+    vera ast       <file.vera>         Parse and print the AST
+    vera ast       --json <file.vera>  Parse and print the AST as JSON
 """
 
 from __future__ import annotations
@@ -33,9 +34,27 @@ def cmd_parse(path: str) -> int:
 
 
 def cmd_check(path: str) -> int:
-    """Parse a .vera file and report errors (no output on success)."""
+    """Parse, transform, and type-check a .vera file."""
+    from vera.checker import typecheck
+
     try:
-        parse_file(path)
+        p = Path(path)
+        source = p.read_text(encoding="utf-8")
+        tree = parse_file(path)
+        ast = transform(tree)
+        diagnostics = typecheck(ast, source, file=str(p))
+
+        errors = [d for d in diagnostics if d.severity == "error"]
+        warnings = [d for d in diagnostics if d.severity == "warning"]
+
+        for w in warnings:
+            print(f"warning: {w.format()}", file=sys.stderr)
+
+        if errors:
+            for e in errors:
+                print(e.format(), file=sys.stderr)
+            return 1
+
         print(f"OK: {path}")
         return 0
     except FileNotFoundError:
@@ -69,7 +88,8 @@ Usage: vera <command> [options] <file>
 
 Commands:
     parse          Parse a .vera file and print the parse tree
-    check          Parse a .vera file and report errors
+    check          Parse and type-check a .vera file
+    typecheck      Same as check (explicit alias)
     ast            Parse a .vera file and print the AST
     ast --json     Parse a .vera file and print the AST as JSON
 """
@@ -86,7 +106,7 @@ def main() -> None:
 
     if command == "parse":
         sys.exit(cmd_parse(args[1]))
-    elif command == "check":
+    elif command in ("check", "typecheck"):
         sys.exit(cmd_check(args[1]))
     elif command == "ast":
         if "--json" in args:

--- a/vera/environment.py
+++ b/vera/environment.py
@@ -1,0 +1,298 @@
+"""Type environment for the Vera type checker.
+
+Manages scope stacks, binding registries, and the De Bruijn slot
+reference resolution algorithm.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from vera.types import (
+    BOOL,
+    FLOAT64,
+    INT,
+    NAT,
+    PRIMITIVES,
+    STRING,
+    UNIT,
+    AdtType,
+    ConcreteEffectRow,
+    EffectInstance,
+    EffectRowType,
+    FunctionType,
+    PureEffectRow,
+    Type,
+    TypeVar,
+    canonical_type_name,
+)
+
+
+# =====================================================================
+# Registry data structures
+# =====================================================================
+
+@dataclass
+class FunctionInfo:
+    """Registered function signature."""
+    name: str
+    forall_vars: tuple[str, ...] | None
+    param_types: tuple[Type, ...]
+    return_type: Type
+    effect: EffectRowType
+    span: object | None = None  # ast.Span
+
+
+@dataclass
+class AdtInfo:
+    """Registered algebraic data type."""
+    name: str
+    type_params: tuple[str, ...] | None
+    constructors: dict[str, ConstructorInfo]
+
+
+@dataclass
+class ConstructorInfo:
+    """Registered ADT constructor."""
+    name: str
+    parent_type: str
+    parent_type_params: tuple[str, ...] | None
+    field_types: tuple[Type, ...] | None  # None = nullary
+
+
+@dataclass
+class TypeAliasInfo:
+    """Registered type alias."""
+    name: str
+    type_params: tuple[str, ...] | None
+    resolved_type: Type
+
+
+@dataclass
+class EffectInfo:
+    """Registered effect declaration."""
+    name: str
+    type_params: tuple[str, ...] | None
+    operations: dict[str, OpInfo]
+
+
+@dataclass
+class OpInfo:
+    """Registered effect operation."""
+    name: str
+    param_types: tuple[Type, ...]
+    return_type: Type
+    parent_effect: str
+
+
+# =====================================================================
+# Binding
+# =====================================================================
+
+@dataclass
+class Binding:
+    """A single binding in the type environment.
+
+    type_name is the *syntactic* name used for slot reference matching.
+    Type aliases are OPAQUE: @PosInt.0 counts PosInt bindings, not Int.
+    """
+    type_name: str       # canonical name for slot matching
+    resolved_type: Type  # fully resolved semantic type
+    source: str          # "param", "let", "match", "handler", "destruct"
+
+
+# =====================================================================
+# Type environment
+# =====================================================================
+
+@dataclass
+class TypeEnv:
+    """Layered type environment with De Bruijn slot reference resolution."""
+
+    # Scope stack: each scope is a list of bindings (innermost scope last)
+    _scopes: list[list[Binding]] = field(default_factory=lambda: [[]])
+
+    # Declaration registries (not scope-stacked)
+    functions: dict[str, FunctionInfo] = field(default_factory=dict)
+    data_types: dict[str, AdtInfo] = field(default_factory=dict)
+    type_aliases: dict[str, TypeAliasInfo] = field(default_factory=dict)
+    effects: dict[str, EffectInfo] = field(default_factory=dict)
+    constructors: dict[str, ConstructorInfo] = field(default_factory=dict)
+
+    # Type variables currently in scope (from forall<T>)
+    type_params: dict[str, TypeVar] = field(default_factory=dict)
+
+    # Context flags
+    in_ensures: bool = False
+    in_contract: bool = False
+    current_return_type: Type | None = None
+    current_effect_row: EffectRowType | None = None
+
+    def __post_init__(self) -> None:
+        """Register built-in types, effects, and functions."""
+        self._register_builtins()
+
+    # -----------------------------------------------------------------
+    # Built-ins
+    # -----------------------------------------------------------------
+
+    def _register_builtins(self) -> None:
+        """Register the built-in types, effects, and functions."""
+        # Built-in parameterised ADTs (so constructors are found)
+        # Option<T>
+        self.data_types["Option"] = AdtInfo(
+            name="Option",
+            type_params=("T",),
+            constructors={
+                "None": ConstructorInfo("None", "Option", ("T",), None),
+                "Some": ConstructorInfo("Some", "Option", ("T",),
+                                        (TypeVar("T"),)),
+            },
+        )
+        for c in self.data_types["Option"].constructors.values():
+            self.constructors[c.name] = c
+
+        # Result<T, E>
+        self.data_types["Result"] = AdtInfo(
+            name="Result",
+            type_params=("T", "E"),
+            constructors={
+                "Ok": ConstructorInfo("Ok", "Result", ("T", "E"),
+                                      (TypeVar("T"),)),
+                "Err": ConstructorInfo("Err", "Result", ("T", "E"),
+                                       (TypeVar("E"),)),
+            },
+        )
+        for c in self.data_types["Result"].constructors.values():
+            self.constructors[c.name] = c
+
+        # State<T> effect with get/put
+        self.effects["State"] = EffectInfo(
+            name="State",
+            type_params=("T",),
+            operations={
+                "get": OpInfo("get", (UNIT,), TypeVar("T"), "State"),
+                "put": OpInfo("put", (TypeVar("T"),), UNIT, "State"),
+            },
+        )
+
+        # IO effect (no operations exposed at type level in C3)
+        self.effects["IO"] = EffectInfo(
+            name="IO",
+            type_params=None,
+            operations={},
+        )
+
+        # Built-in function: length
+        self.functions["length"] = FunctionInfo(
+            name="length",
+            forall_vars=("T",),
+            param_types=(AdtType("Array", (TypeVar("T"),)),),
+            return_type=INT,
+            effect=PureEffectRow(),
+        )
+
+    # -----------------------------------------------------------------
+    # Scope management
+    # -----------------------------------------------------------------
+
+    def push_scope(self) -> None:
+        """Enter a new scope (block, match arm, handler body, fn body)."""
+        self._scopes.append([])
+
+    def pop_scope(self) -> None:
+        """Exit the current scope."""
+        if len(self._scopes) > 1:
+            self._scopes.pop()
+
+    def bind(self, type_name: str, resolved_type: Type, source: str) -> None:
+        """Add a binding to the current (innermost) scope."""
+        self._scopes[-1].append(Binding(type_name, resolved_type, source))
+
+    # -----------------------------------------------------------------
+    # Slot reference resolution (De Bruijn counting)
+    # -----------------------------------------------------------------
+
+    def resolve_slot(self, type_name: str, index: int) -> Type | None:
+        """Resolve @T.n by counting bindings whose canonical type_name matches.
+
+        Walks scopes innermost-to-outermost.  Returns the resolved type of
+        the n-th match, or None if fewer than n+1 bindings exist.
+        """
+        count = 0
+        # Walk scopes from innermost to outermost
+        for scope in reversed(self._scopes):
+            # Walk bindings from most recent to earliest within each scope
+            for binding in reversed(scope):
+                if binding.type_name == type_name:
+                    if count == index:
+                        return binding.resolved_type
+                    count += 1
+        return None
+
+    def count_bindings(self, type_name: str) -> int:
+        """Count how many bindings of the given type name are in scope."""
+        count = 0
+        for scope in self._scopes:
+            for binding in scope:
+                if binding.type_name == type_name:
+                    count += 1
+        return count
+
+    def list_bindings(self, type_name: str) -> list[Binding]:
+        """List all bindings of the given type name (for error messages)."""
+        result = []
+        for scope in self._scopes:
+            for binding in scope:
+                if binding.type_name == type_name:
+                    result.append(binding)
+        return result
+
+    # -----------------------------------------------------------------
+    # Lookups
+    # -----------------------------------------------------------------
+
+    def lookup_function(self, name: str) -> FunctionInfo | None:
+        """Look up a function by name."""
+        return self.functions.get(name)
+
+    def lookup_constructor(self, name: str) -> ConstructorInfo | None:
+        """Look up a constructor by name."""
+        return self.constructors.get(name)
+
+    def lookup_effect(self, name: str) -> EffectInfo | None:
+        """Look up an effect by name."""
+        return self.effects.get(name)
+
+    def lookup_effect_op(self, op_name: str,
+                         qualifier: str | None = None) -> OpInfo | None:
+        """Look up an effect operation, optionally qualified.
+
+        If qualifier is given, look only in that effect.
+        Otherwise, search all effects in the current effect row.
+        """
+        if qualifier:
+            eff = self.effects.get(qualifier)
+            if eff and op_name in eff.operations:
+                return eff.operations[op_name]
+            return None
+
+        # Search effects in the current effect row
+        if isinstance(self.current_effect_row, ConcreteEffectRow):
+            for ei in self.current_effect_row.effects:
+                eff = self.effects.get(ei.name)
+                if eff and op_name in eff.operations:
+                    return eff.operations[op_name]
+
+        # Also search all registered effects (for handler clauses)
+        for eff in self.effects.values():
+            if op_name in eff.operations:
+                return eff.operations[op_name]
+
+        return None
+
+    def is_type_name(self, name: str) -> bool:
+        """Check if a name refers to a known type (primitive, ADT, or alias)."""
+        return (name in PRIMITIVES
+                or name in self.data_types
+                or name in self.type_aliases)

--- a/vera/errors.py
+++ b/vera/errors.py
@@ -113,6 +113,12 @@ class TransformError(VeraError):
     pass
 
 
+class TypeError(VeraError):
+    """A type-checking error."""
+
+    pass
+
+
 # =====================================================================
 # Common parse error patterns
 # =====================================================================

--- a/vera/parser.py
+++ b/vera/parser.py
@@ -91,3 +91,27 @@ def parse_to_ast(source: str, file: str | None = None):
 
     tree = parse(source, file=file)
     return transform(tree)
+
+
+def typecheck_file(path: str | Path) -> list:
+    """Parse, transform, and type-check a .vera file.
+
+    Args:
+        path: Path to the .vera file.
+
+    Returns:
+        A list of Diagnostic objects (empty if no issues found).
+
+    Raises:
+        ParseError: If the file contains syntax errors.
+        TransformError: If the parse tree cannot be transformed.
+        FileNotFoundError: If the file does not exist.
+    """
+    from vera.checker import typecheck
+    from vera.transform import transform
+
+    path = Path(path)
+    source = path.read_text(encoding="utf-8")
+    tree = parse(source, file=str(path))
+    ast = transform(tree)
+    return typecheck(ast, source, file=str(path))

--- a/vera/types.py
+++ b/vera/types.py
@@ -1,0 +1,300 @@
+"""Internal type representation for the Vera type checker.
+
+These semantic types are distinct from the syntactic AST TypeExpr nodes.
+AST types mirror what the user wrote; these represent resolved, canonical
+types suitable for comparison, subtyping, and substitution.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from vera import ast as _ast
+
+
+# =====================================================================
+# Type hierarchy
+# =====================================================================
+
+@dataclass(frozen=True)
+class Type:
+    """Abstract base for all resolved types."""
+
+
+@dataclass(frozen=True)
+class PrimitiveType(Type):
+    """A built-in primitive type (Int, Nat, Bool, Float64, ...)."""
+    name: str
+
+
+@dataclass(frozen=True)
+class AdtType(Type):
+    """A parameterised algebraic data type (Array<T>, Option<Int>, user ADTs)."""
+    name: str
+    type_args: tuple[Type, ...]  # () for non-parameterised
+
+
+@dataclass(frozen=True)
+class FunctionType(Type):
+    """A function type: params -> return with effect row."""
+    params: tuple[Type, ...]
+    return_type: Type
+    effect: EffectRowType
+
+
+@dataclass(frozen=True)
+class RefinedType(Type):
+    """A refinement type.  Tracks the base type and preserves the predicate
+    AST node for later verification (C4).  In C3, treated as its base type
+    for subtyping purposes."""
+    base: Type
+    predicate: _ast.Expr  # kept opaque — not verified in C3
+
+
+@dataclass(frozen=True)
+class TypeVar(Type):
+    """A universally-quantified type variable (from forall<T>)."""
+    name: str
+
+
+@dataclass(frozen=True)
+class UnknownType(Type):
+    """Placeholder for unresolved or error-recovery types.
+
+    Any operation involving UnknownType silently propagates it,
+    preventing cascading error messages."""
+
+
+# =====================================================================
+# Effect types
+# =====================================================================
+
+@dataclass(frozen=True)
+class EffectRowType:
+    """Abstract base for effect rows."""
+
+
+@dataclass(frozen=True)
+class PureEffectRow(EffectRowType):
+    """The empty effect row (effects(pure))."""
+
+
+@dataclass(frozen=True)
+class EffectInstance:
+    """A single effect instantiation, e.g. State<Int>."""
+    name: str
+    type_args: tuple[Type, ...]
+
+    def __hash__(self) -> int:
+        return hash((self.name, self.type_args))
+
+
+@dataclass(frozen=True)
+class ConcreteEffectRow(EffectRowType):
+    """A set of concrete effects, possibly with an open row variable tail."""
+    effects: frozenset[EffectInstance]
+    row_var: str | None = None  # None = closed row; "E" = open variable
+
+
+# =====================================================================
+# Primitive constants
+# =====================================================================
+
+INT = PrimitiveType("Int")
+NAT = PrimitiveType("Nat")
+BOOL = PrimitiveType("Bool")
+FLOAT64 = PrimitiveType("Float64")
+STRING = PrimitiveType("String")
+BYTE = PrimitiveType("Byte")
+UNIT = PrimitiveType("Unit")
+NEVER = PrimitiveType("Never")
+
+PRIMITIVES: dict[str, Type] = {
+    "Int": INT,
+    "Nat": NAT,
+    "Bool": BOOL,
+    "Float64": FLOAT64,
+    "Float": FLOAT64,  # common alias used in examples
+    "String": STRING,
+    "Byte": BYTE,
+    "Unit": UNIT,
+    "Never": NEVER,
+}
+
+# Numeric types (for operator checking)
+NUMERIC_TYPES: frozenset[Type] = frozenset({INT, NAT, FLOAT64})
+ORDERABLE_TYPES: frozenset[Type] = frozenset({INT, NAT, FLOAT64, BYTE, STRING})
+
+
+# =====================================================================
+# Utility functions
+# =====================================================================
+
+def canonical_type_name(type_name: str,
+                        type_args: tuple[Type, ...] | None = None) -> str:
+    """Form the canonical string used for slot reference matching.
+
+    Type aliases are OPAQUE: @PosInt.0 and @Int.0 are separate namespaces.
+    Parameterised types include args: "Option<Int>", "List<T>".
+    """
+    if not type_args:
+        return type_name
+    arg_strs = ", ".join(pretty_type(a) for a in type_args)
+    return f"{type_name}<{arg_strs}>"
+
+
+def pretty_type(ty: Type) -> str:
+    """Human-readable type string for error messages."""
+    if isinstance(ty, PrimitiveType):
+        return ty.name
+    if isinstance(ty, AdtType):
+        if ty.type_args:
+            args = ", ".join(pretty_type(a) for a in ty.type_args)
+            return f"{ty.name}<{args}>"
+        return ty.name
+    if isinstance(ty, FunctionType):
+        params = ", ".join(pretty_type(p) for p in ty.params)
+        ret = pretty_type(ty.return_type)
+        eff = pretty_effect(ty.effect)
+        return f"fn({params} -> {ret}) {eff}"
+    if isinstance(ty, RefinedType):
+        return f"{{@{pretty_type(ty.base)} | ...}}"
+    if isinstance(ty, TypeVar):
+        return ty.name
+    if isinstance(ty, UnknownType):
+        return "?"
+    return str(ty)
+
+
+def pretty_effect(eff: EffectRowType) -> str:
+    """Human-readable effect row string."""
+    if isinstance(eff, PureEffectRow):
+        return "effects(pure)"
+    if isinstance(eff, ConcreteEffectRow):
+        parts = sorted(
+            canonical_type_name(e.name, e.type_args if e.type_args else None)
+            for e in eff.effects
+        )
+        if eff.row_var:
+            parts.append(eff.row_var)
+        return f"effects(<{', '.join(parts)}>)"
+    return "effects(?)"
+
+
+def base_type(ty: Type) -> Type:
+    """Strip refinement wrappers to get the underlying base type."""
+    while isinstance(ty, RefinedType):
+        ty = ty.base
+    return ty
+
+
+def is_subtype(sub: Type, sup: Type) -> bool:
+    """Check if sub <: sup under the C3 subtyping rules.
+
+    Rules:
+    1. Reflexivity: T <: T
+    2. Never <: T for all T
+    3. Nat <: Int
+    4. RefinedType(base, _) <: base
+    5. RefinedType(base, _) <: T if base <: T
+    6. UnknownType is compatible with everything (error recovery)
+    """
+    # Unknown propagates silently
+    if isinstance(sub, UnknownType) or isinstance(sup, UnknownType):
+        return True
+
+    # Reflexivity (structural equality)
+    if types_equal(sub, sup):
+        return True
+
+    # Never is bottom
+    if isinstance(sub, PrimitiveType) and sub.name == "Never":
+        return True
+
+    # Nat <: Int (always valid)
+    # Int <: Nat (allowed in C3 — refinement verification deferred to C4)
+    if isinstance(sub, PrimitiveType) and isinstance(sup, PrimitiveType):
+        if sub.name == "Nat" and sup.name == "Int":
+            return True
+        if sub.name == "Int" and sup.name == "Nat":
+            return True
+
+    # TypeVar is compatible with anything (C3 — full unification deferred)
+    if isinstance(sub, TypeVar) or isinstance(sup, TypeVar):
+        return True
+
+    # ADT with compatible type args (e.g. Option<T> <: Option<Int>)
+    if isinstance(sub, AdtType) and isinstance(sup, AdtType):
+        if sub.name == sup.name and len(sub.type_args) == len(sup.type_args):
+            return all(
+                is_subtype(sa, pa) for sa, pa in
+                zip(sub.type_args, sup.type_args)
+            )
+
+    # Refinement to base: { @T | P } <: T
+    if isinstance(sub, RefinedType):
+        return is_subtype(sub.base, sup)
+
+    # Refinement on the sup side: T <: { @T | P } only if T <: base
+    # (predicate verification deferred to C4)
+    if isinstance(sup, RefinedType):
+        return is_subtype(sub, sup.base)
+
+    return False
+
+
+def types_equal(a: Type, b: Type) -> bool:
+    """Structural type equality."""
+    if isinstance(a, UnknownType) or isinstance(b, UnknownType):
+        return True
+    if type(a) != type(b):
+        return False
+    if isinstance(a, PrimitiveType) and isinstance(b, PrimitiveType):
+        return a.name == b.name
+    if isinstance(a, AdtType) and isinstance(b, AdtType):
+        return (a.name == b.name
+                and len(a.type_args) == len(b.type_args)
+                and all(types_equal(x, y)
+                        for x, y in zip(a.type_args, b.type_args)))
+    if isinstance(a, FunctionType) and isinstance(b, FunctionType):
+        return (len(a.params) == len(b.params)
+                and all(types_equal(x, y)
+                        for x, y in zip(a.params, b.params))
+                and types_equal(a.return_type, b.return_type))
+    if isinstance(a, RefinedType) and isinstance(b, RefinedType):
+        return types_equal(a.base, b.base)
+    if isinstance(a, TypeVar) and isinstance(b, TypeVar):
+        return a.name == b.name
+    return a == b
+
+
+def substitute(ty: Type, mapping: dict[str, Type]) -> Type:
+    """Apply a type-variable substitution."""
+    if isinstance(ty, TypeVar):
+        return mapping.get(ty.name, ty)
+    if isinstance(ty, AdtType):
+        new_args = tuple(substitute(a, mapping) for a in ty.type_args)
+        return AdtType(ty.name, new_args)
+    if isinstance(ty, FunctionType):
+        new_params = tuple(substitute(p, mapping) for p in ty.params)
+        new_ret = substitute(ty.return_type, mapping)
+        return FunctionType(new_params, new_ret, ty.effect)
+    if isinstance(ty, RefinedType):
+        return RefinedType(substitute(ty.base, mapping), ty.predicate)
+    # PrimitiveType, UnknownType — unchanged
+    return ty
+
+
+def substitute_effect(eff: EffectRowType,
+                      mapping: dict[str, Type]) -> EffectRowType:
+    """Apply a type-variable substitution to an effect row."""
+    if isinstance(eff, ConcreteEffectRow):
+        new_effects = frozenset(
+            EffectInstance(e.name, tuple(substitute(a, mapping)
+                                        for a in e.type_args))
+            for e in eff.effects
+        )
+        return ConcreteEffectRow(new_effects, eff.row_var)
+    return eff


### PR DESCRIPTION
## Summary

- **Type checker** (`vera/types.py`, `vera/environment.py`, `vera/checker.py`): Tier 1 decidable type checking — validates expression types, slot reference resolution, effect annotations, and contract well-formedness
- Two-pass architecture: pass 1 registers all declaration signatures (forward references, mutual recursion), pass 2 checks bodies
- Expression type synthesis for all AST node types, De Bruijn slot resolution with alias opacity, generic type argument inference, handler effect discharge, error accumulation with `UnknownType` propagation
- `vera check` now runs the full pipeline (parse → AST → typecheck); `vera typecheck` added as explicit alias
- 91 new tests across 19 test classes (284 total, up from 193)
- All 13 example programs type-check cleanly

## Test plan

- [x] All 284 tests pass (`pytest tests/ -q`)
- [x] All 13 examples pass `vera check` (11 clean, 2 with only unresolved-name warnings)
- [x] `vera check examples/factorial.vera` prints "OK"
- [x] `vera typecheck examples/factorial.vera` prints "OK"
- [x] Type error diagnostics include description, location, rationale, fix, spec_ref

🤖 Generated with [Claude Code](https://claude.com/claude-code)