### PR TITLE
Housekeeping: documentation consistency pass

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,7 +108,7 @@ Each stage is a module with a single public API function (`parse_file`, `transfo
 ### Testing
 
 ```bash
-pytest tests/ -v                       # Run all tests (553 tests)
+pytest tests/ -v                       # Run all tests (660 tests)
 mypy vera/                             # Type-check the compiler
 python scripts/check_examples.py       # All 14 examples must pass
 ```
@@ -119,7 +119,7 @@ Test helpers follow a pattern: `_check_ok(source)` / `_check_err(source, match)`
 
 - All 14 examples in `examples/` must pass `vera check` and `vera verify`
 - `mypy vera/` must be clean
-- `pytest tests/ -v` must pass (currently 553 tests)
+- `pytest tests/ -v` must pass (currently 660 tests)
 - Version must be in sync across `vera/__init__.py`, `pyproject.toml`, and `CHANGELOG.md`
 
 ### Contributing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-## [0.0.17] - 2026-02-24
+## [0.0.17] - 2026-02-24 ([#42](https://github.com/aallan/vera/pull/42))
 
 ### Added
 - **Generics monomorphization** (C6i — closes #29): compile `forall<T>` functions to WASM via monomorphization
@@ -18,7 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   - Supports: literal args, slot ref args, constructor args, chained generic calls, arithmetic expression args
 - **Codegen tests**: 17 new tests — identity/const/is_some instantiation, two-instantiation exports, ADT match, chained calls, if-branches, let bindings, example files (660 total, up from 643)
 
-## [0.0.16] - 2026-02-24
+## [0.0.16] - 2026-02-24 ([#41](https://github.com/aallan/vera/pull/41))
 
 ### Added
 - **Match expression codegen** (C6g — closes #26): compile `MatchExpr` AST nodes to WASM chained if-else cascades
@@ -30,7 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   - Environment scoping: each arm gets fresh bindings from pattern extraction, no cross-arm leakage
 - **Codegen tests**: 20 new tests — ADT tag dispatch, field extraction, wildcard catch-alls, Bool/Int literal patterns, binding patterns, composability (643 total, up from 623)
 
-## [0.0.15] - 2026-02-24
+## [0.0.15] - 2026-02-24 ([#40](https://github.com/aallan/vera/pull/40))
 
 ### Added
 - **ADT constructor codegen** (C6f): compile `ConstructorCall` and `NullaryConstructor` AST nodes to WASM heap-allocated tagged unions
@@ -42,7 +42,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   - Functions using ADT constructors now compile (no longer skipped with warning)
 - **Codegen tests**: 12 new tests — nullary/tagged constructors, Int/Bool fields, Option None/Some, WAT inspection, let bindings, if-then-else branches, ADT parameters (623 total, up from 611)
 
-## [0.0.14] - 2026-02-24
+## [0.0.14] - 2026-02-24 ([#39](https://github.com/aallan/vera/pull/39))
 
 ### Added
 - **Bump allocator infrastructure** (C6e): heap allocation support for upcoming ADT constructor codegen
@@ -54,7 +54,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   - `StringPool.heap_offset` property exposes first free byte after string constants
 - **Codegen tests**: 26 new tests — layout helpers, WAT output inspection, ADT metadata registration, conditional emission (611 total, up from 585)
 
-## [0.0.13] - 2026-02-24
+## [0.0.13] - 2026-02-24 ([#38](https://github.com/aallan/vera/pull/38))
 
 ### Added
 - **State\<T\> WASM host imports** (C6d): compile `get`/`put` operations for `State<T>` effects as WASM host imports
@@ -68,7 +68,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Codegen tests**: 15 new tests — get default, put-then-get, increment pattern, example file, Bool/Float64/Nat state, String rejection, mixed effects, WAT imports, multiple types, void semantics, initial state override, pure function purity (585 total, up from 570)
 - `examples/increment.vera` now compiles and runs (7 of 14 examples compilable)
 
-## [0.0.12] - 2026-02-24
+## [0.0.12] - 2026-02-24 ([#37](https://github.com/aallan/vera/pull/37))
 
 ### Added
 - **Match exhaustiveness checking** (C6c — closes #18): compile-time verification that match expressions cover all possible values
@@ -80,7 +80,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   - Error diagnostics include missing constructor/value names and fix suggestions
 - **Type checker tests**: 17 new tests — ADT exhaustive/missing/wildcard/binding, Bool exhaustive/missing/wildcard, Int/String without wildcard, unreachable arms (single/multiple/after binding), wildcard only, refined type stripping (570 total, up from 553)
 
-## [0.0.11] - 2026-02-24
+## [0.0.11] - 2026-02-24 ([#36](https://github.com/aallan/vera/pull/36))
 
 ### Added
 - **Callee precondition verification** (C6b — closes #19): modular call-site contract checking
@@ -98,7 +98,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `SmtContext` constructor accepts optional `fn_lookup` callback for callee contract resolution
 - Caller precondition assumptions now asserted into the Z3 solver before body translation
 
-## [0.0.10] - 2026-02-24
+## [0.0.10] - 2026-02-24 ([#35](https://github.com/aallan/vera/pull/35))
 
 ### Added
 - **Float64 WASM codegen** (C6a — closes #25): compile Float64/Float values to WebAssembly `f64` instructions
@@ -116,7 +116,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Warning messages updated to mention Float64 as a compilable type
 - CLI `fn_args` type widened to `list[int | float]` for future float argument parsing
 
-## [0.0.9] - 2026-02-23
+## [0.0.9] - 2026-02-23 ([#31](https://github.com/aallan/vera/pull/31))
 
 ### Added
 - **WASM code generation** (`vera/codegen.py`, `vera/wasm.py`): compile verified Vera programs to WebAssembly and execute them via wasmtime — **first light** 🌅
@@ -152,7 +152,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 - Documentation consistency: all `print(...)` calls in README.md, spec/05-functions.md, spec/07-effects.md, and SKILLS.md corrected to use qualified `IO.print(...)` syntax (matching the language's "one canonical form" design principle)
 
-## [0.0.8] - 2026-02-23
+## [0.0.8] - 2026-02-23 ([#10](https://github.com/aallan/vera/pull/10))
 
 ### Added
 - **Contract verifier** (`vera/verifier.py`): Z3-backed verification of `requires`/`ensures` contracts on functions
@@ -201,7 +201,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   - **LLM Inference effect**: `<Inference>` as an algebraic effect for AI runtime calls — testable via mock handlers, explicit in type signatures, contracts still apply
   - **Standard library collections**: `Set<T>`, `Map<K, V>` (depend on abilities), `Decimal` (software implementation for WASM)
 
-## [0.0.5] - 2026-02-23
+## [0.0.5] - 2026-02-23 ([#2](https://github.com/aallan/vera/pull/2))
 
 ### Added
 - **Type checker**: Tier 1 decidable type checking — validates expression types, slot reference resolution, effect annotations, and contract well-formedness
@@ -227,7 +227,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - README: updated status table (Type checker: Working), added type checker to project structure, documented `vera typecheck` alias
 - SKILLS.md: added `vera typecheck` to toolchain section
 
-## [0.0.4] - 2026-02-23
+## [0.0.4] - 2026-02-23 ([#1](https://github.com/aallan/vera/pull/1))
 
 ### Added
 - **Typed AST layer**: frozen dataclass nodes with source spans, covering all grammar constructs (~50 node classes)
@@ -300,7 +300,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Grammar: handler body simplified to avoid LALR reduce/reduce conflict
 - `pyproject.toml`: corrected build backend, package discovery, PEP 639 compliance
 
-[Unreleased]: https://github.com/aallan/vera/compare/v0.0.11...HEAD
+[Unreleased]: https://github.com/aallan/vera/compare/v0.0.17...HEAD
+[0.0.17]: https://github.com/aallan/vera/compare/v0.0.16...v0.0.17
+[0.0.16]: https://github.com/aallan/vera/compare/v0.0.15...v0.0.16
+[0.0.15]: https://github.com/aallan/vera/compare/v0.0.14...v0.0.15
+[0.0.14]: https://github.com/aallan/vera/compare/v0.0.13...v0.0.14
+[0.0.13]: https://github.com/aallan/vera/compare/v0.0.12...v0.0.13
+[0.0.12]: https://github.com/aallan/vera/compare/v0.0.11...v0.0.12
 [0.0.11]: https://github.com/aallan/vera/compare/v0.0.10...v0.0.11
 [0.0.10]: https://github.com/aallan/vera/compare/v0.0.9...v0.0.10
 [0.0.9]: https://github.com/aallan/vera/compare/v0.0.8...v0.0.9

--- a/README.md
+++ b/README.md
@@ -165,25 +165,25 @@ Development follows an **interleaved spiral** — each phase adds a complete com
 
 ### What's next: C6 — Codegen Completeness (v0.0.10–v0.0.23)
 
-The code generator compiles 7 of 14 examples. C6 extends WASM compilation to all language constructs, working through the dependency graph from simplest to most complex.
+C6 extends WASM compilation to all language constructs, working through the dependency graph from simplest to most complex. All 14 examples now compile.
 
 **Independent tasks (no dependencies on each other):**
 
 | Sub-phase | Scope | Closes | Unlocks |
 |-----------|-------|--------|---------|
-| ~~C6a~~ | ~~Float64 — `f64` literals, arithmetic, comparisons~~ | ~~#25~~ | ~~Done (v0.0.10)~~ |
-| ~~C6b~~ | ~~Callee preconditions — verify `requires()` at call sites~~ | ~~#19~~ | ~~Done (v0.0.11)~~ |
-| ~~C6c~~ | ~~Match exhaustiveness — verify all constructors covered~~ | ~~#18~~ | ~~Done (v0.0.12)~~ |
-| ~~C6d~~ | ~~State\<T\> operations — get/put as host imports~~ | — | ~~Done (v0.0.13)~~ |
+| ~~C6a~~ | ~~Float64 — `f64` literals, arithmetic, comparisons~~ | ~~#25~~ | ~~Done (v0.0.10, [#35](https://github.com/aallan/vera/pull/35))~~ |
+| ~~C6b~~ | ~~Callee preconditions — verify `requires()` at call sites~~ | ~~#19~~ | ~~Done (v0.0.11, [#36](https://github.com/aallan/vera/pull/36))~~ |
+| ~~C6c~~ | ~~Match exhaustiveness — verify all constructors covered~~ | ~~#18~~ | ~~Done (v0.0.12, [#37](https://github.com/aallan/vera/pull/37))~~ |
+| ~~C6d~~ | ~~State\<T\> operations — get/put as host imports~~ | — | ~~Done (v0.0.13, [#38](https://github.com/aallan/vera/pull/38))~~ |
 
 **Allocator and data types (sequential chain):**
 
 | Sub-phase | Scope | Closes | Unlocks |
 |-----------|-------|--------|---------|
-| ~~C6e~~ | ~~Bump allocator — heap allocation for tagged values~~ | — | ~~Done (v0.0.14)~~ |
-| ~~C6f~~ | ~~ADT constructors — heap-allocated tagged unions~~ | — | ~~Done (v0.0.15)~~ |
-| ~~C6g~~ | ~~Match expressions — tag dispatch, field extraction~~ | ~~#26~~ | ~~Done (v0.0.16)~~ |
-| ~~C6i~~ | ~~Generics — monomorphization of `forall<T>` functions~~ | ~~#29~~ | ~~Done (v0.0.17)~~ |
+| ~~C6e~~ | ~~Bump allocator — heap allocation for tagged values~~ | — | ~~Done (v0.0.14, [#39](https://github.com/aallan/vera/pull/39))~~ |
+| ~~C6f~~ | ~~ADT constructors — heap-allocated tagged unions~~ | — | ~~Done (v0.0.15, [#40](https://github.com/aallan/vera/pull/40))~~ |
+| ~~C6g~~ | ~~Match expressions — tag dispatch, field extraction~~ | ~~#26~~ | ~~Done (v0.0.16, [#41](https://github.com/aallan/vera/pull/41))~~ |
+| ~~C6i~~ | ~~Generics — monomorphization of `forall<T>` functions~~ | ~~#29~~ | ~~Done (v0.0.17, [#42](https://github.com/aallan/vera/pull/42))~~ |
 
 **Higher-order and effects:**
 
@@ -465,7 +465,7 @@ vera/
 │   ├── errors.py                  # LLM-oriented diagnostics
 │   └── cli.py                     # Command-line interface
 ├── examples/                      # 14 example Vera programs
-├── tests/                         # Test suite (553 tests)
+├── tests/                         # Test suite (660 tests)
 ├── scripts/                       # CI and validation scripts
 │   ├── check_examples.py          # Verify all .vera examples
 │   ├── check_spec_examples.py     # Verify spec code blocks parse

--- a/spec/11-compilation.md
+++ b/spec/11-compilation.md
@@ -16,8 +16,8 @@ Source (.vera)
 
 The compilation target is a standalone WASM module containing:
 - Exported functions (callable from the host or other modules)
-- A linear memory segment (for string constants and future heap allocation)
-- Imported host functions (for IO operations)
+- A linear memory segment (for string constants and heap-allocated ADTs)
+- Imported host functions (for IO and State\<T\> operations)
 - An optional data section (for string literals)
 
 ## 11.2 Type Mapping
@@ -29,10 +29,12 @@ Vera types map to WASM value types as follows:
 | `Int` | `i64` | 64-bit signed integer |
 | `Nat` | `i64` | Non-negativity enforced by contracts, not by WASM type |
 | `Bool` | `i32` | `0` = `false`, `1` = `true` |
+| `Float64` / `Float` | `f64` | 64-bit IEEE 754 floating point |
 | `Unit` | *(none)* | Functions returning `Unit` have no WASM result type |
 | `String` | `i32, i32` | Pointer and length pair (UTF-8 bytes in linear memory) |
+| ADTs | `i32` | Heap pointer to tagged union (see Section 11.6) |
 
-Types not in this table (ADTs, arrays, closures, generic type variables) are not yet compilable. Functions using non-compilable types are skipped with a warning.
+Generic type variables are resolved via monomorphization — each concrete instantiation of a `forall<T>` function produces a specialized copy with type variables replaced by concrete types (e.g. `identity$Int`). Types not in this table (arrays, closures) are not yet compilable. Functions using non-compilable types are skipped with a warning.
 
 ### 11.2.1 Nat as i64
 
@@ -55,6 +57,7 @@ Each AST expression node compiles to a sequence of WASM instructions that leaves
 | Expression | WASM Output |
 |------------|-------------|
 | `IntLit(42)` | `i64.const 42` |
+| `FloatLit(3.14)` | `f64.const 3.14` |
 | `BoolLit(true)` | `i32.const 1` |
 | `BoolLit(false)` | `i32.const 0` |
 | `UnitLit` | *(nothing)* |
@@ -68,27 +71,30 @@ Each AST expression node compiles to a sequence of WASM instructions that leaves
 
 Binary operators compile to their WASM equivalents:
 
-| Operator | Int/Nat (i64) | Bool (i32) |
-|----------|---------------|------------|
-| `+` | `i64.add` | — |
-| `-` | `i64.sub` | — |
-| `*` | `i64.mul` | — |
-| `/` | `i64.div_s` | — |
-| `%` | `i64.rem_s` | — |
-| `==` | `i64.eq` | `i32.eq` |
-| `!=` | `i64.ne` | `i32.ne` |
-| `<` | `i64.lt_s` | `i32.lt_s` |
-| `>` | `i64.gt_s` | `i32.gt_s` |
-| `<=` | `i64.le_s` | `i32.le_s` |
-| `>=` | `i64.ge_s` | `i32.ge_s` |
-| `&&` | — | `i32.and` |
-| `\|\|` | — | `i32.or` |
+| Operator | Int/Nat (i64) | Float64 (f64) | Bool (i32) |
+|----------|---------------|---------------|------------|
+| `+` | `i64.add` | `f64.add` | — |
+| `-` | `i64.sub` | `f64.sub` | — |
+| `*` | `i64.mul` | `f64.mul` | — |
+| `/` | `i64.div_s` | `f64.div` | — |
+| `%` | `i64.rem_s` | *(unsupported)* | — |
+| `==` | `i64.eq` | `f64.eq` | `i32.eq` |
+| `!=` | `i64.ne` | `f64.ne` | `i32.ne` |
+| `<` | `i64.lt_s` | `f64.lt` | `i32.lt_s` |
+| `>` | `i64.gt_s` | `f64.gt` | `i32.gt_s` |
+| `<=` | `i64.le_s` | `f64.le` | `i32.le_s` |
+| `>=` | `i64.ge_s` | `f64.ge` | `i32.ge_s` |
+| `&&` | — | — | `i32.and` |
+| `\|\|` | — | — | `i32.or` |
+
+Float64 comparisons return `i32` (0 or 1), matching WASM's native comparison semantics.
 
 Unary operators:
 
 | Operator | WASM Output |
 |----------|-------------|
-| `-` (negation) | `i64.const 0  [expr]  i64.sub` |
+| `-` (Int negation) | `i64.const 0  [expr]  i64.sub` |
+| `-` (Float64 negation) | `f64.neg` |
 | `!` (Boolean not) | `[expr]  i32.eqz` |
 
 The implies operator `==>` is lowered to `(!a) || b`:
@@ -153,9 +159,11 @@ call $vera.print
 
 A function is compilable if:
 
-1. All parameter and return types map to WASM primitives (Section 11.2)
+1. All parameter and return types map to WASM types (Section 11.2) — primitives, ADTs, or monomorphized generics
 2. The function body uses only supported expression types
-3. Effects are either `pure` or `<IO>`
+3. Effects are `pure`, `<IO>`, or `<State<T>>` where T is a compilable type
+
+Generic (`forall<T>`) functions are compiled via monomorphization: for each concrete call site, a specialized copy is produced with type variables replaced by concrete types.
 
 Functions that fail any of these criteria are skipped with a diagnostic warning. This is analogous to the verifier's Tier 3 classification — the compiler degrades gracefully rather than failing.
 
@@ -194,11 +202,17 @@ All strings are concatenated into a single data segment starting at offset 0. Ea
 The WASM module exports one page (64 KiB) of linear memory as `"memory"`. This memory holds:
 
 - **String constants** (data section, starting at offset 0)
-- **Future:** heap-allocated data (ADTs, arrays, closures)
+- **Heap-allocated ADTs** (bump-allocated after string data)
+
+A bump allocator manages heap allocation. A mutable global `$heap_ptr` tracks the next free byte (initialized to the first byte after string data). The `$alloc` internal function bump-allocates with 8-byte alignment and returns a pointer to the allocated block. The allocator and heap global are only emitted when the program declares ADT types.
+
+ADT constructors allocate heap blocks containing a tag (i32) followed by field values at computed offsets. Match expressions dispatch on the tag and extract fields at the corresponding offsets.
 
 The memory is exported so the host runtime can read string data for IO operations.
 
-## 11.7 IO Host Bindings
+## 11.7 Host Bindings
+
+### 11.7.1 IO
 
 The `IO` effect is implemented via host imports. The WASM module imports:
 
@@ -213,6 +227,17 @@ The host runtime (wasmtime) provides the implementation:
 3. Print to stdout
 
 This means `IO.print("Hello")` compiles to pushing the string's offset and length, then calling the imported host function. The effect system ensures only functions declaring `effects(<IO>)` can call `IO.print`.
+
+### 11.7.2 State\<T\>
+
+The `State<T>` effect compiles to typed host import pairs for `get` and `put`:
+
+```wat
+(import "vera" "state_get_Int" (func $vera.state_get_Int (result i64)))
+(import "vera" "state_put_Int" (func $vera.state_put_Int (param i64)))
+```
+
+Each concrete `State<T>` type (`State<Int>`, `State<Bool>`, `State<Nat>`, `State<Float64>`) generates a separate pair of imports. The host runtime maintains mutable state cells per type, initialized to zero. Mixed effects (e.g. `effects(<State<Int>, IO>)`) are supported — both sets of imports are emitted.
 
 ## 11.8 Runtime Contract Insertion
 
@@ -300,12 +325,9 @@ The current compilation model has the following limitations, each tracked as a G
 
 | Limitation | Issue | Notes |
 |-----------|-------|-------|
-| No Float64 codegen | [#25](https://github.com/aallan/vera/issues/25) | Straightforward i64 → f64 extension |
-| No ADT / match codegen | [#26](https://github.com/aallan/vera/issues/26) | Needs tagged union representation in linear memory |
 | No closure / anonymous function codegen | [#27](https://github.com/aallan/vera/issues/27) | Needs closure conversion pass |
 | No effect handler codegen | [#28](https://github.com/aallan/vera/issues/28) | Needs continuation-passing transform |
-| No generic function codegen | [#29](https://github.com/aallan/vera/issues/29) | Needs monomorphization or type erasure |
 | No Byte type codegen | [#30](https://github.com/aallan/vera/issues/30) | Needs linear memory byte operations |
 | No module-level code generation | — | Each file compiles independently |
-| No garbage collection | — | Linear memory is not reclaimed |
+| No garbage collection | — | Bump allocator only; linear memory is not reclaimed |
 | String constants only | — | No dynamic string construction |

--- a/vera/README.md
+++ b/vera/README.md
@@ -74,15 +74,16 @@ execute(compile_result, ...)    # → run WASM via wasmtime
 | `ast.py` | 682 | Transform | Frozen dataclass AST nodes | `Program`, `Node`, `Expr` |
 | `types.py` | 302 | Type check | Semantic type representation | `Type`, `is_subtype()` |
 | `environment.py` | 299 | Type check | Type environment, scope stacks | `TypeEnv` |
-| `checker.py` | 1,569 | Type check | Two-pass type checker | `typecheck()` |
-| `smt.py` | 363 | Verify | Z3 translation layer | `SmtContext`, `SlotEnv` |
-| `verifier.py` | 539 | Verify | Contract verification | `verify()` |
-| `wasm.py` | 585 | Compile | WASM translation layer | `WasmContext`, `WasmSlotEnv` |
-| `codegen.py` | 653 | Compile | Codegen orchestrator | `compile()`, `execute()` |
+| `checker.py` | 1,668 | Type check | Two-pass type checker | `typecheck()` |
+| `smt.py` | 485 | Verify | Z3 translation layer | `SmtContext`, `SlotEnv` |
+| `verifier.py` | 601 | Verify | Contract verification | `verify()` |
+| `wasm.py` | 1,250 | Compile | WASM translation layer | `WasmContext`, `WasmSlotEnv` |
+| `codegen.py` | 1,376 | Compile | Codegen orchestrator | `compile()`, `execute()` |
 | `errors.py` | 354 | All | Diagnostic class, error hierarchy | `Diagnostic`, `VeraError` |
-| `cli.py` | 541 | All | CLI commands | `main()` |
+| `cli.py` | 563 | All | CLI commands | `main()` |
+| `registration.py` | 56 | Type check | Shared function registration | `register_fn()` |
 
-Total: ~7,082 lines of Python + 328 lines of grammar.
+Total: ~9,102 lines of Python + 328 lines of grammar.
 
 ## Parsing
 
@@ -168,7 +169,7 @@ Node
 
 ## Type Checking
 
-**Files:** `checker.py` (1,569 lines), `types.py` (302 lines), `environment.py` (299 lines)
+**Files:** `checker.py` (1,668 lines), `types.py` (302 lines), `environment.py` (300 lines)
 
 This is the most architecturally complex stage.
 
@@ -345,7 +346,7 @@ Error at line 3, column 3:
 
 ## Code Generation
 
-**Files:** `codegen.py` (653 lines), `wasm.py` (585 lines)
+**Files:** `codegen.py` (1,376 lines), `wasm.py` (1,250 lines)
 
 ### Compilation pipeline
 
@@ -451,7 +452,7 @@ Every diagnostic includes a description (what went wrong), rationale (which lang
 
 ## Test Suite
 
-**553 tests** across 8 files, plus 4 validation scripts and CI infrastructure.
+**660 tests** across 8 files, plus 4 validation scripts and CI infrastructure.
 
 ### Test files
 
@@ -459,14 +460,14 @@ Every diagnostic includes a description (what went wrong), rationale (which lang
 |------|------:|------:|----------------|
 | `test_parser.py` | 95 | 791 | Grammar rules, operator precedence, parse errors |
 | `test_ast.py` | 84 | 896 | AST transformation, node structure, serialisation |
-| `test_checker.py` | 91 | 950 | Type synthesis, slot resolution, effects, contracts |
-| `test_verifier.py` | 68 | 897 | Z3 verification, counterexamples, tier classification, Int→Nat enforcement, call-site preconditions |
-| `test_codegen.py` | 130 | 1,397 | WASM compilation, arithmetic, Float64, control flow, strings, IO, contracts, example round-trips |
-| `test_cli.py` | 67 | 832 | CLI commands (check, verify, compile, run), subprocess integration, runtime traps, arg validation |
+| `test_checker.py` | 108 | 1,203 | Type synthesis, slot resolution, effects, contracts, exhaustiveness |
+| `test_verifier.py` | 68 | 894 | Z3 verification, counterexamples, tier classification, Int→Nat enforcement, call-site preconditions |
+| `test_codegen.py` | 220 | 2,686 | WASM compilation, arithmetic, Float64, ADTs, match, generics, State\<T\>, control flow, strings, IO, contracts, example round-trips |
+| `test_cli.py` | 67 | 833 | CLI commands (check, verify, compile, run), subprocess integration, runtime traps, arg validation |
 | `test_readme.py` | 2 | 68 | README code sample parsing |
 | `test_errors.py` | 16 | 129 | Diagnostic formatting, error patterns |
 
-Total: 5,717 lines of test code (77% of source code size).
+Total: 7,500 lines of test code (82% of source code size).
 
 ### Round-trip testing
 
@@ -507,7 +508,7 @@ _run_trap(source, fn, args)    # compile + execute, assert WASM trap
 **CI** runs on every push and PR to `main`:
 - **Test matrix:** 6 jobs (ubuntu + macOS × Python 3.11, 3.12, 3.13)
 - **Coverage:** ≥80% threshold (Python 3.12 on ubuntu)
-- **Mypy:** strict mode, 11 source files
+- **Mypy:** strict mode, 14 source files
 - **Lint:** example validation + version sync + spec code blocks
 
 **Pre-commit hooks** run on every local commit:
@@ -534,11 +535,9 @@ Honest inventory of what the compiler cannot do, and where each limitation is ad
 
 | Limitation | Why | Planned |
 |-----------|-----|---------|
-| **No ADT/match codegen** | Needs tagged union representation in linear memory | [#26](https://github.com/aallan/vera/issues/26) |
 | **No closure codegen** | Needs closure conversion pass | [#27](https://github.com/aallan/vera/issues/27) |
 | **No effect handler codegen** | Needs continuation-passing transform | [#28](https://github.com/aallan/vera/issues/28) |
-| **No generic function codegen** | Needs monomorphization or type erasure | [#29](https://github.com/aallan/vera/issues/29) |
-| **No Float64/Byte codegen** | Straightforward extensions | [#25](https://github.com/aallan/vera/issues/25), [#30](https://github.com/aallan/vera/issues/30) |
+| **No Byte type codegen** | Needs linear memory byte operations | [#30](https://github.com/aallan/vera/issues/30) |
 | **No module resolution** | `import` declarations parsed but not resolved | C7 (module system) |
 | **Limited effect checking** | Pure vs effectful only; no subeffecting or row unification | Incremental |
 | **No termination verification** | `decreases` clauses parsed but always Tier 3 | Future |
@@ -546,7 +545,8 @@ Honest inventory of what the compiler cannot do, and where each limitation is ad
 | **No match/constructor body verification** | Untranslatable to Z3, always Tier 3 | Tier 2 |
 | **Minimal type inference** | Call-site generic instantiation only, no Hindley-Milner | Incremental |
 | **No incremental compilation** | Full file processed from scratch each time | Low priority |
-| **No exhaustiveness checking** | Match expressions not checked for missing cases | Incremental |
+| **No garbage collection** | Bump allocator only; linear memory is not reclaimed | Future |
+| **String constants only** | No dynamic string construction | Future |
 | **Spec/parser `@T` notation mismatch** | Spec uses `@T` in data/effect declarations; parser expects bare `T` — see below | Reconciliation |
 
 ### Spec/parser notation mismatch


### PR DESCRIPTION
## Summary

- **CHANGELOG**: link 12 version headers (v0.0.4–v0.0.17) to their PRs, add 6 missing comparison links (v0.0.12–v0.0.17), fix `[Unreleased]` target
- **README**: link all 8 completed C6 sub-phases to PRs (#35–#42), fix "7 of 14 examples" → "all 14 compile", fix test count (553→660)
- **AGENTS.md**: fix stale test counts (553→660)
- **vera/README.md**: update module line counts (wasm.py 585→1,250, codegen.py 653→1,376, etc.), add `registration.py`, update totals (7,082→9,102), update test suite table (553→660, per-file counts), remove 4 resolved limitations, fix mypy count (11→14)
- **spec/11-compilation.md**: add Float64 and ADT type rows, document monomorphization, add Float64 arithmetic column, update compilable subset for State\<T\> and generics, document bump allocator and ADT heap layout, add State\<T\> host bindings section, remove 3 resolved limitations

No compiler changes. No version bump.

## Test plan

- [x] `python scripts/check_readme_examples.py` — README code blocks parse
- [x] `python scripts/check_spec_examples.py` — spec code blocks parse
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)