### PR TITLE
Housekeeping: stale comments, test count, LICENSE format

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
-# MIT License
+MIT License
 
-Vera is licensed under the [MIT License](LICENSE).
+Vera is licensed under the MIT License.
 
 Copyright (c) 2026 Alasdair Allan
 

--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ vera/
 │   ├── errors.py                  # LLM-oriented diagnostics
 │   └── cli.py                     # Command-line interface
 ├── examples/                      # Example Vera programs
-├── tests/                         # Test suite (335 tests)
+├── tests/                         # Test suite (361 tests)
 ├── scripts/                       # CI and validation scripts
 │   ├── check_examples.py          # Verify all .vera examples
 │   ├── check_spec_examples.py     # Verify spec code blocks parse

--- a/vera/checker.py
+++ b/vera/checker.py
@@ -4,8 +4,8 @@ Validates expression types, slot reference resolution, effect annotations,
 and contract well-formedness.  Consumes Program AST nodes from parse_to_ast()
 and produces a list of Diagnostic errors (empty = success).
 
-Refinement predicate verification and contract satisfiability are deferred
-to C4 (Z3 solver).
+Refinement predicate verification and contract satisfiability are handled
+by the contract verifier (vera/verifier.py) via Z3.
 """
 
 from __future__ import annotations
@@ -497,7 +497,7 @@ class TypeChecker:
             self.env.in_contract = True
             for expr in contract.exprs:
                 ty = self._synth_expr(expr)
-                # Type is checked but verification deferred to C4
+                # Type is checked; termination verification is Tier 3
             self.env.in_contract = False
 
     # -----------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Update stale "deferred to C4" comments in `checker.py` (C4 is now done)
- Update test count in root README from 335 to 361 (after CLI test PR)
- Convert LICENSE from Markdown to plain text format

No behavioural changes.

Generated with [Claude Code](https://claude.com/claude-code)