### PR TITLE
Break C6 into 14 atomic sub-milestones

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,18 +159,47 @@ Development follows an **interleaved spiral** — each phase adds a complete com
 | C3 | v0.0.5 | **Type checker** — decidable type checking, slot resolution, effect tracking | Done |
 | C4 | v0.0.8 | **Contract verifier** — Z3 integration, refinement types, counterexamples | Done |
 | C5 | v0.0.9 | **WASM codegen** — compile to WebAssembly, `vera compile` / `vera run` | Done |
-| C6 | v0.0.10 | **Stdlib + runtime** — core library, effect handlers as continuations, GC | Planned |
-| C7 | v0.0.11 | **Module system** — cross-file imports, public/private visibility | Planned |
-| C8 | v0.1.0 | **End-to-end** — `.vera` → parse → typecheck → verify → compile → run | Planned |
+| C6 | v0.0.10–0.0.23 | **Codegen completeness** — ADTs, match, closures, effects, generics in WASM | Planned |
+| C7 | — | **Module system** — cross-file imports, public/private visibility | Planned |
+| C8 | v0.1.0 | **End-to-end** — all examples compile and run, spec complete, polish | Planned |
 
-### What's next: C6 — Stdlib + Runtime (v0.0.10)
+### What's next: C6 — Codegen Completeness (v0.0.10–v0.0.23)
 
-The code generator compiles verified programs to executable WebAssembly. The next phase adds a standard library and runtime support.
+The code generator compiles 6 of 14 examples. C6 extends WASM compilation to all language constructs, working through the dependency graph from simplest to most complex.
 
-- Core library functions (string operations, array operations, Option/Result utilities)
-- Effect handlers compiled as continuations
-- Garbage collection for heap-allocated data
-- ADT and match expression codegen (#26)
+**Independent tasks (no dependencies on each other):**
+
+| Sub-phase | Scope | Closes | Unlocks |
+|-----------|-------|--------|---------|
+| C6a | Float64 — `f64` literals, arithmetic, comparisons | #25 | — |
+| C6b | Callee preconditions — verify `requires()` at call sites | #19 | — |
+| C6c | Match exhaustiveness — verify all constructors covered | #18 | — |
+| C6d | State\<T\> operations — get/put as host imports | — | increment.vera |
+
+**Allocator and data types (sequential chain):**
+
+| Sub-phase | Scope | Closes | Unlocks |
+|-----------|-------|--------|---------|
+| C6e | Bump allocator — heap allocation for tagged values | — | — |
+| C6f | ADT constructors — heap-allocated tagged unions | — | — |
+| C6g | Match expressions — tag dispatch, field extraction | #26 | pattern_matching.vera |
+| C6i | Generics — monomorphization of `forall<T>` functions | #29 | generics.vera, list_ops.vera |
+
+**Higher-order and effects:**
+
+| Sub-phase | Scope | Closes | Unlocks |
+|-----------|-------|--------|---------|
+| C6h | Closures — closure conversion, `call_indirect` | #27 | closures.vera |
+| C6j | Effect handlers — handle/resume compilation | #28 | effect_handler.vera |
+
+**Collections, runtime, and documentation:**
+
+| Sub-phase | Scope | Closes | Unlocks |
+|-----------|-------|--------|---------|
+| C6k | Byte + arrays — linear memory arrays with bounds | #30 | — |
+| C6l | Quantifiers — forall/exists as runtime loops | — | quantifiers.vera |
+| C6m | Refinement returns + stdlib utilities | — | refinement_types.vera |
+| C6n | Spec chapters 9 (Standard library) and 12 (Runtime) | — | — |
 
 ### Specification chapters
 
@@ -179,9 +208,9 @@ The language specification grows alongside the compiler. Chapters 0–7 and 10 a
 | Chapter | Topic | Written with |
 |---------|-------|-------------|
 | 8 | Modules and imports | C7 |
-| 9 | Standard library | C6 |
+| 9 | Standard library | C6n |
 | 11 | Compilation model | C5 ✓ |
-| 12 | Runtime and execution | C6 |
+| 12 | Runtime and execution | C6n |
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary

The original C6 milestone (Stdlib + runtime) was a single monolithic entry. This PR breaks it into 14 atomic sub-milestones (C6a-C6n) ordered by dependency.

## Changes

Updates the README.md roadmap section:
- **Roadmap table**: C6 becomes a version range (v0.0.10-0.0.23) titled Codegen completeness
- **What's next section**: Detailed sub-milestone table organized by dependency group
- **Spec chapters table**: Maps chapters 9 and 12 to C6n specifically

## Sub-milestone breakdown

**Independent:** C6a Float64 (#25), C6b Callee preconditions (#19), C6c Match exhaustiveness (#18), C6d State operations (unlocks increment.vera)

**ADT chain:** C6e Bump allocator, C6f ADT constructors, C6g Match expressions (#26), C6i Generics (#29)

**Higher-order:** C6h Closures (#27), C6j Effect handlers (#28)

**Collections:** C6k Arrays (#30), C6l Quantifiers, C6m Refinement returns, C6n Spec chapters

## Test plan

- [x] 508 tests pass
- [x] mypy clean
- [x] All 14 examples pass
- [x] README code blocks parse
- [x] Pre-commit hooks pass