### PR TITLE
Add State<T> host imports for WASM codegen (C6d)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.13] - 2026-02-24
+
+### Added
+- **State\<T\> WASM host imports** (C6d): compile `get`/`put` operations for `State<T>` effects as WASM host imports
+  - `State<Int>`, `State<Nat>`, `State<Bool>`, `State<Float64>` compile to typed host import pairs
+  - `get(())` → `call $vera.state_get_{T}` (returns typed value); `put(x)` → `call $vera.state_put_{T}` (consumes typed value)
+  - Host runtime maintains mutable state cells per type, initialized to zero
+  - `execute()` accepts optional `initial_state` parameter and returns final `state` in `ExecuteResult`
+  - Mixed effects supported: `effects(<State<Int>, IO>)` compiles correctly
+  - `effect_ops` dict mechanism in `WasmContext` redirects bare `get`/`put` calls to host imports
+  - `_is_void_expr` recognizes `put()` as void (no `drop` emitted in ExprStmt)
+- **Codegen tests**: 15 new tests — get default, put-then-get, increment pattern, example file, Bool/Float64/Nat state, String rejection, mixed effects, WAT imports, multiple types, void semantics, initial state override, pure function purity (585 total, up from 570)
+- `examples/increment.vera` now compiles and runs (7 of 14 examples compilable)
+
 ## [0.0.12] - 2026-02-24
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ vera parse file.vera              # Print the parse tree
 vera ast file.vera                # Print the typed AST
 vera ast --json file.vera         # Print the AST as JSON
 
-pytest tests/ -v                  # Run the test suite (570 tests)
+pytest tests/ -v                  # Run the test suite (585 tests)
 mypy vera/                        # Type-check the compiler itself
 
 python scripts/check_examples.py      # Verify all 14 examples parse + check + verify

--- a/README.md
+++ b/README.md
@@ -159,13 +159,13 @@ Development follows an **interleaved spiral** — each phase adds a complete com
 | C3 | v0.0.5 | **Type checker** — decidable type checking, slot resolution, effect tracking | Done |
 | C4 | v0.0.8 | **Contract verifier** — Z3 integration, refinement types, counterexamples | Done |
 | C5 | v0.0.9 | **WASM codegen** — compile to WebAssembly, `vera compile` / `vera run` | Done |
-| C6 | v0.0.10–0.0.23 | **Codegen completeness** — ADTs, match, closures, effects, generics in WASM | **In progress** (C6a done) |
+| C6 | v0.0.10–0.0.23 | **Codegen completeness** — ADTs, match, closures, effects, generics in WASM | **In progress** (C6a–C6d done) |
 | C7 | — | **Module system** — cross-file imports, public/private visibility | Planned |
 | C8 | v0.1.0 | **End-to-end** — all examples compile and run, spec complete, polish | Planned |
 
 ### What's next: C6 — Codegen Completeness (v0.0.10–v0.0.23)
 
-The code generator compiles 6 of 14 examples. C6 extends WASM compilation to all language constructs, working through the dependency graph from simplest to most complex.
+The code generator compiles 7 of 14 examples. C6 extends WASM compilation to all language constructs, working through the dependency graph from simplest to most complex.
 
 **Independent tasks (no dependencies on each other):**
 
@@ -174,7 +174,7 @@ The code generator compiles 6 of 14 examples. C6 extends WASM compilation to all
 | ~~C6a~~ | ~~Float64 — `f64` literals, arithmetic, comparisons~~ | ~~#25~~ | ~~Done (v0.0.10)~~ |
 | ~~C6b~~ | ~~Callee preconditions — verify `requires()` at call sites~~ | ~~#19~~ | ~~Done (v0.0.11)~~ |
 | ~~C6c~~ | ~~Match exhaustiveness — verify all constructors covered~~ | ~~#18~~ | ~~Done (v0.0.12)~~ |
-| C6d | State\<T\> operations — get/put as host imports | — | increment.vera |
+| ~~C6d~~ | ~~State\<T\> operations — get/put as host imports~~ | — | ~~Done (v0.0.13)~~ |
 
 **Allocator and data types (sequential chain):**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.12"
