### PR TITLE
Add match exhaustiveness checking (C6c) — closes #18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.12] - 2026-02-24
+
+### Added
+- **Match exhaustiveness checking** (C6c — closes #18): compile-time verification that match expressions cover all possible values
+  - ADT exhaustiveness: all constructors must be covered or a catch-all pattern must be present
+  - Bool exhaustiveness: both `true` and `false` must be covered or a catch-all present
+  - Infinite type exhaustiveness: `Int`, `String`, `Float64`, `Nat` matches require a wildcard `_` or binding pattern
+  - Unreachable arm warnings: arms after a wildcard or binding catch-all produce warnings (Spec Section 4.9.3)
+  - Refinement types properly stripped via `base_type()` before analysis
+  - Error diagnostics include missing constructor/value names and fix suggestions
+- **Type checker tests**: 17 new tests — ADT exhaustive/missing/wildcard/binding, Bool exhaustive/missing/wildcard, Int/String without wildcard, unreachable arms (single/multiple/after binding), wildcard only, refined type stripping (570 total, up from 553)
+
 ## [0.0.11] - 2026-02-24
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ vera parse file.vera              # Print the parse tree
 vera ast file.vera                # Print the typed AST
 vera ast --json file.vera         # Print the AST as JSON
 
-pytest tests/ -v                  # Run the test suite (553 tests)
+pytest tests/ -v                  # Run the test suite (570 tests)
 mypy vera/                        # Type-check the compiler itself
 
 python scripts/check_examples.py      # Verify all 14 examples parse + check + verify

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ The code generator compiles 6 of 14 examples. C6 extends WASM compilation to all
 |-----------|-------|--------|---------|
 | ~~C6a~~ | ~~Float64 — `f64` literals, arithmetic, comparisons~~ | ~~#25~~ | ~~Done (v0.0.10)~~ |
 | ~~C6b~~ | ~~Callee preconditions — verify `requires()` at call sites~~ | ~~#19~~ | ~~Done (v0.0.11)~~ |
-| C6c | Match exhaustiveness — verify all constructors covered | #18 | — |
+| ~~C6c~~ | ~~Match exhaustiveness — verify all constructors covered~~ | ~~#18~~ | ~~Done (v0.0.12)~~ |
 | C6d | State\<T\> operations — get/put as host imports | — | increment.vera |
 
 **Allocator and data types (sequential chain):**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.11"
+version = "0.0.12"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -948,3 +948,256 @@ fn foo(@Unit -> @Nat)
   requires(true) ensures(true) effects(pure)
 { 42 }
 """)
+
+
+# =====================================================================
+# Exhaustiveness checking
+# =====================================================================
+
+class TestExhaustiveness:
+
+    # --- ADT exhaustiveness ---
+
+    def test_adt_exhaustive(self) -> None:
+        """All constructors covered → no error."""
+        _check_ok("""
+data Option<T> { None, Some(T) }
+
+fn unwrap(@Option<Int> -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  match @Option<Int>.0 {
+    None -> 0,
+    Some(@Int) -> @Int.0
+  }
+}
+""")
+
+    def test_adt_missing_constructor(self) -> None:
+        """Missing None constructor → non-exhaustive error."""
+        _check_err("""
+data Option<T> { None, Some(T) }
+
+fn unwrap(@Option<Int> -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  match @Option<Int>.0 {
+    Some(@Int) -> @Int.0
+  }
+}
+""", "Non-exhaustive")
+
+    def test_adt_missing_multiple(self) -> None:
+        """Missing both Err constructor → error mentions missing ones."""
+        errs = _check_err("""
+data Result<T, E> { Ok(T), Err(E) }
+
+fn get(@Result<Int, String> -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  match @Result<Int, String>.0 {
+    Ok(@Int) -> @Int.0
+  }
+}
+""", "Non-exhaustive")
+        desc = " ".join(e.description for e in errs)
+        assert "Err" in desc
+
+    def test_adt_with_wildcard(self) -> None:
+        """Wildcard after Some covers None → exhaustive."""
+        _check_ok("""
+data Option<T> { None, Some(T) }
+
+fn unwrap(@Option<Int> -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  match @Option<Int>.0 {
+    Some(@Int) -> @Int.0,
+    _ -> 0
+  }
+}
+""")
+
+    def test_adt_with_binding(self) -> None:
+        """Binding pattern is a catch-all → exhaustive."""
+        _check_ok("""
+data Option<T> { None, Some(T) }
+
+fn unwrap(@Option<Int> -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  match @Option<Int>.0 {
+    Some(@Int) -> @Int.0,
+    @Option<Int> -> 0
+  }
+}
+""")
+
+    # --- Bool exhaustiveness ---
+
+    def test_bool_exhaustive(self) -> None:
+        """Both true and false covered → no error."""
+        _check_ok("""
+fn to_str(@Bool -> @String)
+  requires(true) ensures(true) effects(pure)
+{
+  match @Bool.0 {
+    true -> "yes",
+    false -> "no"
+  }
+}
+""")
+
+    def test_bool_missing_true(self) -> None:
+        """Only false covered → non-exhaustive."""
+        _check_err("""
+fn to_str(@Bool -> @String)
+  requires(true) ensures(true) effects(pure)
+{
+  match @Bool.0 {
+    false -> "no"
+  }
+}
+""", "Non-exhaustive")
+
+    def test_bool_missing_false(self) -> None:
+        """Only true covered → non-exhaustive."""
+        _check_err("""
+fn to_str(@Bool -> @String)
+  requires(true) ensures(true) effects(pure)
+{
+  match @Bool.0 {
+    true -> "yes"
+  }
+}
+""", "Non-exhaustive")
+
+    def test_bool_with_wildcard(self) -> None:
+        """true + wildcard → exhaustive."""
+        _check_ok("""
+fn to_str(@Bool -> @String)
+  requires(true) ensures(true) effects(pure)
+{
+  match @Bool.0 {
+    true -> "yes",
+    _ -> "no"
+  }
+}
+""")
+
+    # --- Infinite type exhaustiveness ---
+
+    def test_int_with_wildcard(self) -> None:
+        """Int literals + wildcard → exhaustive."""
+        _check_ok("""
+fn classify(@Int -> @String)
+  requires(true) ensures(true) effects(pure)
+{
+  match @Int.0 {
+    0 -> "zero",
+    1 -> "one",
+    _ -> "other"
+  }
+}
+""")
+
+    def test_int_without_wildcard(self) -> None:
+        """Int with only literals → non-exhaustive."""
+        _check_err("""
+fn classify(@Int -> @String)
+  requires(true) ensures(true) effects(pure)
+{
+  match @Int.0 {
+    0 -> "zero",
+    1 -> "one"
+  }
+}
+""", "Non-exhaustive")
+
+    def test_string_without_wildcard(self) -> None:
+        """String with only literals → non-exhaustive."""
+        _check_err("""
+fn classify(@String -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  match @String.0 {
+    "hello" -> 1,
+    "world" -> 2
+  }
+}
+""", "Non-exhaustive")
+
+    # --- Unreachable arms ---
+
+    def test_unreachable_after_wildcard(self) -> None:
+        """Arm after wildcard → unreachable warning."""
+        warns = _warnings("""
+fn classify(@Int -> @String)
+  requires(true) ensures(true) effects(pure)
+{
+  match @Int.0 {
+    0 -> "zero",
+    _ -> "other",
+    1 -> "one"
+  }
+}
+""")
+        assert any("Unreachable" in w.description for w in warns)
+
+    def test_unreachable_after_binding(self) -> None:
+        """Arm after binding pattern → unreachable warning."""
+        warns = _warnings("""
+fn classify(@Int -> @String)
+  requires(true) ensures(true) effects(pure)
+{
+  match @Int.0 {
+    0 -> "zero",
+    @Int -> "other",
+    1 -> "one"
+  }
+}
+""")
+        assert any("Unreachable" in w.description for w in warns)
+
+    def test_multiple_unreachable(self) -> None:
+        """Multiple arms after wildcard → multiple warnings."""
+        warns = _warnings("""
+fn classify(@Int -> @String)
+  requires(true) ensures(true) effects(pure)
+{
+  match @Int.0 {
+    _ -> "any",
+    0 -> "zero",
+    1 -> "one"
+  }
+}
+""")
+        unreachable = [w for w in warns if "Unreachable" in w.description]
+        assert len(unreachable) == 2
+
+    # --- Edge cases ---
+
+    def test_wildcard_only(self) -> None:
+        """Single wildcard arm → exhaustive."""
+        _check_ok("""
+fn identity(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  match @Int.0 {
+    _ -> @Int.0
+  }
+}
+""")
+
+    def test_refined_type_stripped(self) -> None:
+        """Refined Int scrutinee still needs wildcard."""
+        _check_err("""
+fn classify(@Int -> @String)
+  requires(@Int.0 > 0) ensures(true) effects(pure)
+{
+  match @Int.0 {
+    1 -> "one",
+    2 -> "two"
+  }
+}
+""", "Non-exhaustive")

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.11"
+__version__ = "0.0.12"

--- a/vera/checker.py
+++ b/vera/checker.py
@@ -38,6 +38,7 @@ from vera.types import (
     EffectInstance,
     EffectRowType,
     FunctionType,
+    PrimitiveType,
     PureEffectRow,
     RefinedType,
     Type,
@@ -1174,7 +1175,105 @@ class TypeChecker:
                         spec_ref='Chapter 4, Section 4.9 "Pattern Matching"',
                     )
 
+        self._check_exhaustiveness(expr, scrutinee_ty)
         return result_type or UnknownType()
+
+    def _check_exhaustiveness(
+        self, expr: ast.MatchExpr, scrutinee_ty: Type
+    ) -> None:
+        """Check that match arms cover all possible values of the scrutinee.
+
+        Spec Section 4.9.2: compiler MUST verify match is exhaustive.
+        Spec Section 4.9.3: compiler SHOULD warn about unreachable arms.
+        """
+        raw_ty = base_type(scrutinee_ty)
+
+        # --- Unreachable arm detection ---
+        catch_all_idx: int | None = None
+        for i, arm in enumerate(expr.arms):
+            pat = arm.pattern
+            if isinstance(pat, (ast.WildcardPattern, ast.BindingPattern)):
+                catch_all_idx = i
+                break
+
+        if catch_all_idx is not None:
+            # Warn about arms after the catch-all
+            for j in range(catch_all_idx + 1, len(expr.arms)):
+                self._error(
+                    expr.arms[j].pattern,
+                    "Unreachable match arm: pattern after catch-all "
+                    "will never match.",
+                    severity="warning",
+                    rationale="A wildcard or binding pattern already "
+                    "matches all remaining values.",
+                    fix="Remove this arm or move it before the catch-all.",
+                    spec_ref='Chapter 4, Section 4.9.3 "Unreachable Arms"',
+                )
+            return  # catch-all guarantees exhaustiveness
+
+        # --- ADT exhaustiveness ---
+        if isinstance(raw_ty, AdtType):
+            adt_info = self.env.data_types.get(raw_ty.name)
+            if adt_info is None:
+                return  # unknown ADT, can't check
+            all_ctors = set(adt_info.constructors.keys())
+            covered: set[str] = set()
+            for arm in expr.arms:
+                pat = arm.pattern
+                if isinstance(pat, ast.ConstructorPattern):
+                    covered.add(pat.name)
+                elif isinstance(pat, ast.NullaryPattern):
+                    covered.add(pat.name)
+            missing = sorted(all_ctors - covered)
+            if missing:
+                self._error(
+                    expr,
+                    f"Non-exhaustive match: missing patterns for "
+                    f"{', '.join(missing)}.",
+                    rationale="All constructors of the matched type "
+                    "must be covered.",
+                    fix="Add a wildcard '_' arm or cover all cases.",
+                    spec_ref='Chapter 4, Section 4.9.2 '
+                    '"Exhaustiveness Checking"',
+                )
+            return
+
+        # --- Bool exhaustiveness ---
+        if isinstance(raw_ty, PrimitiveType) and raw_ty.name == "Bool":
+            covered_bools: set[bool] = set()
+            for arm in expr.arms:
+                pat = arm.pattern
+                if isinstance(pat, ast.BoolPattern):
+                    covered_bools.add(pat.value)
+            missing_bools = []
+            if True not in covered_bools:
+                missing_bools.append("true")
+            if False not in covered_bools:
+                missing_bools.append("false")
+            if missing_bools:
+                self._error(
+                    expr,
+                    f"Non-exhaustive match: missing patterns for "
+                    f"{', '.join(missing_bools)}.",
+                    rationale="Bool matches must cover both true and false.",
+                    fix="Add a wildcard '_' arm or cover all cases.",
+                    spec_ref='Chapter 4, Section 4.9.2 '
+                    '"Exhaustiveness Checking"',
+                )
+            return
+
+        # --- Infinite types (Int, String, Float64, Nat, etc.) ---
+        # No catch-all found and type has infinite domain → non-exhaustive
+        self._error(
+            expr,
+            "Non-exhaustive match: type has infinite domain, "
+            "a wildcard '_' or binding pattern is required.",
+            rationale="Matches on types with infinite values cannot "
+            "enumerate all cases.",
+            fix="Add a wildcard '_' arm or a binding pattern.",
+            spec_ref='Chapter 4, Section 4.9.2 '
+            '"Exhaustiveness Checking"',
+        )
 
     # -----------------------------------------------------------------
     # Patterns


### PR DESCRIPTION
## Summary
- **Match exhaustiveness checking** in the type checker (`checker.py`) — Spec Section 4.9.2
- ADT types: all constructors must be covered or a catch-all pattern present
- Bool: both `true` and `false` must be covered or a catch-all present
- Infinite types (Int, String, Float64, Nat): require wildcard `_` or binding pattern
- Unreachable arm warnings after catch-all patterns (Spec Section 4.9.3)
- 17 new tests in `TestExhaustiveness` (570 total, up from 553)
- Version bump to v0.0.12

## Test plan
- [x] All 570 tests pass (`pytest tests/ -v`)
- [x] mypy clean (`mypy vera/`)
- [x] All 14 examples pass (`python scripts/check_examples.py`)
- [x] Version sync verified (`python scripts/check_version_sync.py`)
- [x] Pre-commit hooks pass (mypy, pytest, examples, readme)

🤖 Generated with [Claude Code](https://claude.com/claude-code)