### PR TITLE
Add bump allocator infrastructure for ADT codegen (C6e)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.14] - 2026-02-24
+
+### Added
+- **Bump allocator infrastructure** (C6e): heap allocation support for upcoming ADT constructor codegen
+  - `$heap_ptr` mutable global: initialized to first byte after string data, exported as `"heap_ptr"`
+  - `$alloc` internal function: bump-allocates with 8-byte alignment, returns pointer to allocated block
+  - ADT layout metadata: `ConstructorLayout` dataclass stores tag, field offsets, and total size per constructor
+  - Layout computed eagerly during registration pass — available for C6f (constructor codegen) and C6g (match codegen)
+  - Allocator and heap global emitted only when user-declared ADTs are present (no overhead for pure programs)
+  - `StringPool.heap_offset` property exposes first free byte after string constants
+- **Codegen tests**: 26 new tests — layout helpers, WAT output inspection, ADT metadata registration, conditional emission (611 total, up from 585)
+
 ## [0.0.13] - 2026-02-24
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ vera parse file.vera              # Print the parse tree
 vera ast file.vera                # Print the typed AST
 vera ast --json file.vera         # Print the AST as JSON
 
-pytest tests/ -v                  # Run the test suite (585 tests)
+pytest tests/ -v                  # Run the test suite (611 tests)
 mypy vera/                        # Type-check the compiler itself
 
 python scripts/check_examples.py      # Verify all 14 examples parse + check + verify

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Development follows an **interleaved spiral** — each phase adds a complete com
 | C3 | v0.0.5 | **Type checker** — decidable type checking, slot resolution, effect tracking | Done |
 | C4 | v0.0.8 | **Contract verifier** — Z3 integration, refinement types, counterexamples | Done |
 | C5 | v0.0.9 | **WASM codegen** — compile to WebAssembly, `vera compile` / `vera run` | Done |
-| C6 | v0.0.10–0.0.23 | **Codegen completeness** — ADTs, match, closures, effects, generics in WASM | **In progress** (C6a–C6d done) |
+| C6 | v0.0.10–0.0.23 | **Codegen completeness** — ADTs, match, closures, effects, generics in WASM | **In progress** (C6a–C6e done) |
 | C7 | — | **Module system** — cross-file imports, public/private visibility | Planned |
 | C8 | v0.1.0 | **End-to-end** — all examples compile and run, spec complete, polish | Planned |
 
@@ -180,7 +180,7 @@ The code generator compiles 7 of 14 examples. C6 extends WASM compilation to all
 
 | Sub-phase | Scope | Closes | Unlocks |
 |-----------|-------|--------|---------|
-| C6e | Bump allocator — heap allocation for tagged values | — | — |
+| ~~C6e~~ | ~~Bump allocator — heap allocation for tagged values~~ | — | ~~Done (v0.0.14)~~ |
 | C6f | ADT constructors — heap-allocated tagged unions | — | — |
 | C6g | Match expressions — tag dispatch, field extraction | #26 | pattern_matching.vera |
 | C6i | Generics — monomorphization of `forall<T>` functions | #29 | generics.vera, list_ops.vera |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.13"
+version = "0.0.14"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -13,7 +13,16 @@ from __future__ import annotations
 import pytest
 import wasmtime
 
-from vera.codegen import CompileResult, ExecuteResult, compile, execute
+from vera.codegen import (
+    CompileResult,
+    ConstructorLayout,
+    ExecuteResult,
+    _align_up,
+    _wasm_type_align,
+    _wasm_type_size,
+    compile,
+    execute,
+)
 from vera.parser import parse_file
 from vera.transform import transform
 
@@ -1603,3 +1612,282 @@ fn f(-> @Int)
         result = _compile_ok(source)
         assert "state_get" not in result.wat
         assert "state_put" not in result.wat
