### PR TITLE
Add callee precondition verification (C6b) — closes #19

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,7 +108,7 @@ Each stage is a module with a single public API function (`parse_file`, `transfo
 ### Testing
 
 ```bash
-pytest tests/ -v                       # Run all tests (540 tests)
+pytest tests/ -v                       # Run all tests (553 tests)
 mypy vera/                             # Type-check the compiler
 python scripts/check_examples.py       # All 14 examples must pass
 ```
@@ -119,7 +119,7 @@ Test helpers follow a pattern: `_check_ok(source)` / `_check_err(source, match)`
 
 - All 14 examples in `examples/` must pass `vera check` and `vera verify`
 - `mypy vera/` must be clean
-- `pytest tests/ -v` must pass (currently 540 tests)
+- `pytest tests/ -v` must pass (currently 553 tests)
 - Version must be in sync across `vera/__init__.py`, `pyproject.toml`, and `CHANGELOG.md`
 
 ### Contributing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.11] - 2026-02-24
+
+### Added
+- **Callee precondition verification** (C6b — closes #19): modular call-site contract checking
+  - When function `f` calls function `g`, the verifier now checks that `g`'s `requires()` clauses hold at the call site given `f`'s assumptions
+  - Callee postconditions (`ensures()`) are assumed at the call site, enabling symbolic reasoning about return values
+  - Fresh Z3 variables created per call, with postconditions asserted — supports chained calls, let bindings, and recursive calls
+  - Recursive functions (e.g., `factorial`) now verify `ensures()` at Tier 1 instead of falling to Tier 3
+  - `CallViolation` dataclass in `smt.py` records call-site violations with callee name, precondition, and counterexample
+  - `_report_call_violation()` in verifier produces LLM-oriented diagnostics with fix suggestions
+  - `param_type_exprs` field added to `FunctionInfo` for callee parameter slot resolution
+- **Verifier tests**: 13 new tests — satisfied/violated/forwarded preconditions, assumed postconditions, recursive calls, trivial preconditions, let bindings, where-block calls, generic call fallback, multiple preconditions, sequential calls, error message quality (553 total, up from 540)
+
+### Changed
+- Tier 3 warning rationale updated: "recursive calls" replaced with "generic calls" (recursive calls now handled via modular verification)
+- `SmtContext` constructor accepts optional `fn_lookup` callback for callee contract resolution
+- Caller precondition assumptions now asserted into the Z3 solver before body translation
+
 ## [0.0.10] - 2026-02-24
 
 ### Added
@@ -208,7 +226,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Grammar: handler body simplified to avoid LALR reduce/reduce conflict
 - `pyproject.toml`: corrected build backend, package discovery, PEP 639 compliance
 
-[Unreleased]: https://github.com/aallan/vera/compare/v0.0.10...HEAD
+[Unreleased]: https://github.com/aallan/vera/compare/v0.0.11...HEAD
+[0.0.11]: https://github.com/aallan/vera/compare/v0.0.10...v0.0.11
 [0.0.10]: https://github.com/aallan/vera/compare/v0.0.9...v0.0.10
 [0.0.9]: https://github.com/aallan/vera/compare/v0.0.8...v0.0.9
 [0.0.8]: https://github.com/aallan/vera/compare/v0.0.7...v0.0.8

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ vera parse file.vera              # Print the parse tree
 vera ast file.vera                # Print the typed AST
 vera ast --json file.vera         # Print the AST as JSON
 
-pytest tests/ -v                  # Run the test suite (540 tests)
+pytest tests/ -v                  # Run the test suite (553 tests)
 mypy vera/                        # Type-check the compiler itself
 
 python scripts/check_examples.py      # Verify all 14 examples parse + check + verify

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ The code generator compiles 6 of 14 examples. C6 extends WASM compilation to all
 | Sub-phase | Scope | Closes | Unlocks |
 |-----------|-------|--------|---------|
 | ~~C6a~~ | ~~Float64 — `f64` literals, arithmetic, comparisons~~ | ~~#25~~ | ~~Done (v0.0.10)~~ |
-| C6b | Callee preconditions — verify `requires()` at call sites | #19 | — |
+| ~~C6b~~ | ~~Callee preconditions — verify `requires()` at call sites~~ | ~~#19~~ | ~~Done (v0.0.11)~~ |
 | C6c | Match exhaustiveness — verify all constructors covered | #18 | — |
 | C6d | State\<T\> operations — get/put as host imports | — | increment.vera |
 
@@ -465,7 +465,7 @@ vera/
 │   ├── errors.py                  # LLM-oriented diagnostics
 │   └── cli.py                     # Command-line interface
 ├── examples/                      # 14 example Vera programs
-├── tests/                         # Test suite (540 tests)
+├── tests/                         # Test suite (553 tests)
 ├── scripts/                       # CI and validation scripts
 │   ├── check_examples.py          # Verify all .vera examples
 │   ├── check_spec_examples.py     # Verify spec code blocks parse

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.10"
+version = "0.0.11"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -453,7 +453,7 @@ fn invert(@Bool2 -> @Bool2)
         assert result.summary.tier1_verified >= 2
 
     def test_recursive_call_is_tier3(self) -> None:
-        """Recursive function bodies can't be translated to Z3."""
+        """Recursive functions still have Tier 3 for decreases."""
         result = _verify("""
 fn factorial(@Nat -> @Nat)
   requires(true)
@@ -465,7 +465,7 @@ fn factorial(@Nat -> @Nat)
   else { @Nat.0 * factorial(@Nat.0 - 1) }
 }
 """)
-        # ensures(@Nat.result >= 1) — body has recursive call → Tier 3
+        # ensures(@Nat.result >= 1) — now Tier 1 via modular verification
         # decreases — always Tier 3 for now
         assert result.summary.tier3_runtime >= 1
 
@@ -576,7 +576,8 @@ fn f(@Nat -> @Nat)
 }
 """)
         # requires(true) → Tier 1 trivial
-        # ensures with recursive body → Tier 3
+        # ensures — now Tier 1 via modular verification (recursive call
+        #   returns fresh Nat var with assumed postcondition)
         # decreases → Tier 3
         assert result.summary.total >= 3
         assert result.summary.tier1_verified >= 1
@@ -652,3 +653,242 @@ fn f(@Int -> @Int)
   effects(pure)
 { @Int.0 }
 """)
+
+
+# =====================================================================
+# Call-site precondition verification (C6b)
+# =====================================================================
+
+class TestCallSiteVerification:
+    """Modular verification: callee preconditions checked at call sites."""
+
+    def test_call_satisfied_precondition(self) -> None:
+        """Calling with a literal that satisfies requires(@Int.0 != 0)."""
+        _verify_ok("""
+fn non_zero(@Int -> @Int)
+  requires(@Int.0 != 0)
+  ensures(true)
+  effects(pure)
+{ @Int.0 }
+
+fn caller(@Unit -> @Int)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{ non_zero(1) }
+""")
+
+    def test_call_violated_precondition(self) -> None:
+        """Calling with literal 0 violates requires(@Int.0 != 0)."""
+        _verify_err("""
+fn non_zero(@Int -> @Int)
+  requires(@Int.0 != 0)
+  ensures(true)
+  effects(pure)
+{ @Int.0 }
+
+fn bad_caller(@Unit -> @Int)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{ non_zero(0) }
+""", "precondition")
+
+    def test_call_precondition_forwarded(self) -> None:
+        """Caller's precondition implies callee's — passes."""
+        _verify_ok("""
+fn non_zero(@Int -> @Int)
+  requires(@Int.0 != 0)
+  ensures(true)
+  effects(pure)
+{ @Int.0 }
+
+fn safe_caller(@Int -> @Int)
+  requires(@Int.0 != 0)
+  ensures(true)
+  effects(pure)
+{ non_zero(@Int.0) }
+""")
+
+    def test_call_postcondition_assumed(self) -> None:
+        """Caller's ensures relies on callee's postcondition."""
+        _verify_ok("""
+fn succ(@Int -> @Int)
+  requires(true)
+  ensures(@Int.result == @Int.0 + 1)
+  effects(pure)
+{ @Int.0 + 1 }
+
+fn add_two(@Int -> @Int)
+  requires(true)
+  ensures(@Int.result == @Int.0 + 2)
+  effects(pure)
+{ succ(succ(@Int.0)) }
+""")
+
+    def test_recursive_call_uses_postcondition(self) -> None:
+        """Recursive factorial: ensures(@Nat.result >= 1) now Tier 1.
+
+        The postcondition is assumed at the recursive call site,
+        and base case returns 1, so result >= 1 is provable.
+        """
+        result = _verify("""
+fn factorial(@Nat -> @Nat)
+  requires(true)
+  ensures(@Nat.result >= 1)
+  decreases(@Nat.0)
+  effects(pure)
+{
+  if @Nat.0 == 0 then { 1 }
+  else { @Nat.0 * factorial(@Nat.0 - 1) }
+}
+""")
+        errors = [d for d in result.diagnostics if d.severity == "error"]
+        assert errors == [], f"Expected no errors, got: {[e.description for e in errors]}"
+        # ensures now Tier 1 (modular verification), decreases still Tier 3
+        assert result.summary.tier1_verified >= 2
+
+    def test_call_trivial_precondition(self) -> None:
+        """Callee with requires(true) — always satisfied."""
+        _verify_ok("""
+fn id(@Int -> @Int)
+  requires(true)
+  ensures(@Int.result == @Int.0)
+  effects(pure)
+{ @Int.0 }
+
+fn caller(@Int -> @Int)
+  requires(true)
+  ensures(@Int.result == @Int.0)
+  effects(pure)
+{ id(@Int.0) }
+""")
+
+    def test_call_in_let_binding(self) -> None:
+        """Call result used via let binding, passed to second call."""
+        _verify_ok("""
+fn succ(@Int -> @Int)
+  requires(true)
+  ensures(@Int.result == @Int.0 + 1)
+  effects(pure)
+{ @Int.0 + 1 }
+
+fn add_two_let(@Int -> @Int)
+  requires(true)
+  ensures(@Int.result == @Int.0 + 2)
+  effects(pure)
+{
+  let @Int = succ(@Int.0);
+  succ(@Int.0)
+}
+""")
+
+    def test_where_block_call(self) -> None:
+        """Call to a where-block helper function."""
+        _verify_ok("""
+fn outer(@Int -> @Int)
+  requires(true)
+  ensures(@Int.result == @Int.0 + 1)
+  effects(pure)
+{ helper(@Int.0) }
+where {
+  fn helper(@Int -> @Int)
+    requires(true)
+    ensures(@Int.result == @Int.0 + 1)
+    effects(pure)
+  { @Int.0 + 1 }
+}
+""")
+
+    def test_generic_call_falls_to_tier3(self) -> None:
+        """Calls to generic functions bail to Tier 3."""
+        result = _verify("""
+forall<T>
+fn id(@T -> @T)
+  requires(true)
+  ensures(@T.result == @T.0)
+  effects(pure)
+{ @T.0 }
+
+fn caller(@Int -> @Int)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{ id(@Int.0) }
+""")
+        # id's contracts → Tier 3 (generic)
+        # caller's body has generic call → body_expr is None
+        # Since caller's ensures is trivial, it doesn't matter
+        assert result.summary.tier3_runtime >= 1
+
+    def test_multiple_preconditions_all_checked(self) -> None:
+        """Two requires on callee, second one violated."""
+        _verify_err("""
+fn guarded(@Int -> @Int)
+  requires(@Int.0 > 0)
+  requires(@Int.0 < 100)
+  ensures(true)
+  effects(pure)
+{ @Int.0 }
+
+fn bad_caller(@Int -> @Int)
+  requires(@Int.0 > 0)
+  ensures(true)
+  effects(pure)
+{ guarded(@Int.0) }
+""", "precondition")
+
+    def test_precondition_via_caller_requires(self) -> None:
+        """Caller's requires forwards two constraints to satisfy callee."""
+        _verify_ok("""
+fn guarded(@Int -> @Int)
+  requires(@Int.0 > 0)
+  requires(@Int.0 < 100)
+  ensures(true)
+  effects(pure)
+{ @Int.0 }
+
+fn good_caller(@Int -> @Int)
+  requires(@Int.0 > 0)
+  requires(@Int.0 < 100)
+  ensures(true)
+  effects(pure)
+{ guarded(@Int.0) }
+""")
+
+    def test_multiple_calls_in_sequence(self) -> None:
+        """Two calls in sequence, each gets a fresh return variable."""
+        _verify_ok("""
+fn inc(@Int -> @Int)
+  requires(true)
+  ensures(@Int.result == @Int.0 + 1)
+  effects(pure)
+{ @Int.0 + 1 }
+
+fn add_two_seq(@Int -> @Int)
+  requires(true)
+  ensures(@Int.result == @Int.0 + 2)
+  effects(pure)
+{
+  let @Int = inc(@Int.0);
+  inc(@Int.0)
+}
+""")
+
+    def test_violation_error_mentions_callee_name(self) -> None:
+        """Error message includes the callee function name."""
+        errors = _verify_err("""
+fn non_zero(@Int -> @Int)
+  requires(@Int.0 != 0)
+  ensures(true)
+  effects(pure)
+{ @Int.0 }
+
+fn bad(@Int -> @Int)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{ non_zero(0) }
+""", "precondition")
+        # Check that the error mentions the callee name
+        assert any("non_zero" in e.description for e in errors)

--- a/vera/README.md
+++ b/vera/README.md
@@ -451,7 +451,7 @@ Every diagnostic includes a description (what went wrong), rationale (which lang
 
 ## Test Suite
 
-**540 tests** across 8 files, plus 4 validation scripts and CI infrastructure.
+**553 tests** across 8 files, plus 4 validation scripts and CI infrastructure.
 
 ### Test files
 
@@ -460,7 +460,7 @@ Every diagnostic includes a description (what went wrong), rationale (which lang
 | `test_parser.py` | 95 | 791 | Grammar rules, operator precedence, parse errors |
 | `test_ast.py` | 84 | 896 | AST transformation, node structure, serialisation |
 | `test_checker.py` | 91 | 950 | Type synthesis, slot resolution, effects, contracts |
-| `test_verifier.py` | 55 | 654 | Z3 verification, counterexamples, tier classification, Int→Nat enforcement |
+| `test_verifier.py` | 68 | 897 | Z3 verification, counterexamples, tier classification, Int→Nat enforcement, call-site preconditions |
 | `test_codegen.py` | 130 | 1,397 | WASM compilation, arithmetic, Float64, control flow, strings, IO, contracts, example round-trips |
 | `test_cli.py` | 67 | 832 | CLI commands (check, verify, compile, run), subprocess integration, runtime traps, arg validation |
 | `test_readme.py` | 2 | 68 | README code sample parsing |

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.10"
+__version__ = "0.0.11"

--- a/vera/environment.py
+++ b/vera/environment.py
@@ -42,6 +42,7 @@ class FunctionInfo:
     effect: EffectRowType
     span: object | None = None  # ast.Span
     contracts: tuple[object, ...] = ()  # ast.Contract nodes (for C4)
+    param_type_exprs: tuple[object, ...] = ()  # ast.TypeExpr nodes (for C6b)
 
 
 @dataclass

--- a/vera/registration.py
+++ b/vera/registration.py
@@ -46,6 +46,7 @@ def register_fn(
         effect=eff,
         span=decl.span,
         contracts=decl.contracts,
+        param_type_exprs=decl.params,
     )
 
     if decl.where_fns:

--- a/vera/smt.py
+++ b/vera/smt.py
@@ -11,10 +11,14 @@ from __future__ import annotations
 
 from copy import deepcopy
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Callable
 
 import z3
 
 from vera import ast
+
+if TYPE_CHECKING:
+    pass
 
 
 # =====================================================================
@@ -58,6 +62,16 @@ class SmtResult:
     counterexample: dict[str, str] | None = None  # slot_name → value
 
 
+@dataclass
+class CallViolation:
+    """Records a call site where a callee's precondition may not hold."""
+
+    callee_name: str
+    call_node: ast.FnCall
+    precondition: ast.Requires
+    counterexample: dict[str, str] | None = None
+
+
 # =====================================================================
 # SMT context — solver and translation
 # =====================================================================
@@ -86,13 +100,21 @@ _BOOL_OPS: set[ast.BinOp] = {ast.BinOp.AND, ast.BinOp.OR, ast.BinOp.IMPLIES}
 class SmtContext:
     """Z3 solver context with AST-to-Z3 expression translation."""
 
-    def __init__(self, timeout_ms: int = 10_000) -> None:
+    def __init__(
+        self,
+        timeout_ms: int = 10_000,
+        fn_lookup: Callable[[str], Any] | None = None,
+    ) -> None:
         self.solver = z3.Solver()
         self.solver.set("timeout", timeout_ms)
         self._vars: dict[str, z3.ExprRef] = {}
         self._result_var: z3.ExprRef | None = None
         # Uninterpreted function for length (constrained >= 0)
         self._length_fn = z3.Function("length", z3.IntSort(), z3.IntSort())
+        # Callee contract verification
+        self._fn_lookup = fn_lookup
+        self._call_violations: list[CallViolation] = []
+        self._fresh_counter: int = 0
 
     # -----------------------------------------------------------------
     # Variable management
@@ -124,6 +146,17 @@ class SmtContext:
     def get_var(self, name: str) -> z3.ExprRef | None:
         """Look up a declared variable by name."""
         return self._vars.get(name)
+
+    def _fresh_name(self, prefix: str) -> str:
+        """Generate a unique Z3 variable name."""
+        self._fresh_counter += 1
+        return f"_call_{prefix}_{self._fresh_counter}"
+
+    def drain_call_violations(self) -> list[CallViolation]:
+        """Return accumulated call-site violations and clear the list."""
+        violations = list(self._call_violations)
+        self._call_violations.clear()
+        return violations
 
     # -----------------------------------------------------------------
     # Expression translation
@@ -260,19 +293,106 @@ class SmtContext:
     def _translate_call(
         self, call: ast.FnCall, env: SlotEnv
     ) -> z3.ExprRef | None:
-        """Translate built-in function calls.
+        """Translate a function call via modular contract verification.
 
-        Only ``length()`` is supported (as an uninterpreted function
-        constrained to return >= 0).  All other calls return None.
+        For ``length()``, uses the built-in uninterpreted function.
+        For user-defined functions:
+          1. Look up the callee's FunctionInfo
+          2. Translate actual arguments in the caller's env
+          3. Check each callee precondition holds (solver has caller assumptions)
+          4. Create a fresh return variable
+          5. Assume callee postconditions about the return variable
+          6. Return the fresh variable
         """
+        # Built-in: length()
         if call.name == "length" and len(call.args) == 1:
             arg = self.translate_expr(call.args[0], env)
             if arg is not None:
                 result = self._length_fn(arg)
-                # length is always non-negative
                 self.solver.add(result >= 0)
                 return result
-        return None
+            return None
+
+        # No function lookup → can't do modular verification
+        if self._fn_lookup is None:
+            return None
+
+        callee_info = self._fn_lookup(call.name)
+        if callee_info is None:
+            return None
+
+        # Generic functions can't be translated to Z3
+        if callee_info.forall_vars:
+            return None
+
+        # Must have matching arity
+        if len(call.args) != len(callee_info.param_type_exprs):
+            return None
+
+        # Translate actual arguments in the caller's env
+        z3_args: list[z3.ExprRef] = []
+        for arg_expr in call.args:
+            z3_arg = self.translate_expr(arg_expr, env)
+            if z3_arg is None:
+                return None
+            z3_args.append(z3_arg)
+
+        # Build callee's SlotEnv: push params in declaration order
+        callee_env = SlotEnv()
+        for param_te, z3_arg in zip(callee_info.param_type_exprs, z3_args):
+            slot_name = self._type_expr_to_slot_name(param_te)
+            if slot_name is None:
+                return None
+            callee_env = callee_env.push(slot_name, z3_arg)
+
+        # Check each callee precondition
+        for contract in callee_info.contracts:
+            if not isinstance(contract, ast.Requires):
+                continue
+            # Skip trivial requires(true)
+            if isinstance(contract.expr, ast.BoolLit) and contract.expr.value:
+                continue
+            z3_pre = self.translate_expr(contract.expr, callee_env)
+            if z3_pre is None:
+                # Can't translate precondition → bail to Tier 3
+                return None
+            # Check validity: solver state already has caller's assumptions
+            result = self.check_valid(z3_pre, [])
+            if result.status != "verified":
+                self._call_violations.append(CallViolation(
+                    callee_name=call.name,
+                    call_node=call,
+                    precondition=contract,
+                    counterexample=result.counterexample,
+                ))
+                return None
+
+        # Create fresh return variable
+        from vera.types import NAT, BOOL, RefinedType
+        ret_type = callee_info.return_type
+        base_ret = ret_type.base if isinstance(ret_type, RefinedType) else ret_type
+        fresh = self._fresh_name(call.name)
+        if base_ret == NAT:
+            ret_var = self.declare_nat(fresh)
+        elif base_ret == BOOL:
+            ret_var = self.declare_bool(fresh)
+        else:
+            ret_var = self.declare_int(fresh)
+
+        # Assume callee postconditions about the return variable
+        saved_result = self._result_var
+        self._result_var = ret_var
+        for contract in callee_info.contracts:
+            if not isinstance(contract, ast.Ensures):
+                continue
+            if isinstance(contract.expr, ast.BoolLit) and contract.expr.value:
+                continue
+            z3_post = self.translate_expr(contract.expr, callee_env)
+            if z3_post is not None:
+                self.solver.add(z3_post)
+        self._result_var = saved_result
+
+        return ret_var
 
     def _translate_block(
         self, block: ast.Block, env: SlotEnv
@@ -361,3 +481,5 @@ class SmtContext:
         self.solver.reset()
         self._vars.clear()
         self._result_var = None
+        self._call_violations.clear()
+        self._fresh_counter = 0

--- a/vera/verifier.py
+++ b/vera/verifier.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass, field
 from vera import ast
 from vera.environment import FunctionInfo, TypeEnv
 from vera.errors import Diagnostic, SourceLocation
-from vera.smt import SlotEnv, SmtContext
+from vera.smt import CallViolation, SlotEnv, SmtContext
 from vera.types import (
     BOOL,
     INT,
@@ -296,7 +296,10 @@ class ContractVerifier:
                     self.summary.total += 1
             return
 
-        smt = SmtContext(timeout_ms=self.timeout_ms)
+        smt = SmtContext(
+            timeout_ms=self.timeout_ms,
+            fn_lookup=self.env.lookup_function,
+        )
         slot_env = SlotEnv()
 
         # 1. Declare Z3 constants for parameters
@@ -351,10 +354,22 @@ class ContractVerifier:
                 assumptions.append(z3_pre)
                 self.summary.tier1_verified += 1
 
-        # 4. Translate function body
+        # 4. Assert caller assumptions into solver so _translate_call
+        #    can see them during body translation.
+        for a in assumptions:
+            smt.solver.add(a)
+
+        # 5. Translate function body
         body_expr = smt.translate_expr(decl.body, slot_env)
 
-        # 5. Verify ensures clauses
+        # 6. Report any call-site precondition violations
+        for v in smt.drain_call_violations():
+            self._report_call_violation(
+                decl, v.callee_name, v.call_node,
+                v.precondition, v.counterexample,
+            )
+
+        # 7. Verify ensures clauses
         for contract in decl.contracts:
             if isinstance(contract, ast.Ensures):
                 self.summary.total += 1
@@ -372,8 +387,8 @@ class ContractVerifier:
                         f"Contract will be checked at runtime.",
                         rationale="The function body contains constructs that "
                                   "cannot be translated to SMT (e.g., "
-                                  "pattern matching, recursive calls, "
-                                  "effect operations).",
+                                  "pattern matching, effect operations, "
+                                  "generic calls).",
                         spec_ref='Chapter 6, Section 6.5 "Verification Tiers"',
                     )
                     continue
@@ -481,6 +496,53 @@ class ContractVerifier:
                 "postcondition to match the actual function behaviour."
             ),
             spec_ref='Chapter 6, Section 6.4 "Verification Conditions"',
+        )
+
+    def _report_call_violation(
+        self,
+        caller: ast.FnDecl,
+        callee_name: str,
+        call_node: ast.FnCall,
+        precondition: ast.Requires,
+        counterexample: dict[str, str] | None,
+    ) -> None:
+        """Report a call site where the callee's precondition may not hold."""
+        pre_text = self._contract_source_text(precondition)
+
+        # Build counterexample description
+        ce_lines: list[str] = []
+        if counterexample:
+            ce_lines.append("Counterexample:")
+            for name, value in sorted(counterexample.items()):
+                if not name.startswith("_call_"):
+                    ce_lines.append(f"    {name} = {value}")
+
+        ce_text = "\n  ".join(ce_lines) if ce_lines else ""
+
+        description = (
+            f"Call to '{callee_name}' in function '{caller.name}' "
+            f"may violate the callee's precondition."
+        )
+        if pre_text:
+            description += f"\n  Precondition: {pre_text}"
+        if ce_text:
+            description += f"\n  {ce_text}"
+
+        self._error(
+            call_node,
+            description,
+            rationale=(
+                "The SMT solver could not prove that the callee's "
+                "precondition holds at this call site given the caller's "
+                "assumptions. The callee may receive arguments that violate "
+                "its contract."
+            ),
+            fix=(
+                f"Add a precondition to '{caller.name}' or guard the call "
+                f"with an if-expression that ensures the callee's "
+                f"precondition is satisfied."
+            ),
+            spec_ref='Chapter 6, Section 6.4.2 "Call-Site Verification"',
         )
 
     def _contract_source_text(self, contract: ast.Contract) -> str:


### PR DESCRIPTION
## Summary
- **Modular call-site contract checking**: when function `f` calls `g`, the verifier checks `g`'s `requires()` holds at the call site given `f`'s assumptions, and assumes `g`'s `ensures()` about the return value
- Recursive functions (e.g., `factorial`) now verify `ensures()` at **Tier 1** instead of falling to Tier 3 — the single biggest gap in the verification pipeline is closed
- 13 new verifier tests (553 total), all passing; mypy clean; all 14 examples verify

### Key changes
| File | What |
|------|------|
| `vera/smt.py` | `CallViolation` dataclass, `fn_lookup`/`_fresh_counter` on `SmtContext`, rewritten `_translate_call()` with full modular verification (~100 LOC) |
| `vera/verifier.py` | Pass `fn_lookup`, assert caller assumptions into solver, drain violations, `_report_call_violation()` method (~40 LOC) |
| `vera/environment.py` | `param_type_exprs` field on `FunctionInfo` |
| `vera/registration.py` | Store `param_type_exprs=decl.params` |
| `tests/test_verifier.py` | 13 new `TestCallSiteVerification` tests + comment updates |

### Before / After
```
$ vera verify examples/factorial.vera

# Before (v0.0.10): Verification: 1 verified (Tier 1), 2 runtime checks (Tier 3)
# After  (v0.0.11): Verification: 2 verified (Tier 1), 1 runtime checks (Tier 3)
```

## Test plan
- [x] `pytest tests/ -v` — 553 tests pass
- [x] `mypy vera/` — clean
- [x] `python scripts/check_examples.py` — all 14 examples pass
- [x] `python scripts/check_version_sync.py` — v0.0.11 in sync
- [x] `vera verify examples/factorial.vera` — ensures now Tier 1
- [x] `vera verify examples/safe_divide.vera` — still passes
- [x] Pre-commit hooks all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)