### PR TITLE
Add match expression codegen (C6g)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.16] - 2026-02-24
+
+### Added
+- **Match expression codegen** (C6g — closes #26): compile `MatchExpr` AST nodes to WASM chained if-else cascades
+  - ADT tag dispatch: load tag from heap pointer, compare with constructor tag, branch
+  - Field extraction: load constructor fields at computed offsets into locals, bind in environment
+  - Monomorphized offsets: field offsets computed from concrete binding types (same approach as C6f constructor calls)
+  - Pattern types: `ConstructorPattern`, `NullaryPattern`, `WildcardPattern`, `BindingPattern`, `BoolPattern`, `IntPattern`
+  - Recursive if-else cascade: each arm generates a condition check and branches, last arm emits directly
+  - Environment scoping: each arm gets fresh bindings from pattern extraction, no cross-arm leakage
+- **Codegen tests**: 20 new tests — ADT tag dispatch, field extraction, wildcard catch-alls, Bool/Int literal patterns, binding patterns, composability (643 total, up from 623)
+
 ## [0.0.15] - 2026-02-24
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ vera parse file.vera              # Print the parse tree
 vera ast file.vera                # Print the typed AST
 vera ast --json file.vera         # Print the AST as JSON
 
-pytest tests/ -v                  # Run the test suite (623 tests)
+pytest tests/ -v                  # Run the test suite (643 tests)
 mypy vera/                        # Type-check the compiler itself
 
 python scripts/check_examples.py      # Verify all 14 examples parse + check + verify

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Development follows an **interleaved spiral** — each phase adds a complete com
 | C3 | v0.0.5 | **Type checker** — decidable type checking, slot resolution, effect tracking | Done |
 | C4 | v0.0.8 | **Contract verifier** — Z3 integration, refinement types, counterexamples | Done |
 | C5 | v0.0.9 | **WASM codegen** — compile to WebAssembly, `vera compile` / `vera run` | Done |
-| C6 | v0.0.10–0.0.23 | **Codegen completeness** — ADTs, match, closures, effects, generics in WASM | **In progress** (C6a–C6f done) |
+| C6 | v0.0.10–0.0.23 | **Codegen completeness** — ADTs, match, closures, effects, generics in WASM | **In progress** (C6a–C6g done) |
 | C7 | — | **Module system** — cross-file imports, public/private visibility | Planned |
 | C8 | v0.1.0 | **End-to-end** — all examples compile and run, spec complete, polish | Planned |
 
@@ -182,7 +182,7 @@ The code generator compiles 7 of 14 examples. C6 extends WASM compilation to all
 |-----------|-------|--------|---------|
 | ~~C6e~~ | ~~Bump allocator — heap allocation for tagged values~~ | — | ~~Done (v0.0.14)~~ |
 | ~~C6f~~ | ~~ADT constructors — heap-allocated tagged unions~~ | — | ~~Done (v0.0.15)~~ |
-| C6g | Match expressions — tag dispatch, field extraction | #26 | pattern_matching.vera |
+| ~~C6g~~ | ~~Match expressions — tag dispatch, field extraction~~ | ~~#26~~ | ~~Done (v0.0.16)~~ |
 | C6i | Generics — monomorphization of `forall<T>` functions | #29 | generics.vera, list_ops.vera |
 
 **Higher-order and effects:**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.15"
+version = "0.0.16"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -2083,3 +2083,340 @@ fn identity(@Color -> @Color)
         result = _compile_ok(source)
         assert "identity" in result.exports
         assert "(param" in result.wat  # at least one i32 param
+
+
+# =====================================================================
+# C6g: Match expression codegen
+# =====================================================================
+
+
+class TestMatchExpressions:
+    """Test compilation of match expressions to WASM."""
+
+    def test_match_option_none_arm(self) -> None:
+        """Match on None arm returns 0."""
+        source = """\
+data Option<T> { None, Some(T) }
+
+fn test_none(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  let @Option<Int> = None;
+  match @Option<Int>.0 {
+    None -> 0,
+    Some(@Int) -> @Int.0
+  }
+}
+"""
+        assert _run(source, fn="test_none") == 0
+
+    def test_match_option_some_arm(self) -> None:
+        """Match on Some arm extracts value."""
+        source = """\
+data Option<T> { None, Some(T) }
+
+fn test_some(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  let @Option<Int> = Some(42);
+  match @Option<Int>.0 {
+    None -> 0,
+    Some(@Int) -> @Int.0
+  }
+}
+"""
+        assert _run(source, fn="test_some") == 42
+
+    def test_match_color_red(self) -> None:
+        """Match on Red arm returns 0."""
+        source = """\
+data Color { Red, Green, Blue }
+
+fn test_red(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  let @Color = Red;
+  match @Color.0 {
+    Red -> 0,
+    Green -> 1,
+    Blue -> 2
+  }
+}
+"""
+        assert _run(source, fn="test_red") == 0
+
+    def test_match_color_green(self) -> None:
+        """Match on Green arm returns 1."""
+        source = """\
+data Color { Red, Green, Blue }
+
+fn test_green(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  let @Color = Green;
+  match @Color.0 {
+    Red -> 0,
+    Green -> 1,
+    Blue -> 2
+  }
+}
+"""
+        assert _run(source, fn="test_green") == 1
+
+    def test_match_color_blue(self) -> None:
+        """Match on Blue arm returns 2."""
+        source = """\
+data Color { Red, Green, Blue }
+
+fn test_blue(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  let @Color = Blue;
+  match @Color.0 {
+    Red -> 0,
+    Green -> 1,
+    Blue -> 2
+  }
+}
+"""
+        assert _run(source, fn="test_blue") == 2
+
+    def test_match_extracts_int(self) -> None:
+        """Match extracts Int field and uses it in body."""
+        source = """\
+data Option<T> { None, Some(T) }
+
+fn test(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  let @Option<Int> = Some(99);
+  match @Option<Int>.0 {
+    None -> 0,
+    Some(@Int) -> @Int.0 + 1
+  }
+}
+"""
+        assert _run(source, fn="test") == 100
+
+    def test_match_extracts_bool(self) -> None:
+        """Match extracts Bool field."""
+        source = """\
+data Toggle { MkToggle(Bool) }
+
+fn test(-> @Bool)
+  requires(true) ensures(true) effects(pure)
+{
+  let @Toggle = MkToggle(true);
+  match @Toggle.0 {
+    MkToggle(@Bool) -> @Bool.0
+  }
+}
+"""
+        assert _run(source, fn="test") == 1
+
+    def test_match_two_fields(self) -> None:
+        """Match extracts first of two fields."""
+        source = """\
+data Pair { MkPair(Int, Bool) }
+
+fn test(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  let @Pair = MkPair(42, true);
+  match @Pair.0 {
+    MkPair(@Int, @Bool) -> @Int.0
+  }
+}
+"""
+        assert _run(source, fn="test") == 42
+
+    def test_match_wildcard_catchall(self) -> None:
+        """Wildcard catch-all matches None."""
+        source = """\
+data Option<T> { None, Some(T) }
+
+fn test(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  let @Option<Int> = None;
+  match @Option<Int>.0 {
+    Some(@Int) -> @Int.0,
+    _ -> 0
+  }
+}
+"""
+        assert _run(source, fn="test") == 0
+
+    def test_match_wildcard_only(self) -> None:
+        """Single wildcard arm on Int."""
+        source = """\
+fn test(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  match @Int.0 {
+    _ -> 42
+  }
+}
+"""
+        assert _run(source, fn="test", args=[999]) == 42
+
+    def test_match_wildcard_sub_pattern(self) -> None:
+        """Wildcard inside constructor sub-pattern."""
+        source = """\
+data Option<T> { None, Some(T) }
+
+fn test(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  let @Option<Int> = Some(77);
+  match @Option<Int>.0 {
+    Some(_) -> 1,
+    None -> 0
+  }
+}
+"""
+        assert _run(source, fn="test") == 1
+
+    def test_match_bool_true(self) -> None:
+        """Bool match on true arm."""
+        source = """\
+fn test(@Bool -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  match @Bool.0 {
+    true -> 1,
+    false -> 0
+  }
+}
+"""
+        assert _run(source, fn="test", args=[1]) == 1
+
+    def test_match_bool_false(self) -> None:
+        """Bool match on false arm."""
+        source = """\
+fn test(@Bool -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  match @Bool.0 {
+    true -> 1,
+    false -> 0
+  }
+}
+"""
+        assert _run(source, fn="test", args=[0]) == 0
+
+    def test_match_int_literal(self) -> None:
+        """Int literal match, first arm."""
+        source = """\
+fn test(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  match @Int.0 {
+    0 -> 100,
+    1 -> 200,
+    _ -> 300
+  }
+}
+"""
+        assert _run(source, fn="test", args=[0]) == 100
+
+    def test_match_int_second_arm(self) -> None:
+        """Int literal match, second arm."""
+        source = """\
+fn test(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  match @Int.0 {
+    0 -> 100,
+    1 -> 200,
+    _ -> 300
+  }
+}
+"""
+        assert _run(source, fn="test", args=[1]) == 200
+
+    def test_match_int_wildcard_fallback(self) -> None:
+        """Int literal match, wildcard fallback."""
+        source = """\
+fn test(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  match @Int.0 {
+    0 -> 100,
+    1 -> 200,
+    _ -> 300
+  }
+}
+"""
+        assert _run(source, fn="test", args=[99]) == 300
+
+    def test_match_binding_catchall(self) -> None:
+        """Binding pattern as catch-all."""
+        source = """\
+data Option<T> { None, Some(T) }
+
+fn test(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  let @Option<Int> = None;
+  match @Option<Int>.0 {
+    Some(@Int) -> @Int.0,
+    @Option<Int> -> 0
+  }
+}
+"""
+        assert _run(source, fn="test") == 0
+
+    def test_match_in_let_binding(self) -> None:
+        """Match result used in a let binding."""
+        source = """\
+data Option<T> { None, Some(T) }
+
+fn test(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  let @Option<Int> = Some(10);
+  let @Int = match @Option<Int>.0 {
+    None -> 0,
+    Some(@Int) -> @Int.0
+  };
+  @Int.0 + 1
+}
+"""
+        assert _run(source, fn="test") == 11
+
+    def test_match_wat_contains_tag_load(self) -> None:
+        """WAT output for ADT match contains i32.load (tag load)."""
+        source = """\
+data Color { Red, Green, Blue }
+
+fn test(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  let @Color = Red;
+  match @Color.0 {
+    Red -> 0,
+    Green -> 1,
+    Blue -> 2
+  }
+}
+"""
+        result = _compile_ok(source)
+        assert "i32.load" in result.wat
+
+    def test_match_function_compiles(self) -> None:
+        """Function with match is now exported (not skipped)."""
+        source = """\
+data Option<T> { None, Some(T) }
+
+fn unwrap_or(@Option<Int> -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  match @Option<Int>.0 {
+    None -> 0,
+    Some(@Int) -> @Int.0
+  }
+}
+"""
+        result = _compile_ok(source)
+        assert "unwrap_or" in result.exports

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.15"
+__version__ = "0.0.16"

--- a/vera/wasm.py
+++ b/vera/wasm.py
@@ -255,7 +255,10 @@ class WasmContext:
         if isinstance(expr, ast.NullaryConstructor):
             return self._translate_nullary_constructor(expr)
 
-        # Unsupported: match, handle, lambdas,
+        if isinstance(expr, ast.MatchExpr):
+            return self._translate_match(expr, env)
+
+        # Unsupported: handle, lambdas,
         # quantifiers, old/new, assert/assume, arrays, etc.
         return None
 
@@ -423,6 +426,10 @@ class WasmContext:
             return "i32" if expr.name in self._ctor_layouts else None
         if isinstance(expr, ast.NullaryConstructor):
             return "i32" if expr.name in self._ctor_layouts else None
+        if isinstance(expr, ast.MatchExpr):
+            if expr.arms:
+                return self._infer_expr_wasm_type(expr.arms[0].body)
+            return None
         return None
 
     # -----------------------------------------------------------------
@@ -535,6 +542,10 @@ class WasmContext:
             return "i32" if expr.name in self._ctor_layouts else None
         if isinstance(expr, ast.NullaryConstructor):
             return "i32" if expr.name in self._ctor_layouts else None
+        if isinstance(expr, ast.MatchExpr):
+            if expr.arms:
+                return self._infer_expr_wasm_type(expr.arms[0].body)
+            return None
         return None
 
     # -----------------------------------------------------------------
@@ -734,6 +745,248 @@ class WasmContext:
         # Leave pointer as result
         instructions.append(f"local.get {tmp}")
         return instructions
+
+    # -----------------------------------------------------------------
+    # Match expressions
+    # -----------------------------------------------------------------
+
+    def _translate_match(
+        self, expr: ast.MatchExpr, env: WasmSlotEnv
+    ) -> list[str] | None:
+        """Translate a match expression to WAT.
+
+        Evaluates the scrutinee once, saves to a local, then emits a
+        chained if-else cascade for each arm.
+        """
+        # Translate scrutinee
+        scr_instrs = self.translate_expr(expr.scrutinee, env)
+        if scr_instrs is None:
+            return None
+
+        scr_wasm_type = self._infer_expr_wasm_type(expr.scrutinee)
+        if scr_wasm_type is None:
+            return None
+
+        # Save scrutinee to a local
+        scr_local = self.alloc_local(scr_wasm_type)
+        instructions: list[str] = list(scr_instrs)
+        instructions.append(f"local.set {scr_local}")
+
+        # Infer result type of the match
+        result_type = self._infer_match_result_type(expr)
+
+        # Compile arms as chained if-else
+        arm_instrs = self._compile_match_arms(
+            expr.arms, scr_local, scr_wasm_type, result_type, env
+        )
+        if arm_instrs is None:
+            return None
+
+        instructions.extend(arm_instrs)
+        return instructions
+
+    def _infer_match_result_type(
+        self, expr: ast.MatchExpr
+    ) -> str | None:
+        """Infer the WASM result type from the first arm body."""
+        for arm in expr.arms:
+            wt = self._infer_expr_wasm_type(arm.body)
+            if wt is not None:
+                return wt
+        return None
+
+    def _compile_match_arms(
+        self,
+        arms: tuple[ast.MatchArm, ...],
+        scr_local: int,
+        scr_wasm_type: str,
+        result_type: str | None,
+        env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """Compile match arms as a chained if-else cascade."""
+        if not arms:
+            return None
+
+        arm = arms[0]
+        remaining = arms[1:]
+
+        # Check if this arm needs a condition
+        cond = self._translate_match_condition(
+            arm.pattern, scr_local, scr_wasm_type
+        )
+
+        if cond is None or not remaining:
+            # Unconditional arm (catch-all) or last arm — emit directly
+            setup = self._setup_match_arm_env(
+                arm.pattern, scr_local, scr_wasm_type, env
+            )
+            if setup is None:
+                return None
+            setup_instrs, arm_env = setup
+            body = self.translate_expr(arm.body, arm_env)
+            if body is None:
+                return None
+            return setup_instrs + body
+
+        # Conditional arm with more arms following
+        setup = self._setup_match_arm_env(
+            arm.pattern, scr_local, scr_wasm_type, env
+        )
+        if setup is None:
+            return None
+        setup_instrs, arm_env = setup
+        body = self.translate_expr(arm.body, arm_env)
+        if body is None:
+            return None
+
+        # Compile remaining arms (else branch)
+        else_instrs = self._compile_match_arms(
+            remaining, scr_local, scr_wasm_type, result_type, env
+        )
+        if else_instrs is None:
+            return None
+
+        # Build if-else block
+        result_annot = f" (result {result_type})" if result_type else ""
+        instrs: list[str] = list(cond)
+        instrs.append(f"if{result_annot}")
+        for i in setup_instrs:
+            instrs.append(f"  {i}")
+        for i in body:
+            instrs.append(f"  {i}")
+        instrs.append("else")
+        for i in else_instrs:
+            instrs.append(f"  {i}")
+        instrs.append("end")
+        return instrs
+
+    def _translate_match_condition(
+        self,
+        pattern: ast.Pattern,
+        scr_local: int,
+        scr_wasm_type: str,
+    ) -> list[str] | None:
+        """Emit i32 condition for a pattern check.
+
+        Returns None for unconditional patterns (wildcard/binding).
+        """
+        if isinstance(pattern, (ast.NullaryPattern, ast.ConstructorPattern)):
+            name = pattern.name
+            layout = self._ctor_layouts.get(name)
+            if layout is None:
+                return None
+            return [
+                f"local.get {scr_local}",
+                "i32.load",
+                f"i32.const {layout.tag}",
+                "i32.eq",
+            ]
+
+        if isinstance(pattern, ast.BoolPattern):
+            if pattern.value:
+                return [f"local.get {scr_local}"]
+            else:
+                return [f"local.get {scr_local}", "i32.eqz"]
+
+        if isinstance(pattern, ast.IntPattern):
+            return [
+                f"local.get {scr_local}",
+                f"i64.const {pattern.value}",
+                "i64.eq",
+            ]
+
+        # WildcardPattern, BindingPattern — unconditional
+        return None
+
+    def _setup_match_arm_env(
+        self,
+        pattern: ast.Pattern,
+        scr_local: int,
+        scr_wasm_type: str,
+        env: WasmSlotEnv,
+    ) -> tuple[list[str], WasmSlotEnv] | None:
+        """Extract fields and set up environment bindings for a match arm.
+
+        Returns (instructions, new_env) or None on failure.
+        """
+        if isinstance(pattern, (ast.WildcardPattern, ast.NullaryPattern,
+                                ast.BoolPattern, ast.IntPattern)):
+            return ([], env)
+
+        if isinstance(pattern, ast.BindingPattern):
+            # Bind the scrutinee itself to a new local
+            type_name = self._type_expr_to_slot_name(pattern.type_expr)
+            if type_name is None:
+                return None
+            local_idx = self.alloc_local(scr_wasm_type)
+            instrs = [
+                f"local.get {scr_local}",
+                f"local.set {local_idx}",
+            ]
+            new_env = env.push(type_name, local_idx)
+            return (instrs, new_env)
+
+        if isinstance(pattern, ast.ConstructorPattern):
+            layout = self._ctor_layouts.get(pattern.name)
+            if layout is None:
+                return None
+            return self._extract_constructor_fields(
+                pattern, scr_local, layout, env
+            )
+
+        return None
+
+    def _extract_constructor_fields(
+        self,
+        pattern: ast.ConstructorPattern,
+        scr_local: int,
+        layout: ConstructorLayout,
+        env: WasmSlotEnv,
+    ) -> tuple[list[str], WasmSlotEnv] | None:
+        """Extract fields from a constructor match into locals.
+
+        Computes field offsets from concrete binding types (same
+        monomorphization approach as _translate_constructor_call).
+        """
+        _sizes = {"i32": 4, "i64": 8, "f64": 8}
+        _aligns = {"i32": 4, "i64": 8, "f64": 8}
+        offset = 4  # after tag (i32, 4 bytes)
+        instrs: list[str] = []
+        new_env = env
+
+        for i, sub_pat in enumerate(pattern.sub_patterns):
+            if isinstance(sub_pat, ast.BindingPattern):
+                # Resolve concrete WASM type from the binding's type_expr
+                type_name = self._type_expr_to_slot_name(sub_pat.type_expr)
+                if type_name is None:
+                    return None
+                wt = self._slot_name_to_wasm_type(type_name)
+                if wt is None:
+                    return None
+                # Compute aligned offset for this field
+                align = _aligns.get(wt, 8)
+                offset = (offset + align - 1) & ~(align - 1)
+                # Load field from scrutinee pointer
+                local_idx = self.alloc_local(wt)
+                instrs.append(f"local.get {scr_local}")
+                instrs.append(f"{wt}.load offset={offset}")
+                instrs.append(f"local.set {local_idx}")
+                new_env = new_env.push(type_name, local_idx)
+                offset += _sizes.get(wt, 8)
+
+            elif isinstance(sub_pat, ast.WildcardPattern):
+                # Skip this field but advance offset using layout's type
+                if i < len(layout.field_offsets):
+                    _, generic_wt = layout.field_offsets[i]
+                    align = _aligns.get(generic_wt, 8)
+                    offset = (offset + align - 1) & ~(align - 1)
+                    offset += _sizes.get(generic_wt, 8)
+
+            else:
+                # Nested constructor patterns — deferred
+                return None
+
+        return (instrs, new_env)
 
     # -----------------------------------------------------------------
     # Helpers


### PR DESCRIPTION
## Summary
- Compile `MatchExpr` AST nodes to WASM chained if-else cascades with tag dispatch and field extraction
- ADT patterns: load tag from heap pointer (`i32.load`), compare with constructor tag, branch
- Constructor field extraction: load fields at monomorphized offsets into fresh locals, bind in scoped environment
- Bool patterns: direct `i32` value test; Int patterns: `i64` equality comparison
- Wildcard and binding patterns as unconditional catch-alls
- Recursive arm compilation: each arm emits condition → `if (result T)` → body → `else` → remaining arms → `end`

Closes #26.

## Changes
- **`vera/wasm.py`**: `_translate_match`, `_compile_match_arms`, `_translate_match_condition`, `_setup_match_arm_env`, `_extract_constructor_fields` — 5 new methods (~120 LOC); updated `_infer_expr_wasm_type` and `_infer_block_result_type` for `MatchExpr`
- **`tests/test_codegen.py`**: 20 new `TestMatchExpressions` tests — ADT tag dispatch (Option, Color), field extraction (Int, Bool, two-field), wildcard catch-alls, Bool/Int literal patterns, binding patterns, let-binding composability, WAT inspection
- Version bump to v0.0.16, CHANGELOG, README roadmap updated

## Test plan
- [x] 643 tests pass (`pytest tests/ -v`)
- [x] mypy clean (`mypy vera/`)
- [x] All 14 examples pass (`python scripts/check_examples.py`)
- [x] Version consistent (`python scripts/check_version_sync.py`)
- [x] Pre-commit hooks pass (mypy, pytest, examples, readme)

🤖 Generated with [Claude Code](https://claude.com/claude-code)