+
+
+# =====================================================================
+# 6e: Bump allocator infrastructure
+# =====================================================================
+
+
+def _compile_with_generator(source: str):
+    """Compile and return both result and CodeGenerator for metadata inspection."""
+    import tempfile
+    from vera.codegen import CodeGenerator
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".vera", delete=False
+    ) as f:
+        f.write(source)
+        f.flush()
+        path = f.name
+
+    tree = parse_file(path)
+    program = transform(tree)
+    gen = CodeGenerator(source=source, file=path)
+    result = gen.compile_program(program)
+    return result, gen
+
+
+class TestLayoutHelpers:
+    """Unit tests for ADT memory layout helper functions."""
+
+    def test_align_up_already_aligned(self) -> None:
+        assert _align_up(8, 8) == 8
+
+    def test_align_up_needs_padding(self) -> None:
+        assert _align_up(5, 8) == 8
+
+    def test_align_up_zero(self) -> None:
+        assert _align_up(0, 8) == 0
+
+    def test_align_up_to_four(self) -> None:
+        assert _align_up(5, 4) == 8
+
+    def test_align_up_one(self) -> None:
+        assert _align_up(1, 8) == 8
+
+    def test_wasm_type_size_i32(self) -> None:
+        assert _wasm_type_size("i32") == 4
+
+    def test_wasm_type_size_i64(self) -> None:
+        assert _wasm_type_size("i64") == 8
+
+    def test_wasm_type_size_f64(self) -> None:
+        assert _wasm_type_size("f64") == 8
+
+    def test_wasm_type_align_i32(self) -> None:
+        assert _wasm_type_align("i32") == 4
+
+    def test_wasm_type_align_i64(self) -> None:
+        assert _wasm_type_align("i64") == 8
+
+    def test_wasm_type_align_f64(self) -> None:
+        assert _wasm_type_align("f64") == 8
+
+
+class TestHeapAllocation:
+    """Test heap infrastructure emission in WAT output."""
+
+    def test_heap_ptr_global_emitted(self) -> None:
+        """When ADTs are declared, $heap_ptr global appears in WAT."""
+        source = """\
+data Color { Red, Green, Blue }
+
+fn f(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{ 42 }
+"""
+        result = _compile_ok(source)
+        assert "global $heap_ptr" in result.wat
+        assert 'export "heap_ptr"' in result.wat
+
+    def test_alloc_function_emitted(self) -> None:
+        """When ADTs are declared, $alloc function appears in WAT."""
+        source = """\
+data Color { Red, Green, Blue }
+
+fn f(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{ 42 }
+"""
+        result = _compile_ok(source)
+        assert "func $alloc" in result.wat
+        assert "global.get $heap_ptr" in result.wat
+        assert "global.set $heap_ptr" in result.wat
+
+    def test_no_alloc_without_adt(self) -> None:
+        """Pure programs without ADTs should NOT emit allocator."""
+        source = """\
+fn f(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{ 42 }
+"""
+        result = _compile_ok(source)
+        assert "heap_ptr" not in result.wat
+        assert "$alloc" not in result.wat
+
+    def test_heap_ptr_starts_after_strings(self) -> None:
+        """Heap pointer initial value should be after string data."""
+        source = """\
+data Color { Red, Green, Blue }
+
+fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{ IO.print("hello") }
+"""
+        result = _compile_ok(source)
+        # "hello" is 5 bytes, so heap_ptr should start at offset 5
+        assert "global $heap_ptr" in result.wat
+        assert "i32.const 5" in result.wat
+
+    def test_heap_ptr_zero_without_strings(self) -> None:
+        """Without strings, heap starts at offset 0."""
+        source = """\
+data Flag { On, Off }
+
+fn f(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{ 42 }
+"""
+        result = _compile_ok(source)
+        assert "i32.const 0)" in result.wat  # heap_ptr init
+
+    def test_alloc_alignment_logic(self) -> None:
+        """Alloc function contains 8-byte alignment rounding."""
+        source = """\
+data Bit { Zero, One }
+
+fn f(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{ 42 }
+"""
+        result = _compile_ok(source)
+        assert "i32.const 7" in result.wat
+        assert "i32.const -8" in result.wat
+
+    def test_memory_emitted_with_adt(self) -> None:
+        """ADTs cause memory to be declared even without strings."""
+        source = """\
+data Flag { On, Off }
+
+fn f(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{ 42 }
+"""
+        result = _compile_ok(source)
+        assert "(memory" in result.wat
+
+
+class TestAdtMetadata:
+    """Test ADT constructor layout metadata registration."""
+
+    def test_nullary_layout(self) -> None:
+        """Nullary constructor: tag only, total_size = 8."""
+        source = """\
+data Unit2 { MkUnit }
+
+fn f(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{ 42 }
+"""
+        _result, gen = _compile_with_generator(source)
+        layout = gen._adt_layouts["Unit2"]["MkUnit"]
+        assert layout.tag == 0
+        assert layout.field_offsets == ()
+        assert layout.total_size == 8
+
+    def test_single_int_field_layout(self) -> None:
+        """Constructor with Int field: tag(4) + pad(4) + i64(8) = 16."""
+        source = """\
+data Wrapper { Wrap(Int) }
+
+fn f(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{ 42 }
+"""
+        _result, gen = _compile_with_generator(source)
+        layout = gen._adt_layouts["Wrapper"]["Wrap"]
+        assert layout.tag == 0
+        assert layout.field_offsets == ((8, "i64"),)
+        assert layout.total_size == 16
+
+    def test_multiple_fields_layout(self) -> None:
+        """Constructor with Int + Bool: tag(4) + pad(4) + i64(8) + i32(4) → 24."""
+        source = """\
+data Pair { MkPair(Int, Bool) }
+
+fn f(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{ 42 }
+"""
+        _result, gen = _compile_with_generator(source)
+        layout = gen._adt_layouts["Pair"]["MkPair"]
+        assert layout.tag == 0
+        assert layout.field_offsets[0] == (8, "i64")   # Int at offset 8
+        assert layout.field_offsets[1] == (16, "i32")   # Bool at offset 16
+        assert layout.total_size == 24  # 20 aligned up to 24
+
+    def test_multiple_constructors_tags(self) -> None:
+        """Each constructor gets a sequential tag."""
+        source = """\
+data Color { Red, Green, Blue }
+
+fn f(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{ 42 }
+"""
+        _result, gen = _compile_with_generator(source)
+        layouts = gen._adt_layouts["Color"]
+        assert layouts["Red"].tag == 0
+        assert layouts["Green"].tag == 1
+        assert layouts["Blue"].tag == 2
+
+    def test_float64_field_layout(self) -> None:
+        """Constructor with Float64 field: tag(4) + pad(4) + f64(8) = 16."""
+        source = """\
+data Box { MkBox(Float64) }
+
+fn f(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{ 42 }
+"""
+        _result, gen = _compile_with_generator(source)
+        layout = gen._adt_layouts["Box"]["MkBox"]
+        assert layout.field_offsets == ((8, "f64"),)
+        assert layout.total_size == 16
+
+    def test_bool_field_layout(self) -> None:
+        """Constructor with Bool field: tag(4) + i32(4) = 8."""
+        source = """\
+data Toggle { MkToggle(Bool) }
+
+fn f(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{ 42 }
+"""
+        _result, gen = _compile_with_generator(source)
+        layout = gen._adt_layouts["Toggle"]["MkToggle"]
+        assert layout.field_offsets == ((4, "i32"),)  # i32 aligns to 4
+        assert layout.total_size == 8
+
+    def test_type_param_is_pointer(self) -> None:
+        """Type parameters map to i32 (pointer)."""
+        source = """\
+data Box<T> { MkBox(T) }
+
+fn f(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{ 42 }
+"""
+        _result, gen = _compile_with_generator(source)
+        layout = gen._adt_layouts["Box"]["MkBox"]
+        assert layout.field_offsets == ((4, "i32"),)  # T → pointer
+        assert layout.total_size == 8
+
+    def test_mixed_adt_constructors(self) -> None:
+        """Option-like ADT: None is nullary, Some has a field."""
+        source = """\
+data MyOption<T> { MyNone, MySome(T) }
+
+fn f(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{ 42 }
+"""
+        _result, gen = _compile_with_generator(source)
+        layouts = gen._adt_layouts["MyOption"]
+        assert layouts["MyNone"].tag == 0
+        assert layouts["MyNone"].field_offsets == ()
+        assert layouts["MyNone"].total_size == 8
+        assert layouts["MySome"].tag == 1
+        assert layouts["MySome"].field_offsets == ((4, "i32"),)  # T → pointer
+        assert layouts["MySome"].total_size == 8

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.13"
+__version__ = "0.0.14"