+version = "0.0.13"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -1395,3 +1395,211 @@ fn compute(-> @Int)
         assert "main" not in result.exports
         exec_result = execute(result)  # no fn_name specified
         assert exec_result.value == 99
+
+
+# =====================================================================
+# 6d: State<T> host imports
+# =====================================================================
+
+def _run_state(
+    source: str,
+    fn: str | None = None,
+    args: list[int | float] | None = None,
+    initial_state: dict[str, int | float] | None = None,
+) -> ExecuteResult:
+    """Compile, execute, and return the full ExecuteResult."""
+    result = _compile_ok(source)
+    return execute(result, fn_name=fn, args=args, initial_state=initial_state)
+
+
+class TestStateEffect:
+
+    def test_state_int_get_default(self) -> None:
+        """get(()) returns 0 by default for State<Int>."""
+        source = """\
+fn f(-> @Int)
+  requires(true) ensures(true) effects(<State<Int>>)
+{ get(()) }
+"""
+        exec_result = _run_state(source, fn="f")
+        assert exec_result.value == 0
+
+    def test_state_int_put_then_get(self) -> None:
+        """put(42) then get(()) returns 42."""
+        source = """\
+fn f(-> @Int)
+  requires(true) ensures(true) effects(<State<Int>>)
+{
+  put(42);
+  get(())
+}
+"""
+        exec_result = _run_state(source, fn="f")
+        assert exec_result.value == 42
+
+    def test_increment_pattern(self) -> None:
+        """Classic increment: get, add 1, put — state goes from 0 to 1."""
+        source = """\
+fn increment(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<State<Int>>)
+{
+  let @Int = get(());
+  put(@Int.0 + 1);
+  ()
+}
+"""
+        exec_result = _run_state(source, fn="increment")
+        assert exec_result.value is None  # Unit return
+        assert exec_result.state["State_Int"] == 1
+
+    def test_increment_example_file(self) -> None:
+        """examples/increment.vera compiles and executes."""
+        from pathlib import Path
+        path = Path(__file__).parent.parent / "examples" / "increment.vera"
+        source = path.read_text()
+        tree = parse_file(str(path))
+        program = transform(tree)
+        result = compile(program, source=source, file=str(path))
+        assert result.ok
+        assert "increment" in result.exports
+        exec_result = execute(result, fn_name="increment")
+        assert exec_result.state["State_Int"] == 1
+
+    def test_state_bool_get_default(self) -> None:
+        """Bool state defaults to 0 (false)."""
+        source = """\
+fn f(-> @Bool)
+  requires(true) ensures(true) effects(<State<Bool>>)
+{ get(()) }
+"""
+        exec_result = _run_state(source, fn="f")
+        assert exec_result.value == 0
+
+    def test_state_bool_put_get(self) -> None:
+        """put(true) then get(()) returns 1."""
+        source = """\
+fn f(-> @Bool)
+  requires(true) ensures(true) effects(<State<Bool>>)
+{
+  put(true);
+  get(())
+}
+"""
+        exec_result = _run_state(source, fn="f")
+        assert exec_result.value == 1
+
+    def test_state_float64_get_default(self) -> None:
+        """Float64 state defaults to 0.0."""
+        source = """\
+fn f(-> @Float64)
+  requires(true) ensures(true) effects(<State<Float64>>)
+{ get(()) }
+"""
+        exec_result = _run_state(source, fn="f")
+        assert exec_result.value == 0.0
+
+    def test_state_nat_compiles(self) -> None:
+        """State<Nat> compiles (Nat maps to i64)."""
+        source = """\
+fn f(-> @Nat)
+  requires(true) ensures(true) effects(<State<Nat>>)
+{ get(()) }
+"""
+        exec_result = _run_state(source, fn="f")
+        assert exec_result.value == 0
+
+    def test_state_string_rejected(self) -> None:
+        """State<String> is unsupported — function skipped with warning."""
+        source = """\
+fn f(-> @Int)
+  requires(true) ensures(true) effects(<State<String>>)
+{ 42 }
+"""
+        result = _compile(source)
+        warnings = [d for d in result.diagnostics if d.severity == "warning"]
+        assert any("unsupported" in w.description.lower() for w in warnings)
+        assert "f" not in result.exports
+
+    def test_state_with_io(self) -> None:
+        """Mixed effects(<State<Int>, IO>) compiles and both work."""
+        source = """\
+fn f(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<State<Int>, IO>)
+{
+  put(42);
+  IO.print("done");
+  ()
+}
+"""
+        exec_result = _run_state(source, fn="f")
+        assert exec_result.state["State_Int"] == 42
+        assert exec_result.stdout == "done"
+
+    def test_state_wat_has_imports(self) -> None:
+        """WAT output contains State import declarations."""
+        source = """\
+fn f(-> @Int)
+  requires(true) ensures(true) effects(<State<Int>>)
+{ get(()) }
+"""
+        result = _compile_ok(source)
+        assert 'import "vera" "state_get_Int"' in result.wat
+        assert 'import "vera" "state_put_Int"' in result.wat
+
+    def test_multiple_state_types(self) -> None:
+        """Multiple State types emit all imports."""
+        source = """\
+fn f(@Int -> @Unit)
+  requires(true) ensures(true) effects(<State<Int>, State<Bool>>)
+{
+  put(@Int.0);
+  ()
+}
+"""
+        result = _compile_ok(source)
+        assert 'import "vera" "state_get_Int"' in result.wat
+        assert 'import "vera" "state_put_Int"' in result.wat
+        assert 'import "vera" "state_get_Bool"' in result.wat
+        assert 'import "vera" "state_put_Bool"' in result.wat
+        assert len(result.state_types) == 2
+
+    def test_put_void_no_drop(self) -> None:
+        """put(x) in ExprStmt does not emit a drop instruction."""
+        source = """\
+fn f(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<State<Int>>)
+{
+  put(42);
+  ()
+}
+"""
+        result = _compile_ok(source)
+        # The function body should NOT contain 'drop' after the put call
+        fn_start = result.wat.index("(func $f")
+        fn_body = result.wat[fn_start:]
+        # put call should be present, drop should not follow it
+        assert "call $vera.state_put_Int" in fn_body
+        assert "drop" not in fn_body
+
+    def test_state_initial_value(self) -> None:
+        """Initial state override: get(()) returns the initial value."""
+        source = """\
+fn f(-> @Int)
+  requires(true) ensures(true) effects(<State<Int>>)
+{ get(()) }
+"""
+        exec_result = _run_state(
+            source, fn="f", initial_state={"State_Int": 10}
+        )
+        assert exec_result.value == 10
+
+    def test_pure_no_state_imports(self) -> None:
+        """Pure functions don't produce State imports."""
+        source = """\
+fn f(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{ 42 }
+"""
+        result = _compile_ok(source)
+        assert "state_get" not in result.wat
+        assert "state_put" not in result.wat

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.12"
+__version__ = "0.0.13"

