### PR TITLE
Adopt proper semver versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-## [0.0.5-2] - 2026-02-23
+## [0.0.7] - 2026-02-23
 
 ### Added
 - **Spec code block validator** (`scripts/check_spec_examples.py`) — extracts 154 code blocks from spec Markdown, classifies them as parseable/fragment/non-Vera, and verifies parseable blocks still parse with the current grammar. Categorised allowlist tracks 30 spec/parser mismatches (spec uses `@T` in data/effect declarations, parser expects bare `T`), 4 future-syntax design proposals, and 3 fragment overrides. Stale allowlist detection catches when spec edits shift line numbers.
@@ -21,7 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **CONTRIBUTING.md** — added pre-commit setup instructions, validation script documentation, branch protection rules
 - **CI lint job** — now runs version sync check and spec code block validator alongside example validation
 
-## [0.0.5-1] - 2026-02-23
+## [0.0.6] - 2026-02-23
 
 ### Added
 - **Hello World example** in README — first example in "What Vera Looks Like" section, demonstrates IO effect and mandatory contracts
@@ -128,3 +128,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Grammar: function signatures use `@Type` prefix to declare binding sites
 - Grammar: handler body simplified to avoid LALR reduce/reduce conflict
 - `pyproject.toml`: corrected build backend, package discovery, PEP 639 compliance
+
+[Unreleased]: https://github.com/aallan/vera/compare/v0.0.7...HEAD
+[0.0.7]: https://github.com/aallan/vera/compare/v0.0.6...v0.0.7
+[0.0.6]: https://github.com/aallan/vera/compare/v0.0.5...v0.0.6
+[0.0.5]: https://github.com/aallan/vera/compare/v0.0.4...v0.0.5
+[0.0.4]: https://github.com/aallan/vera/compare/v0.0.3...v0.0.4
+[0.0.3]: https://github.com/aallan/vera/compare/v0.0.2...v0.0.3
+[0.0.2]: https://github.com/aallan/vera/compare/v0.0.1...v0.0.2
+[0.0.1]: https://github.com/aallan/vera/releases/tag/v0.0.1

--- a/README.md
+++ b/README.md
@@ -152,13 +152,13 @@ Development follows an **interleaved spiral** — each phase adds a complete com
 | C1 | v0.0.1–0.0.3 | **Parser** — Lark LALR(1) grammar, LLM diagnostics, 13 examples | Done |
 | C2 | v0.0.4 | **AST** — typed syntax tree, Lark→AST transformer | Done |
 | C3 | v0.0.5 | **Type checker** — decidable type checking, slot resolution, effect tracking | Done |
-| C4 | v0.0.6 | **Contract verifier** — Z3 integration, refinement types, counterexamples | Next |
-| C5 | v0.0.7 | **WASM codegen** — compile pure functions, `vera compile` / `vera run` | Planned |
-| C6 | v0.0.8 | **Stdlib + runtime** — core library, effect handlers as continuations, GC | Planned |
-| C7 | v0.0.9 | **Module system** — cross-file imports, public/private visibility | Planned |
+| C4 | v0.0.8 | **Contract verifier** — Z3 integration, refinement types, counterexamples | Next |
+| C5 | v0.0.9 | **WASM codegen** — compile pure functions, `vera compile` / `vera run` | Planned |
+| C6 | v0.0.10 | **Stdlib + runtime** — core library, effect handlers as continuations, GC | Planned |
+| C7 | v0.0.11 | **Module system** — cross-file imports, public/private visibility | Planned |
 | C8 | v0.1.0 | **End-to-end** — `.vera` → parse → typecheck → verify → compile → run | Planned |
 
-### What's next: C4 — Contract Verifier (v0.0.6)
+### What's next: C4 — Contract Verifier (v0.0.8)
 
 The type checker validates *types*. The contract verifier validates *logic* — that preconditions are satisfiable, postconditions follow from the implementation, and refinement types actually constrain what they claim.
 


### PR DESCRIPTION
## Summary
- Rename tags `v0.0.5-1` → `v0.0.6` and `v0.0.5-2` → `v0.0.7` (tags already updated on remote)
- Update CHANGELOG entries to match new version numbers
- Add Keep a Changelog comparison links at bottom of CHANGELOG
- Shift README roadmap versions (C4 → v0.0.8, C5 → v0.0.9, etc.)

The `-1`/`-2` suffixes are pre-release identifiers in strict semver (lower precedence than `v0.0.5`), which wasn't the intent. Proper patch versions avoid confusion.

## Test plan
- [x] CHANGELOG version headers match tag names
- [x] Comparison links resolve correctly on GitHub
- [x] README roadmap versions are consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)