### PR TITLE
Update stale C4 comments and add CLI test coverage

### DIFF
--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -821,7 +821,7 @@ fn foo(@PosInt -> @Int)
 """)
 
     def test_int_to_nat_allowed(self) -> None:
-        """Int -> Nat is allowed in C3 (deferred to C4)."""
+        """Int -> Nat allowed by checker; verifier enforces >= 0 via Z3."""
         _check_ok("""
 fn foo(@Int -> @Nat)
   requires(true) ensures(true) effects(pure)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,297 @@
+"""Tests for vera.cli — command-line interface."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from vera.cli import cmd_ast, cmd_check, cmd_parse, cmd_verify
+
+EXAMPLES_DIR = Path(__file__).parent.parent / "examples"
+INCREMENT = str(EXAMPLES_DIR / "increment.vera")
+FACTORIAL = str(EXAMPLES_DIR / "factorial.vera")
+CLOSURES = str(EXAMPLES_DIR / "closures.vera")
+
+
+# =====================================================================
+# Helpers
+# =====================================================================
+
+
+def _bad_vera(tmp_path: Path, content: str) -> str:
+    """Write a bad .vera file and return its path."""
+    p = tmp_path / "bad.vera"
+    p.write_text(content)
+    return str(p)
+
+
+def _type_error_source() -> str:
+    """A .vera program that parses but fails type-checking."""
+    return """\
+fn bad(@Int -> @Bool)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 }
+"""
+
+
+def _syntax_error_source() -> str:
+    """A .vera program that fails to parse."""
+    return "fn broken(@@@ -> ???) {{"
+
+
+# =====================================================================
+# cmd_parse
+# =====================================================================
+
+
+class TestCmdParse:
+    def test_valid_file(self, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = cmd_parse(INCREMENT)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert len(out) > 0
+
+    def test_missing_file(self, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = cmd_parse("/nonexistent/file.vera")
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "file not found" in err
+
+    def test_syntax_error(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        path = _bad_vera(tmp_path, _syntax_error_source())
+        rc = cmd_parse(path)
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert len(err) > 0
+
+
+# =====================================================================
+# cmd_check
+# =====================================================================
+
+
+class TestCmdCheck:
+    def test_clean_example(self, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = cmd_check(INCREMENT)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "OK:" in out
+
+    def test_warning_only_example(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """closures.vera produces warnings but no errors."""
+        rc = cmd_check(CLOSURES)
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "OK:" in captured.out
+        assert "warning" in captured.err.lower()
+
+    def test_type_error(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        path = _bad_vera(tmp_path, _type_error_source())
+        rc = cmd_check(path)
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert len(err) > 0
+
+    def test_missing_file(self, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = cmd_check("/nonexistent/file.vera")
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "file not found" in err
+
+    def test_syntax_error(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        path = _bad_vera(tmp_path, _syntax_error_source())
+        rc = cmd_check(path)
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert len(err) > 0
+
+
+# =====================================================================
+# cmd_verify
+# =====================================================================
+
+
+class TestCmdVerify:
+    def test_tier1_example(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """increment.vera has Tier 1 verifiable contracts."""
+        rc = cmd_verify(INCREMENT)
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "OK:" in captured.out
+        assert "Verification:" in captured.out
+        assert "verified (Tier 1)" in captured.out
+
+    def test_tier3_example(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """factorial.vera has recursive contracts that fall to Tier 3."""
+        rc = cmd_verify(FACTORIAL)
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "OK:" in captured.out
+        assert "runtime checks (Tier 3)" in captured.out
+
+    def test_type_error_blocks_verify(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        path = _bad_vera(tmp_path, _type_error_source())
+        rc = cmd_verify(path)
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert len(err) > 0
+
+    def test_missing_file(self, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = cmd_verify("/nonexistent/file.vera")
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "file not found" in err
+
+    def test_syntax_error(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        path = _bad_vera(tmp_path, _syntax_error_source())
+        rc = cmd_verify(path)
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert len(err) > 0
+
+
+# =====================================================================
+# cmd_ast
+# =====================================================================
+
+
+class TestCmdAst:
+    def test_text_output(self, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = cmd_ast(INCREMENT)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert len(out) > 0
+
+    def test_json_output(self, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = cmd_ast(INCREMENT, as_json=True)
+        assert rc == 0
+        out = capsys.readouterr().out
+        parsed = json.loads(out)
+        assert isinstance(parsed, dict)
+
+    def test_missing_file(self, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = cmd_ast("/nonexistent/file.vera")
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "file not found" in err
+
+    def test_syntax_error(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        path = _bad_vera(tmp_path, _syntax_error_source())
+        rc = cmd_ast(path)
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert len(err) > 0
+
+
+# =====================================================================
+# main() — subprocess integration tests
+# =====================================================================
+
+
+class TestMain:
+    def test_no_args(self) -> None:
+        result = subprocess.run(
+            [sys.executable, "-m", "vera.cli"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 1
+        assert "Usage:" in result.stderr
+
+    def test_one_arg_only(self) -> None:
+        result = subprocess.run(
+            [sys.executable, "-m", "vera.cli", "check"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 1
+        assert "Usage:" in result.stderr
+
+    def test_unknown_command(self) -> None:
+        result = subprocess.run(
+            [sys.executable, "-m", "vera.cli", "bogus", "file.vera"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 1
+        assert "Unknown command" in result.stderr
+
+    def test_dispatch_parse(self) -> None:
+        result = subprocess.run(
+            [sys.executable, "-m", "vera.cli", "parse", INCREMENT],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0
+        assert len(result.stdout) > 0
+
+    def test_dispatch_check(self) -> None:
+        result = subprocess.run(
+            [sys.executable, "-m", "vera.cli", "check", INCREMENT],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0
+        assert "OK:" in result.stdout
+
+    def test_dispatch_typecheck_alias(self) -> None:
+        result = subprocess.run(
+            [sys.executable, "-m", "vera.cli", "typecheck", INCREMENT],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0
+        assert "OK:" in result.stdout
+
+    def test_dispatch_verify(self) -> None:
+        result = subprocess.run(
+            [sys.executable, "-m", "vera.cli", "verify", INCREMENT],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0
+        assert "OK:" in result.stdout
+        assert "Verification:" in result.stdout
+
+    def test_dispatch_ast(self) -> None:
+        result = subprocess.run(
+            [sys.executable, "-m", "vera.cli", "ast", INCREMENT],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0
+
+    def test_dispatch_ast_json(self) -> None:
+        result = subprocess.run(
+            [sys.executable, "-m", "vera.cli", "ast", "--json", INCREMENT],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0
+        parsed = json.loads(result.stdout)
+        assert isinstance(parsed, dict)

--- a/vera/types.py
+++ b/vera/types.py
@@ -191,15 +191,17 @@ def base_type(ty: Type) -> Type:
 
 
 def is_subtype(sub: Type, sup: Type) -> bool:
-    """Check if sub <: sup under the C3 subtyping rules.
+    """Check if sub <: sup under the subtyping rules.
 
     Rules:
     1. Reflexivity: T <: T
     2. Never <: T for all T
-    3. Nat <: Int
+    3a. Nat <: Int (widening — always safe)
+    3b. Int <: Nat (checker permits; verifier enforces non-negativity via Z3)
     4. RefinedType(base, _) <: base
     5. RefinedType(base, _) <: T if base <: T
-    6. UnknownType is compatible with everything (error recovery)
+    6. T <: RefinedType(base, _) if T <: base (predicate enforced by verifier)
+    7. UnknownType is compatible with everything (error recovery)
     """
     # Unknown propagates silently
     if isinstance(sub, UnknownType) or isinstance(sup, UnknownType):
