### PR TITLE
Add ADT constructor codegen (C6f)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.15] - 2026-02-24
+
+### Added
+- **ADT constructor codegen** (C6f): compile `ConstructorCall` and `NullaryConstructor` AST nodes to WASM heap-allocated tagged unions
+  - Nullary constructors (e.g. `Red`, `None`): alloc → store tag → return pointer
+  - Constructors with fields (e.g. `Some(42)`, `Wrap(@Int.0)`): alloc → store tag → store each field at computed offset → return pointer
+  - Field offsets computed from concrete argument types at translation time — handles monomorphized generic constructors (e.g. `Some(T)` with `T=Int` stores i64)
+  - ADT types compile to `i32` (heap pointer) in function signatures, slot references, and type inference
+  - `WasmContext` accepts `ctor_layouts` and `adt_type_names` for constructor-aware translation
+  - Functions using ADT constructors now compile (no longer skipped with warning)
+- **Codegen tests**: 12 new tests — nullary/tagged constructors, Int/Bool fields, Option None/Some, WAT inspection, let bindings, if-then-else branches, ADT parameters (623 total, up from 611)
+
 ## [0.0.14] - 2026-02-24
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ vera parse file.vera              # Print the parse tree
 vera ast file.vera                # Print the typed AST
 vera ast --json file.vera         # Print the AST as JSON
 
-pytest tests/ -v                  # Run the test suite (611 tests)
+pytest tests/ -v                  # Run the test suite (623 tests)
 mypy vera/                        # Type-check the compiler itself
 
 python scripts/check_examples.py      # Verify all 14 examples parse + check + verify

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Development follows an **interleaved spiral** — each phase adds a complete com
 | C3 | v0.0.5 | **Type checker** — decidable type checking, slot resolution, effect tracking | Done |
 | C4 | v0.0.8 | **Contract verifier** — Z3 integration, refinement types, counterexamples | Done |
 | C5 | v0.0.9 | **WASM codegen** — compile to WebAssembly, `vera compile` / `vera run` | Done |
-| C6 | v0.0.10–0.0.23 | **Codegen completeness** — ADTs, match, closures, effects, generics in WASM | **In progress** (C6a–C6e done) |
+| C6 | v0.0.10–0.0.23 | **Codegen completeness** — ADTs, match, closures, effects, generics in WASM | **In progress** (C6a–C6f done) |
 | C7 | — | **Module system** — cross-file imports, public/private visibility | Planned |
 | C8 | v0.1.0 | **End-to-end** — all examples compile and run, spec complete, polish | Planned |
 
@@ -181,7 +181,7 @@ The code generator compiles 7 of 14 examples. C6 extends WASM compilation to all
 | Sub-phase | Scope | Closes | Unlocks |
 |-----------|-------|--------|---------|
 | ~~C6e~~ | ~~Bump allocator — heap allocation for tagged values~~ | — | ~~Done (v0.0.14)~~ |
-| C6f | ADT constructors — heap-allocated tagged unions | — | — |
+| ~~C6f~~ | ~~ADT constructors — heap-allocated tagged unions~~ | — | ~~Done (v0.0.15)~~ |
 | C6g | Match expressions — tag dispatch, field extraction | #26 | pattern_matching.vera |
 | C6i | Generics — monomorphization of `forall<T>` functions | #29 | generics.vera, list_ops.vera |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.14"
+version = "0.0.15"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -743,12 +743,13 @@ fn positive(@Int -> @Int)
     ) -> None:
         """Compile JSON mode includes warnings from compilation."""
         import tempfile
+        # Use an unsupported effect to trigger a compilation warning
         source = """\
-data Opt<T> { None, Some(T) }
+effect Counter { op inc(Unit -> Unit); }
 
-fn make_none(-> @Opt<Int>)
-  requires(true) ensures(true) effects(pure)
-{ None }
+fn count(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<Counter>)
+{ () }
 
 fn simple(-> @Int)
   requires(true) ensures(true) effects(pure)
@@ -763,7 +764,7 @@ fn simple(-> @Int)
         assert rc == 0
         data = json.loads(capsys.readouterr().out)
         assert data["ok"] is True
-        # The ADT function produces a compilation warning
+        # The Counter effect function produces a compilation warning
         assert len(data["warnings"]) > 0
 
     def test_run_invalid_int_arg(self) -> None:

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -1052,8 +1052,8 @@ fn factorial(@Nat -> @Nat)
 
 
 class TestUnsupportedSkipped:
-    def test_adt_function_skipped(self) -> None:
-        """Functions with ADT types produce warnings, not errors."""
+    def test_adt_function_compiles(self) -> None:
+        """Functions with ADT types now compile (not skipped)."""
         source = """\
 data Option<T> { None, Some(T) }
 
