### PR TITLE
C6a: Float64 WASM codegen — closes #25

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,7 +108,7 @@ Each stage is a module with a single public API function (`parse_file`, `transfo
 ### Testing
 
 ```bash
-pytest tests/ -v                       # Run all tests (514 tests)
+pytest tests/ -v                       # Run all tests (540 tests)
 mypy vera/                             # Type-check the compiler
 python scripts/check_examples.py       # All 14 examples must pass
 ```
@@ -119,7 +119,7 @@ Test helpers follow a pattern: `_check_ok(source)` / `_check_err(source, match)`
 
 - All 14 examples in `examples/` must pass `vera check` and `vera verify`
 - `mypy vera/` must be clean
-- `pytest tests/ -v` must pass (currently 514 tests)
+- `pytest tests/ -v` must pass (currently 540 tests)
 - Version must be in sync across `vera/__init__.py`, `pyproject.toml`, and `CHANGELOG.md`
 
 ### Contributing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.10] - 2026-02-24
+
+### Added
+- **Float64 WASM codegen** (C6a — closes #25): compile Float64/Float values to WebAssembly `f64` instructions
+  - Type mapping: Float64/Float → `f64` in `wasm_type()`, `_type_expr_to_wasm_type()`, `_slot_name_to_wasm_type()`, `_infer_expr_wasm_type()`, `_infer_block_result_type()`
+  - `FloatLit` emission: `f64.const` literals
+  - Float64 arithmetic: `f64.add`, `f64.sub`, `f64.mul`, `f64.div` (MOD unsupported — WASM has no `f64.rem`)
+  - Float64 comparisons: `f64.eq`, `f64.ne`, `f64.lt`, `f64.gt`, `f64.le`, `f64.ge` (result is `i32`)
+  - Float64 negation: `f64.neg`
+  - Float64 slot references, let bindings, if/else branches, function parameters and returns all compile
+  - `ExecuteResult.value` widened to `int | float | None`; `execute()` accepts `list[int | float]` args
+- **Codegen tests**: 26 new tests — Float64 literals, slot references, arithmetic, comparisons, negation, if/else, let bindings, WAT output validation (540 total, up from 514)
+
+### Changed
+- `execute()` signature updated: `args` parameter accepts `list[int | float]` for Float64 arguments
+- Warning messages updated to mention Float64 as a compilable type
+- CLI `fn_args` type widened to `list[int | float]` for future float argument parsing
+
 ## [0.0.9] - 2026-02-23
 
 ### Added
@@ -190,7 +208,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Grammar: handler body simplified to avoid LALR reduce/reduce conflict
 - `pyproject.toml`: corrected build backend, package discovery, PEP 639 compliance
 
-[Unreleased]: https://github.com/aallan/vera/compare/v0.0.9...HEAD
+[Unreleased]: https://github.com/aallan/vera/compare/v0.0.10...HEAD
+[0.0.10]: https://github.com/aallan/vera/compare/v0.0.9...v0.0.10
 [0.0.9]: https://github.com/aallan/vera/compare/v0.0.8...v0.0.9
 [0.0.8]: https://github.com/aallan/vera/compare/v0.0.7...v0.0.8
 [0.0.7]: https://github.com/aallan/vera/compare/v0.0.6...v0.0.7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ vera parse file.vera              # Print the parse tree
 vera ast file.vera                # Print the typed AST
 vera ast --json file.vera         # Print the AST as JSON
 
-pytest tests/ -v                  # Run the test suite (514 tests)
+pytest tests/ -v                  # Run the test suite (540 tests)
 mypy vera/                        # Type-check the compiler itself
 
 python scripts/check_examples.py      # Verify all 14 examples parse + check + verify

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Development follows an **interleaved spiral** — each phase adds a complete com
 | C3 | v0.0.5 | **Type checker** — decidable type checking, slot resolution, effect tracking | Done |
 | C4 | v0.0.8 | **Contract verifier** — Z3 integration, refinement types, counterexamples | Done |
 | C5 | v0.0.9 | **WASM codegen** — compile to WebAssembly, `vera compile` / `vera run` | Done |
-| C6 | v0.0.10–0.0.23 | **Codegen completeness** — ADTs, match, closures, effects, generics in WASM | Planned |
+| C6 | v0.0.10–0.0.23 | **Codegen completeness** — ADTs, match, closures, effects, generics in WASM | **In progress** (C6a done) |
 | C7 | — | **Module system** — cross-file imports, public/private visibility | Planned |
 | C8 | v0.1.0 | **End-to-end** — all examples compile and run, spec complete, polish | Planned |
 
@@ -171,7 +171,7 @@ The code generator compiles 6 of 14 examples. C6 extends WASM compilation to all
 
 | Sub-phase | Scope | Closes | Unlocks |
 |-----------|-------|--------|---------|
-| C6a | Float64 — `f64` literals, arithmetic, comparisons | #25 | — |
+| ~~C6a~~ | ~~Float64 — `f64` literals, arithmetic, comparisons~~ | ~~#25~~ | ~~Done (v0.0.10)~~ |
 | C6b | Callee preconditions — verify `requires()` at call sites | #19 | — |
 | C6c | Match exhaustiveness — verify all constructors covered | #18 | — |
 | C6d | State\<T\> operations — get/put as host imports | — | increment.vera |
@@ -465,7 +465,7 @@ vera/
 │   ├── errors.py                  # LLM-oriented diagnostics
 │   └── cli.py                     # Command-line interface
 ├── examples/                      # 14 example Vera programs
-├── tests/                         # Test suite (514 tests)
+├── tests/                         # Test suite (540 tests)
 ├── scripts/                       # CI and validation scripts
 │   ├── check_examples.py          # Verify all .vera examples
 │   ├── check_spec_examples.py     # Verify spec code blocks parse

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.9"
+version = "0.0.10"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -57,6 +57,19 @@ def _run(source: str, fn: str | None = None, args: list[int] | None = None) -> i
     return exec_result.value
 
 
+def _run_float(
+    source: str, fn: str | None = None, args: list[int | float] | None = None
+) -> float:
+    """Compile, execute, and return the float result."""
+    result = _compile_ok(source)
+    exec_result = execute(result, fn_name=fn, args=args)
+    assert exec_result.value is not None, "Expected a return value"
+    assert isinstance(exec_result.value, float), (
+        f"Expected float, got {type(exec_result.value).__name__}"
+    )
+    return exec_result.value
+
+
 def _run_io(
     source: str, fn: str | None = None, args: list[int] | None = None
 ) -> str:
@@ -103,6 +116,209 @@ class TestBoolLit:
 
     def test_false(self) -> None:
         assert _run("fn f(-> @Bool) requires(true) ensures(true) effects(pure) { false }") == 0
+
+
+class TestFloatLit:
+    def test_zero(self) -> None:
+        assert _run_float(
+            "fn f(-> @Float64) requires(true) ensures(true) effects(pure) { 0.0 }"
+        ) == 0.0
+
+    def test_positive(self) -> None:
+        result = _run_float(
+            "fn f(-> @Float64) requires(true) ensures(true) effects(pure) { 3.14 }"
+        )
+        assert abs(result - 3.14) < 1e-10
+
+    def test_one(self) -> None:
+        assert _run_float(
+            "fn f(-> @Float64) requires(true) ensures(true) effects(pure) { 1.0 }"
+        ) == 1.0
+
+
+class TestFloatSlotRef:
+    def test_identity_float64(self) -> None:
+        """Float64 identity function: param in, same value out."""
+        source = (
+            "fn id(@Float64 -> @Float64) requires(true) ensures(true) "
+            "effects(pure) { @Float64.0 }"
+        )
+        result = _compile_ok(source)
+        exec_result = execute(result, fn_name="id", args=[7.5])
+        assert exec_result.value == 7.5
+
+    def test_two_float_params(self) -> None:
+        """@Float64.0 = most recent (second), @Float64.1 = first."""
+        source = (
+            "fn second(@Float64, @Float64 -> @Float64) requires(true) "
+            "ensures(true) effects(pure) { @Float64.0 }"
+        )
+        result = _compile_ok(source)
+        exec_result = execute(result, fn_name="second", args=[1.5, 2.5])
+        assert exec_result.value == 2.5
+
+    def test_float_param_arithmetic(self) -> None:
+        """Float64 param used in arithmetic."""
+        source = (
+            "fn add_one(@Float64 -> @Float64) requires(true) ensures(true) "
+            "effects(pure) { @Float64.0 + 1.0 }"
+        )
+        result = _compile_ok(source)
+        exec_result = execute(result, fn_name="add_one", args=[2.5])
+        assert exec_result.value == 3.5
+
+
+class TestFloatArithmetic:
+    def test_add(self) -> None:
+        assert _run_float(
+            "fn f(-> @Float64) requires(true) ensures(true) effects(pure) "
+            "{ 1.5 + 2.5 }"
+        ) == 4.0
+
+    def test_sub(self) -> None:
+        assert _run_float(
+            "fn f(-> @Float64) requires(true) ensures(true) effects(pure) "
+            "{ 5.0 - 2.5 }"
+        ) == 2.5
+
+    def test_mul(self) -> None:
+        assert _run_float(
+            "fn f(-> @Float64) requires(true) ensures(true) effects(pure) "
+            "{ 3.0 * 2.5 }"
+        ) == 7.5
+
+    def test_div(self) -> None:
+        assert _run_float(
+            "fn f(-> @Float64) requires(true) ensures(true) effects(pure) "
+            "{ 7.5 / 2.5 }"
+        ) == 3.0
+
+    def test_nested(self) -> None:
+        """(1.0 + 2.0) * 3.0 = 9.0"""
+        assert _run_float(
+            "fn f(-> @Float64) requires(true) ensures(true) effects(pure) "
+            "{ (1.0 + 2.0) * 3.0 }"
+        ) == 9.0
+
+
+class TestFloatComparison:
+    def test_eq_true(self) -> None:
+        assert _run(
+            "fn f(-> @Bool) requires(true) ensures(true) effects(pure) "
+            "{ 1.5 == 1.5 }"
+        ) == 1
+
+    def test_eq_false(self) -> None:
+        assert _run(
+            "fn f(-> @Bool) requires(true) ensures(true) effects(pure) "
+            "{ 1.5 == 2.5 }"
+        ) == 0
+
+    def test_neq(self) -> None:
+        assert _run(
+            "fn f(-> @Bool) requires(true) ensures(true) effects(pure) "
+            "{ 1.5 != 2.5 }"
+        ) == 1
+
+    def test_lt(self) -> None:
+        assert _run(
+            "fn f(-> @Bool) requires(true) ensures(true) effects(pure) "
+            "{ 1.5 < 2.5 }"
+        ) == 1
+
+    def test_gt(self) -> None:
+        assert _run(
+            "fn f(-> @Bool) requires(true) ensures(true) effects(pure) "
+            "{ 2.5 > 1.5 }"
+        ) == 1
+
+    def test_le(self) -> None:
+        assert _run(
+            "fn f(-> @Bool) requires(true) ensures(true) effects(pure) "
+            "{ 1.5 <= 1.5 }"
+        ) == 1
+
+    def test_ge(self) -> None:
+        assert _run(
+            "fn f(-> @Bool) requires(true) ensures(true) effects(pure) "
+            "{ 2.5 >= 1.5 }"
+        ) == 1
+
+
+class TestFloatNeg:
+    def test_neg_literal(self) -> None:
+        assert _run_float(
+            "fn f(-> @Float64) requires(true) ensures(true) effects(pure) "
+            "{ -3.5 }"
+        ) == -3.5
+
+    def test_neg_expr(self) -> None:
+        assert _run_float(
+            "fn f(-> @Float64) requires(true) ensures(true) effects(pure) "
+            "{ -(1.0 + 2.5) }"
+        ) == -3.5
+
+
+class TestFloatIfExpr:
+    def test_if_float_result(self) -> None:
+        """If expression returning Float64."""
+        source = """\
+fn f(-> @Float64)
+  requires(true) ensures(true) effects(pure)
+{ if true then { 1.5 } else { 2.5 } }
+"""
+        assert _run_float(source) == 1.5
+
+    def test_if_float_else(self) -> None:
+        source = """\
+fn f(-> @Float64)
+  requires(true) ensures(true) effects(pure)
+{ if false then { 1.5 } else { 2.5 } }
+"""
+        assert _run_float(source) == 2.5
+
+
+class TestFloatLet:
+    def test_let_float(self) -> None:
+        """Let binding with Float64 type."""
+        source = """\
+fn f(-> @Float64)
+  requires(true) ensures(true) effects(pure)
+{
+  let @Float64 = 1.5 + 2.5;
+  @Float64.0
+}
+"""
+        assert _run_float(source) == 4.0
+
+    def test_let_float_chain(self) -> None:
+        """Multiple let bindings with Float64."""
+        source = """\
+fn f(-> @Float64)
+  requires(true) ensures(true) effects(pure)
+{
+  let @Float64 = 3.0;
+  let @Float64 = @Float64.0 * 2.0;
+  @Float64.0
+}
+"""
+        assert _run_float(source) == 6.0
+
+
+class TestFloatCompileResult:
+    def test_wat_has_f64(self) -> None:
+        """WAT output contains f64 instructions."""
+        result = _compile_ok(
+            "fn f(-> @Float64) requires(true) ensures(true) effects(pure) { 3.14 }"
+        )
+        assert "f64.const" in result.wat
+
+    def test_float_fn_exported(self) -> None:
+        """Float64 functions are exported (no longer skipped)."""
+        result = _compile_ok(
+            "fn f(-> @Float64) requires(true) ensures(true) effects(pure) { 1.0 }"
+        )
+        assert "f" in result.exports
 
 
 class TestCompileResult:

--- a/vera/README.md
+++ b/vera/README.md
@@ -451,7 +451,7 @@ Every diagnostic includes a description (what went wrong), rationale (which lang
 
 ## Test Suite
 
-**514 tests** across 8 files, plus 4 validation scripts and CI infrastructure.
+**540 tests** across 8 files, plus 4 validation scripts and CI infrastructure.
 
 ### Test files
 
@@ -461,12 +461,12 @@ Every diagnostic includes a description (what went wrong), rationale (which lang
 | `test_ast.py` | 84 | 896 | AST transformation, node structure, serialisation |
 | `test_checker.py` | 91 | 950 | Type synthesis, slot resolution, effects, contracts |
 | `test_verifier.py` | 55 | 654 | Z3 verification, counterexamples, tier classification, Int→Nat enforcement |
-| `test_codegen.py` | 104 | 1,181 | WASM compilation, arithmetic, control flow, strings, IO, contracts, example round-trips |
+| `test_codegen.py` | 130 | 1,397 | WASM compilation, arithmetic, Float64, control flow, strings, IO, contracts, example round-trips |
 | `test_cli.py` | 67 | 832 | CLI commands (check, verify, compile, run), subprocess integration, runtime traps, arg validation |
 | `test_readme.py` | 2 | 68 | README code sample parsing |
 | `test_errors.py` | 16 | 129 | Diagnostic formatting, error patterns |
 
-Total: 5,501 lines of test code (74% of source code size).
+Total: 5,717 lines of test code (77% of source code size).
 
 ### Round-trip testing
 

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.9"
+__version__ = "0.0.10"

--- a/vera/cli.py
+++ b/vera/cli.py
@@ -308,7 +308,7 @@ def cmd_run(
     *,
     as_json: bool = False,
     fn_name: str | None = None,
-    fn_args: list[int] | None = None,
+    fn_args: list[int | float] | None = None,
 ) -> int:
     """Parse, type-check, compile, and execute a .vera file."""
     from vera.checker import typecheck
@@ -495,7 +495,7 @@ def main() -> None:
             output_path = args[o_idx + 1]
 
     # Parse -- <args> for run command
-    fn_args: list[int] | None = None
+    fn_args: list[int | float] | None = None
     if "--" in args:
         dash_idx = args.index("--")
         raw_args = args[dash_idx + 1:]

--- a/vera/codegen.py
+++ b/vera/codegen.py
@@ -57,7 +57,7 @@ class CompileResult:
 class ExecuteResult:
     """Result of executing a WASM function."""
 
-    value: int | None  # Return value (None for void/Unit functions)
+    value: int | float | None  # Return value (None for void/Unit functions)
     stdout: str  # Captured IO.print output
 
 
@@ -79,7 +79,7 @@ def compile(
 def execute(
     result: CompileResult,
     fn_name: str | None = None,
-    args: list[int] | None = None,
+    args: list[int | float] | None = None,
 ) -> ExecuteResult:
     """Execute a function from a compiled WASM module.
 
@@ -132,12 +132,15 @@ def execute(
         raise RuntimeError(f"Function '{fn_name}' not found in exports")
 
     # Call with arguments
-    call_args: list[int] = args or []
+    call_args: list[int | float] = args or []
     raw_result = func(store, *call_args)
 
     # Extract return value
+    value: int | float | None
     if raw_result is None:
         value = None
+    elif isinstance(raw_result, float):
+        value = raw_result
     elif isinstance(raw_result, int):
         value = raw_result
     else:
@@ -317,8 +320,8 @@ class CodeGenerator:
                 self._warning(
                     decl,
                     f"Function '{decl.name}' has unsupported parameter type.",
-                    rationale="Only Int, Nat, Bool, and Unit types are "
-                    "compilable in the current WASM backend.",
+                    rationale="Only Int, Nat, Float64, Bool, and Unit types "
+                    "are compilable in the current WASM backend.",
                 )
                 return None
             local_idx = ctx.alloc_param()
@@ -603,6 +606,8 @@ class CodeGenerator:
             name = te.name
             if name in ("Int", "Nat"):
                 return "i64"
+            if name in ("Float64", "Float"):
+                return "f64"
             if name == "Bool":
                 return "i32"
             if name == "Unit":

--- a/vera/wasm.py
+++ b/vera/wasm.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass, field
 from vera import ast
 from vera.types import (
     BOOL,
+    FLOAT64,
     INT,
     NAT,
     STRING,
@@ -107,6 +108,8 @@ def wasm_type(t: Type) -> str | None:
     if isinstance(t, PrimitiveType):
         if t.name in ("Int", "Nat"):
             return "i64"
+        if t.name in ("Float64", "Float"):
+            return "f64"
         if t.name == "Bool":
             return "i32"
         if t.name == "Unit":
@@ -190,6 +193,9 @@ class WasmContext:
         if isinstance(expr, ast.BoolLit):
             return [f"i32.const {1 if expr.value else 0}"]
 
+        if isinstance(expr, ast.FloatLit):
+            return [f"f64.const {expr.value}"]
+
         if isinstance(expr, ast.UnitLit):
             return []  # Unit produces no value on the stack
 
@@ -251,7 +257,7 @@ class WasmContext:
     # Binary operators
     # -----------------------------------------------------------------
 
-    # Arithmetic: i64 ops
+    # Arithmetic: i64 ops (default for Int/Nat)
     _ARITH_OPS: dict[ast.BinOp, str] = {
         ast.BinOp.ADD: "i64.add",
         ast.BinOp.SUB: "i64.sub",
@@ -260,7 +266,16 @@ class WasmContext:
         ast.BinOp.MOD: "i64.rem_s",
     }
 
-    # Comparison: i64 → i32
+    # Arithmetic: f64 ops (Float64)
+    _ARITH_OPS_F64: dict[ast.BinOp, str] = {
+        ast.BinOp.ADD: "f64.add",
+        ast.BinOp.SUB: "f64.sub",
+        ast.BinOp.MUL: "f64.mul",
+        ast.BinOp.DIV: "f64.div",
+        # MOD: WASM has no f64.rem — unsupported for floats
+    }
+
+    # Comparison: i64 → i32 (default)
     _CMP_OPS: dict[ast.BinOp, str] = {
         ast.BinOp.EQ: "i64.eq",
         ast.BinOp.NEQ: "i64.ne",
@@ -268,6 +283,16 @@ class WasmContext:
         ast.BinOp.GT: "i64.gt_s",
         ast.BinOp.LE: "i64.le_s",
         ast.BinOp.GE: "i64.ge_s",
+    }
+
+    # Comparison: f64 → i32 (Float64)
+    _CMP_OPS_F64: dict[ast.BinOp, str] = {
+        ast.BinOp.EQ: "f64.eq",
+        ast.BinOp.NEQ: "f64.ne",
+        ast.BinOp.LT: "f64.lt",
+        ast.BinOp.GT: "f64.gt",
+        ast.BinOp.LE: "f64.le",
+        ast.BinOp.GE: "f64.ge",
     }
 
     def _translate_binary(
@@ -280,15 +305,21 @@ class WasmContext:
             return None
 
         op = expr.op
+        ltype = self._infer_expr_wasm_type(expr.left)
 
         # Arithmetic
         if op in self._ARITH_OPS:
+            if ltype == "f64":
+                if op not in self._ARITH_OPS_F64:
+                    return None  # MOD unsupported for f64
+                return left + right + [self._ARITH_OPS_F64[op]]
             return left + right + [self._ARITH_OPS[op]]
 
-        # Comparison — choose i32/i64 based on operand types
+        # Comparison — choose i32/i64/f64 based on operand types
         if op in self._CMP_OPS:
-            ltype = self._infer_expr_wasm_type(expr.left)
             rtype = self._infer_expr_wasm_type(expr.right)
+            if ltype == "f64" or rtype == "f64":
+                return left + right + [self._CMP_OPS_F64[op]]
             if ltype == "i32" and rtype == "i32":
                 # Bool operands — use i32 comparison
                 i32_op = self._CMP_OPS[op].replace("i64.", "i32.")
@@ -311,11 +342,13 @@ class WasmContext:
     def _infer_expr_wasm_type(self, expr: ast.Expr) -> str | None:
         """Infer the WAT result type of an expression.
 
-        Returns "i64" for Int/Nat, "i32" for Bool, None for unknown/Unit.
-        Used to select the correct comparison operators.
+        Returns "i64" for Int/Nat, "f64" for Float64, "i32" for Bool,
+        None for unknown/Unit.  Used to select the correct operators.
         """
         if isinstance(expr, ast.IntLit):
             return "i64"
+        if isinstance(expr, ast.FloatLit):
+            return "f64"
         if isinstance(expr, ast.BoolLit):
             return "i32"
         if isinstance(expr, ast.UnitLit):
@@ -323,25 +356,32 @@ class WasmContext:
         if isinstance(expr, ast.SlotRef):
             if expr.type_name in ("Int", "Nat"):
                 return "i64"
+            if expr.type_name in ("Float64", "Float"):
+                return "f64"
             if expr.type_name == "Bool":
                 return "i32"
             return None
         if isinstance(expr, ast.ResultRef):
             if expr.type_name in ("Int", "Nat"):
                 return "i64"
+            if expr.type_name in ("Float64", "Float"):
+                return "f64"
             if expr.type_name == "Bool":
                 return "i32"
             return None
         if isinstance(expr, ast.BinaryExpr):
             if expr.op in self._ARITH_OPS:
-                return "i64"
+                # Propagate operand type: f64 if operands are f64
+                inner = self._infer_expr_wasm_type(expr.left)
+                return inner if inner == "f64" else "i64"
             if expr.op in self._CMP_OPS:
                 return "i32"
             if expr.op in (ast.BinOp.AND, ast.BinOp.OR, ast.BinOp.IMPLIES):
                 return "i32"
         if isinstance(expr, ast.UnaryExpr):
             if expr.op == ast.UnaryOp.NEG:
-                return "i64"
+                inner = self._infer_expr_wasm_type(expr.operand)
+                return inner if inner == "f64" else "i64"
             if expr.op == ast.UnaryOp.NOT:
                 return "i32"
         if isinstance(expr, ast.FnCall):
@@ -363,6 +403,8 @@ class WasmContext:
         if expr.op == ast.UnaryOp.NOT:
             return operand + ["i32.eqz"]
         if expr.op == ast.UnaryOp.NEG:
+            if self._infer_expr_wasm_type(expr.operand) == "f64":
+                return operand + ["f64.neg"]
             return ["i64.const 0"] + operand + ["i64.sub"]
         return None
 
@@ -409,6 +451,8 @@ class WasmContext:
         expr = block.expr
         if isinstance(expr, ast.IntLit):
             return "i64"
+        if isinstance(expr, ast.FloatLit):
+            return "f64"
         if isinstance(expr, ast.BoolLit):
             return "i32"
         if isinstance(expr, ast.UnitLit):
@@ -418,19 +462,23 @@ class WasmContext:
             name = expr.type_name
             if name in ("Int", "Nat"):
                 return "i64"
+            if name in ("Float64", "Float"):
+                return "f64"
             if name == "Bool":
                 return "i32"
             return None
         if isinstance(expr, ast.BinaryExpr):
             if expr.op in self._ARITH_OPS:
-                return "i64"
+                inner = self._infer_expr_wasm_type(expr.left)
+                return inner if inner == "f64" else "i64"
             if expr.op in self._CMP_OPS:
                 return "i32"
             if expr.op in (ast.BinOp.AND, ast.BinOp.OR, ast.BinOp.IMPLIES):
                 return "i32"
         if isinstance(expr, ast.UnaryExpr):
             if expr.op == ast.UnaryOp.NEG:
-                return "i64"
+                inner = self._infer_expr_wasm_type(expr.operand)
+                return inner if inner == "f64" else "i64"
             if expr.op == ast.UnaryOp.NOT:
                 return "i32"
         if isinstance(expr, ast.IfExpr):
@@ -580,6 +628,8 @@ class WasmContext:
         """Map a slot type name to a WAT type string."""
         if name in ("Int", "Nat"):
             return "i64"
+        if name in ("Float64", "Float"):
+            return "f64"
         if name == "Bool":
             return "i32"
         return None


### PR DESCRIPTION
## Summary
- Float64/Float values compile to WebAssembly `f64` instructions: type mapping, literal emission (`f64.const`), arithmetic (`f64.add/sub/mul/div`), comparisons (`f64.eq/ne/lt/gt/le/ge`), negation (`f64.neg`), slot references, let bindings, and if/else branches
- `ExecuteResult.value` widened to `int | float | None`; `execute()` accepts `list[int | float]` args for Float64 function parameters
- 26 new codegen tests (540 total), version bumped to v0.0.10

## Files changed
| File | Changes |
|------|---------|
| `vera/wasm.py` | Float64 type mapping, `FloatLit` emission, f64 arithmetic/comparison/negation ops, block result type inference |
| `vera/codegen.py` | Float64 type mapping, `ExecuteResult` float support, `execute()` float args |
| `vera/cli.py` | Widened `fn_args` type to `list[int \| float]` |
| `tests/test_codegen.py` | `_run_float()` helper + 8 test classes: `TestFloatLit`, `TestFloatSlotRef`, `TestFloatArithmetic`, `TestFloatComparison`, `TestFloatNeg`, `TestFloatIfExpr`, `TestFloatLet`, `TestFloatCompileResult` |
| `CHANGELOG.md` | v0.0.10 entry |
| `README.md`, `CLAUDE.md`, `AGENTS.md`, `vera/README.md` | Test count updates, C6a marked done in roadmap |

## Test plan
- [x] `pytest tests/ -v` — 540 tests pass
- [x] `mypy vera/` — clean
- [x] `python scripts/check_examples.py` — all 14 examples pass
- [x] `python scripts/check_version_sync.py` — v0.0.10 in sync
- [x] `python scripts/check_readme_examples.py` — README blocks parse
- [x] Pre-commit hooks all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)