--- a/vera/codegen.py
+++ b/vera/codegen.py
@@ -35,6 +35,43 @@ from vera.wasm import StringPool, WasmContext, WasmSlotEnv, wasm_type
 
 
 # =====================================================================
+# ADT memory layout
+# =====================================================================
+
+
+@dataclass
+class ConstructorLayout:
+    """WASM memory layout for a single ADT constructor."""
+
+    tag: int  # discriminant (0, 1, 2, ...)
+    field_offsets: tuple[tuple[int, str], ...]  # (byte_offset, wasm_type) per field
+    total_size: int  # total bytes, 8-byte aligned
+
+
+def _wasm_type_size(wt: str) -> int:
+    """Byte size of a WASM value type."""
+    if wt == "i32":
+        return 4
+    if wt in ("i64", "f64"):
+        return 8
+    raise ValueError(f"Unknown WASM type: {wt}")
+
+
+def _wasm_type_align(wt: str) -> int:
+    """Natural alignment of a WASM value type."""
+    if wt == "i32":
+        return 4
+    if wt in ("i64", "f64"):
+        return 8
+    raise ValueError(f"Unknown WASM type: {wt}")
+
+
+def _align_up(offset: int, align: int) -> int:
+    """Round offset up to the next multiple of align."""
+    return (offset + align - 1) & ~(align - 1)
+
+
+# =====================================================================
 # Public API
 # =====================================================================
 
