### PR TITLE
Address code review: Int/Nat subtyping, CLI validation, mismatch docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,7 +108,7 @@ Each stage is a module with a single public API function (`parse_file`, `transfo
 ### Testing
 
 ```bash
-pytest tests/ -v                       # Run all tests (508 tests)
+pytest tests/ -v                       # Run all tests (514 tests)
 mypy vera/                             # Type-check the compiler
 python scripts/check_examples.py       # All 14 examples must pass
 ```
@@ -119,7 +119,7 @@ Test helpers follow a pattern: `_check_ok(source)` / `_check_err(source, match)`
 
 - All 14 examples in `examples/` must pass `vera check` and `vera verify`
 - `mypy vera/` must be clean
-- `pytest tests/ -v` must pass (currently 508 tests)
+- `pytest tests/ -v` must pass (currently 514 tests)
 - Version must be in sync across `vera/__init__.py`, `pyproject.toml`, and `CHANGELOG.md`
 
 ### Contributing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ vera parse file.vera              # Print the parse tree
 vera ast file.vera                # Print the typed AST
 vera ast --json file.vera         # Print the AST as JSON
 
-pytest tests/ -v                  # Run the test suite (508 tests)
+pytest tests/ -v                  # Run the test suite (514 tests)
 mypy vera/                        # Type-check the compiler itself
 
 python scripts/check_examples.py      # Verify all 14 examples parse + check + verify

--- a/README.md
+++ b/README.md
@@ -465,7 +465,7 @@ vera/
 │   ├── errors.py                  # LLM-oriented diagnostics
 │   └── cli.py                     # Command-line interface
 ├── examples/                      # 14 example Vera programs
-├── tests/                         # Test suite (508 tests)
+├── tests/                         # Test suite (514 tests)
 ├── scripts/                       # CI and validation scripts
 │   ├── check_examples.py          # Verify all .vera examples
 │   ├── check_spec_examples.py     # Verify spec code blocks parse

--- a/spec/02-types.md
+++ b/spec/02-types.md
@@ -263,6 +263,8 @@ Vera has minimal subtyping. The complete subtyping relation is:
 4. **Never subtyping**: `Never <: T` for all types `T`.
 5. **No other subtyping**: there is no structural subtyping, no implicit numeric conversions, no covariance/contravariance on compound types.
 
+> **Implementation note:** The type checker additionally permits `Int <: Nat` (the reverse of the `Nat <: Int` relationship in Section 2.1) to allow functions that compute a natural number from integer inputs without explicit conversion. Non-negativity is not enforced by the type checker alone — the contract verifier enforces the `>= 0` constraint via Z3. Code that passes `vera check` but fails `vera verify` on a `Nat` return type indicates that the verifier could not prove the result is non-negative.
+
 This means `Array<PosInt>` is NOT a subtype of `Array<Int>`. Converting between them requires an explicit mapping.
 
 ## 2.9 Type Equality

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -765,3 +765,68 @@ fn simple(-> @Int)
         assert data["ok"] is True
         # The ADT function produces a compilation warning
         assert len(data["warnings"]) > 0
+
+    def test_run_invalid_int_arg(self) -> None:
+        """Non-integer arguments after -- produce a clean error."""
+        import tempfile
+        source = """\
+fn id(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 }
+"""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".vera", delete=False
+        ) as f:
+            f.write(source)
+            path = f.name
+        result = subprocess.run(
+            [sys.executable, "-m", "vera.cli",
+             "run", path, "--fn", "id", "--", "abc"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 1
+        assert "Invalid integer" in result.stderr
+
+    def test_run_invalid_float_arg(self) -> None:
+        """Float arguments after -- produce a clean error."""
+        import tempfile
+        source = """\
+fn id(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 }
+"""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".vera", delete=False
+        ) as f:
+            f.write(source)
+            path = f.name
+        result = subprocess.run(
+            [sys.executable, "-m", "vera.cli",
+             "run", path, "--fn", "id", "--", "1.5"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 1
+        assert "Invalid integer" in result.stderr
+
+    def test_run_invalid_arg_json(self) -> None:
+        """Invalid args with --json produce JSON error."""
+        import tempfile
+        source = """\
+fn id(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 }
+"""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".vera", delete=False
+        ) as f:
+            f.write(source)
+            path = f.name
+        result = subprocess.run(
+            [sys.executable, "-m", "vera.cli",
+             "run", "--json", path, "--fn", "id", "--", "xyz"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 1
+        data = json.loads(result.stdout)
+        assert data["ok"] is False
+        assert "Invalid integer" in data["diagnostics"][0]["description"]

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -496,6 +496,44 @@ fn nat_plus_one(@Nat -> @Int)
 { @Nat.0 + 1 }
 """)
 
+    def test_int_to_nat_negative_caught(self) -> None:
+        """Int body returning -1 as Nat: verifier must catch the violation.
+
+        The type checker permits Int <: Nat (rule 3b), deferring the
+        non-negativity check to the verifier.  Returning a literal -1
+        contradicts the Nat >= 0 constraint, so verification must fail.
+        """
+        _verify_err("""
+fn bad(@Unit -> @Nat)
+  requires(true)
+  ensures(@Nat.result >= 0)
+  effects(pure)
+{ -1 }
+""", "postcondition")
+
+    def test_int_to_nat_positive_ok(self) -> None:
+        """Int expression returned as Nat: verifier passes when >= 0."""
+        _verify_ok("""
+fn good(@Nat -> @Nat)
+  requires(true)
+  ensures(@Nat.result >= 0)
+  effects(pure)
+{ @Nat.0 + 1 }
+""")
+
+    def test_int_to_nat_conditional(self) -> None:
+        """Int body with conditional: verifier checks all paths >= 0."""
+        _verify_ok("""
+fn abs_nat(@Int -> @Nat)
+  requires(true)
+  ensures(@Nat.result >= 0)
+  effects(pure)
+{
+  if @Int.0 >= 0 then { @Int.0 }
+  else { 0 - @Int.0 }
+}
+""")
+
     def test_modular_arithmetic(self) -> None:
         _verify_ok("""
 fn remainder(@Int, @Int -> @Int)

--- a/vera/README.md
+++ b/vera/README.md
@@ -451,7 +451,7 @@ Every diagnostic includes a description (what went wrong), rationale (which lang
 
 ## Test Suite
 
-**508 tests** across 8 files, plus 4 validation scripts and CI infrastructure.
+**514 tests** across 8 files, plus 4 validation scripts and CI infrastructure.
 
 ### Test files
 
@@ -460,13 +460,13 @@ Every diagnostic includes a description (what went wrong), rationale (which lang
 | `test_parser.py` | 95 | 791 | Grammar rules, operator precedence, parse errors |
 | `test_ast.py` | 84 | 896 | AST transformation, node structure, serialisation |
 | `test_checker.py` | 91 | 950 | Type synthesis, slot resolution, effects, contracts |
-| `test_verifier.py` | 52 | 616 | Z3 verification, counterexamples, tier classification |
+| `test_verifier.py` | 55 | 654 | Z3 verification, counterexamples, tier classification, Int→Nat enforcement |
 | `test_codegen.py` | 104 | 1,181 | WASM compilation, arithmetic, control flow, strings, IO, contracts, example round-trips |
-| `test_cli.py` | 64 | 767 | CLI commands (check, verify, compile, run), subprocess integration, runtime traps |
+| `test_cli.py` | 67 | 832 | CLI commands (check, verify, compile, run), subprocess integration, runtime traps, arg validation |
 | `test_readme.py` | 2 | 68 | README code sample parsing |
 | `test_errors.py` | 16 | 129 | Diagnostic formatting, error patterns |
 
-Total: 5,398 lines of test code (73% of source code size).
+Total: 5,501 lines of test code (74% of source code size).
 
 ### Round-trip testing
 
@@ -547,6 +547,15 @@ Honest inventory of what the compiler cannot do, and where each limitation is ad
 | **Minimal type inference** | Call-site generic instantiation only, no Hindley-Milner | Incremental |
 | **No incremental compilation** | Full file processed from scratch each time | Low priority |
 | **No exhaustiveness checking** | Match expressions not checked for missing cases | Incremental |
+| **Spec/parser `@T` notation mismatch** | Spec uses `@T` in data/effect declarations; parser expects bare `T` — see below | Reconciliation |
+
+### Spec/parser notation mismatch
+
+The language specification uses `@T` notation in data type constructor fields and effect operation signatures (e.g., `data Option<T> { Some(@T), None }`, `op get(@Unit -> @T)`). The parser expects bare types in these positions (e.g., `Some(T)`, `op get(Unit -> T)`).
+
+This is an intentional design distinction: the grammar reserves `@` for value-level bindings (function parameters, where `@T.0` creates a slot reference) and uses bare types in type-level signatures (constructor fields, effect ops) where no runtime bindings are created. The spec aspirationally shows `@T` for visual consistency with function parameters.
+
+There are 30 spec code blocks affected, tracked as MISMATCH entries in `scripts/check_spec_examples.py`. Reconciliation will update either the spec or the parser to match; the question is whether binding-site notation should be syntactically uniform across all declaration forms.
 
 ## Extending the Compiler
 

--- a/vera/cli.py
+++ b/vera/cli.py
@@ -28,6 +28,15 @@ from vera.parser import parse_file
 from vera.transform import transform
 
 
+def _is_int_str(s: str) -> bool:
+    """Return True if *s* can be parsed as a Python int literal."""
+    try:
+        int(s)
+        return True
+    except ValueError:
+        return False
+
+
 def cmd_parse(path: str) -> int:
     """Parse a .vera file and print the parse tree."""
     try:
@@ -490,7 +499,20 @@ def main() -> None:
     if "--" in args:
         dash_idx = args.index("--")
         raw_args = args[dash_idx + 1:]
-        fn_args = [int(a) for a in raw_args] if raw_args else None
+        if raw_args:
+            try:
+                fn_args = [int(a) for a in raw_args]
+            except ValueError:
+                bad = [a for a in raw_args if not _is_int_str(a)]
+                msg = f"Invalid integer argument(s): {', '.join(bad)}"
+                if use_json:
+                    print(json.dumps({"ok": False, "file": "",
+                                      "diagnostics": [{"severity": "error",
+                                                       "description": msg}]},
+                                     indent=2))
+                else:
+                    print(f"Error: {msg}", file=sys.stderr)
+                sys.exit(1)
 
     # Remove flags from remaining args to find the filepath
     skip_flags = {"--json", "--wat"}


### PR DESCRIPTION
## Summary

Housekeeping PR addressing substantive points from a code review before starting C6.

### 1. Int/Nat bidirectional subtyping (+3 verifier tests, +spec note)

The type checker permits `Int <: Nat` (rule 3b in `is_subtype()`) but this was:
- **Untested in the verifier** — no test showing a negative Int returned as Nat gets caught
- **Undocumented in the spec** — `spec/02-types.md` listed the complete subtyping relation without mentioning Int→Nat

**Fix:** Added 3 verifier tests (negative caught, positive passes, conditional paths) and an implementation note in the spec's subtyping section.

### 2. CLI argument validation (+3 CLI tests, +bug fix)

`vera run file.vera -- abc` caused a raw Python `ValueError` traceback instead of a clean error message. The `int(a)` parsing in `main()` had no error handling.

**Fix:** Added try/except with clean error message (`Invalid integer argument(s): abc`), JSON mode support, and 3 subprocess tests.

### 3. Spec/parser mismatch documentation

The 30 MISMATCH items in `check_spec_examples.py` (spec uses `@T` in data/effect declarations, parser expects bare `T`) were tracked in the script but not documented anywhere user-facing.

**Fix:** Added a paragraph to `vera/README.md` Current Limitations explaining the design distinction (value-level vs type-level binding notation) and that reconciliation is tracked.

### 4. Test count updates

508 → 514 tests across all documentation files.

## Test plan

- [x] 514 tests pass
- [x] mypy clean (14 source files)
- [x] All 14 examples pass check + verify
- [x] All spec code blocks parse
- [x] Pre-commit hooks pass