### PR TITLE
Add generics monomorphization — compile forall<T> to WASM (C6i)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.17] - 2026-02-24
+
+### Added
+- **Generics monomorphization** (C6i — closes #29): compile `forall<T>` functions to WASM via monomorphization
+  - Collection pass: walk non-generic function bodies to find calls to generic functions, infer concrete type variable bindings
+  - AST substitution: create monomorphized FnDecl copies with type variables replaced by concrete types (e.g. `@T.0` → `@Int.0`)
+  - Name mangling: `identity` + `(Int,)` → `identity$Int`, `const` + `(Int, Bool)` → `const$Int_Bool`
+  - Call rewriting: generic function calls resolve to mangled names at WASM translation time
+  - FnCall type inference: infer WASM return types and Vera type names for function call expressions (improves if-branch and chained-call handling)
+  - Supports: literal args, slot ref args, constructor args, chained generic calls, arithmetic expression args
+- **Codegen tests**: 17 new tests — identity/const/is_some instantiation, two-instantiation exports, ADT match, chained calls, if-branches, let bindings, example files (660 total, up from 643)
+
 ## [0.0.16] - 2026-02-24
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ vera parse file.vera              # Print the parse tree
 vera ast file.vera                # Print the typed AST
 vera ast --json file.vera         # Print the AST as JSON
 
-pytest tests/ -v                  # Run the test suite (643 tests)
+pytest tests/ -v                  # Run the test suite (660 tests)
 mypy vera/                        # Type-check the compiler itself
 
 python scripts/check_examples.py      # Verify all 14 examples parse + check + verify

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Development follows an **interleaved spiral** — each phase adds a complete com
 | C3 | v0.0.5 | **Type checker** — decidable type checking, slot resolution, effect tracking | Done |
 | C4 | v0.0.8 | **Contract verifier** — Z3 integration, refinement types, counterexamples | Done |
 | C5 | v0.0.9 | **WASM codegen** — compile to WebAssembly, `vera compile` / `vera run` | Done |
-| C6 | v0.0.10–0.0.23 | **Codegen completeness** — ADTs, match, closures, effects, generics in WASM | **In progress** (C6a–C6g done) |
+| C6 | v0.0.10–0.0.23 | **Codegen completeness** — ADTs, match, closures, effects, generics in WASM | **In progress** (C6a–C6i done) |
 | C7 | — | **Module system** — cross-file imports, public/private visibility | Planned |
 | C8 | v0.1.0 | **End-to-end** — all examples compile and run, spec complete, polish | Planned |
 
@@ -183,7 +183,7 @@ The code generator compiles 7 of 14 examples. C6 extends WASM compilation to all
 | ~~C6e~~ | ~~Bump allocator — heap allocation for tagged values~~ | — | ~~Done (v0.0.14)~~ |
 | ~~C6f~~ | ~~ADT constructors — heap-allocated tagged unions~~ | — | ~~Done (v0.0.15)~~ |
 | ~~C6g~~ | ~~Match expressions — tag dispatch, field extraction~~ | ~~#26~~ | ~~Done (v0.0.16)~~ |
-| C6i | Generics — monomorphization of `forall<T>` functions | #29 | generics.vera, list_ops.vera |
+| ~~C6i~~ | ~~Generics — monomorphization of `forall<T>` functions~~ | ~~#29~~ | ~~Done (v0.0.17)~~ |
 
 **Higher-order and effects:**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.16"
+version = "0.0.17"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -2420,3 +2420,267 @@ fn unwrap_or(@Option<Int> -> @Int)
 """
         result = _compile_ok(source)
         assert "unwrap_or" in result.exports
+
+
+# =====================================================================
+# C6i: Monomorphization of generic (forall<T>) functions
+# =====================================================================
+
+
+class TestMonomorphization:
+    """Tests for monomorphization of forall<T> functions."""
+
+    def test_identity_int(self) -> None:
+        """forall<T> fn identity instantiated with Int."""
+        source = """\
+forall<T> fn identity(@T -> @T)
+  requires(true) ensures(true) effects(pure)
+{ @T.0 }
+
+fn main(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{ identity(42) }
+"""
+        assert _run(source, fn="main") == 42
+
+    def test_identity_bool(self) -> None:
+        """forall<T> fn identity instantiated with Bool."""
+        source = """\
+forall<T> fn identity(@T -> @T)
+  requires(true) ensures(true) effects(pure)
+{ @T.0 }
+
+fn main(-> @Bool)
+  requires(true) ensures(true) effects(pure)
+{ identity(true) }
+"""
+        assert _run(source, fn="main") == 1
+
+    def test_identity_two_instantiations(self) -> None:
+        """Same generic function instantiated with both Int and Bool."""
+        source = """\
+forall<T> fn identity(@T -> @T)
+  requires(true) ensures(true) effects(pure)
+{ @T.0 }
+
+fn test_int(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{ identity(42) }
+
+fn test_bool(-> @Bool)
+  requires(true) ensures(true) effects(pure)
+{ identity(false) }
+"""
+        result = _compile_ok(source)
+        assert "identity$Int" in result.exports
+        assert "identity$Bool" in result.exports
+        # Run both
+        exec_int = execute(result, fn_name="test_int")
+        assert exec_int.value == 42
+        exec_bool = execute(result, fn_name="test_bool")
+        assert exec_bool.value == 0
+
+    def test_identity_slot_ref_arg(self) -> None:
+        """Generic function called with a slot reference argument."""
+        source = """\
+forall<T> fn identity(@T -> @T)
+  requires(true) ensures(true) effects(pure)
+{ @T.0 }
+
+fn main(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ identity(@Int.0) }
+"""
+        assert _run(source, fn="main", args=[99]) == 99
+
+    def test_const_function(self) -> None:
+        """forall<A, B> fn const with two type parameters."""
+        source = """\
+forall<A, B> fn const(@A, @B -> @A)
+  requires(true) ensures(true) effects(pure)
+{ @A.0 }
+
+fn main(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{ const(42, true) }
+"""
+        assert _run(source, fn="main") == 42
+
+    def test_generic_with_adt_match(self) -> None:
+        """forall<T> fn is_some with ADT match (Some case)."""
+        source = """\
+data Option<T> { None, Some(T) }
+
+forall<T> fn is_some(@Option<T> -> @Bool)
+  requires(true) ensures(true) effects(pure)
+{
+  match @Option<T>.0 {
+    None -> false,
+    Some(@T) -> true
+  }
+}
+
+fn main(-> @Bool)
+  requires(true) ensures(true) effects(pure)
+{ is_some(Some(1)) }
+"""
+        assert _run(source, fn="main") == 1
+
+    def test_generic_with_adt_match_none(self) -> None:
+        """forall<T> fn is_some with ADT match (None case)."""
+        source = """\
+data Option<T> { None, Some(T) }
+
+forall<T> fn is_some(@Option<T> -> @Bool)
+  requires(true) ensures(true) effects(pure)
+{
+  match @Option<T>.0 {
+    None -> false,
+    Some(@T) -> true
+  }
+}
+
+fn main(-> @Bool)
+  requires(true) ensures(true) effects(pure)
+{
+  let @Option<Int> = None;
+  is_some(@Option<Int>.0)
+}
+"""
+        assert _run(source, fn="main") == 0
+
+    def test_generic_fn_wat_has_mangled_name(self) -> None:
+        """WAT output contains mangled function name."""
+        source = """\
+forall<T> fn identity(@T -> @T)
+  requires(true) ensures(true) effects(pure)
+{ @T.0 }
+
+fn main(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{ identity(42) }
+"""
+        result = _compile_ok(source)
+        assert "$identity$Int" in result.wat
+
+    def test_generic_fn_mangled_in_exports(self) -> None:
+        """Mangled name appears in exports, original generic does not."""
+        source = """\
+forall<T> fn identity(@T -> @T)
+  requires(true) ensures(true) effects(pure)
+{ @T.0 }
+
+fn main(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{ identity(42) }
+"""
+        result = _compile_ok(source)
+        assert "identity$Int" in result.exports
+        assert "identity" not in result.exports
+
+    def test_non_generic_fn_unaffected(self) -> None:
+        """Non-generic functions compile normally alongside generic ones."""
+        source = """\
+forall<T> fn identity(@T -> @T)
+  requires(true) ensures(true) effects(pure)
+{ @T.0 }
+
+fn double(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 + @Int.0 }
+
+fn main(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{ double(identity(21)) }
+"""
+        assert _run(source, fn="main") == 42
+
+    def test_generic_identity_in_let_binding(self) -> None:
+        """Generic call result used in a let binding."""
+        source = """\
+forall<T> fn identity(@T -> @T)
+  requires(true) ensures(true) effects(pure)
+{ @T.0 }
+
+fn main(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  let @Int = identity(10);
+  @Int.0 + 5
+}
+"""
+        assert _run(source, fn="main") == 15
+
+    def test_generic_chained_calls(self) -> None:
+        """Generic function called with result of another generic call."""
+        source = """\
+forall<T> fn identity(@T -> @T)
+  requires(true) ensures(true) effects(pure)
+{ @T.0 }
+
+fn main(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{ identity(identity(99)) }
+"""
+        assert _run(source, fn="main") == 99
+
+    def test_generic_in_if_branch(self) -> None:
+        """Generic call inside an if-then-else branch."""
+        source = """\
+forall<T> fn identity(@T -> @T)
+  requires(true) ensures(true) effects(pure)
+{ @T.0 }
+
+fn main(@Bool -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  if @Bool.0 then { identity(1) } else { identity(2) }
+}
+"""
+        assert _run(source, fn="main", args=[1]) == 1
+        assert _run(source, fn="main", args=[0]) == 2
+
+    def test_generic_with_arithmetic_arg(self) -> None:
+        """Generic function called with arithmetic expression as argument."""
+        source = """\
+forall<T> fn identity(@T -> @T)
+  requires(true) ensures(true) effects(pure)
+{ @T.0 }
+
+fn main(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{ identity(3 + 4) }
+"""
+        assert _run(source, fn="main") == 7
+
+    def test_generic_no_callers_skipped(self) -> None:
+        """Generic function with no callers is gracefully skipped."""
+        source = """\
+forall<T> fn identity(@T -> @T)
+  requires(true) ensures(true) effects(pure)
+{ @T.0 }
+
+fn main(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{ 42 }
+"""
+        result = _compile_ok(source)
+        assert "main" in result.exports
+        # identity has no callers → no monomorphized version → not in exports
+        assert "identity" not in result.exports
+
+    def test_generics_example_file(self) -> None:
+        """examples/generics.vera compiles without errors."""
+        from pathlib import Path
+        path = Path(__file__).parent.parent / "examples" / "generics.vera"
+        source = path.read_text()
+        result = _compile(source)
+        assert result.ok
+
+    def test_list_ops_example_file(self) -> None:
+        """examples/list_ops.vera still compiles (concrete, not generic)."""
+        from pathlib import Path
+        path = Path(__file__).parent.parent / "examples" / "list_ops.vera"
+        source = path.read_text()
+        result = _compile(source)
+        assert result.ok

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.16"
+__version__ = "0.0.17"

--- a/vera/codegen.py
+++ b/vera/codegen.py
@@ -11,8 +11,9 @@ See spec/11-compilation.md for the compilation specification.
 from __future__ import annotations
 
 import sys
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields, replace
 from io import StringIO
+from typing import Any
 
 import wasmtime
 
@@ -312,6 +313,11 @@ class CodeGenerator:
         # Pass 1: register all function signatures
         self._register_all(program)
 
+        # Pass 1.5: monomorphize generic functions
+        mono_decls = self._monomorphize(program)
+        for mdecl in mono_decls:
+            self._register_fn(mdecl)
+
         # Pass 2: compile function bodies
         functions_wat: list[str] = []
         exports: list[str] = []
@@ -329,6 +335,13 @@ class CodeGenerator:
                             wfn_wat = self._compile_fn(wfn, export=False)
                             if wfn_wat is not None:
                                 functions_wat.append(wfn_wat)
+
+        # Compile monomorphized functions
+        for mdecl in mono_decls:
+            fn_wat = self._compile_fn(mdecl)
+            if fn_wat is not None:
+                functions_wat.append(fn_wat)
+                exports.append(mdecl.name)
 
         # Assemble the module
         wat = self._assemble_module(functions_wat)
@@ -395,6 +408,433 @@ class CodeGenerator:
         self._adt_layouts[decl.name] = layouts
         self._needs_alloc = True
         self._needs_memory = True
+
+    # -----------------------------------------------------------------
+    # Monomorphization
+    # -----------------------------------------------------------------
+
+    def _monomorphize(
+        self, program: ast.Program,
+    ) -> list[ast.FnDecl]:
+        """Monomorphize generic functions for all concrete call sites.
+
+        Returns a list of new FnDecl nodes with type variables replaced
+        by concrete types and names mangled.
+        """
+        # Identify generic function declarations
+        generic_decls: dict[str, ast.FnDecl] = {}
+        for tld in program.declarations:
+            decl = tld.decl
+            if isinstance(decl, ast.FnDecl) and decl.forall_vars:
+                generic_decls[decl.name] = decl
+
+        if not generic_decls:
+            return []
+
+        # Build constructor → ADT name mapping
+        ctor_to_adt: dict[str, str] = {}
+        for adt_name in self._adt_layouts:
+            for ctor_name in self._adt_layouts[adt_name]:
+                ctor_to_adt[ctor_name] = adt_name
+
+        # Collect concrete instantiations from non-generic function bodies
+        instances: dict[str, set[tuple[str, ...]]] = {
+            name: set() for name in generic_decls
+        }
+        for tld in program.declarations:
+            decl = tld.decl
+            if isinstance(decl, ast.FnDecl) and not decl.forall_vars:
+                self._collect_calls_in_expr(
+                    decl.body, generic_decls, ctor_to_adt, instances,
+                )
+
+        # Generate monomorphized FnDecls
+        mono_decls: list[ast.FnDecl] = []
+        for fn_name, type_arg_set in instances.items():
+            for concrete_types in type_arg_set:
+                decl = generic_decls[fn_name]
+                mono = self._monomorphize_fn(decl, concrete_types)
+                mono_decls.append(mono)
+
+        # Store generic fn info for call rewriting in wasm.py
+        self._generic_fn_info: dict[
+            str, tuple[tuple[str, ...], tuple[ast.TypeExpr, ...]]
+        ] = {}
+        for name, decl in generic_decls.items():
+            assert decl.forall_vars is not None
+            self._generic_fn_info[name] = (decl.forall_vars, decl.params)
+
+        return mono_decls
+
+    def _collect_calls_in_expr(
+        self,
+        expr: ast.Expr,
+        generic_decls: dict[str, ast.FnDecl],
+        ctor_to_adt: dict[str, str],
+        instances: dict[str, set[tuple[str, ...]]],
+    ) -> None:
+        """Walk an expression tree collecting generic call sites."""
+        if isinstance(expr, ast.FnCall) and expr.name in generic_decls:
+            decl = generic_decls[expr.name]
+            type_args = self._infer_type_args_from_call(
+                decl, expr, ctor_to_adt, generic_decls,
+            )
+            if type_args is not None:
+                instances[expr.name].add(type_args)
+
+        # Recurse into sub-expressions
+        if isinstance(expr, ast.Block):
+            for stmt in expr.statements:
+                if isinstance(stmt, ast.LetStmt):
+                    self._collect_calls_in_expr(
+                        stmt.value, generic_decls, ctor_to_adt, instances,
+                    )
+                elif isinstance(stmt, ast.ExprStmt):
+                    self._collect_calls_in_expr(
+                        stmt.expr, generic_decls, ctor_to_adt, instances,
+                    )
+            self._collect_calls_in_expr(
+                expr.expr, generic_decls, ctor_to_adt, instances,
+            )
+        elif isinstance(expr, ast.BinaryExpr):
+            self._collect_calls_in_expr(
+                expr.left, generic_decls, ctor_to_adt, instances,
+            )
+            self._collect_calls_in_expr(
+                expr.right, generic_decls, ctor_to_adt, instances,
+            )
+        elif isinstance(expr, ast.UnaryExpr):
+            self._collect_calls_in_expr(
+                expr.operand, generic_decls, ctor_to_adt, instances,
+            )
+        elif isinstance(expr, ast.IfExpr):
+            self._collect_calls_in_expr(
+                expr.condition, generic_decls, ctor_to_adt, instances,
+            )
+            self._collect_calls_in_expr(
+                expr.then_branch, generic_decls, ctor_to_adt, instances,
+            )
+            self._collect_calls_in_expr(
+                expr.else_branch, generic_decls, ctor_to_adt, instances,
+            )
+        elif isinstance(expr, ast.FnCall):
+            for arg in expr.args:
+                self._collect_calls_in_expr(
+                    arg, generic_decls, ctor_to_adt, instances,
+                )
+        elif isinstance(expr, ast.ConstructorCall):
+            for arg in expr.args:
+                self._collect_calls_in_expr(
+                    arg, generic_decls, ctor_to_adt, instances,
+                )
+        elif isinstance(expr, ast.MatchExpr):
+            self._collect_calls_in_expr(
+                expr.scrutinee, generic_decls, ctor_to_adt, instances,
+            )
+            for arm in expr.arms:
+                self._collect_calls_in_expr(
+                    arm.body, generic_decls, ctor_to_adt, instances,
+                )
+
+    def _infer_type_args_from_call(
+        self,
+        decl: ast.FnDecl,
+        call: ast.FnCall,
+        ctor_to_adt: dict[str, str],
+        generic_decls: dict[str, ast.FnDecl] | None = None,
+    ) -> tuple[str, ...] | None:
+        """Infer concrete type variable bindings from a call's arguments.
+
+        Returns a tuple of concrete type names, one per forall_var, or
+        None if inference fails.
+        """
+        forall_vars = decl.forall_vars
+        if not forall_vars:
+            return None
+
+        mapping: dict[str, str] = {}
+        for param_te, arg in zip(decl.params, call.args):
+            self._unify_param_arg(param_te, arg, forall_vars, ctor_to_adt,
+                                  mapping, generic_decls)
+
+        # Check all type vars are resolved
+        result = []
+        for tv in forall_vars:
+            if tv not in mapping:
+                return None
+            result.append(mapping[tv])
+        return tuple(result)
+
+    def _unify_param_arg(
+        self,
+        param_te: ast.TypeExpr,
+        arg: ast.Expr,
+        forall_vars: tuple[str, ...],
+        ctor_to_adt: dict[str, str],
+        mapping: dict[str, str],
+        generic_decls: dict[str, ast.FnDecl] | None = None,
+    ) -> None:
+        """Unify a parameter TypeExpr against an argument to bind type vars."""
+        if isinstance(param_te, ast.RefinementType):
+            self._unify_param_arg(
+                param_te.base_type, arg, forall_vars, ctor_to_adt, mapping,
+                generic_decls,
+            )
+            return
+
+        if not isinstance(param_te, ast.NamedType):
+            return
+
+        if param_te.name in forall_vars:
+            # Direct type variable — infer from argument
+            vera_type = self._infer_vera_type_name(
+                arg, ctor_to_adt, generic_decls)
+            if vera_type and param_te.name not in mapping:
+                mapping[param_te.name] = vera_type
+            return
+
+        # Parameterized type like Option<T> — match type args
+        if param_te.type_args:
+            arg_info = self._get_arg_type_info(arg, ctor_to_adt)
+            if arg_info and arg_info[0] == param_te.name:
+                for param_ta, arg_ta_name in zip(
+                    param_te.type_args, arg_info[1]
+                ):
+                    if (isinstance(param_ta, ast.NamedType)
+                            and param_ta.name in forall_vars
+                            and param_ta.name not in mapping):
+                        mapping[param_ta.name] = arg_ta_name
+
+    def _infer_vera_type_name(
+        self,
+        expr: ast.Expr,
+        ctor_to_adt: dict[str, str],
+        generic_decls: dict[str, ast.FnDecl] | None = None,
+    ) -> str | None:
+        """Infer the simple Vera type name of an expression."""
+        if isinstance(expr, ast.IntLit):
+            return "Int"
+        if isinstance(expr, ast.BoolLit):
+            return "Bool"
+        if isinstance(expr, ast.FloatLit):
+            return "Float64"
+        if isinstance(expr, ast.UnitLit):
+            return "Unit"
+        if isinstance(expr, ast.SlotRef):
+            return expr.type_name
+        if isinstance(expr, ast.ConstructorCall):
+            return ctor_to_adt.get(expr.name)
+        if isinstance(expr, ast.NullaryConstructor):
+            return ctor_to_adt.get(expr.name)
+        if isinstance(expr, ast.BinaryExpr):
+            if expr.op in (ast.BinOp.EQ, ast.BinOp.NEQ, ast.BinOp.LT,
+                           ast.BinOp.GT, ast.BinOp.LE, ast.BinOp.GE,
+                           ast.BinOp.AND, ast.BinOp.OR, ast.BinOp.IMPLIES):
+                return "Bool"
+            return self._infer_vera_type_name(
+                expr.left, ctor_to_adt, generic_decls)
+        if isinstance(expr, ast.UnaryExpr):
+            if expr.op == ast.UnaryOp.NOT:
+                return "Bool"
+            return self._infer_vera_type_name(
+                expr.operand, ctor_to_adt, generic_decls)
+        if isinstance(expr, ast.IfExpr):
+            return self._infer_vera_type_name(
+                expr.then_branch.expr, ctor_to_adt, generic_decls)
+        if isinstance(expr, ast.FnCall) and generic_decls:
+            return self._infer_fncall_vera_type(
+                expr, ctor_to_adt, generic_decls)
+        if isinstance(expr, ast.FnCall):
+            return self._infer_fncall_vera_type_simple(expr)
+        return None
+
+    def _infer_fncall_vera_type(
+        self,
+        call: ast.FnCall,
+        ctor_to_adt: dict[str, str],
+        generic_decls: dict[str, ast.FnDecl],
+    ) -> str | None:
+        """Infer the Vera return type of a function call.
+
+        For generic calls, infers type variable bindings from arguments,
+        then substitutes into the return TypeExpr.
+        """
+        if call.name in generic_decls:
+            decl = generic_decls[call.name]
+            type_args = self._infer_type_args_from_call(
+                decl, call, ctor_to_adt, generic_decls,
+            )
+            if type_args and decl.forall_vars:
+                mapping = dict(zip(decl.forall_vars, type_args))
+                ret_te = decl.return_type
+                if isinstance(ret_te, ast.NamedType):
+                    return mapping.get(ret_te.name, ret_te.name)
+        return self._infer_fncall_vera_type_simple(call)
+
+    def _infer_fncall_vera_type_simple(self, call: ast.FnCall) -> str | None:
+        """Infer Vera return type from registered function signatures."""
+        sig = self._fn_sigs.get(call.name)
+        if sig:
+            _, ret_wt = sig
+            if ret_wt == "i64":
+                return "Int"
+            if ret_wt == "i32":
+                return "Bool"
+            if ret_wt == "f64":
+                return "Float64"
+        return None
+
+    def _get_arg_type_info(
+        self, expr: ast.Expr, ctor_to_adt: dict[str, str],
+    ) -> tuple[str, tuple[str, ...]] | None:
+        """Get (type_name, type_arg_names) for an argument expression.
+
+        Used to match parameterized types like Option<T> against
+        concrete arguments like @Option<Int>.0.
+        """
+        if isinstance(expr, ast.SlotRef):
+            if expr.type_args:
+                arg_names = []
+                for ta in expr.type_args:
+                    if isinstance(ta, ast.NamedType):
+                        arg_names.append(ta.name)
+                    else:
+                        return None
+                return (expr.type_name, tuple(arg_names))
+            return (expr.type_name, ())
+        if isinstance(expr, ast.ConstructorCall):
+            adt_name = ctor_to_adt.get(expr.name)
+            if adt_name:
+                # Infer type args from constructor arguments
+                arg_types = []
+                for a in expr.args:
+                    t = self._infer_vera_type_name(a, ctor_to_adt)
+                    if t:
+                        arg_types.append(t)
+                    else:
+                        return None
+                return (adt_name, tuple(arg_types))
+        return None
+
+    @staticmethod
+    def _mangle_fn_name(name: str, concrete_types: tuple[str, ...]) -> str:
+        """Produce a mangled name for a monomorphized function.
+
+        Example: identity + ("Int",) -> "identity$Int"
+        """
+        return f"{name}${'_'.join(concrete_types)}"
+
+    def _monomorphize_fn(
+        self,
+        decl: ast.FnDecl,
+        concrete_types: tuple[str, ...],
+    ) -> ast.FnDecl:
+        """Create a monomorphized copy of a generic function.
+
+        Replaces type variables with concrete types throughout the AST
+        and mangles the function name.
+        """
+        assert decl.forall_vars is not None
+        mapping = dict(zip(decl.forall_vars, concrete_types))
+        mangled = self._mangle_fn_name(decl.name, concrete_types)
+
+        # Substitute type variables in the entire FnDecl
+        substituted = self._substitute_in_ast(decl, mapping)
+        assert isinstance(substituted, ast.FnDecl)
+
+        # Override name and clear forall_vars
+        return replace(substituted, name=mangled, forall_vars=None)
+
+    def _substitute_in_ast(
+        self, node: ast.Node, mapping: dict[str, str],
+    ) -> ast.Node:
+        """Recursively substitute type variable names in an AST subtree.
+
+        Handles NamedType (type expressions) and SlotRef (slot references)
+        as special cases; all other nodes are walked generically via
+        dataclass fields.
+        """
+        # Special case: NamedType — substitute type variable names
+        if isinstance(node, ast.NamedType):
+            new_name = mapping.get(node.name, node.name)
+            new_args: tuple[ast.TypeExpr, ...] | None = node.type_args
+            if node.type_args:
+                new_args = tuple(
+                    self._substitute_type_expr(ta, mapping)
+                    for ta in node.type_args
+                )
+            if new_name != node.name or new_args is not node.type_args:
+                return replace(node, name=new_name, type_args=new_args)
+            return node
+
+        # Special case: SlotRef — substitute type_name and type_args
+        if isinstance(node, ast.SlotRef):
+            new_type_name = mapping.get(node.type_name, node.type_name)
+            new_slot_args: tuple[ast.TypeExpr, ...] | None = node.type_args
+            if node.type_args:
+                new_slot_args = tuple(
+                    self._substitute_type_expr(ta, mapping)
+                    for ta in node.type_args
+                )
+            if (new_type_name != node.type_name
+                    or new_slot_args is not node.type_args):
+                return replace(
+                    node, type_name=new_type_name, type_args=new_slot_args,
+                )
+            return node
+
+        # Special case: ResultRef — substitute type_name and type_args
+        if isinstance(node, ast.ResultRef):
+            new_type_name = mapping.get(node.type_name, node.type_name)
+            new_res_args: tuple[ast.TypeExpr, ...] | None = node.type_args
+            if node.type_args:
+                new_res_args = tuple(
+                    self._substitute_type_expr(ta, mapping)
+                    for ta in node.type_args
+                )
+            if (new_type_name != node.type_name
+                    or new_res_args is not node.type_args):
+                return replace(
+                    node, type_name=new_type_name, type_args=new_res_args,
+                )
+            return node
+
+        # Generic case: recurse into all dataclass fields
+        changes: dict[str, Any] = {}
+        for f in fields(node):
+            if f.name == "span":
+                continue
+            val = getattr(node, f.name)
+            new_val = self._substitute_value(val, mapping)
+            if new_val is not val:
+                changes[f.name] = new_val
+
+        if changes:
+            return replace(node, **changes)
+        return node
+
+    def _substitute_value(
+        self, val: Any, mapping: dict[str, str],
+    ) -> Any:
+        """Recursively substitute type variables in a field value."""
+        if isinstance(val, ast.Node):
+            return self._substitute_in_ast(val, mapping)
+        if isinstance(val, tuple):
+            new_items = tuple(
+                self._substitute_value(v, mapping) for v in val
+            )
+            if any(n is not o for n, o in zip(new_items, val)):
+                return new_items
+            return val
+        return val
+
+    def _substitute_type_expr(
+        self, te: ast.TypeExpr, mapping: dict[str, str],
+    ) -> ast.TypeExpr:
+        """Substitute type variables in a TypeExpr, returning a TypeExpr."""
+        result = self._substitute_in_ast(te, mapping)
+        assert isinstance(result, ast.TypeExpr)
+        return result
 
     def _compute_constructor_layout(
         self,
@@ -485,8 +925,11 @@ class CodeGenerator:
 
         # Flatten ADT layouts into ctor_name -> layout for WasmContext
         ctor_layouts = {}
-        for layouts in self._adt_layouts.values():
+        ctor_to_adt: dict[str, str] = {}
+        for adt_name, layouts in self._adt_layouts.items():
             ctor_layouts.update(layouts)
+            for ctor_name in layouts:
+                ctor_to_adt[ctor_name] = adt_name
         adt_type_names = set(self._adt_layouts.keys())
 
         ctx = WasmContext(
@@ -494,7 +937,15 @@ class CodeGenerator:
             effect_ops=effect_ops,
             ctor_layouts=ctor_layouts,
             adt_type_names=adt_type_names,
+            generic_fn_info=getattr(self, "_generic_fn_info", None),
+            ctor_to_adt=ctor_to_adt,
         )
+        # Build function return type map for FnCall type inference
+        fn_ret_types: dict[str, str | None] = {}
+        for fn_name, (_, ret_wt) in self._fn_sigs.items():
+            if ret_wt != "unsupported":
+                fn_ret_types[fn_name] = ret_wt
+        ctx.set_fn_ret_types(fn_ret_types)
         env = WasmSlotEnv()
 
         # Allocate parameters

--- a/vera/wasm.py
+++ b/vera/wasm.py
@@ -159,6 +159,10 @@ class WasmContext:
         effect_ops: dict[str, tuple[str, bool]] | None = None,
         ctor_layouts: dict[str, ConstructorLayout] | None = None,
         adt_type_names: set[str] | None = None,
+        generic_fn_info: (
+            dict[str, tuple[tuple[str, ...], tuple[ast.TypeExpr, ...]]] | None
+        ) = None,
+        ctor_to_adt: dict[str, str] | None = None,
     ) -> None:
         self.string_pool = string_pool
         self._next_local: int = 0
@@ -172,6 +176,22 @@ class WasmContext:
         self._ctor_layouts: dict[str, ConstructorLayout] = ctor_layouts or {}
         # ADT type names for slot/param type resolution
         self._adt_type_names: set[str] = adt_type_names or set()
+        # Generic function info for call rewriting:
+        # fn_name -> (forall_vars, param_type_exprs)
+        self._generic_fn_info: dict[
+            str, tuple[tuple[str, ...], tuple[ast.TypeExpr, ...]]
+        ] = generic_fn_info or {}
+        # Constructor name → ADT name reverse mapping
+        self._ctor_to_adt: dict[str, str] = ctor_to_adt or {}
+        # Function return WASM types for type inference:
+        # fn_name → return_wasm_type (str | None)
+        self._fn_ret_types: dict[str, str | None] = {}
+
+    def set_fn_ret_types(
+        self, ret_types: dict[str, str | None],
+    ) -> None:
+        """Set function return WASM types for FnCall type inference."""
+        self._fn_ret_types = ret_types
 
     def set_result_local(self, local_idx: int) -> None:
         """Set the local index used for @T.result in postconditions."""
@@ -421,7 +441,7 @@ class WasmContext:
             if expr.op == ast.UnaryOp.NOT:
                 return "i32"
         if isinstance(expr, ast.FnCall):
-            return None  # can't infer without type info
+            return self._infer_fncall_wasm_type(expr)
         if isinstance(expr, ast.ConstructorCall):
             return "i32" if expr.name in self._ctor_layouts else None
         if isinstance(expr, ast.NullaryConstructor):
@@ -430,6 +450,23 @@ class WasmContext:
             if expr.arms:
                 return self._infer_expr_wasm_type(expr.arms[0].body)
             return None
+        return None
+
+    def _infer_fncall_wasm_type(self, expr: ast.FnCall) -> str | None:
+        """Infer the WASM return type of a function call.
+
+        For generic calls, resolves the mangled name and looks up its
+        registered return type.  For non-generic calls, uses the
+        registered return type directly.
+        """
+        # Try generic call resolution first
+        if expr.name in self._generic_fn_info:
+            mangled = self._resolve_generic_call(expr)
+            if mangled and mangled in self._fn_ret_types:
+                return self._fn_ret_types[mangled]
+        # Non-generic function — direct lookup
+        if expr.name in self._fn_ret_types:
+            return self._fn_ret_types[expr.name]
         return None
 
     # -----------------------------------------------------------------
@@ -531,7 +568,7 @@ class WasmContext:
         if isinstance(expr, ast.IfExpr):
             return self._infer_block_result_type(expr.then_branch)
         if isinstance(expr, ast.FnCall):
-            return None  # can't infer without type info
+            return self._infer_fncall_wasm_type(expr)
         if isinstance(expr, ast.QualifiedCall):
             return None  # effect ops return Unit (void)
         if isinstance(expr, ast.StringLit):
@@ -620,6 +657,13 @@ class WasmContext:
             instructions.append(f"call {import_name}")
             return instructions
 
+        # Resolve call target — rewrite generic calls to mangled names
+        call_target = call.name
+        if call.name in self._generic_fn_info:
+            resolved = self._resolve_generic_call(call)
+            if resolved is not None:
+                call_target = resolved
+
         # Regular function call
         instructions = []
         for arg in call.args:
@@ -627,7 +671,7 @@ class WasmContext:
             if arg_instrs is None:
                 return None
             instructions.extend(arg_instrs)
-        instructions.append(f"call ${call.name}")
+        instructions.append(f"call ${call_target}")
         return instructions
 
     def _translate_qualified_call(
@@ -643,6 +687,173 @@ class WasmContext:
             instructions.extend(arg_instrs)
         instructions.append(f"call $vera.{call.name}")
         return instructions
+
+    # -----------------------------------------------------------------
+    # Generic call resolution
+    # -----------------------------------------------------------------
+
+    def _resolve_generic_call(self, call: ast.FnCall) -> str | None:
+        """Resolve a call to a generic function to its mangled name.
+
+        Infers concrete type variable bindings from the call's argument
+        expressions, then produces the mangled name like 'identity$Int'.
+        Returns None if type inference fails.
+        """
+        forall_vars, param_types = self._generic_fn_info[call.name]
+        mapping: dict[str, str] = {}
+
+        for param_te, arg in zip(param_types, call.args):
+            self._unify_param_arg_wasm(param_te, arg, forall_vars, mapping)
+
+        # Build mangled name
+        parts = []
+        for tv in forall_vars:
+            if tv not in mapping:
+                return None
+            parts.append(mapping[tv])
+        return f"{call.name}${'_'.join(parts)}"
+
+    def _unify_param_arg_wasm(
+        self,
+        param_te: ast.TypeExpr,
+        arg: ast.Expr,
+        forall_vars: tuple[str, ...],
+        mapping: dict[str, str],
+    ) -> None:
+        """Unify a parameter TypeExpr against an argument to bind type vars.
+
+        Mirrors CodeGenerator._unify_param_arg for use during WASM
+        translation.
+        """
+        if isinstance(param_te, ast.RefinementType):
+            self._unify_param_arg_wasm(
+                param_te.base_type, arg, forall_vars, mapping,
+            )
+            return
+
+        if not isinstance(param_te, ast.NamedType):
+            return
+
+        if param_te.name in forall_vars:
+            vera_type = self._infer_vera_type(arg)
+            if vera_type and param_te.name not in mapping:
+                mapping[param_te.name] = vera_type
+            return
+
+        # Parameterized type like Option<T>
+        if param_te.type_args:
+            arg_info = self._get_arg_type_info_wasm(arg)
+            if arg_info and arg_info[0] == param_te.name:
+                for param_ta, arg_ta_name in zip(
+                    param_te.type_args, arg_info[1]
+                ):
+                    if (isinstance(param_ta, ast.NamedType)
+                            and param_ta.name in forall_vars
+                            and param_ta.name not in mapping):
+                        mapping[param_ta.name] = arg_ta_name
+
+    def _infer_vera_type(self, expr: ast.Expr) -> str | None:
+        """Infer the Vera type name of an expression for call rewriting."""
+        if isinstance(expr, ast.IntLit):
+            return "Int"
+        if isinstance(expr, ast.BoolLit):
+            return "Bool"
+        if isinstance(expr, ast.FloatLit):
+            return "Float64"
+        if isinstance(expr, ast.UnitLit):
+            return "Unit"
+        if isinstance(expr, ast.SlotRef):
+            return expr.type_name
+        if isinstance(expr, ast.ConstructorCall):
+            return self._ctor_to_adt_name(expr.name)
+        if isinstance(expr, ast.NullaryConstructor):
+            return self._ctor_to_adt_name(expr.name)
+        if isinstance(expr, ast.BinaryExpr):
+            if expr.op in (ast.BinOp.EQ, ast.BinOp.NEQ, ast.BinOp.LT,
+                           ast.BinOp.GT, ast.BinOp.LE, ast.BinOp.GE,
+                           ast.BinOp.AND, ast.BinOp.OR, ast.BinOp.IMPLIES):
+                return "Bool"
+            return self._infer_vera_type(expr.left)
+        if isinstance(expr, ast.UnaryExpr):
+            if expr.op == ast.UnaryOp.NOT:
+                return "Bool"
+            return self._infer_vera_type(expr.operand)
+        if isinstance(expr, ast.FnCall):
+            return self._infer_fncall_vera_type(expr)
+        return None
+
+    def _infer_fncall_vera_type(self, call: ast.FnCall) -> str | None:
+        """Infer Vera return type of a function call.
+
+        For generic calls, resolves type args and substitutes into
+        the return TypeExpr.  For non-generic calls, maps from WASM
+        return type back to Vera type name.
+        """
+        if call.name in self._generic_fn_info:
+            forall_vars, param_types = self._generic_fn_info[call.name]
+            mapping: dict[str, str] = {}
+            for pt, arg in zip(param_types, call.args):
+                self._unify_param_arg_wasm(pt, arg, forall_vars, mapping)
+            # Use the first param's type to determine return type
+            # (Generic fn return type is typically a type var)
+            # We need to figure out the return type from forall info
+            # Actually, look at the monomorphized fn sig
+            parts = []
+            for tv in forall_vars:
+                if tv not in mapping:
+                    return None
+                parts.append(mapping[tv])
+            mangled = f"{call.name}${'_'.join(parts)}"
+            # Look up WASM return type and map back
+            ret_wt = self._fn_ret_types.get(mangled)
+            if ret_wt == "i64":
+                return "Int"
+            if ret_wt == "i32":
+                return "Bool"
+            if ret_wt == "f64":
+                return "Float64"
+            return None
+        # Non-generic: map from WASM return type
+        ret_wt = self._fn_ret_types.get(call.name)
+        if ret_wt == "i64":
+            return "Int"
+        if ret_wt == "i32":
+            return "Bool"
+        if ret_wt == "f64":
+            return "Float64"
+        return None
+
+    def _ctor_to_adt_name(self, ctor_name: str) -> str | None:
+        """Find the ADT type name for a constructor name."""
+        return self._ctor_to_adt.get(ctor_name)
+
+    def _get_arg_type_info_wasm(
+        self, expr: ast.Expr,
+    ) -> tuple[str, tuple[str, ...]] | None:
+        """Get (type_name, type_arg_names) for an argument expression."""
+        if isinstance(expr, ast.SlotRef):
+            if expr.type_args:
+                arg_names = []
+                for ta in expr.type_args:
+                    if isinstance(ta, ast.NamedType):
+                        arg_names.append(ta.name)
+                    else:
+                        return None
+                return (expr.type_name, tuple(arg_names))
+            return (expr.type_name, ())
+        if isinstance(expr, ast.ConstructorCall):
+            # Infer from constructor args
+            adt_name = self._ctor_to_adt_name(expr.name)
+            if adt_name:
+                arg_types = []
+                for a in expr.args:
+                    t = self._infer_vera_type(a)
+                    if t:
+                        arg_types.append(t)
+                    else:
+                        return None
+                return (adt_name, tuple(arg_types))
+        return None
 
     # -----------------------------------------------------------------
     # String literals


### PR DESCRIPTION
## Summary

- **Monomorphization pipeline** in `codegen.py`: collection pass finds concrete call sites of `forall<T>` functions, infers type variable bindings, creates specialized `FnDecl` copies with type variables replaced, and name-mangles (e.g. `identity$Int`, `const$Int_Bool`)
- **Call rewriting** in `wasm.py`: generic function calls resolve to mangled names at WASM translation time, with type inference for chained calls and if-branches
- **17 new tests** in `TestMonomorphization` covering identity/const/is_some instantiation, two-instantiation exports, ADT match, chained calls (`identity(identity(99))`), if-branches, let bindings, arithmetic args, and example file compilation
- Version bump to v0.0.17 (660 tests, up from 643)

Closes #29.

## Test plan

- [x] `pytest tests/ -v` — 660 tests pass
- [x] `mypy vera/` — clean
- [x] `python scripts/check_examples.py` — all 14 examples pass check + verify
- [x] Pre-commit hooks pass (mypy, pytest, examples, readme)

🤖 Generated with [Claude Code](https://claude.com/claude-code)