### PR TITLE
Housekeeping: link issue refs, fix stale counts, file untracked issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [0.0.17] - 2026-02-24 ([#42](https://github.com/aallan/vera/pull/42))
 
 ### Added
-- **Generics monomorphization** (C6i — closes #29): compile `forall<T>` functions to WASM via monomorphization
+- **Generics monomorphization** (C6i — closes [#29](https://github.com/aallan/vera/issues/29)): compile `forall<T>` functions to WASM via monomorphization
   - Collection pass: walk non-generic function bodies to find calls to generic functions, infer concrete type variable bindings
   - AST substitution: create monomorphized FnDecl copies with type variables replaced by concrete types (e.g. `@T.0` → `@Int.0`)
   - Name mangling: `identity` + `(Int,)` → `identity$Int`, `const` + `(Int, Bool)` → `const$Int_Bool`
@@ -21,7 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [0.0.16] - 2026-02-24 ([#41](https://github.com/aallan/vera/pull/41))
 
 ### Added
-- **Match expression codegen** (C6g — closes #26): compile `MatchExpr` AST nodes to WASM chained if-else cascades
+- **Match expression codegen** (C6g — closes [#26](https://github.com/aallan/vera/issues/26)): compile `MatchExpr` AST nodes to WASM chained if-else cascades
   - ADT tag dispatch: load tag from heap pointer, compare with constructor tag, branch
   - Field extraction: load constructor fields at computed offsets into locals, bind in environment
   - Monomorphized offsets: field offsets computed from concrete binding types (same approach as C6f constructor calls)
@@ -71,7 +71,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [0.0.12] - 2026-02-24 ([#37](https://github.com/aallan/vera/pull/37))
 
 ### Added
-- **Match exhaustiveness checking** (C6c — closes #18): compile-time verification that match expressions cover all possible values
+- **Match exhaustiveness checking** (C6c — closes [#18](https://github.com/aallan/vera/issues/18)): compile-time verification that match expressions cover all possible values
   - ADT exhaustiveness: all constructors must be covered or a catch-all pattern must be present
   - Bool exhaustiveness: both `true` and `false` must be covered or a catch-all present
   - Infinite type exhaustiveness: `Int`, `String`, `Float64`, `Nat` matches require a wildcard `_` or binding pattern
@@ -83,7 +83,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [0.0.11] - 2026-02-24 ([#36](https://github.com/aallan/vera/pull/36))
 
 ### Added
-- **Callee precondition verification** (C6b — closes #19): modular call-site contract checking
+- **Callee precondition verification** (C6b — closes [#19](https://github.com/aallan/vera/issues/19)): modular call-site contract checking
   - When function `f` calls function `g`, the verifier now checks that `g`'s `requires()` clauses hold at the call site given `f`'s assumptions
   - Callee postconditions (`ensures()`) are assumed at the call site, enabling symbolic reasoning about return values
   - Fresh Z3 variables created per call, with postconditions asserted — supports chained calls, let bindings, and recursive calls
@@ -101,7 +101,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [0.0.10] - 2026-02-24 ([#35](https://github.com/aallan/vera/pull/35))
 
 ### Added
-- **Float64 WASM codegen** (C6a — closes #25): compile Float64/Float values to WebAssembly `f64` instructions
+- **Float64 WASM codegen** (C6a — closes [#25](https://github.com/aallan/vera/issues/25)): compile Float64/Float values to WebAssembly `f64` instructions
   - Type mapping: Float64/Float → `f64` in `wasm_type()`, `_type_expr_to_wasm_type()`, `_slot_name_to_wasm_type()`, `_infer_expr_wasm_type()`, `_infer_block_result_type()`
   - `FloatLit` emission: `f64.const` literals
   - Float64 arithmetic: `f64.add`, `f64.sub`, `f64.mul`, `f64.div` (MOD unsupported — WASM has no `f64.rem`)

--- a/README.md
+++ b/README.md
@@ -171,9 +171,9 @@ C6 extends WASM compilation to all language constructs, working through the depe
 
 | Sub-phase | Scope | Closes | Unlocks |
 |-----------|-------|--------|---------|
-| ~~C6a~~ | ~~Float64 — `f64` literals, arithmetic, comparisons~~ | ~~#25~~ | ~~Done (v0.0.10, [#35](https://github.com/aallan/vera/pull/35))~~ |
-| ~~C6b~~ | ~~Callee preconditions — verify `requires()` at call sites~~ | ~~#19~~ | ~~Done (v0.0.11, [#36](https://github.com/aallan/vera/pull/36))~~ |
-| ~~C6c~~ | ~~Match exhaustiveness — verify all constructors covered~~ | ~~#18~~ | ~~Done (v0.0.12, [#37](https://github.com/aallan/vera/pull/37))~~ |
+| ~~C6a~~ | ~~Float64 — `f64` literals, arithmetic, comparisons~~ | ~~[#25](https://github.com/aallan/vera/issues/25)~~ | ~~Done (v0.0.10, [#35](https://github.com/aallan/vera/pull/35))~~ |
+| ~~C6b~~ | ~~Callee preconditions — verify `requires()` at call sites~~ | ~~[#19](https://github.com/aallan/vera/issues/19)~~ | ~~Done (v0.0.11, [#36](https://github.com/aallan/vera/pull/36))~~ |
+| ~~C6c~~ | ~~Match exhaustiveness — verify all constructors covered~~ | ~~[#18](https://github.com/aallan/vera/issues/18)~~ | ~~Done (v0.0.12, [#37](https://github.com/aallan/vera/pull/37))~~ |
 | ~~C6d~~ | ~~State\<T\> operations — get/put as host imports~~ | — | ~~Done (v0.0.13, [#38](https://github.com/aallan/vera/pull/38))~~ |
 
 **Allocator and data types (sequential chain):**
@@ -182,21 +182,21 @@ C6 extends WASM compilation to all language constructs, working through the depe
 |-----------|-------|--------|---------|
 | ~~C6e~~ | ~~Bump allocator — heap allocation for tagged values~~ | — | ~~Done (v0.0.14, [#39](https://github.com/aallan/vera/pull/39))~~ |
 | ~~C6f~~ | ~~ADT constructors — heap-allocated tagged unions~~ | — | ~~Done (v0.0.15, [#40](https://github.com/aallan/vera/pull/40))~~ |
-| ~~C6g~~ | ~~Match expressions — tag dispatch, field extraction~~ | ~~#26~~ | ~~Done (v0.0.16, [#41](https://github.com/aallan/vera/pull/41))~~ |
-| ~~C6i~~ | ~~Generics — monomorphization of `forall<T>` functions~~ | ~~#29~~ | ~~Done (v0.0.17, [#42](https://github.com/aallan/vera/pull/42))~~ |
+| ~~C6g~~ | ~~Match expressions — tag dispatch, field extraction~~ | ~~[#26](https://github.com/aallan/vera/issues/26)~~ | ~~Done (v0.0.16, [#41](https://github.com/aallan/vera/pull/41))~~ |
+| ~~C6i~~ | ~~Generics — monomorphization of `forall<T>` functions~~ | ~~[#29](https://github.com/aallan/vera/issues/29)~~ | ~~Done (v0.0.17, [#42](https://github.com/aallan/vera/pull/42))~~ |
 
 **Higher-order and effects:**
 
 | Sub-phase | Scope | Closes | Unlocks |
 |-----------|-------|--------|---------|
-| C6h | Closures — closure conversion, `call_indirect` | #27 | closures.vera |
-| C6j | Effect handlers — handle/resume compilation | #28 | effect_handler.vera |
+| C6h | Closures — closure conversion, `call_indirect` | [#27](https://github.com/aallan/vera/issues/27) | closures.vera |
+| C6j | Effect handlers — handle/resume compilation | [#28](https://github.com/aallan/vera/issues/28) | effect_handler.vera |
 
 **Collections, runtime, and documentation:**
 
 | Sub-phase | Scope | Closes | Unlocks |
 |-----------|-------|--------|---------|
-| C6k | Byte + arrays — linear memory arrays with bounds | #30 | — |
+| C6k | Byte + arrays — linear memory arrays with bounds | [#30](https://github.com/aallan/vera/issues/30) | — |
 | C6l | Quantifiers — forall/exists as runtime loops | — | quantifiers.vera |
 | C6m | Refinement returns + stdlib utilities | — | refinement_types.vera |
 | C6n | Spec chapters 9 (Standard library) and 12 (Runtime) | — | — |

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -169,7 +169,7 @@ fn abs(@Int -> @Nat)
 - `Bool` — `true`, `false`
 - `Int` — signed integers (arbitrary precision)
 - `Nat` — natural numbers (non-negative)
-- `Float` — floating-point
+- `Float64` / `Float` — 64-bit floating-point
 - `String` — text
 - `Unit` — singleton type, value is `()`
 

--- a/vera/README.md
+++ b/vera/README.md
@@ -262,7 +262,7 @@ Context flags (`in_ensures`, `in_contract`, `current_return_type`, `current_effe
 
 ## Contract Verification
 
-**Files:** `verifier.py` (539 lines), `smt.py` (363 lines)
+**Files:** `verifier.py` (601 lines), `smt.py` (485 lines)
 
 ### Tiered model
 


### PR DESCRIPTION
## Summary

- **README**: link 8 bare `#N` issue refs in roadmap tables to full GitHub URLs
- **CHANGELOG**: link 5 bare `closes #N` refs to full GitHub URLs
- **vera/README.md**: fix stale line counts in Contract Verification section (verifier.py 539→601, smt.py 363→485)
- **SKILLS.md**: clarify Float type as `Float64 / Float` (matches spec/11-compilation.md convention)
- **New issues filed**: pipe operator compilation (#44), decreases clause verification (#45), Float64 modulo (#46)

No compiler changes. No version bump.

## Test plan

- [x] `python scripts/check_readme_examples.py` — README code blocks parse
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)