--- a/vera/codegen.py
+++ b/vera/codegen.py
@@ -3,7 +3,7 @@
 Compiles a type-checked and verified Vera Program AST to WebAssembly.
 Generates WAT (WebAssembly Text Format) as the intermediate representation,
 then converts to WASM binary via wasmtime.  Provides execution support
-with host function bindings for IO effects.
+with host function bindings for IO and State effects.
 
 See spec/11-compilation.md for the compilation specification.
 """
@@ -46,6 +46,7 @@ class CompileResult:
     wasm_bytes: bytes
     exports: list[str]
     diagnostics: list[Diagnostic] = field(default_factory=list)
+    state_types: list[tuple[str, str]] = field(default_factory=list)
 
     @property
     def ok(self) -> bool:
@@ -59,6 +60,7 @@ class ExecuteResult:
 
     value: int | float | None  # Return value (None for void/Unit functions)
     stdout: str  # Captured IO.print output
+    state: dict[str, int | float] = field(default_factory=dict)
 
 
 def compile(
@@ -80,12 +82,13 @@ def execute(
     result: CompileResult,
     fn_name: str | None = None,
     args: list[int | float] | None = None,
+    initial_state: dict[str, int | float] | None = None,
 ) -> ExecuteResult:
     """Execute a function from a compiled WASM module.
 
     Uses wasmtime to instantiate the module with host bindings
