### PR TITLE
Credit Eiffel, F*, and Idris in Prior Art

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,9 +421,12 @@ For compiler architecture, pipeline internals, design patterns, and how to exten
 
 Vera draws on ideas from:
 
+- [Eiffel](https://www.eiffel.org/) — Design by Contract (the originator of `require`/`ensure`)
 - [Dafny](https://dafny.org/) — full functional verification with contracts
+- [F*](https://fstar-lang.org/) — refinement types, algebraic effects, and SMT verification
 - [Koka](https://koka-lang.github.io/koka/doc/book.html) — row-polymorphic algebraic effects
 - [Liquid Haskell](https://ucsd-progsys.github.io/liquidhaskell/) — refinement types via SMT
+- [Idris](https://www.idris-lang.org/) — totality checking and termination proofs
 - [SPARK/Ada](https://www.adacore.com/about-spark) — contract-based industrial verification
 - [bruijn](https://bruijn.marvinborner.de/) — De Bruijn indices as surface syntax
 


### PR DESCRIPTION
## Summary

- **Eiffel** -- originated Design by Contract; Vera requires/ensures descends from Meyer require/ensure
- **F\*** -- combines refinement types, algebraic effects, and SMT verification (closest existing language to Vera)
- **Idris** -- totality checking and termination proofs; influenced the decreases clause

This commit was pushed to agent-accessibility after PR #23 was merged, so it needs its own PR.

## Test plan

- [x] No code changes, README only

Generated with [Claude Code](https://claude.com/claude-code)