### PR TITLE
Consistency audit: fix stale docs, track all outstanding work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,20 @@
 
 Vera is a programming language designed for LLMs to write. It has mandatory contracts, algebraic effects, typed slot references (`@T.n`), and compiles to WebAssembly. The reference compiler is written in Python.
 
+## Virtual environment
+
+Always use the project venv. All commands below assume it is active:
+
+```bash
+source .venv/bin/activate
+```
+
+If the venv does not exist, create it first:
+
+```bash
+python -m venv .venv && source .venv/bin/activate && pip install -e ".[dev]"
+```
+
 ## Key commands
 
 ```bash
@@ -74,3 +88,11 @@ Each stage is a module with a public API function and is independently testable.
 ```
 
 Each diagnostic includes: `severity`, `description`, `location` (`file`, `line`, `column`), `source_line`, `rationale`, `fix`, and `spec_ref`. The `verify --json` output also includes a `verification` summary with `tier1_verified`, `tier3_runtime`, and `total` counts.
+
+## Git commits
+
+When creating commits, use this co-author trailer:
+
+    Co-Authored-By: Claude <noreply@anthropic.invalid>
+
+Do NOT use `noreply@anthropic.com` — that email resolves to an unrelated GitHub account. The `.invalid` TLD (RFC 2606) is reserved and will never resolve to a real address.

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -179,7 +179,7 @@ fn abs(@Int -> @Nat)
 @Array<Int>                              -- array of ints
 @Tuple<Int, String>                      -- tuple
 @Option<Int>                             -- Option type (Some/None)