-    for IO effects.  Returns the function's return value and
-    any captured stdout output.
+    for IO and State effects.  Returns the function's return value,
+    any captured stdout output, and final state values.
     """
     if not result.ok:
         raise RuntimeError("Cannot execute: compilation had errors")
@@ -114,6 +117,52 @@ def execute(
     linker.define_func(
         "vera", "print", print_type, host_print, access_caller=True
     )
+
+    # State<T> host functions
+    _WASM_VAL_TYPE = {
+        "i64": wasmtime.ValType.i64(),
+        "i32": wasmtime.ValType.i32(),
+        "f64": wasmtime.ValType.f64(),
+    }
+    _DEFAULT_STATE: dict[str, int | float] = {
+        "i64": 0, "i32": 0, "f64": 0.0,
+    }
+
+    state_store: dict[str, int | float] = {}
+
+    for type_name, wasm_t in result.state_types:
+        state_key = f"State_{type_name}"
+        state_store[state_key] = _DEFAULT_STATE[wasm_t]
+        val_type = _WASM_VAL_TYPE[wasm_t]
+
+        # Closure factories to capture correct state_key per type
+        def _make_host_get(key: str):  # type: ignore[no-untyped-def]
+            def host_get() -> int | float:
+                return state_store[key]
+            return host_get
+
+        def _make_host_put(key: str):  # type: ignore[no-untyped-def]
+            def host_put(val: int | float) -> None:
+                state_store[key] = val
+            return host_put
+
+        get_type = wasmtime.FuncType([], [val_type])
+        linker.define_func(
+            "vera", f"state_get_{type_name}", get_type,
+            _make_host_get(state_key),
+        )
+
+        put_type = wasmtime.FuncType([val_type], [])
+        linker.define_func(
+            "vera", f"state_put_{type_name}", put_type,
+            _make_host_put(state_key),
+        )
+
+    # Apply initial state overrides (for testing)
+    if initial_state:
+        for key, val in initial_state.items():
+            if key in state_store:
+                state_store[key] = val
 
     instance = linker.instantiate(store, module)
 
@@ -149,6 +198,7 @@ def execute(
     return ExecuteResult(
         value=value,
         stdout=output_buf.getvalue(),
+        state=dict(state_store),
     )
 
 
@@ -179,6 +229,7 @@ class CodeGenerator:
         # Track which effect operations are needed
         self._needs_io_print: bool = False
         self._needs_memory: bool = False
+        self._state_types: list[tuple[str, str]] = []  # (type_name, wasm_type)
 
     # -----------------------------------------------------------------
     # Diagnostics
@@ -255,6 +306,7 @@ class CodeGenerator:
                 wasm_bytes=b"",
                 exports=exports,
                 diagnostics=self.diagnostics,
+                state_types=list(self._state_types),
             )
 
         return CompileResult(
@@ -262,6 +314,7 @@ class CodeGenerator:
             wasm_bytes=bytes(wasm_bytes),
             exports=exports,
             diagnostics=self.diagnostics,
+            state_types=list(self._state_types),
         )
 
     # -----------------------------------------------------------------
@@ -306,7 +359,25 @@ class CodeGenerator:
         if not self._is_compilable(decl):
             return None
 
-        ctx = WasmContext(self.string_pool)
+        # Build effect_ops mapping for State<T> operations
+        effect_ops: dict[str, tuple[str, bool]] = {}
+        if isinstance(decl.effect, ast.EffectSet):
+            for eff in decl.effect.effects:
+                if (isinstance(eff, ast.EffectRef) and eff.name == "State"
+                        and eff.type_args and len(eff.type_args) == 1):
+                    type_name = self._type_expr_to_slot_name(eff.type_args[0])
+                    if type_name:
+                        # Only map if no user-defined function shadows the op
+                        if "get" not in self._fn_sigs:
+                            effect_ops["get"] = (
+                                f"$vera.state_get_{type_name}", False
+                            )
+                        if "put" not in self._fn_sigs:
+                            effect_ops["put"] = (
+                                f"$vera.state_put_{type_name}", True
+                            )
+
+        ctx = WasmContext(self.string_pool, effect_ops=effect_ops)
         env = WasmSlotEnv()
 
         # Allocate parameters
@@ -522,6 +593,17 @@ class CodeGenerator:
                 "(func $vera.print (param i32 i32)))"
             )
 
+        # Import State<T> host functions if needed
+        for type_name, wasm_t in self._state_types:
+            parts.append(
+                f'  (import "vera" "state_get_{type_name}" '
+                f"(func $vera.state_get_{type_name} (result {wasm_t})))"
+            )
+            parts.append(
+                f'  (import "vera" "state_put_{type_name}" '
+                f"(func $vera.state_put_{type_name} (param {wasm_t})))"
+            )
+
         # Memory (for string data)
         if self._needs_memory or self.string_pool.has_strings():
             parts.append('  (memory (export "memory") 1)')
@@ -544,25 +626,32 @@ class CodeGenerator:
     # -----------------------------------------------------------------
 
     def _is_compilable(self, decl: ast.FnDecl) -> bool:
-        """Check if a function can be compiled to WASM."""
-        # Check effect: must be pure or <IO>
+        """Check if a function can be compiled to WASM.
+
+        Accepts pure functions, IO effects, and State<T> where T is
+        a compilable primitive type (Int, Nat, Bool, Float64).
+        """
+        # Check effect: must be pure, <IO>, or <State<T>>
         effect = decl.effect
         if isinstance(effect, ast.PureEffect):
             pass  # OK
         elif isinstance(effect, ast.EffectSet):
-            # Check if all effects are IO
             for eff in effect.effects:
                 if isinstance(eff, ast.EffectRef):
                     if eff.name == "IO":
                         self._needs_io_print = True
                         self._needs_memory = True
+                    elif eff.name == "State":
+                        # State<T> — T must be a compilable primitive
+                        if not self._check_state_type(decl, eff):
+                            return False
                     else:
                         self._warning(
                             decl,
                             f"Function '{decl.name}' uses unsupported "
                             f"effect '{eff.name}' — skipped.",
-                            rationale="Only pure functions and functions "
-                            "with IO effects are compilable.",
+                            rationale="Only pure, IO, and State<T> effects "
+                            "are compilable.",
                         )
                         return False
                 else:
@@ -591,6 +680,37 @@ class CodeGenerator:
             )
             return False
 
+        return True
+
+    def _check_state_type(
+        self, decl: ast.FnDecl, eff: ast.EffectRef
+    ) -> bool:
+        """Validate a State<T> effect and register its type.
+
+        Returns True if compilable, False otherwise.
+        """
+        if not eff.type_args or len(eff.type_args) != 1:
+            self._warning(
+                decl,
+                f"Function '{decl.name}' uses State without "
+                f"a type argument — skipped.",
+                rationale="State<T> requires exactly one type argument.",
+            )
+            return False
+        type_arg = eff.type_args[0]
+        wt = self._type_expr_to_wasm_type(type_arg)
+        if wt is None or wt == "unsupported":
+            self._warning(
+                decl,
+                f"Function '{decl.name}' uses State with "
+                f"unsupported type — skipped.",
+                rationale="State<T> requires a compilable primitive type "
+                "(Int, Nat, Bool, Float64).",
+            )
+            return False
+        type_name = self._type_expr_to_slot_name(type_arg)
+        if type_name and (type_name, wt) not in self._state_types:
+            self._state_types.append((type_name, wt))
         return True
 
     # -----------------------------------------------------------------

--- a/vera/wasm.py
+++ b/vera/wasm.py
@@ -144,11 +144,19 @@ class WasmContext:
     translation.  Mirrors SmtContext in smt.py.
     """
 