@@ -231,6 +268,10 @@ class CodeGenerator:
         self._needs_memory: bool = False
         self._state_types: list[tuple[str, str]] = []  # (type_name, wasm_type)
 
+        # ADT layout metadata (populated during registration)
+        self._adt_layouts: dict[str, dict[str, ConstructorLayout]] = {}
+        self._needs_alloc: bool = False
+
     # -----------------------------------------------------------------
     # Diagnostics
     # -----------------------------------------------------------------
@@ -322,11 +363,13 @@ class CodeGenerator:
     # -----------------------------------------------------------------
 
     def _register_all(self, program: ast.Program) -> None:
-        """Register all function signatures for forward references."""
+        """Register all function signatures and ADT layouts."""
         for tld in program.declarations:
             decl = tld.decl
             if isinstance(decl, ast.FnDecl):
                 self._register_fn(decl)
+            elif isinstance(decl, ast.DataDecl):
+                self._register_data(decl)
 
     def _register_fn(self, decl: ast.FnDecl) -> None:
         """Register a function's WASM signature."""
@@ -342,6 +385,69 @@ class CodeGenerator:
         if decl.where_fns:
             for wfn in decl.where_fns:
                 self._register_fn(wfn)
+
+    def _register_data(self, decl: ast.DataDecl) -> None:
+        """Register an ADT and precompute constructor layouts."""
+        layouts: dict[str, ConstructorLayout] = {}
+        for tag, ctor in enumerate(decl.constructors):
+            layout = self._compute_constructor_layout(tag, ctor, decl)
+            layouts[ctor.name] = layout
+        self._adt_layouts[decl.name] = layouts
+        self._needs_alloc = True
+        self._needs_memory = True
+
+    def _compute_constructor_layout(
+        self,
+        tag: int,
+        ctor: ast.Constructor,
+        decl: ast.DataDecl,
+    ) -> ConstructorLayout:
+        """Compute the memory layout for a single constructor.
+
+        Layout: [tag: i32 (4 bytes)] [pad] [field0] [field1] ...
+        Total size rounded up to 8-byte multiple.
+        """
+        offset = 4  # tag (i32) at offset 0, occupies 4 bytes
+        field_offsets: list[tuple[int, str]] = []
+
+        if ctor.fields is not None:
+            for field_te in ctor.fields:
+                wt = self._resolve_field_wasm_type(field_te, decl)
+                align = _wasm_type_align(wt)
+                offset = _align_up(offset, align)
+                field_offsets.append((offset, wt))
+                offset += _wasm_type_size(wt)
+
+        total_size = _align_up(offset, 8) if offset > 0 else 8
+        return ConstructorLayout(
+            tag=tag,
+            field_offsets=tuple(field_offsets),
+            total_size=total_size,
+        )
+
+    def _resolve_field_wasm_type(
+        self,
+        te: ast.TypeExpr,
+        decl: ast.DataDecl,
+    ) -> str:
+        """Resolve a constructor field's TypeExpr to a WASM type.
+
+        Type parameters and ADT references map to i32 (heap pointer).
+        Known primitives map to their native WASM types.
+        """
+        if isinstance(te, ast.NamedType):
+            # Type parameter of the parent ADT → pointer
+            if decl.type_params and te.name in decl.type_params:
+                return "i32"
+            wt = self._type_expr_to_wasm_type(te)
+            if wt is None:
+                return "i32"  # Unit → pointer (shouldn't appear, safe fallback)
+            if wt == "unsupported":
+                return "i32"  # ADT/String/other → heap pointer
+            return wt
+        if isinstance(te, ast.RefinementType):
+            return self._resolve_field_wasm_type(te.base_type, decl)
+        return "i32"  # default: pointer
 
     # -----------------------------------------------------------------
     # Function compilation