-Fn(@Int -> @Int) effects(pure)           -- function type
+Fn(Int -> Int) effects(pure)              -- function type
 { @Int | @Int.0 > 0 }                   -- refinement type
 ```
 

--- a/spec/00-introduction.md
+++ b/spec/00-introduction.md
@@ -147,11 +147,11 @@ Throughout this specification:
 
 The following design decisions are noted here for future specification work:
 
-### Network Access as an Effect
+### Network Access as an Effect ([#57](https://github.com/aallan/vera/issues/57))
 
 Network I/O SHOULD be modelled as an algebraic effect (e.g., `<Http>` or `<Net>`) with operations like `get`, `post`, etc. Functions performing network access declare `effects(<Http>)`. Handlers provide the implementation — real HTTP in production, mocks in tests. This fits naturally with Vera's algebraic effect system and makes network I/O explicit and testable. Almost all practical programs need network access; this should be a first-class part of the standard library (Chapter 9).
 
-### JSON as a Standard Library Type
+### JSON as a Standard Library Type ([#58](https://github.com/aallan/vera/issues/58))
 
 JSON SHOULD be a standard library ADT, not a primitive type:
 
@@ -168,7 +168,7 @@ data Json {
 
 Parse and serialize operations belong in the standard library. Refinement types can express JSON schemas (e.g., `type ApiResponse = { @Json | has_field(@Json.0, "status") }`). This approach keeps the core language small while providing ergonomic JSON support.
 
-### Asynchronous Promises/Futures
+### Asynchronous Promises/Futures ([#59](https://github.com/aallan/vera/issues/59))
 
 Async operations SHOULD be first-class citizens in Vera, modelled as an algebraic effect. An `<Async>` effect with an `await` operation fits naturally:
 
@@ -196,7 +196,7 @@ Key design points:
 
 This avoids coloured-function problems (async vs sync) because algebraic effects already separate the description of an operation from its execution. A handler can run `<Http>` operations sequentially or concurrently — the function code is the same either way.
 
-### Abilities (Restricted Type Constraints)
+### Abilities (Restricted Type Constraints) ([#60](https://github.com/aallan/vera/issues/60))
 
 Vera's type variables are currently unconstrained (`forall<T>`). To support practical generic programming — sorting, hashing, serialisation — type variables need constraints. Vera SHOULD adopt **Roc-style restricted abilities** rather than full Haskell-style typeclasses:
 
@@ -231,7 +231,7 @@ This design draws on Roc's abilities (deliberately no HKTs, auto-derivable), Gle
 
 Abilities are a post-v0.1 feature. They will be specified in Chapter 2 when implemented.
 
-### LLM Inference as an Effect
+### LLM Inference as an Effect ([#61](https://github.com/aallan/vera/issues/61))
 
 Vera is designed for LLMs to write. It SHOULD also support LLMs as a runtime component, modelled as an algebraic effect:
 
@@ -264,7 +264,7 @@ Key design points:
 
 The `Inference` effect belongs in the standard library (Chapter 9). The WASM runtime provides handler implementations that bind to HTTP APIs or local model runtimes. No language changes are needed — the existing effect system supports this directly.
 
-### Standard Library Collections
+### Standard Library Collections ([#62](https://github.com/aallan/vera/issues/62))
 
 The standard library (Chapter 9) SHOULD include:
 

--- a/vera/README.md
+++ b/vera/README.md
@@ -73,17 +73,17 @@ execute(compile_result, ...)    # → run WASM via wasmtime
 | `transform.py` | 990 | Transform | Lark tree → AST transformer | `transform()` |
 | `ast.py` | 682 | Transform | Frozen dataclass AST nodes | `Program`, `Node`, `Expr` |
 | `types.py` | 302 | Type check | Semantic type representation | `Type`, `is_subtype()` |
-| `environment.py` | 299 | Type check | Type environment, scope stacks | `TypeEnv` |
+| `environment.py` | 300 | Type check | Type environment, scope stacks | `TypeEnv` |
 | `checker.py` | 1,668 | Type check | Two-pass type checker | `typecheck()` |
 | `smt.py` | 485 | Verify | Z3 translation layer | `SmtContext`, `SlotEnv` |
 | `verifier.py` | 601 | Verify | Contract verification | `verify()` |
-| `wasm.py` | 1,250 | Compile | WASM translation layer | `WasmContext`, `WasmSlotEnv` |
-| `codegen.py` | 1,376 | Compile | Codegen orchestrator | `compile()`, `execute()` |
+| `wasm.py` | 1,707 | Compile | WASM translation layer | `WasmContext`, `WasmSlotEnv` |
+| `codegen.py` | 1,634 | Compile | Codegen orchestrator | `compile()`, `execute()` |
 | `errors.py` | 354 | All | Diagnostic class, error hierarchy | `Diagnostic`, `VeraError` |
 | `cli.py` | 563 | All | CLI commands | `main()` |
 | `registration.py` | 56 | Type check | Shared function registration | `register_fn()` |
 
-Total: ~9,102 lines of Python + 328 lines of grammar.
+Total: ~9,489 lines of Python + 328 lines of grammar.
 
 ## Parsing
 
@@ -539,12 +539,12 @@ Honest inventory of what the compiler cannot do, and where each limitation is ad
 |-----------|-----|---------|
 | **No Byte type codegen** | Needs linear memory byte operations | [#30](https://github.com/aallan/vera/issues/30) |
 | **No module resolution** | `import` declarations parsed but not resolved | [#50](https://github.com/aallan/vera/issues/50) |
-| **Limited effect checking** | Pure vs effectful only; no subeffecting or row unification | Incremental |
-| **No termination verification** | `decreases` clauses parsed but always Tier 3 | Future |
-| **No quantifier verification** | `forall`/`exists` in contracts always Tier 3 | Tier 2 |
-| **No match/constructor body verification** | Untranslatable to Z3, always Tier 3 | Tier 2 |
-| **Minimal type inference** | Call-site generic instantiation only, no Hindley-Milner | Incremental |
-| **No incremental compilation** | Full file processed from scratch each time | Low priority |
+| **Limited effect checking** | Pure vs effectful only; no subeffecting or row unification | [#21](https://github.com/aallan/vera/issues/21) |
+| **No termination verification** | `decreases` clauses parsed but always Tier 3 | [#45](https://github.com/aallan/vera/issues/45) |
+| **No quantifier verification** | `forall`/`exists` in contracts always Tier 3 | [#13](https://github.com/aallan/vera/issues/13) |
+| **No match/constructor body verification** | Untranslatable to Z3, always Tier 3 | [#13](https://github.com/aallan/vera/issues/13) |
+| **Minimal type inference** | Call-site generic instantiation only, no Hindley-Milner | [#55](https://github.com/aallan/vera/issues/55) |
+| **No incremental compilation** | Full file processed from scratch each time | [#56](https://github.com/aallan/vera/issues/56) |
 | **No garbage collection** | Bump allocator only; linear memory is not reclaimed | [#51](https://github.com/aallan/vera/issues/51) |
 | **String constants only** | No dynamic string construction | [#52](https://github.com/aallan/vera/issues/52) |
 


### PR DESCRIPTION
## Summary

Full repo consistency audit across docs, spec, tests, and compiler code.

- **Doc fixes:** README module line counts were stale (codegen.py and wasm.py grew significantly during v0.0.19/v0.0.20). SKILLS.md had a `Fn(@Int -> @Int)` notation mismatch missed during the v0.0.20 spec @T fix. CLAUDE.md now includes venv activation guidance and a non-resolving Co-Authored-By email.
- **Issue tracking:** Every README limitation table entry now links to a GitHub issue. All spec §0.8 design notes now have dedicated issues (#57–#62) and are referenced from the spec headings. New `design` label for future language design items.
- **Labels:** Added `limitation` label to #13, #21, #44, #45, #46 for consistency with the limitations table.

### New issues created
| Issue | Title |
|-------|-------|
| #55 | Minimal type inference |
| #56 | Incremental compilation |
| #57 | Network access effect (`<Http>`) |
| #58 | JSON standard library type |
| #59 | Async futures and promises (`<Async>`) |
| #60 | Abilities and type constraints |
| #61 | LLM inference effect (`<Inference>`) |
| #62 | Standard library collections (Set, Map, Decimal) |
| #63 | Spec Chapter 12: Runtime and Execution |

### Audit confirmed clean ✓
- 795 tests pass, 14 examples pass, mypy clean, all validation scripts green
- Version sync correct (0.0.20)
- Test counts accurate (parametrized tests expand grep count)

## Test plan
- [x] `pytest tests/ -q` — 795 passed
- [x] `mypy vera/` — no issues
- [x] `python scripts/check_examples.py` — 14/14
- [x] `python scripts/check_spec_examples.py` — 0 failed
- [x] `python scripts/check_readme_examples.py` — 0 failed
- [x] `python scripts/check_version_sync.py` — consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)