-    def __init__(self, string_pool: StringPool) -> None:
+    def __init__(
+        self,
+        string_pool: StringPool,
+        effect_ops: dict[str, tuple[str, bool]] | None = None,
+    ) -> None:
         self.string_pool = string_pool
         self._next_local: int = 0
         self._locals: list[tuple[str, str]] = []  # (name, wat_type)
         self._result_local: int | None = None
+        # Effect operation mapping: op_name -> (wasm_call_target, is_void)
+        # e.g. {"get": ("$vera.state_get_Int", False),
+        #        "put": ("$vera.state_put_Int", True)}
+        self._effect_ops = effect_ops or {}
 
     def set_result_local(self, local_idx: int) -> None:
         """Set the local index used for @T.result in postconditions."""
@@ -548,8 +556,25 @@ class WasmContext:
     def _translate_call(
         self, call: ast.FnCall, env: WasmSlotEnv
     ) -> list[str] | None:
-        """Translate a function call to WASM call instruction."""
-        instructions: list[str] = []
+        """Translate a function call to WASM call instruction.
+
+        If the call name matches an effect operation (e.g. get/put for
+        State<T>), redirects to the corresponding host import.
+        """
+        # Check if this is an effect operation (e.g. get/put)
+        if call.name in self._effect_ops:
+            import_name, _is_void = self._effect_ops[call.name]
+            instructions: list[str] = []
+            for arg in call.args:
+                arg_instrs = self.translate_expr(arg, env)
+                if arg_instrs is None:
+                    return None
+                instructions.extend(arg_instrs)
+            instructions.append(f"call {import_name}")
+            return instructions
+
+        # Regular function call
+        instructions = []
         for arg in call.args:
             arg_instrs = self.translate_expr(arg, env)
             if arg_instrs is None:
