### PR TITLE
Update SECURITY.md and README project structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,10 @@ vera/
 │   └── cli.py                     # Command-line interface
 ├── examples/                      # Example Vera programs
 ├── tests/                         # Test suite (284 tests)
-├── scripts/                       # CI and maintenance scripts
+├── scripts/                       # CI and validation scripts
+│   ├── check_examples.py          # Verify all .vera examples
+│   ├── check_spec_examples.py     # Verify spec code blocks parse
+│   └── check_version_sync.py      # Verify version consistency
 └── runtime/                       # WASM runtime support (future)
 ```
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,13 @@
 
 If you discover a security vulnerability in Vera, please report it responsibly.
 
-**Do not open a public issue.** Instead, email **alasdair@babilim.co.uk** with:
+**Do not open a public issue.** Instead, use one of these channels:
+
+1. **GitHub private vulnerability reporting** (preferred) — go to the [Security tab](https://github.com/aallan/vera/security/advisories/new) and click "Report a vulnerability". This keeps the report within GitHub and allows coordinated disclosure.
+
+2. **Email** — send details to **alasdair@babilim.co.uk** if you prefer.
+
+In either case, include:
 
 - A description of the vulnerability
 - Steps to reproduce


### PR DESCRIPTION
## Summary

- Update SECURITY.md to list GitHub private vulnerability reporting as the primary channel (now enabled in repo settings), with email as backup
- Expand scripts/ entry in README project structure to list individual validation scripts

## Test plan

- [x] Docs-only change — no code modifications
- [x] Verify SECURITY.md link resolves correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)