@@ -1067,10 +1067,9 @@ fn simple(-> @Int)
 """
         result = _compile(source)
         errors = [d for d in result.diagnostics if d.severity == "error"]
-        warnings = [d for d in result.diagnostics if d.severity == "warning"]
         assert not errors
-        assert len(warnings) > 0
-        # The simple function should still be compiled
+        # Both functions should be compiled
+        assert "make_none" in result.exports
         assert "simple" in result.exports
 
     def test_unsupported_effect_skipped(self) -> None:
@@ -1891,3 +1890,196 @@ fn f(-> @Int)
         assert layouts["MySome"].tag == 1
         assert layouts["MySome"].field_offsets == ((4, "i32"),)  # T → pointer
         assert layouts["MySome"].total_size == 8
+
+
+# =====================================================================
+# C6f: ADT constructor codegen
+# =====================================================================
+
+
+class TestAdtConstructors:
+    """Test compilation of ADT constructor expressions to WASM."""
+
+    def test_nullary_constructor_returns_pointer(self) -> None:
+        """A nullary constructor (Red) compiles and returns an i32 >= 0."""
+        source = """\
+data Color { Red, Green, Blue }
+
+fn make_red(-> @Color)
+  requires(true) ensures(true) effects(pure)
+{ Red }
+"""
+        result = _compile_ok(source)
+        assert "make_red" in result.exports
+        exec_result = execute(result, fn_name="make_red")
+        assert exec_result.value is not None
+        assert exec_result.value >= 0  # heap pointer
+
+    def test_nullary_different_tags(self) -> None:
+        """Different nullary constructors compile to distinct functions."""
+        source = """\
+data Color { Red, Green, Blue }
+
+fn make_red(-> @Color)
+  requires(true) ensures(true) effects(pure)
+{ Red }
+
+fn make_green(-> @Color)
+  requires(true) ensures(true) effects(pure)
+{ Green }
+
+fn make_blue(-> @Color)
+  requires(true) ensures(true) effects(pure)
+{ Blue }
+"""
+        result = _compile_ok(source)
+        assert "make_red" in result.exports
+        assert "make_green" in result.exports
+        assert "make_blue" in result.exports
+
+    def test_constructor_with_int_field(self) -> None:
+        """Constructor with Int field: Wrap(@Int.0) compiles."""
+        source = """\
+data Wrapper { Wrap(Int) }
+
+fn wrap(@Int -> @Wrapper)
+  requires(true) ensures(true) effects(pure)
+{ Wrap(@Int.0) }
+"""
+        result = _compile_ok(source)
+        assert "wrap" in result.exports
+        exec_result = execute(result, fn_name="wrap", args=[42])
+        assert exec_result.value is not None
+        assert exec_result.value >= 0
+
+    def test_constructor_with_bool_field(self) -> None:
+        """Constructor with Bool field: MkToggle(@Bool.0) compiles."""
+        source = """\
+data Toggle { MkToggle(Bool) }
+
+fn toggle(@Bool -> @Toggle)
+  requires(true) ensures(true) effects(pure)
+{ MkToggle(@Bool.0) }
+"""
+        result = _compile_ok(source)
+        assert "toggle" in result.exports
+        exec_result = execute(result, fn_name="toggle", args=[1])
+        assert exec_result.value is not None
+        assert exec_result.value >= 0
+
+    def test_option_none(self) -> None:
+        """None as Option<Int> compiles (nullary constructor)."""
+        source = """\
+data Option<T> { None, Some(T) }
+
+fn make_none(-> @Option<Int>)
+  requires(true) ensures(true) effects(pure)
+{ None }
+"""
+        result = _compile_ok(source)
+        assert "make_none" in result.exports
+        exec_result = execute(result, fn_name="make_none")
+        assert exec_result.value is not None
+
+    def test_option_some(self) -> None:
+        """Some(@Int.0) as Option<Int> compiles."""
+        source = """\
+data Option<T> { None, Some(T) }
+
+fn make_some(@Int -> @Option<Int>)
+  requires(true) ensures(true) effects(pure)
+{ Some(@Int.0) }
+"""
+        result = _compile_ok(source)
+        assert "make_some" in result.exports
+        exec_result = execute(result, fn_name="make_some", args=[99])
+        assert exec_result.value is not None
+        assert exec_result.value >= 0
+
+    def test_wat_contains_alloc_call(self) -> None:
+        """WAT output for constructor contains call $alloc."""
+        source = """\
+data Color { Red, Green, Blue }
+
+fn make_red(-> @Color)
+  requires(true) ensures(true) effects(pure)
+{ Red }
+"""
+        result = _compile_ok(source)
+        assert "call $alloc" in result.wat
+
+    def test_wat_contains_store_with_offset(self) -> None:
+        """WAT output for Some(x) contains field store with offset."""
+        source = """\
+data Wrapper { Wrap(Int) }
+
+fn wrap(@Int -> @Wrapper)
+  requires(true) ensures(true) effects(pure)
+{ Wrap(@Int.0) }
+"""
+        result = _compile_ok(source)
+        assert "i64.store offset=8" in result.wat
+
+    def test_nullary_tag_store(self) -> None:
+        """WAT for Red (tag=0) stores tag 0; Green (tag=1) stores tag 1."""
+        source = """\
+data Color { Red, Green, Blue }
+
+fn make_green(-> @Color)
+  requires(true) ensures(true) effects(pure)
+{ Green }
+"""
+        result = _compile_ok(source)
+        # Green has tag=1, so WAT should contain i32.const 1 before i32.store
+        assert "i32.const 1" in result.wat
+        assert "i32.store\n" in result.wat or "i32.store)" in result.wat or "i32.store" in result.wat
+
+    def test_constructor_in_let_binding(self) -> None:
+        """Constructor result in a let binding compiles."""
+        source = """\
+data Wrapper { Wrap(Int) }
+
+fn make_wrap(@Int -> @Wrapper)
+  requires(true) ensures(true) effects(pure)
+{
+  let @Wrapper = Wrap(@Int.0);
+  @Wrapper.0
+}
+"""
+        result = _compile_ok(source)
+        assert "make_wrap" in result.exports
+        exec_result = execute(result, fn_name="make_wrap", args=[7])
+        assert exec_result.value is not None
+
+    def test_constructor_in_if_branches(self) -> None:
+        """Constructors in both branches of if-then-else compile."""
+        source = """\
+data Option<T> { None, Some(T) }
+
+fn maybe(@Bool -> @Option<Int>)
+  requires(true) ensures(true) effects(pure)
+{
+  if @Bool.0 then { Some(42) }
+  else { None }
+}
+"""
+        result = _compile_ok(source)
+        assert "maybe" in result.exports
+        # Both branches should produce valid pointers
+        exec_true = execute(result, fn_name="maybe", args=[1])
+        exec_false = execute(result, fn_name="maybe", args=[0])
+        assert exec_true.value is not None
+        assert exec_false.value is not None
+
+    def test_adt_param_compiles(self) -> None:
+        """Function taking ADT param uses (param $p0 i32) in WAT."""
+        source = """\
+data Color { Red, Green, Blue }
+
+fn identity(@Color -> @Color)
+  requires(true) ensures(true) effects(pure)
+{ @Color.0 }
+"""
+        result = _compile_ok(source)
+        assert "identity" in result.exports
+        assert "(param" in result.wat  # at least one i32 param

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.14"
+__version__ = "0.0.15"

--- a/vera/codegen.py
+++ b/vera/codegen.py
@@ -483,7 +483,18 @@ class CodeGenerator:
                                 f"$vera.state_put_{type_name}", True
                             )
 
-        ctx = WasmContext(self.string_pool, effect_ops=effect_ops)
+        # Flatten ADT layouts into ctor_name -> layout for WasmContext
+        ctor_layouts = {}
+        for layouts in self._adt_layouts.values():
+            ctor_layouts.update(layouts)
+        adt_type_names = set(self._adt_layouts.keys())
+
+        ctx = WasmContext(
+            self.string_pool,
+            effect_ops=effect_ops,
+            ctor_layouts=ctor_layouts,
+            adt_type_names=adt_type_names,
+        )
         env = WasmSlotEnv()
 
         # Allocate parameters
@@ -867,6 +878,9 @@ class CodeGenerator:
                 return None
             if name == "String":
                 return "unsupported"
+            # ADT types compile to i32 (heap pointer)
+            if name in self._adt_layouts:
+                return "i32"
             return "unsupported"
         if isinstance(te, ast.RefinementType):
             return self._type_expr_to_wasm_type(te.base_type)

--- a/vera/wasm.py
+++ b/vera/wasm.py
@@ -10,8 +10,12 @@ See spec/11-compilation.md for the compilation specification.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 from vera import ast
+
+if TYPE_CHECKING:
+    from vera.codegen import ConstructorLayout
 from vera.types import (
     BOOL,
     FLOAT64,
@@ -153,6 +157,8 @@ class WasmContext:
         self,
         string_pool: StringPool,
         effect_ops: dict[str, tuple[str, bool]] | None = None,
+        ctor_layouts: dict[str, ConstructorLayout] | None = None,
+        adt_type_names: set[str] | None = None,
     ) -> None:
         self.string_pool = string_pool
         self._next_local: int = 0
@@ -162,6 +168,10 @@ class WasmContext:
         # e.g. {"get": ("$vera.state_get_Int", False),
         #        "put": ("$vera.state_put_Int", True)}
         self._effect_ops = effect_ops or {}
+        # Constructor layout mapping: ctor_name -> ConstructorLayout
+        self._ctor_layouts: dict[str, ConstructorLayout] = ctor_layouts or {}
+        # ADT type names for slot/param type resolution
+        self._adt_type_names: set[str] = adt_type_names or set()
 
     def set_result_local(self, local_idx: int) -> None:
         """Set the local index used for @T.result in postconditions."""
@@ -239,7 +249,13 @@ class WasmContext:
         if isinstance(expr, ast.ResultRef):
             return self._translate_result_ref()
 
-        # Unsupported: match, handle, lambdas, constructors,
+        if isinstance(expr, ast.ConstructorCall):
+            return self._translate_constructor_call(expr, env)
+
+        if isinstance(expr, ast.NullaryConstructor):
+            return self._translate_nullary_constructor(expr)
+
+        # Unsupported: match, handle, lambdas,
         # quantifiers, old/new, assert/assume, arrays, etc.
         return None
 
@@ -373,6 +389,10 @@ class WasmContext:
                 return "f64"
             if expr.type_name == "Bool":
                 return "i32"
+            base = (expr.type_name.split("<")[0]
+                    if "<" in expr.type_name else expr.type_name)
+            if base in self._adt_type_names:
+                return "i32"
             return None
         if isinstance(expr, ast.ResultRef):
             if expr.type_name in ("Int", "Nat"):
@@ -399,6 +419,10 @@ class WasmContext:
                 return "i32"
         if isinstance(expr, ast.FnCall):
             return None  # can't infer without type info
+        if isinstance(expr, ast.ConstructorCall):
+            return "i32" if expr.name in self._ctor_layouts else None
+        if isinstance(expr, ast.NullaryConstructor):
+            return "i32" if expr.name in self._ctor_layouts else None
         return None
 
     # -----------------------------------------------------------------
@@ -479,6 +503,9 @@ class WasmContext:
                 return "f64"
             if name == "Bool":
                 return "i32"
+            base = name.split("<")[0] if "<" in name else name
+            if base in self._adt_type_names:
+                return "i32"
             return None
         if isinstance(expr, ast.BinaryExpr):
             if expr.op in self._ARITH_OPS:
@@ -504,6 +531,10 @@ class WasmContext:
             return None  # strings are (i32, i32) — handled specially
         if isinstance(expr, ast.Block):
             return self._infer_block_result_type(expr)
+        if isinstance(expr, ast.ConstructorCall):
+            return "i32" if expr.name in self._ctor_layouts else None
+        if isinstance(expr, ast.NullaryConstructor):
+            return "i32" if expr.name in self._ctor_layouts else None
         return None
 
     # -----------------------------------------------------------------
@@ -622,6 +653,89 @@ class WasmContext:
         return None
 
     # -----------------------------------------------------------------
+    # Constructors
+    # -----------------------------------------------------------------
+
+    def _translate_nullary_constructor(
+        self, expr: ast.NullaryConstructor
+    ) -> list[str] | None:
+        """Translate a nullary constructor (e.g., None, Red) to WAT.
+
+        Emits: alloc → store tag → return pointer.
+        """
+        layout = self._ctor_layouts.get(expr.name)
+        if layout is None:
+            return None
+
+        tmp = self.alloc_local("i32")
+        return [
+            f"i32.const {layout.total_size}",
+            "call $alloc",
+            f"local.tee {tmp}",
+            f"i32.const {layout.tag}",
+            "i32.store",
+            f"local.get {tmp}",
+        ]
+
+    def _translate_constructor_call(
+        self, expr: ast.ConstructorCall, env: WasmSlotEnv
+    ) -> list[str] | None:
+        """Translate a constructor call (e.g., Some(42)) to WAT.
+
+        Emits: alloc → store tag → store each field → return pointer.
+        Field offsets are computed from the concrete argument types so that
+        generic constructors (e.g. Some(T) instantiated as Some(Int))
+        use the correct WASM types and alignment.
+        """
+        layout = self._ctor_layouts.get(expr.name)
+        if layout is None:
+            return None
+
+        # Translate all arguments and infer their concrete WASM types
+        arg_instrs_list: list[list[str]] = []
+        arg_wasm_types: list[str] = []
+        for arg in expr.args:
+            arg_instrs = self.translate_expr(arg, env)
+            if arg_instrs is None:
+                return None
+            arg_wt = self._infer_expr_wasm_type(arg)
+            if arg_wt is None:
+                return None
+            arg_instrs_list.append(arg_instrs)
+            arg_wasm_types.append(arg_wt)
+
+        # Compute field offsets from concrete argument types
+        _sizes = {"i32": 4, "i64": 8, "f64": 8}
+        _aligns = {"i32": 4, "i64": 8, "f64": 8}
+        offset = 4  # after tag (i32, 4 bytes)
+        field_offsets: list[tuple[int, str]] = []
+        for wt in arg_wasm_types:
+            align = _aligns.get(wt, 8)
+            offset = (offset + align - 1) & ~(align - 1)  # align up
+            field_offsets.append((offset, wt))
+            offset += _sizes.get(wt, 8)
+        total_size = ((offset + 7) & ~7) if offset > 0 else 8  # 8-byte aligned
+
+        tmp = self.alloc_local("i32")
+        instructions: list[str] = [
+            f"i32.const {total_size}",
+            "call $alloc",
+            f"local.tee {tmp}",
+            f"i32.const {layout.tag}",
+            "i32.store",
+        ]
+
+        # Store each field at its computed offset
+        for i, (fo, wt) in enumerate(field_offsets):
+            instructions.append(f"local.get {tmp}")
+            instructions.extend(arg_instrs_list[i])
+            instructions.append(f"{wt}.store offset={fo}")
+
+        # Leave pointer as result
+        instructions.append(f"local.get {tmp}")
+        return instructions
+
+    # -----------------------------------------------------------------
     # Helpers
     # -----------------------------------------------------------------
 
@@ -664,5 +778,9 @@ class WasmContext:
         if name in ("Float64", "Float"):
             return "f64"
         if name == "Bool":
+            return "i32"
+        # ADT types are heap pointers
+        base = name.split("<")[0] if "<" in name else name
+        if base in self._adt_type_names:
             return "i32"
         return None


### PR DESCRIPTION
## Summary
- Compile `ConstructorCall` and `NullaryConstructor` AST nodes to WASM heap-allocated tagged unions using the bump allocator from C6e
- Field offsets computed from concrete argument types at translation time — correctly handles monomorphized generic constructors (e.g. `Some(T)` with `T=Int` stores i64, not i32)
- ADT types compile to `i32` (heap pointer) in function signatures, slot references, and type inference
- Functions using ADT constructors now compile instead of being skipped with a warning

## Changes
- **`vera/wasm.py`**: `WasmContext` gains `ctor_layouts`/`adt_type_names` params, `_translate_nullary_constructor` and `_translate_constructor_call` methods, updated type inference in 3 methods + `_slot_name_to_wasm_type`
- **`vera/codegen.py`**: `_type_expr_to_wasm_type` returns `i32` for ADTs, `_compile_fn` flattens and passes constructor layouts to `WasmContext`
- **`tests/test_codegen.py`**: 12 new `TestAdtConstructors` tests + updated `test_adt_function_compiles`
- **`tests/test_cli.py`**: Updated `test_run_compile_json_with_warnings` to use unsupported effect (ADT functions no longer warn)
- Version bump to v0.0.15, CHANGELOG, README roadmap updated

## Test plan
- [x] 623 tests pass (`pytest tests/ -v`)
- [x] mypy clean (`mypy vera/`)
- [x] All 14 examples pass (`python scripts/check_examples.py`)
- [x] Version consistent (`python scripts/check_version_sync.py`)
- [x] Pre-commit hooks pass (mypy, pytest, examples, readme)

🤖 Generated with [Claude Code](https://claude.com/claude-code)