@@ -595,17 +620,20 @@ class WasmContext:
     # Helpers
     # -----------------------------------------------------------------
 
-    @staticmethod
-    def _is_void_expr(expr: ast.Expr) -> bool:
+    def _is_void_expr(self, expr: ast.Expr) -> bool:
         """Check if an expression produces no value on the WASM stack.
 
         QualifiedCalls (effect operations like IO.print) return Unit
         and produce no stack value.  UnitLit also produces nothing.
+        Effect op calls like put() are also void.
         """
         if isinstance(expr, ast.QualifiedCall):
             return True  # effect ops return Unit (void)
         if isinstance(expr, ast.UnitLit):
             return True
+        if isinstance(expr, ast.FnCall) and expr.name in self._effect_ops:
+            _name, is_void = self._effect_ops[expr.name]
+            return is_void
         return False
 
     def _type_expr_to_slot_name(self, te: ast.TypeExpr) -> str | None:


### PR DESCRIPTION
## Summary
- Compile `get`/`put` operations for `State<T>` effects as WASM host imports, backed by a mutable state store in the Python runtime
- Supports `State<Int>`, `State<Nat>`, `State<Bool>`, `State<Float64>` — mixed effects like `<State<Int>, IO>` work correctly
- `effect_ops` dict mechanism in `WasmContext` redirects bare `get`/`put` calls to host imports without AST changes
- `examples/increment.vera` now compiles and runs end-to-end (7 of 14 examples compilable, up from 6)
- 15 new tests in `TestStateEffect` (585 total, up from 570)
- Version bump to v0.0.13

## Test plan
- [x] `pytest tests/ -v` — 585 tests pass
- [x] `mypy vera/` — clean (14 source files)
- [x] `python scripts/check_examples.py` — all 14 examples pass
- [x] `python scripts/check_version_sync.py` — version 0.0.13 consistent
- [x] Pre-commit hooks all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)