### PR TITLE
C6h: Closure compilation — anonymous functions, captures, call_indirect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ build/
 venv/
 env/
 
+# Lock files
+uv.lock
+
 # IDE
 .idea/
 .vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.18] - 2026-02-25
+
+### Added
+- **Closure compilation** (C6h — closes [#27](https://github.com/aallan/vera/issues/27)): compile anonymous functions and closures to WASM via function tables and `call_indirect`
+  - Closure representation: heap-allocated struct `[func_table_idx: i32, capture_0, ...]` as `i32` pointer, using existing bump allocator
+  - Function table infrastructure: `(type $closure_sig_N ...)`, `(table N funcref)`, `(elem ...)` for indirect calls
+  - Closure lifting: anonymous functions compiled as module-level WASM functions with `$env` parameter for captured variables
+  - Free variable capture: walk `AnonFn` body to detect `SlotRef` nodes referencing outer-scope bindings, store captured values in heap environment
+  - `apply_fn` built-in: compiler-recognized function that emits `call_indirect` with closure's `func_table_idx`
+  - Function type aliases (e.g. `type IntToInt = fn(Int -> Int) effects(pure)`) resolved to `i32` closure pointers
+  - Functions with function-type parameters no longer skipped (recognized as compilable)
+- **Reworked `examples/closures.vera`**: removed `Array<Int>`, undefined `map`, and `forall<T>` generic `map_option`; added `make_adder` (closure capture), `apply` (closure parameter), `map_option` (closure in match arm), `test_closure` and `test_map_option` (end-to-end round-trips)
+- **Codegen tests**: 17 new tests — closure creation with/without capture, `apply_fn`, closures in let bindings and match arms, function-type parameters, WAT structure verification, example file round-trips (677 total, up from 660)
+
 ## [0.0.17] - 2026-02-24 ([#42](https://github.com/aallan/vera/pull/42))
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Development follows an **interleaved spiral** — each phase adds a complete com
 | C3 | v0.0.5 | **Type checker** — decidable type checking, slot resolution, effect tracking | Done |
 | C4 | v0.0.8 | **Contract verifier** — Z3 integration, refinement types, counterexamples | Done |
 | C5 | v0.0.9 | **WASM codegen** — compile to WebAssembly, `vera compile` / `vera run` | Done |
-| C6 | v0.0.10–0.0.23 | **Codegen completeness** — ADTs, match, closures, effects, generics in WASM | **In progress** (C6a–C6i done) |
+| C6 | v0.0.10–0.0.23 | **Codegen completeness** — ADTs, match, closures, effects, generics in WASM | **In progress** (C6a–C6i, C6h done) |
 | C7 | — | **Module system** — cross-file imports, public/private visibility | Planned |
 | C8 | v0.1.0 | **End-to-end** — all examples compile and run, spec complete, polish | Planned |
 
@@ -189,7 +189,7 @@ C6 extends WASM compilation to all language constructs, working through the depe
 
 | Sub-phase | Scope | Closes | Unlocks |
 |-----------|-------|--------|---------|
-| C6h | Closures — closure conversion, `call_indirect` | [#27](https://github.com/aallan/vera/issues/27) | closures.vera |
+| ~~C6h~~ | ~~Closures — closure conversion, `call_indirect`~~ | ~~[#27](https://github.com/aallan/vera/issues/27)~~ | ~~Done (v0.0.18)~~ |
 | C6j | Effect handlers — handle/resume compilation | [#28](https://github.com/aallan/vera/issues/28) | effect_handler.vera |
 
 **Collections, runtime, and documentation:**

--- a/examples/closures.vera
+++ b/examples/closures.vera
@@ -3,6 +3,15 @@
 -- A type alias for a pure function from Int to Int
 type IntToInt = fn(Int -> Int) effects(pure);
 
+-- Create a closure that captures a value from the enclosing scope
+fn make_adder(@Int -> @IntToInt)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  fn(@Int -> @Int) effects(pure) { @Int.0 + @Int.1 }
+}
+
 -- Apply a function to a value
 fn apply(@IntToInt, @Int -> @Int)
   requires(true)
@@ -17,7 +26,7 @@ data Option<T> { None, Some(T) }
 
 type IntMapper = fn(Int -> Int) effects(pure);
 
-forall<T> fn map_option(@Option<Int>, @IntMapper -> @Option<Int>)
+fn map_option(@Option<Int>, @IntMapper -> @Option<Int>)
   requires(true)
   ensures(true)
   effects(pure)
@@ -28,11 +37,26 @@ forall<T> fn map_option(@Option<Int>, @IntMapper -> @Option<Int>)
   }
 }
 
--- Pass an anonymous function as an argument
-fn double_all(@Array<Int> -> @Array<Int>)
+-- End-to-end test: create a closure, apply it, return the result
+fn test_closure(@Unit -> @Int)
   requires(true)
   ensures(true)
   effects(pure)
 {
-  map(@Array<Int>.0, fn(@Int -> @Int) effects(pure) { @Int.0 * 2 })
+  let @IntToInt = make_adder(10);
+  apply(@IntToInt.0, 5)
+}
+
+-- Test: map a closure over an Option
+fn test_map_option(@Unit -> @Int)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  let @IntToInt = make_adder(100);
+  let @Option<Int> = map_option(Some(5), @IntToInt.0);
+  match @Option<Int>.0 {
+    None -> 0,
+    Some(@Int) -> @Int.0
+  }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.17"
+version = "0.0.18"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/spec/11-compilation.md
+++ b/spec/11-compilation.md
@@ -33,8 +33,9 @@ Vera types map to WASM value types as follows:
 | `Unit` | *(none)* | Functions returning `Unit` have no WASM result type |
 | `String` | `i32, i32` | Pointer and length pair (UTF-8 bytes in linear memory) |
 | ADTs | `i32` | Heap pointer to tagged union (see Section 11.6) |
+| Function types | `i32` | Heap pointer to closure struct (see Section 11.11) |
 
-Generic type variables are resolved via monomorphization — each concrete instantiation of a `forall<T>` function produces a specialized copy with type variables replaced by concrete types (e.g. `identity$Int`). Types not in this table (arrays, closures) are not yet compilable. Functions using non-compilable types are skipped with a warning.
+Generic type variables are resolved via monomorphization — each concrete instantiation of a `forall<T>` function produces a specialized copy with type variables replaced by concrete types (e.g. `identity$Int`). Type aliases for function types (e.g. `type IntToInt = fn(Int -> Int) effects(pure)`) are also resolved to `i32` closure pointers. Types not in this table (arrays) are not yet compilable. Functions using non-compilable types are skipped with a warning.
 
 ### 11.2.1 Nat as i64
 
@@ -319,13 +320,82 @@ Flags:
 - `--json` — JSON output with result, stdout capture, and diagnostics
 - Arguments after `--` are passed to the function (parsed as integers)
 
-## 11.10 Limitations
+## 11.10 Closures and Anonymous Functions
+
+Anonymous functions (`AnonFn`) compile to closure values — heap-allocated structs containing a function table index and captured variables.
+
+### 11.10.1 Closure Representation
+
+A closure is an `i32` heap pointer to a struct:
+
+```
+offset 0:   func_table_idx (i32) — index into the WASM function table
+offset 4+:  capture_0 (type varies, 8-byte aligned)
+offset N:   capture_1 ...
+```
+
+This follows the same bump-allocation pattern as ADTs (Section 11.6). The single `i32` pointer representation means closures flow through let bindings, function parameters, match arms, and return values without breaking the one-value-per-expression invariant.
+
+### 11.10.2 Function Tables
+
+The WASM module includes a `funcref` table for indirect function calls:
+
+```wat
+(type $closure_sig_0 (func (param i32) (param i64) (result i64)))
+(table N funcref)
+(elem (i32.const 0) func $anon_0 $anon_1 ...)
+```
+
+Each closure signature (unique combination of parameter and return types) gets a `$closure_sig_N` type declaration. The table is sized to hold all lifted functions, and the element section maps table indices to function names.
+
+### 11.10.3 Closure Lifting
+
+Anonymous functions are compiled as module-level WASM functions (not nested). Each lifted function has:
+
+- `$env` (i32) as the first parameter — the closure environment pointer
+- The original function parameters after `$env`
+- Load instructions at the function entry to extract captured values from the environment
+
+```wat
+(func $anon_0 (param $env i32) (param $p0 i64) (result i64)
+    (local $l2 i64)
+    local.get 0          ;; env pointer
+    i64.load offset=8    ;; load captured value
+    local.set 2          ;; store in capture local
+    local.get 1          ;; function parameter
+    local.get 2          ;; captured value
+    i64.add
+)
+```
+
+### 11.10.4 Free Variable Capture
+
+The compiler walks the `AnonFn` body to find `SlotRef` nodes that reference outer-scope bindings. A `SlotRef(@T.n)` is a capture if its De Bruijn index `n` is greater than or equal to the number of parameters of that type within the anonymous function.
+
+Captured values are evaluated at closure creation time and stored in the heap environment. Each capture occupies 4 bytes (i32) or 8 bytes (i64, f64), with appropriate alignment.
+
+### 11.10.5 Closure Invocation (apply_fn)
+
+The built-in `apply_fn(closure, args...)` invokes a closure via `call_indirect`:
+
+```wat
+local.get <closure>                    ;; save closure pointer
+local.set <tmp>
+local.get <tmp>                        ;; push env as first arg
+[args...]                              ;; push remaining arguments
+local.get <tmp>
+i32.load offset=0                      ;; load func_table_idx
+call_indirect (type $closure_sig_N)    ;; indirect call
+```
+
+`apply_fn` is a compiler built-in, not a user-defined function. The checker issues a warning about it being unresolved, but the code generator recognizes it and emits the appropriate `call_indirect` sequence.
+
+## 11.11 Limitations
 
 The current compilation model has the following limitations, each tracked as a GitHub issue:
 
 | Limitation | Issue | Notes |
 |-----------|-------|-------|
-| No closure / anonymous function codegen | [#27](https://github.com/aallan/vera/issues/27) | Needs closure conversion pass |
 | No effect handler codegen | [#28](https://github.com/aallan/vera/issues/28) | Needs continuation-passing transform |
 | No Byte type codegen | [#30](https://github.com/aallan/vera/issues/30) | Needs linear memory byte operations |
 | No module-level code generation | — | Each file compiles independently |

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -2684,3 +2684,326 @@ fn main(-> @Int)
         source = path.read_text()
         result = _compile(source)
         assert result.ok
+
+
+# =====================================================================
+# C6h: Closures
+# =====================================================================
+
+
+class TestClosures:
+    """Tests for closure compilation — anonymous functions, captures,
+    apply_fn, function tables, and call_indirect."""
+
+    def test_closure_no_capture(self) -> None:
+        """An anonymous function with no free variables compiles and runs."""
+        src = """\
+type IntToInt = fn(Int -> Int) effects(pure);
+fn make_fn(@Unit -> @IntToInt)
+  requires(true) ensures(true) effects(pure)
+{
+  fn(@Int -> @Int) effects(pure) { @Int.0 * 2 }
+}
+fn test(@Unit -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  let @IntToInt = make_fn(());
+  apply_fn(@IntToInt.0, 7)
+}
+"""
+        assert _run(src, "test") == 14
+
+    def test_closure_with_capture(self) -> None:
+        """An anonymous function that captures an outer binding."""
+        src = """\
+type IntToInt = fn(Int -> Int) effects(pure);
+fn make_adder(@Int -> @IntToInt)
+  requires(true) ensures(true) effects(pure)
+{
+  fn(@Int -> @Int) effects(pure) { @Int.0 + @Int.1 }
+}
+fn test(@Unit -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  let @IntToInt = make_adder(10);
+  apply_fn(@IntToInt.0, 5)
+}
+"""
+        assert _run(src, "test") == 15
+
+    def test_apply_fn_basic(self) -> None:
+        """apply_fn invokes a closure with the correct argument."""
+        src = """\
+type IntToInt = fn(Int -> Int) effects(pure);
+fn make_doubler(@Unit -> @IntToInt)
+  requires(true) ensures(true) effects(pure)
+{
+  fn(@Int -> @Int) effects(pure) { @Int.0 * 2 }
+}
+fn test(@Unit -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  let @IntToInt = make_doubler(());
+  apply_fn(@IntToInt.0, 21)
+}
+"""
+        assert _run(src, "test") == 42
+
+    def test_apply_fn_with_capture(self) -> None:
+        """apply_fn on a capturing closure produces the correct result."""
+        src = """\
+type IntToInt = fn(Int -> Int) effects(pure);
+fn make_multiplier(@Int -> @IntToInt)
+  requires(true) ensures(true) effects(pure)
+{
+  fn(@Int -> @Int) effects(pure) { @Int.0 * @Int.1 }
+}
+fn test(@Unit -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  let @IntToInt = make_multiplier(3);
+  apply_fn(@IntToInt.0, 7)
+}
+"""
+        assert _run(src, "test") == 21
+
+    def test_closure_in_let(self) -> None:
+        """Store a closure in a let binding, then use it."""
+        src = """\
+type IntToInt = fn(Int -> Int) effects(pure);
+fn make_fn(@Int -> @IntToInt)
+  requires(true) ensures(true) effects(pure)
+{
+  fn(@Int -> @Int) effects(pure) { @Int.0 + @Int.1 }
+}
+fn test(@Unit -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  let @IntToInt = make_fn(100);
+  let @Int = apply_fn(@IntToInt.0, 23);
+  @Int.0
+}
+"""
+        assert _run(src, "test") == 123
+
+    def test_closure_as_param(self) -> None:
+        """Pass a closure as a function parameter."""
+        src = """\
+type IntToInt = fn(Int -> Int) effects(pure);
+fn apply(@IntToInt, @Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  apply_fn(@IntToInt.0, @Int.0)
+}
+fn make_fn(@Int -> @IntToInt)
+  requires(true) ensures(true) effects(pure)
+{
+  fn(@Int -> @Int) effects(pure) { @Int.0 + @Int.1 }
+}
+fn test(@Unit -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  let @IntToInt = make_fn(50);
+  apply(@IntToInt.0, 50)
+}
+"""
+        assert _run(src, "test") == 100
+
+    def test_closure_in_match(self) -> None:
+        """Use a closure inside a match arm with an ADT constructor."""
+        src = """\
+data Option<T> { None, Some(T) }
+type IntMapper = fn(Int -> Int) effects(pure);
+fn map_option(@Option<Int>, @IntMapper -> @Option<Int>)
+  requires(true) ensures(true) effects(pure)
+{
+  match @Option<Int>.0 {
+    None -> None,
+    Some(@Int) -> Some(apply_fn(@IntMapper.0, @Int.0))
+  }
+}
+fn make_adder(@Int -> @IntMapper)
+  requires(true) ensures(true) effects(pure)
+{
+  fn(@Int -> @Int) effects(pure) { @Int.0 + @Int.1 }
+}
+fn test(@Unit -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  let @IntMapper = make_adder(100);
+  let @Option<Int> = map_option(Some(5), @IntMapper.0);
+  match @Option<Int>.0 {
+    None -> 0,
+    Some(@Int) -> @Int.0
+  }
+}
+"""
+        assert _run(src, "test") == 105
+
+    def test_closure_in_match_none(self) -> None:
+        """map_option on None returns None."""
+        src = """\
+data Option<T> { None, Some(T) }
+type IntMapper = fn(Int -> Int) effects(pure);
+fn map_option(@Option<Int>, @IntMapper -> @Option<Int>)
+  requires(true) ensures(true) effects(pure)
+{
+  match @Option<Int>.0 {
+    None -> None,
+    Some(@Int) -> Some(apply_fn(@IntMapper.0, @Int.0))
+  }
+}
+fn make_adder(@Int -> @IntMapper)
+  requires(true) ensures(true) effects(pure)
+{
+  fn(@Int -> @Int) effects(pure) { @Int.0 + @Int.1 }
+}
+fn test(@Unit -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  let @IntMapper = make_adder(100);
+  let @Option<Int> = map_option(None, @IntMapper.0);
+  match @Option<Int>.0 {
+    None -> -1,
+    Some(@Int) -> @Int.0
+  }
+}
+"""
+        assert _run(src, "test") == -1
+
+    def test_fn_type_param_compiles(self) -> None:
+        """A function with a function-type parameter is not skipped."""
+        src = """\
+type IntToInt = fn(Int -> Int) effects(pure);
+fn apply(@IntToInt, @Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  apply_fn(@IntToInt.0, @Int.0)
+}
+"""
+        result = _compile_ok(src)
+        assert "apply" in result.exports
+
+    def test_table_in_wat(self) -> None:
+        """WAT output includes a funcref table when closures are used."""
+        src = """\
+type IntToInt = fn(Int -> Int) effects(pure);
+fn make_fn(@Unit -> @IntToInt)
+  requires(true) ensures(true) effects(pure)
+{
+  fn(@Int -> @Int) effects(pure) { @Int.0 }
+}
+"""
+        result = _compile_ok(src)
+        assert result.wat is not None
+        assert "funcref" in result.wat
+        assert "(table" in result.wat
+        assert "(elem" in result.wat
+
+    def test_call_indirect_in_wat(self) -> None:
+        """WAT output contains call_indirect for apply_fn."""
+        src = """\
+type IntToInt = fn(Int -> Int) effects(pure);
+fn apply(@IntToInt, @Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  apply_fn(@IntToInt.0, @Int.0)
+}
+fn make_fn(@Unit -> @IntToInt)
+  requires(true) ensures(true) effects(pure)
+{
+  fn(@Int -> @Int) effects(pure) { @Int.0 }
+}
+fn test(@Unit -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  let @IntToInt = make_fn(());
+  apply(@IntToInt.0, 99)
+}
+"""
+        result = _compile_ok(src)
+        assert result.wat is not None
+        assert "call_indirect" in result.wat
+
+    def test_type_sig_in_wat(self) -> None:
+        """WAT output contains a closure type signature declaration."""
+        src = """\
+type IntToInt = fn(Int -> Int) effects(pure);
+fn make_fn(@Unit -> @IntToInt)
+  requires(true) ensures(true) effects(pure)
+{
+  fn(@Int -> @Int) effects(pure) { @Int.0 }
+}
+"""
+        result = _compile_ok(src)
+        assert result.wat is not None
+        assert "$closure_sig_" in result.wat
+        assert "(type" in result.wat
+
+    def test_closures_example_compiles(self) -> None:
+        """examples/closures.vera compiles without errors."""
+        from pathlib import Path
+        path = Path(__file__).parent.parent / "examples" / "closures.vera"
+        source = path.read_text()
+        result = _compile(source)
+        assert result.ok
+
+    def test_closures_example_test_closure(self) -> None:
+        """examples/closures.vera test_closure returns 15."""
+        from pathlib import Path
+        path = Path(__file__).parent.parent / "examples" / "closures.vera"
+        source = path.read_text()
+        result = _compile_ok(source)
+        exec_result = execute(result, fn_name="test_closure")
+        assert exec_result.value == 15
+
+    def test_closures_example_test_map_option(self) -> None:
+        """examples/closures.vera test_map_option returns 105."""
+        from pathlib import Path
+        path = Path(__file__).parent.parent / "examples" / "closures.vera"
+        source = path.read_text()
+        result = _compile_ok(source)
+        exec_result = execute(result, fn_name="test_map_option")
+        assert exec_result.value == 105
+
+    def test_multiple_closures(self) -> None:
+        """Multiple closures get distinct table entries."""
+        src = """\
+type IntToInt = fn(Int -> Int) effects(pure);
+fn make_adder(@Int -> @IntToInt)
+  requires(true) ensures(true) effects(pure)
+{
+  fn(@Int -> @Int) effects(pure) { @Int.0 + @Int.1 }
+}
+fn test(@Unit -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  let @IntToInt = make_adder(10);
+  let @Int = apply_fn(@IntToInt.0, 5);
+  let @IntToInt = make_adder(20);
+  let @Int = apply_fn(@IntToInt.0, 3);
+  @Int.0 + @Int.1
+}
+"""
+        assert _run(src, "test") == 38  # 15 + 23
+
+    def test_closure_captures_correct_value(self) -> None:
+        """Each closure captures the value at its creation point."""
+        src = """\
+type IntToInt = fn(Int -> Int) effects(pure);
+fn make_adder(@Int -> @IntToInt)
+  requires(true) ensures(true) effects(pure)
+{
+  fn(@Int -> @Int) effects(pure) { @Int.0 + @Int.1 }
+}
+fn test(@Unit -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  let @IntToInt = make_adder(1);
+  let @Int = apply_fn(@IntToInt.0, 0);
+  let @IntToInt = make_adder(100);
+  let @Int = apply_fn(@IntToInt.0, 0);
+  @Int.0 + @Int.1
+}
+"""
+        assert _run(src, "test") == 101  # 1 + 100

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.17"
+__version__ = "0.0.18"

--- a/vera/codegen.py
+++ b/vera/codegen.py
@@ -273,6 +273,17 @@ class CodeGenerator:
         self._adt_layouts: dict[str, dict[str, ConstructorLayout]] = {}
         self._needs_alloc: bool = False
 
+        # Type aliases (populated during registration)
+        # Maps alias name -> TypeExpr (for resolving function type aliases)
+        self._type_aliases: dict[str, ast.TypeExpr] = {}
+
+        # Closure compilation state
+        self._closure_table: list[str] = []  # lifted fn names for table
+        self._closure_sigs: dict[str, str] = {}  # sig_key -> WAT type decl
+        self._closure_fns_wat: list[str] = []  # WAT for lifted closures
+        self._needs_table: bool = False
+        self._next_closure_id: int = 0
+
     # -----------------------------------------------------------------
     # Diagnostics
     # -----------------------------------------------------------------
@@ -376,13 +387,15 @@ class CodeGenerator:
     # -----------------------------------------------------------------
 
     def _register_all(self, program: ast.Program) -> None:
-        """Register all function signatures and ADT layouts."""
+        """Register all function signatures, ADT layouts, and type aliases."""
         for tld in program.declarations:
             decl = tld.decl
             if isinstance(decl, ast.FnDecl):
                 self._register_fn(decl)
             elif isinstance(decl, ast.DataDecl):
                 self._register_data(decl)
+            elif isinstance(decl, ast.TypeAliasDecl):
+                self._type_aliases[decl.name] = decl.type_expr
 
     def _register_fn(self, decl: ast.FnDecl) -> None:
         """Register a function's WASM signature."""
@@ -946,6 +959,9 @@ class CodeGenerator:
             if ret_wt != "unsupported":
                 fn_ret_types[fn_name] = ret_wt
         ctx.set_fn_ret_types(fn_ret_types)
+        # Provide type aliases so closures can resolve FnType return types
+        ctx.set_type_aliases(self._type_aliases)
+        ctx.set_closure_id_start(self._next_closure_id)
         env = WasmSlotEnv()
 
         # Allocate parameters
@@ -998,6 +1014,9 @@ class CodeGenerator:
             )
             return None
 
+        # Collect closures created during body compilation and lift them
+        self._lift_pending_closures(ctx)
+
         # Compile postcondition checks (wrap around body result)
         post_instrs = self._compile_postconditions(ctx, decl, env, ret_wt)
 
@@ -1026,6 +1045,171 @@ class CodeGenerator:
         for instr in post_instrs:
             lines.append(f"    {instr}")
 
+        lines.append("  )")
+        return "\n".join(lines)
+
+    # -----------------------------------------------------------------
+    # Closure lifting
+    # -----------------------------------------------------------------
+
+    def _lift_pending_closures(self, ctx: WasmContext) -> None:
+        """Lift all anonymous functions created during body compilation.
+
+        Each pending closure is compiled to a module-level WASM function
+        and added to the function table.
+        """
+        for anon_fn, captures, closure_id in ctx._pending_closures:
+            lifted_wat = self._compile_lifted_closure(
+                closure_id, anon_fn, captures,
+            )
+            if lifted_wat is not None:
+                self._closure_fns_wat.append(lifted_wat)
+                self._closure_table.append(f"$anon_{closure_id}")
+                self._needs_table = True
+                self._needs_alloc = True
+                self._needs_memory = True
+
+                # Register the closure signature for call_indirect
+                param_wasm: list[str] = ["i32"]  # env param
+                for p in anon_fn.params:
+                    pname = self._type_expr_to_slot_name(p)
+                    pwt = self._type_expr_to_wasm_type(p)
+                    if pwt and pwt != "unsupported":
+                        param_wasm.append(pwt)
+                ret_wt = self._type_expr_to_wasm_type(anon_fn.return_type)
+                param_part = " ".join(
+                    f"(param {wt})" for wt in param_wasm
+                )
+                result_part = (
+                    f" (result {ret_wt})" if ret_wt else ""
+                )
+                sig_content = f"{param_part}{result_part}"
+                if sig_content not in self._closure_sigs:
+                    sig_name = (
+                        f"$closure_sig_{len(self._closure_sigs)}"
+                    )
+                    self._closure_sigs[sig_content] = sig_name
+
+        # Update next closure ID for subsequent functions
+        self._next_closure_id = ctx._next_closure_id
+        # Merge closure sigs from the context (content → name)
+        for sig_content, sig_name in ctx._closure_sigs.items():
+            if sig_content not in self._closure_sigs:
+                self._closure_sigs[sig_content] = sig_name
+
+    def _compile_lifted_closure(
+        self,
+        closure_id: int,
+        anon_fn: ast.AnonFn,
+        captures: list[tuple[str, int, str]],
+    ) -> str | None:
+        """Compile an anonymous function to a module-level WASM function.
+
+        The lifted function signature:
+          (func $anon_N (param $env i32) (param ...) (result ...))
+
+        The first parameter is the closure environment pointer.
+        Captured values are loaded from the environment into locals.
+        """
+        # Flatten ADT layouts for context
+        ctor_layouts: dict[str, ConstructorLayout] = {}
+        ctor_to_adt: dict[str, str] = {}
+        for adt_name, layouts in self._adt_layouts.items():
+            ctor_layouts.update(layouts)
+            for ctor_name in layouts:
+                ctor_to_adt[ctor_name] = adt_name
+
+        ctx = WasmContext(
+            self.string_pool,
+            ctor_layouts=ctor_layouts,
+            adt_type_names=set(self._adt_layouts.keys()),
+            ctor_to_adt=ctor_to_adt,
+        )
+        fn_ret_types: dict[str, str | None] = {}
+        for fn_name, (_, ret_wt) in self._fn_sigs.items():
+            if ret_wt != "unsupported":
+                fn_ret_types[fn_name] = ret_wt
+        ctx.set_fn_ret_types(fn_ret_types)
+        ctx.set_type_aliases(self._type_aliases)
+        env = WasmSlotEnv()
+
+        # Parameter 0: $env (i32 — closure environment pointer)
+        env_idx = ctx.alloc_param()
+        param_parts = ["(param $env i32)"]
+
+        # Allocate ALL function parameters BEFORE any locals.
+        # WASM requires params to be contiguous at indices 0..N-1,
+        # with locals following at N, N+1, etc.
+        param_info: list[tuple[int, ast.TypeExpr, int]] = []
+        for i, param_te in enumerate(anon_fn.params):
+            wt = self._type_expr_to_wasm_type(param_te)
+            if wt is None:
+                continue  # Unit param, skip
+            if wt == "unsupported":
+                return None
+            local_idx = ctx.alloc_param()
+            param_parts.append(f"(param $p{i} {wt})")
+            param_info.append((i, param_te, local_idx))
+
+        # Compute capture layout (must match _translate_anon_fn)
+        cap_offsets: list[tuple[int, str]] = []
+        offset = 4  # skip func_table_idx
+        for _tname, _cidx, cap_wt in captures:
+            align = 8 if cap_wt in ("i64", "f64") else 4
+            offset = _align_up(offset, align)
+            cap_offsets.append((offset, cap_wt))
+            offset += 8 if cap_wt in ("i64", "f64") else 4
+
+        # Load captured values from env into locals (allocated AFTER params)
+        cap_locals: list[tuple[str, int]] = []  # (type_name, local_idx)
+        load_instrs: list[str] = []
+        for i, (tname, _cidx, cap_wt) in enumerate(captures):
+            cap_local = ctx.alloc_local(cap_wt)
+            cap_offset, _ = cap_offsets[i]
+            load_op = (
+                "i64.load" if cap_wt == "i64"
+                else "f64.load" if cap_wt == "f64"
+                else "i32.load"
+            )
+            load_instrs.append(f"local.get {env_idx}")
+            load_instrs.append(f"{load_op} offset={cap_offset}")
+            load_instrs.append(f"local.set {cap_local}")
+            cap_locals.append((tname, cap_local))
+
+        # Build slot environment: captures first (outer scope, higher
+        # De Bruijn indices), then function params on top (most recent).
+        for tname, local_idx in cap_locals:
+            env = env.push(tname, local_idx)
+        for _i, param_te, local_idx in param_info:
+            type_name = self._type_expr_to_slot_name(param_te)
+            if type_name:
+                env = env.push(type_name, local_idx)
+
+        # Return type
+        ret_wt = self._type_expr_to_wasm_type(anon_fn.return_type)
+        if ret_wt == "unsupported":
+            return None
+        result_part = f" (result {ret_wt})" if ret_wt else ""
+
+        # Compile the body
+        body_instrs = ctx.translate_block(anon_fn.body, env)
+        if body_instrs is None:
+            return None
+
+        # Assemble the lifted function WAT (not exported)
+        fn_name = f"$anon_{closure_id}"
+        header = f"  (func {fn_name}"
+        if param_parts:
+            header += " " + " ".join(param_parts)
+        header += result_part
+
+        lines = [header]
+        for local_decl in ctx.extra_locals_wat():
+            lines.append(f"    {local_decl}")
+        for instr in load_instrs:
+            lines.append(f"    {instr}")
+        for instr in body_instrs:
+            lines.append(f"    {instr}")
         lines.append("  )")
         return "\n".join(lines)
 
@@ -1209,9 +1393,26 @@ class CodeGenerator:
                 "  )"
             )
 
-        # Functions
+        # Closure type declarations (for call_indirect)
+        for sig_content, sig_name in self._closure_sigs.items():
+            parts.append(f"  (type {sig_name} (func {sig_content}))")
+
+        # Function table (for indirect calls via closures)
+        if self._needs_table and self._closure_table:
+            table_size = len(self._closure_table)
+            parts.append(f"  (table {table_size} funcref)")
+            elem_entries = " ".join(self._closure_table)
+            parts.append(
+                f"  (elem (i32.const 0) func {elem_entries})"
+            )
+
+        # Functions (user-defined)
         for fn_wat in functions:
             parts.append(fn_wat)
+
+        # Lifted closure functions
+        for closure_wat in self._closure_fns_wat:
+            parts.append(closure_wat)
 
         parts.append(")")
         return "\n".join(parts)
@@ -1332,9 +1533,17 @@ class CodeGenerator:
             # ADT types compile to i32 (heap pointer)
             if name in self._adt_layouts:
                 return "i32"
+            # Function type aliases compile to i32 (closure pointer)
+            if name in self._type_aliases:
+                alias_te = self._type_aliases[name]
+                if isinstance(alias_te, ast.FnType):
+                    return "i32"
             return "unsupported"
         if isinstance(te, ast.RefinementType):
             return self._type_expr_to_wasm_type(te.base_type)
+        # Function types compile to i32 (closure pointer)
+        if isinstance(te, ast.FnType):
+            return "i32"
         return "unsupported"
 
     def _type_expr_to_slot_name(self, te: ast.TypeExpr) -> str | None:
@@ -1351,6 +1560,8 @@ class CodeGenerator:
             return te.name
         if isinstance(te, ast.RefinementType):
             return self._type_expr_to_slot_name(te.base_type)
+        if isinstance(te, ast.FnType):
+            return "Fn"
         return None
 
     @staticmethod

--- a/vera/wasm.py
+++ b/vera/wasm.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 from vera.types import (
     BOOL,
     FLOAT64,
+    FunctionType,
     INT,
     NAT,
     STRING,
@@ -104,6 +105,16 @@ class StringPool:
 
 
 # =====================================================================
+# Alignment helper
+# =====================================================================
+
+
+def _align_up(offset: int, align: int) -> int:
+    """Round offset up to the next multiple of align."""
+    return (offset + align - 1) & ~(align - 1)
+
+
+# =====================================================================
 # Type mapping
 # =====================================================================
 
@@ -125,6 +136,8 @@ def wasm_type(t: Type) -> str | None:
             return None
         if t.name == "String":
             return "unsupported"  # handled specially in 5e
+    if isinstance(t, FunctionType):
+        return "i32"  # closure pointer (heap-allocated struct)
     return "unsupported"
 
 
@@ -186,12 +199,34 @@ class WasmContext:
         # Function return WASM types for type inference:
         # fn_name → return_wasm_type (str | None)
         self._fn_ret_types: dict[str, str | None] = {}
+        # Closure compilation state — accumulated during translation
+        # Each entry: (anon_fn, captures, closure_id)
+        # captures: list of (type_name, outer_de_bruijn, wasm_type)
+        self._pending_closures: list[
+            tuple[ast.AnonFn, list[tuple[str, int, str]], int]
+        ] = []
+        # Type aliases: alias_name -> TypeExpr (for FnType resolution)
+        self._type_aliases: dict[str, ast.TypeExpr] = {}
+        # Closure signature registry: sig_key -> (type_name, param/result WAT)
+        self._closure_sigs: dict[str, str] = {}
+        # Next closure id (may be overwritten by codegen)
+        self._next_closure_id: int = 0
 
     def set_fn_ret_types(
         self, ret_types: dict[str, str | None],
     ) -> None:
         """Set function return WASM types for FnCall type inference."""
         self._fn_ret_types = ret_types
+
+    def set_type_aliases(
+        self, aliases: dict[str, ast.TypeExpr],
+    ) -> None:
+        """Set type alias mappings for FnType resolution."""
+        self._type_aliases = aliases
+
+    def set_closure_id_start(self, start: int) -> None:
+        """Set the starting closure ID for this context."""
+        self._next_closure_id = start
 
     def set_result_local(self, local_idx: int) -> None:
         """Set the local index used for @T.result in postconditions."""
@@ -278,7 +313,10 @@ class WasmContext:
         if isinstance(expr, ast.MatchExpr):
             return self._translate_match(expr, env)
 
-        # Unsupported: handle, lambdas,
+        if isinstance(expr, ast.AnonFn):
+            return self._translate_anon_fn(expr, env)
+
+        # Unsupported: handle,
         # quantifiers, old/new, assert/assume, arrays, etc.
         return None
 
@@ -416,6 +454,10 @@ class WasmContext:
                     if "<" in expr.type_name else expr.type_name)
             if base in self._adt_type_names:
                 return "i32"
+            # Function type aliases → i32 (closure pointer)
+            alias_te = self._type_aliases.get(expr.type_name)
+            if isinstance(alias_te, ast.FnType):
+                return "i32"
             return None
         if isinstance(expr, ast.ResultRef):
             if expr.type_name in ("Int", "Nat"):
@@ -457,8 +499,12 @@ class WasmContext:
 
         For generic calls, resolves the mangled name and looks up its
         registered return type.  For non-generic calls, uses the
-        registered return type directly.
+        registered return type directly.  For apply_fn, infers from
+        the closure's function type.
         """
+        # apply_fn(closure, args...) — infer from closure type
+        if expr.name == "apply_fn" and len(expr.args) >= 1:
+            return self._infer_apply_fn_return_type(expr.args[0])
         # Try generic call resolution first
         if expr.name in self._generic_fn_info:
             mangled = self._resolve_generic_call(expr)
@@ -645,6 +691,10 @@ class WasmContext:
         If the call name matches an effect operation (e.g. get/put for
         State<T>), redirects to the corresponding host import.
         """
+        # Check if this is a closure application: apply_fn(closure, args...)
+        if call.name == "apply_fn" and len(call.args) >= 2:
+            return self._translate_apply_fn(call, env)
+
         # Check if this is an effect operation (e.g. get/put)
         if call.name in self._effect_ops:
             import_name, _is_void = self._effect_ops[call.name]
@@ -863,6 +913,326 @@ class WasmContext:
         """Translate a string literal to (ptr, len) on the stack."""
         offset, length = self.string_pool.intern(expr.value)
         return [f"i32.const {offset}", f"i32.const {length}"]
+
+    # -----------------------------------------------------------------
+    # Closures — anonymous function compilation
+    # -----------------------------------------------------------------
+
+    def _translate_anon_fn(
+        self, expr: ast.AnonFn, env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """Translate an anonymous function to a closure value (i32 pointer).
+
+        Creates a heap-allocated closure struct:
+          [func_table_idx: i32] [capture_0] [capture_1] ...
+
+        Records the AnonFn for later lifting by codegen.py.
+        """
+        # Collect free variables (captures from enclosing scope)
+        param_type_counts: dict[str, int] = {}
+        for p in expr.params:
+            pname = self._type_expr_name(p)
+            if pname:
+                param_type_counts[pname] = param_type_counts.get(pname, 0) + 1
+
+        captures = self._collect_free_vars(expr.body, param_type_counts)
+
+        # Assign closure ID and register for later lifting
+        closure_id = self._next_closure_id
+        self._next_closure_id += 1
+        self._pending_closures.append((expr, captures, closure_id))
+
+        # Compute closure struct layout
+        # offset 0: func_table_idx (i32, 4 bytes)
+        field_offsets: list[tuple[int, str]] = []
+        offset = 4  # skip func_table_idx
+        for _tname, _idx, cap_wt in captures:
+            align = 8 if cap_wt in ("i64", "f64") else 4
+            offset = _align_up(offset, align)
+            field_offsets.append((offset, cap_wt))
+            offset += 8 if cap_wt in ("i64", "f64") else 4
+        total_size = max(_align_up(offset, 8), 8)  # at least 8 bytes
+
+        # Emit allocation + stores
+        instructions: list[str] = []
+        tmp = self.alloc_local("i32")
+
+        # Allocate closure struct
+        instructions.append(f"i32.const {total_size}")
+        instructions.append("call $alloc")
+        instructions.append(f"local.set {tmp}")
+
+        # Store func_table_idx at offset 0
+        instructions.append(f"local.get {tmp}")
+        instructions.append(f"i32.const {closure_id}")
+        instructions.append("i32.store offset=0")
+
+        # Store each captured value
+        for i, (tname, cap_idx, cap_wt) in enumerate(captures):
+            cap_offset, _wt = field_offsets[i]
+            local_idx = env.resolve(tname, cap_idx)
+            if local_idx is None:
+                return None  # capture reference unresolvable
+            instructions.append(f"local.get {tmp}")
+            instructions.append(f"local.get {local_idx}")
+            store_op = (
+                "i64.store" if cap_wt == "i64"
+                else "f64.store" if cap_wt == "f64"
+                else "i32.store"
+            )
+            instructions.append(f"{store_op} offset={cap_offset}")
+
+        # Leave closure pointer on stack
+        instructions.append(f"local.get {tmp}")
+        return instructions
+
+    def _translate_apply_fn(
+        self, call: ast.FnCall, env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """Translate apply_fn(closure, arg0, arg1, ...) to call_indirect.
+
+        The closure is an i32 pointer to:
+          [func_table_idx: i32] [captures...]
+
+        The lifted function signature is:
+          (param $env i32) (param $p0 <type>) ... (result <type>)
+        """
+        instructions: list[str] = []
+        closure_arg = call.args[0]
+        value_args = call.args[1:]
+
+        # Translate the closure argument — get i32 pointer
+        closure_instrs = self.translate_expr(closure_arg, env)
+        if closure_instrs is None:
+            return None
+
+        # Save closure pointer to temp local
+        tmp = self.alloc_local("i32")
+        instructions.extend(closure_instrs)
+        instructions.append(f"local.set {tmp}")
+
+        # Push closure pointer as first arg (env for lifted function)
+        instructions.append(f"local.get {tmp}")
+
+        # Translate and push remaining arguments
+        arg_wasm_types: list[str] = []
+        for arg in value_args:
+            arg_instrs = self.translate_expr(arg, env)
+            if arg_instrs is None:
+                return None
+            instructions.extend(arg_instrs)
+            # Infer WASM type for call_indirect type signature
+            wt = self._infer_expr_wasm_type(arg)
+            arg_wasm_types.append(wt or "i64")  # default to i64
+
+        # Load func_table_idx from closure struct
+        instructions.append(f"local.get {tmp}")
+        instructions.append("i32.load offset=0")
+
+        # Build call_indirect type signature
+        # Return type: infer from the enclosing function's expected return
+        # or from the closure's type if available
+        ret_wt = self._infer_apply_fn_return_type(closure_arg)
+        param_parts = " ".join(
+            f"(param {wt})" for wt in ["i32"] + arg_wasm_types
+        )
+        result_part = f" (result {ret_wt})" if ret_wt else ""
+        sig_key = f"{param_parts}{result_part}"
+
+        # Register this signature for the codegen to emit as a type decl
+        if sig_key not in self._closure_sigs:
+            sig_name = f"$closure_sig_{len(self._closure_sigs)}"
+            self._closure_sigs[sig_key] = sig_name
+
+        sig_name = self._closure_sigs[sig_key]
+        instructions.append(f"call_indirect (type {sig_name})")
+        return instructions
+
+    def _infer_apply_fn_return_type(
+        self, closure_arg: ast.Expr,
+    ) -> str | None:
+        """Infer the WASM return type for a closure application.
+
+        Looks at the closure argument's type (via slot ref type name
+        and type alias resolution) to determine the return type.
+        """
+        if isinstance(closure_arg, ast.SlotRef):
+            type_name = closure_arg.type_name
+            # Check if this is a type alias for a function type
+            alias_te = self._type_aliases.get(type_name)
+            if isinstance(alias_te, ast.FnType):
+                return self._fn_type_return_wasm(alias_te)
+        return "i64"  # safe default for most cases
+
+    def _fn_type_return_wasm(self, fn_type: ast.FnType) -> str | None:
+        """Get the WASM return type from a FnType AST node."""
+        ret = fn_type.return_type
+        if isinstance(ret, ast.NamedType):
+            name = ret.name
+            if name in ("Int", "Nat"):
+                return "i64"
+            if name in ("Float64", "Float"):
+                return "f64"
+            if name == "Bool":
+                return "i32"
+            if name == "Unit":
+                return None
+            return "i32"  # ADT or other pointer type
+        return "i64"  # default
+
+    def _fn_type_param_wasm_types(
+        self, fn_type: ast.FnType,
+    ) -> list[str]:
+        """Get WASM parameter types from a FnType AST node."""
+        types: list[str] = []
+        for p in fn_type.params:
+            if isinstance(p, ast.NamedType):
+                name = p.name
+                if name in ("Int", "Nat"):
+                    types.append("i64")
+                elif name in ("Float64", "Float"):
+                    types.append("f64")
+                elif name == "Bool":
+                    types.append("i32")
+                elif name == "Unit":
+                    pass  # skip Unit params
+                else:
+                    types.append("i32")  # ADT pointer
+            else:
+                types.append("i64")  # default
+        return types
+
+    def _collect_free_vars(
+        self,
+        body: ast.Expr,
+        param_counts: dict[str, int],
+    ) -> list[tuple[str, int, str]]:
+        """Collect free variables in an anonymous function body.
+
+        Walks the body and finds SlotRef nodes that reference bindings
+        from the enclosing scope (De Bruijn index >= param count for
+        that type). Returns list of (type_name, adjusted_index, wasm_type).
+        The adjusted_index is the De Bruijn index in the OUTER scope.
+        """
+        free: list[tuple[str, int, str]] = []
+        seen: set[tuple[str, int]] = set()
+        self._walk_free_vars(body, param_counts, free, seen)
+        return free
+
+    def _walk_free_vars(
+        self,
+        expr: ast.Expr,
+        param_counts: dict[str, int],
+        free: list[tuple[str, int, str]],
+        seen: set[tuple[str, int]],
+    ) -> None:
+        """Recursively walk an expression to find free variable references."""
+        if isinstance(expr, ast.SlotRef):
+            type_name = expr.type_name
+            if expr.type_args:
+                arg_names = []
+                for ta in expr.type_args:
+                    if isinstance(ta, ast.NamedType):
+                        arg_names.append(ta.name)
+                    else:
+                        return
+                type_name = f"{expr.type_name}<{', '.join(arg_names)}>"
+            count = param_counts.get(type_name, 0)
+            if expr.index >= count:
+                # This refers to an outer scope binding
+                outer_idx = expr.index - count
+                key = (type_name, outer_idx)
+                if key not in seen:
+                    seen.add(key)
+                    # Infer wasm type from type name
+                    wt = self._type_name_to_wasm(type_name)
+                    free.append((type_name, outer_idx, wt))
+            return
+
+        if isinstance(expr, ast.BinaryExpr):
+            self._walk_free_vars(expr.left, param_counts, free, seen)
+            self._walk_free_vars(expr.right, param_counts, free, seen)
+        elif isinstance(expr, ast.UnaryExpr):
+            self._walk_free_vars(expr.operand, param_counts, free, seen)
+        elif isinstance(expr, ast.IfExpr):
+            self._walk_free_vars(expr.condition, param_counts, free, seen)
+            self._walk_free_vars(expr.then_branch, param_counts, free, seen)
+            self._walk_free_vars(expr.else_branch, param_counts, free, seen)
+        elif isinstance(expr, ast.Block):
+            extra = dict(param_counts)
+            for stmt in expr.statements:
+                if isinstance(stmt, ast.LetStmt):
+                    self._walk_free_vars(stmt.value, extra, free, seen)
+                    # The let binding adds to the local scope
+                    let_name = self._type_expr_name(stmt.type_expr)
+                    if let_name:
+                        extra[let_name] = extra.get(let_name, 0) + 1
+                elif isinstance(stmt, ast.ExprStmt):
+                    self._walk_free_vars(stmt.expr, extra, free, seen)
+            if expr.expr:
+                self._walk_free_vars(expr.expr, extra, free, seen)
+        elif isinstance(expr, ast.FnCall):
+            for arg in expr.args:
+                self._walk_free_vars(arg, param_counts, free, seen)
+        elif isinstance(expr, ast.QualifiedCall):
+            for arg in expr.args:
+                self._walk_free_vars(arg, param_counts, free, seen)
+        elif isinstance(expr, ast.ConstructorCall):
+            for arg in expr.args:
+                self._walk_free_vars(arg, param_counts, free, seen)
+        elif isinstance(expr, ast.MatchExpr):
+            self._walk_free_vars(expr.scrutinee, param_counts, free, seen)
+            for arm in expr.arms:
+                arm_extra = dict(param_counts)
+                # Match arm bindings add to scope
+                self._collect_pattern_bindings(
+                    arm.pattern, arm_extra,
+                )
+                self._walk_free_vars(arm.body, arm_extra, free, seen)
+        # Other expression types (literals, etc.) have no sub-expressions
+
+    def _collect_pattern_bindings(
+        self,
+        pattern: ast.Pattern,
+        counts: dict[str, int],
+    ) -> None:
+        """Collect type bindings introduced by a match pattern."""
+        if isinstance(pattern, ast.BindingPattern):
+            b_name = self._type_expr_name(pattern.type_expr)
+            if b_name:
+                counts[b_name] = counts.get(b_name, 0) + 1
+        elif isinstance(pattern, ast.ConstructorPattern):
+            for sub in pattern.sub_patterns:
+                self._collect_pattern_bindings(sub, counts)
+
+    def _type_expr_name(self, te: ast.TypeExpr) -> str | None:
+        """Extract a simple type name from a TypeExpr."""
+        if isinstance(te, ast.NamedType):
+            if te.type_args:
+                arg_names = []
+                for a in te.type_args:
+                    if isinstance(a, ast.NamedType):
+                        arg_names.append(a.name)
+                    else:
+                        return None
+                return f"{te.name}<{', '.join(arg_names)}>"
+            return te.name
+        if isinstance(te, ast.RefinementType):
+            return self._type_expr_name(te.base_type)
+        return None
+
+    def _type_name_to_wasm(self, type_name: str) -> str:
+        """Map a Vera type name string to a WASM type string."""
+        if type_name in ("Int", "Nat"):
+            return "i64"
+        if type_name in ("Float64", "Float"):
+            return "f64"
+        if type_name == "Bool":
+            return "i32"
+        if type_name == "Unit":
+            return "i32"  # shouldn't appear, safe fallback
+        # ADT or function type alias → i32 pointer
+        return "i32"
 
     # -----------------------------------------------------------------
     # Result references (postconditions)
@@ -1246,5 +1616,13 @@ class WasmContext:
         # ADT types are heap pointers
         base = name.split("<")[0] if "<" in name else name
         if base in self._adt_type_names:
+            return "i32"
+        # Function type aliases are closure pointers (i32)
+        if name in self._type_aliases:
+            alias_te = self._type_aliases[name]
+            if isinstance(alias_te, ast.FnType):
+                return "i32"
+        # Bare "Fn" for anonymous function types
+        if name == "Fn":
             return "i32"
         return None


### PR DESCRIPTION
## Summary

- **Closure compilation** (C6h — closes #27): compile anonymous functions and closures to WASM via function tables and `call_indirect`
  - Closure representation: heap-allocated struct `[func_table_idx: i32, capture_0, ...]` as `i32` pointer, using existing bump allocator
  - Function table infrastructure: `(type $closure_sig_N ...)`, `(table N funcref)`, `(elem ...)` for indirect calls
  - Closure lifting: anonymous functions compiled as module-level WASM functions with `$env` parameter for captured variables
  - Free variable capture: walk `AnonFn` body to detect `SlotRef` nodes referencing outer-scope bindings, store captured values in heap environment
  - `apply_fn` built-in: compiler-recognized function that emits `call_indirect` with closure function table index
  - Function type aliases (e.g. `type IntToInt = fn(Int -> Int) effects(pure)`) resolved to `i32` closure pointers
  - Functions with function-type parameters no longer skipped (recognized as compilable)
- **Reworked examples/closures.vera**: removed Array, undefined map, and forall generic map_option; added make_adder (closure capture), apply (closure parameter), map_option (closure in match arm), test_closure and test_map_option (end-to-end round-trips)
- **Codegen tests**: 17 new tests — closure creation with/without capture, apply_fn, closures in let bindings and match arms, function-type parameters, WAT structure verification, example file round-trips (677 total, up from 660)
- Spec, CHANGELOG, README updated. Version bumped to 0.0.18.

## Test plan

- [x] `mypy vera/` — clean (14 source files)
- [x] `pytest tests/ -v` — 677 tests pass (660 existing + 17 new)
- [x] `python scripts/check_examples.py` — all 14 examples pass check + verify
- [x] `python scripts/check_version_sync.py` — version 0.0.18 consistent
- [x] `vera compile examples/closures.vera` — compiles (5 functions exported)
- [x] `vera run examples/closures.vera --fn test_closure` — returns 15
- [x] `vera run examples/closures.vera --fn test_map_option` — returns 105
- [x] Pre-commit hooks pass (mypy, pytest, examples, readme)

🤖 Generated with [Claude Code](https://claude.com/claude-code)