@@ -213,8 +215,8 @@ def is_subtype(sub: Type, sup: Type) -> bool:
     if isinstance(sub, PrimitiveType) and sub.name == "Never":
         return True
 
-    # Nat <: Int (always valid)
-    # Int <: Nat (allowed in C3 — refinement verification deferred to C4)
+    # Nat <: Int (widening — always safe)
+    # Int <: Nat (checker permits; verifier enforces >= 0 via Z3)
     if isinstance(sub, PrimitiveType) and isinstance(sup, PrimitiveType):
         if sub.name == "Nat" and sup.name == "Int":
             return True
@@ -238,7 +240,7 @@ def is_subtype(sub: Type, sup: Type) -> bool:
         return is_subtype(sub.base, sup)
 
     # Refinement on the sup side: T <: { @T | P } only if T <: base
-    # (predicate verification deferred to C4)
+    # (predicate enforced by the contract verifier, not the type checker)
     if isinstance(sup, RefinedType):
         return is_subtype(sub, sup.base)
 


### PR DESCRIPTION
## Summary
- Update stale `Int <: Nat` comments in `types.py` — now documents that the verifier enforces non-negativity via Z3 (was "deferred to C4" which is now done)
- Update refinement predicate comment and `is_subtype` docstring with explicit rules
- Add `tests/test_cli.py` with 26 tests covering all CLI commands: parse, check, verify, ast (text + JSON), and main() subprocess dispatch
- Test count: 335 -> 361

## Context
Code audit identified CLI as the only untested module (184 lines, 0% coverage). Also flagged stale comments referencing C4 as future work when it shipped in v0.0.8.

No behavioural changes — comment updates and new tests only.

## Test plan
- [x] All 361 tests pass
- [x] mypy clean on changed files
- [x] 13 examples check + verify
- [x] Pre-commit hooks pass

Generated with [Claude Code](https://claude.com/claude-code)