@@ -604,7 +710,7 @@ class CodeGenerator:
                 f"(func $vera.state_put_{type_name} (param {wasm_t})))"
             )
 
-        # Memory (for string data)
+        # Memory (for string data and heap)
         if self._needs_memory or self.string_pool.has_strings():
             parts.append('  (memory (export "memory") 1)')
 
@@ -613,6 +719,33 @@ class CodeGenerator:
             # Escape special characters for WAT string literals
             escaped = self._escape_wat_string(value)
             parts.append(f'  (data (i32.const {offset}) "{escaped}")')
+
+        # Heap pointer global and bump allocator (for ADT allocation)
+        if self._needs_alloc:
+            heap_start = self.string_pool.heap_offset
+            parts.append(
+                f"  (global $heap_ptr (export \"heap_ptr\") "
+                f"(mut i32) (i32.const {heap_start}))"
+            )
+            parts.append(
+                "  (func $alloc (param $size i32) (result i32)\n"
+                "    (local $ptr i32)\n"
+                "    ;; Save current heap pointer\n"
+                "    global.get $heap_ptr\n"
+                "    local.set $ptr\n"
+                "    ;; Advance heap_ptr by size rounded up to 8\n"
+                "    global.get $heap_ptr\n"
+                "    local.get $size\n"
+                "    i32.const 7\n"
+                "    i32.add\n"
+                "    i32.const -8\n"
+                "    i32.and\n"
+                "    i32.add\n"
+                "    global.set $heap_ptr\n"
+                "    ;; Return old pointer\n"
+                "    local.get $ptr\n"
+                "  )"
+            )
 
         # Functions
         for fn_wat in functions:

--- a/vera/wasm.py
+++ b/vera/wasm.py
@@ -93,6 +93,11 @@ class StringPool:
         """Whether any strings have been interned."""
         return len(self._strings) > 0
 
+    @property
+    def heap_offset(self) -> int:
+        """First byte after all string data — heap starts here."""
+        return self._offset
+
 
 # =====================================================================
 # Type mapping


### PR DESCRIPTION
## Summary
- Add `$heap_ptr` mutable global (initialized after string data, exported as `"heap_ptr"`) and `$alloc` bump function with 8-byte alignment
- Precompute ADT constructor layouts during registration pass: `ConstructorLayout` stores tag, field offsets, and total size per constructor
- Emitted only when user-declared `data` types are present — no overhead for pure programs
- Foundation for C6f (ADT constructor codegen) and C6g (match expression codegen)
- 26 new tests in `TestLayoutHelpers`, `TestHeapAllocation`, `TestAdtMetadata` (611 total, up from 585)
- Version bump to v0.0.14

## Test plan
- [x] `pytest tests/ -v` — 611 tests pass
- [x] `mypy vera/` — clean (14 source files)
- [x] `python scripts/check_examples.py` — all 14 examples pass
- [x] `python scripts/check_version_sync.py` — version 0.0.14 consistent
- [x] Pre-commit hooks all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)