### PR TITLE
C6k: Byte type + array compilation with bounds checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.21] - 2026-02-26
+
+### Added
+- **Byte type compilation** (C6k): `Byte` maps to `i32` in WASM with unsigned comparison operators (`i32.lt_u`, `i32.gt_u`, `i32.le_u`, `i32.ge_u`); `i32.wrap_i64` coercion for Byte-returning functions with integer literal bodies
+- **Array compilation** (C6k — closes [#30](https://github.com/aallan/vera/issues/30)): compile `Array<T>` literals, indexing, and `length()` to WASM via linear memory
+  - Array representation: `(ptr: i32, len: i32)` pairs, allocated via bump allocator
+  - Element types: `Byte` (1 byte, `i32.load8_u`/`i32.store8`), `Bool` (4 bytes), `Int`/`Nat` (8 bytes, `i64`), `Float64` (8 bytes, `f64`)
+  - Bounds checking: `i32.ge_u` unsigned comparison + `unreachable` trap on out-of-bounds
+  - `length()` built-in: extracts len from `(ptr, len)` pair, extends to `i64`
+  - Array let bindings: two WASM locals (ptr at N, len at N+1)
+  - Array slot refs: emit two `local.get` ops for `(ptr, len)` pair
+  - Array function params/returns unsupported (skipped with warning, same as String)
+- **Spec Section 11.12**: new "Array Compilation" section covering representation, allocation, indexing, bounds checking, length, let bindings, and scope
+- **Codegen tests**: 26 new tests — Byte identity/zero/max/let/comparisons, array literals/indexing/bounds-check/length, WAT inspection (821 total, up from 795)
+
 ## [0.0.20] - 2026-02-25
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ vera parse file.vera              # Print the parse tree
 vera ast file.vera                # Print the typed AST
 vera ast --json file.vera         # Print the AST as JSON
 
-pytest tests/ -v                  # Run the test suite (795 tests)
+pytest tests/ -v                  # Run the test suite (821 tests)
 mypy vera/                        # Type-check the compiler itself
 
 python scripts/check_examples.py      # Verify all 14 examples parse + check + verify

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ C6 extends WASM compilation to all language constructs, working through the depe
 
 | Sub-phase | Scope | Closes | Unlocks |
 |-----------|-------|--------|---------|
-| C6k | Byte + arrays — linear memory arrays with bounds | [#30](https://github.com/aallan/vera/issues/30) | — |
+| ~~C6k~~ | ~~Byte + arrays — linear memory arrays with bounds~~ | ~~[#30](https://github.com/aallan/vera/issues/30)~~ | ~~Done (v0.0.21)~~ |
 | C6l | Quantifiers — forall/exists as runtime loops | — | quantifiers.vera |
 | C6m | Refinement returns + stdlib utilities | — | refinement_types.vera |
 | C6n | Spec chapters 9 (Standard library) and 12 (Runtime) | — | — |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.20"
+version = "0.0.21"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/spec/11-compilation.md
+++ b/spec/11-compilation.md
@@ -29,13 +29,15 @@ Vera types map to WASM value types as follows:
 | `Int` | `i64` | 64-bit signed integer |
 | `Nat` | `i64` | Non-negativity enforced by contracts, not by WASM type |
 | `Bool` | `i32` | `0` = `false`, `1` = `true` |
+| `Byte` | `i32` | Unsigned 0-255; uses unsigned comparison ops (`i32.lt_u`, etc.) |
 | `Float64` / `Float` | `f64` | 64-bit IEEE 754 floating point |
 | `Unit` | *(none)* | Functions returning `Unit` have no WASM result type |
 | `String` | `i32, i32` | Pointer and length pair (UTF-8 bytes in linear memory) |
+| `Array<T>` | `i32, i32` | Pointer and length pair (elements in linear memory); see Section 11.13 |
 | ADTs | `i32` | Heap pointer to tagged union (see Section 11.6) |
 | Function types | `i32` | Heap pointer to closure struct (see Section 11.11) |
 
-Generic type variables are resolved via monomorphization — each concrete instantiation of a `forall<T>` function produces a specialized copy with type variables replaced by concrete types (e.g. `identity$Int`). Type aliases for function types (e.g. `type IntToInt = fn(Int -> Int) effects(pure)`) are also resolved to `i32` closure pointers. Types not in this table (arrays) are not yet compilable. Functions using non-compilable types are skipped with a warning.
+Generic type variables are resolved via monomorphization — each concrete instantiation of a `forall<T>` function produces a specialized copy with type variables replaced by concrete types (e.g. `identity$Int`). Type aliases for function types (e.g. `type IntToInt = fn(Int -> Int) effects(pure)`) are also resolved to `i32` closure pointers. Array and String types are compilable within function bodies (as let bindings and expressions) but not yet as function parameters or return types. Functions using non-compilable types in their signatures are skipped with a warning.
 
 ### 11.2.1 Nat as i64
 
@@ -425,13 +427,60 @@ A `handle[State<T>]` expression discharges the `State<T>` effect. This means a f
 
 Handler types other than `State<T>` (e.g. `Exn<E>`, custom effects) are not yet compilable. Functions containing unsupported handler types are skipped with a warning.
 
-## 11.12 Limitations
+## 11.12 Array Compilation
+
+### 11.12.1 Array Representation
+
+Array values, like strings, are `(ptr: i32, len: i32)` pairs. The pointer references a contiguous block of elements in linear memory. The length is the number of elements (not bytes). Empty arrays are represented as `(0, 0)` with no allocation.
+
+Element sizes in linear memory:
+
+| Element Type | Byte Size | Load Op | Store Op |
+|-------------|-----------|---------|----------|
+| `Byte` | 1 | `i32.load8_u` | `i32.store8` |
+| `Bool` | 4 | `i32.load` | `i32.store` |
+| `Int` / `Nat` | 8 | `i64.load` | `i64.store` |
+| `Float64` | 8 | `f64.load` | `f64.store` |
+
+### 11.12.2 Array Literal Allocation
+
+An array literal `[a, b, c]` compiles to:
+
+1. Compute `total_bytes = n * element_size`
+2. `call $alloc` to allocate contiguous memory
+3. Store each element at `ptr + i * element_size`
+4. Push `(ptr, n)` on the WASM stack
+
+### 11.12.3 Array Indexing
+
+Array indexing `arr[i]` compiles to a bounds-checked element load:
+
+1. Evaluate the array expression to `(ptr, len)`
+2. Evaluate the index expression to `i64`, wrap to `i32`
+3. Bounds check: `if (u32)idx >= (u32)len then unreachable` (trap)
+4. Compute address: `ptr + idx * element_size`
+5. Load the element with the type-appropriate instruction
+
+The unsigned comparison `i32.ge_u` handles negative indices (which wrap to large unsigned values and always fail the bounds check).
+
+### 11.12.4 Length
+
+The built-in `length(array)` function extracts the length component from the `(ptr, len)` pair and extends it to `i64` (since `length` returns `Int`).
+
+### 11.12.5 Array Let Bindings
+
+A `let @Array<T> = expr` binding allocates two WASM locals (ptr and len) and stores both components. The slot environment maps the type name to the ptr local index; the len local is always at `ptr_index + 1`.
+
+### 11.12.6 Scope
+
+Array types are compilable within function bodies (as let bindings, literals, indexing, and `length` calls) but not yet as function parameters or return types. Functions with `Array<T>` in their signatures are skipped with a warning.
+
+## 11.13 Limitations
 
 The current compilation model has the following limitations, each tracked as a GitHub issue:
 
 | Limitation | Issue | Notes |
 |-----------|-------|-------|
-| No Byte type codegen | [#30](https://github.com/aallan/vera/issues/30) | Needs linear memory byte operations |
 | No module-level code generation | [#50](https://github.com/aallan/vera/issues/50) | Each file compiles independently |
 | No garbage collection | [#51](https://github.com/aallan/vera/issues/51) | Bump allocator only; linear memory is not reclaimed |
 | String constants only | [#52](https://github.com/aallan/vera/issues/52) | No dynamic string construction |

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -3238,3 +3238,284 @@ fn test(@Int -> @Option<Int>)
         result = _compile_ok(source)
         exec_result = execute(result, fn_name="test_put_get")
         assert exec_result.value == 99
+
+
+# =====================================================================
+# C6k: Byte type
+# =====================================================================
+
+
+class TestByteType:
+    def test_byte_identity(self) -> None:
+        src = """
+fn f(@Byte -> @Byte) requires(true) ensures(true) effects(pure) {
+  @Byte.0
+}
+"""
+        assert _run(src, fn="f", args=[42]) == 42
+
+    def test_byte_zero(self) -> None:
+        src = """
+fn f(-> @Byte) requires(true) ensures(true) effects(pure) {
+  0
+}
+"""
+        assert _run(src) == 0
+
+    def test_byte_max(self) -> None:
+        src = """
+fn f(-> @Byte) requires(true) ensures(true) effects(pure) {
+  255
+}
+"""
+        assert _run(src) == 255
+
+    def test_byte_let_binding(self) -> None:
+        src = """
+fn f(@Byte -> @Byte) requires(true) ensures(true) effects(pure) {
+  let @Byte = @Byte.0;
+  @Byte.0
+}
+"""
+        assert _run(src, fn="f", args=[100]) == 100
+
+    def test_byte_eq(self) -> None:
+        src = """
+fn f(@Byte, @Byte -> @Bool) requires(true) ensures(true) effects(pure) {
+  @Byte.0 == @Byte.1
+}
+"""
+        assert _run(src, fn="f", args=[5, 5]) == 1
+        assert _run(src, fn="f", args=[5, 6]) == 0
+
+    def test_byte_lt_unsigned(self) -> None:
+        # @Byte.0 = second param (de Bruijn 0), @Byte.1 = first param
+        src = """
+fn f(@Byte, @Byte -> @Bool) requires(true) ensures(true) effects(pure) {
+  @Byte.0 < @Byte.1
+}
+"""
+        # f(200, 10): @Byte.0=10, @Byte.1=200 → 10 < 200 = true
+        assert _run(src, fn="f", args=[200, 10]) == 1
+        # f(10, 200): @Byte.0=200, @Byte.1=10 → 200 < 10 = false
+        assert _run(src, fn="f", args=[10, 200]) == 0
+
+    def test_byte_gt_unsigned(self) -> None:
+        src = """
+fn f(@Byte, @Byte -> @Bool) requires(true) ensures(true) effects(pure) {
+  @Byte.0 > @Byte.1
+}
+"""
+        # f(10, 200): @Byte.0=200, @Byte.1=10 → 200 > 10 = true
+        assert _run(src, fn="f", args=[10, 200]) == 1
+        # f(200, 10): @Byte.0=10, @Byte.1=200 → 10 > 200 = false
+        assert _run(src, fn="f", args=[200, 10]) == 0
+
+    def test_byte_le(self) -> None:
+        src = """
+fn f(@Byte, @Byte -> @Bool) requires(true) ensures(true) effects(pure) {
+  @Byte.0 <= @Byte.1
+}
+"""
+        assert _run(src, fn="f", args=[5, 5]) == 1
+        # f(6, 5): @Byte.0=5, @Byte.1=6 → 5 <= 6 = true
+        assert _run(src, fn="f", args=[6, 5]) == 1
+        # f(5, 6): @Byte.0=6, @Byte.1=5 → 6 <= 5 = false
+        assert _run(src, fn="f", args=[5, 6]) == 0
+
+    def test_byte_ge(self) -> None:
+        src = """
+fn f(@Byte, @Byte -> @Bool) requires(true) ensures(true) effects(pure) {
+  @Byte.0 >= @Byte.1
+}
+"""
+        assert _run(src, fn="f", args=[5, 5]) == 1
+        # f(5, 6): @Byte.0=6, @Byte.1=5 → 6 >= 5 = true
+        assert _run(src, fn="f", args=[5, 6]) == 1
+        # f(6, 5): @Byte.0=5, @Byte.1=6 → 5 >= 6 = false
+        assert _run(src, fn="f", args=[6, 5]) == 0
+
+    def test_byte_unsigned_comparison_wat(self) -> None:
+        """Byte comparisons should use unsigned i32 ops."""
+        src = """
+fn f(@Byte, @Byte -> @Bool) requires(true) ensures(true) effects(pure) {
+  @Byte.0 < @Byte.1
+}
+"""
+        result = _compile_ok(src)
+        assert "i32.lt_u" in result.wat
+
+
+# =====================================================================
+# C6k: Array literals
+# =====================================================================
+
+
+class TestArrayLit:
+    def test_int_array_index_0(self) -> None:
+        src = """
+fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  let @Array<Int> = [10, 20, 30];
+  @Array<Int>.0[0]
+}
+"""
+        assert _run(src) == 10
+
+    def test_int_array_index_1(self) -> None:
+        src = """
+fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  let @Array<Int> = [10, 20, 30];
+  @Array<Int>.0[1]
+}
+"""
+        assert _run(src) == 20
+
+    def test_int_array_index_2(self) -> None:
+        src = """
+fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  let @Array<Int> = [10, 20, 30];
+  @Array<Int>.0[2]
+}
+"""
+        assert _run(src) == 30
+
+    def test_single_element_array(self) -> None:
+        src = """
+fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  let @Array<Int> = [42];
+  @Array<Int>.0[0]
+}
+"""
+        assert _run(src) == 42
+
+    def test_bool_array(self) -> None:
+        src = """
+fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
+  let @Array<Bool> = [true, false, true];
+  @Array<Bool>.0[1]
+}
+"""
+        assert _run(src) == 0
+
+    def test_array_wat_has_alloc(self) -> None:
+        """Array literal WAT should contain call $alloc."""
+        src = """
+fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  let @Array<Int> = [1, 2, 3];
+  @Array<Int>.0[0]
+}
+"""
+        result = _compile_ok(src)
+        assert "call $alloc" in result.wat
+
+    def test_array_wat_has_bounds_check(self) -> None:
+        """Array indexing WAT should contain unreachable for OOB."""
+        src = """
+fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  let @Array<Int> = [1, 2, 3];
+  @Array<Int>.0[0]
+}
+"""
+        result = _compile_ok(src)
+        assert "unreachable" in result.wat
+
+
+# =====================================================================
+# C6k: Array bounds checking
+# =====================================================================
+
+
+class TestArrayBoundsCheck:
+    def test_oob_positive_index(self) -> None:
+        src = """
+fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  let @Array<Int> = [10, 20, 30];
+  @Array<Int>.0[3]
+}
+"""
+        _run_trap(src)
+
+    def test_oob_large_index(self) -> None:
+        src = """
+fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  let @Array<Int> = [10, 20, 30];
+  @Array<Int>.0[100]
+}
+"""
+        _run_trap(src)
+
+    def test_last_valid_index(self) -> None:
+        src = """
+fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  let @Array<Int> = [10, 20, 30];
+  @Array<Int>.0[2]
+}
+"""
+        assert _run(src) == 30
+
+    def test_first_valid_index(self) -> None:
+        src = """
+fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  let @Array<Int> = [10, 20, 30];
+  @Array<Int>.0[0]
+}
+"""
+        assert _run(src) == 10
+
+
+# =====================================================================
+# C6k: Array length
+# =====================================================================
+
+
+class TestArrayLength:
+    def test_length_three(self) -> None:
+        src = """
+fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  let @Array<Int> = [10, 20, 30];
+  length(@Array<Int>.0)
+}
+"""
+        assert _run(src) == 3
+
+    def test_length_one(self) -> None:
+        src = """
+fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  let @Array<Int> = [42];
+  length(@Array<Int>.0)
+}
+"""
+        assert _run(src) == 1
+
+    def test_length_in_comparison(self) -> None:
+        src = """
+fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
+  let @Array<Int> = [10, 20, 30];
+  length(@Array<Int>.0) == 3
+}
+"""
+        assert _run(src) == 1
+
+    def test_length_in_let(self) -> None:
+        src = """
+fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  let @Array<Int> = [1, 2, 3, 4, 5];
+  let @Int = length(@Array<Int>.0);
+  @Int.0
+}
+"""
+        assert _run(src) == 5
+
+    def test_array_fn_param_skipped(self) -> None:
+        """Functions with Array params should be skipped with warning."""
+        src = """
+fn f(@Array<Int> -> @Int) requires(true) ensures(true) effects(pure) {
+  @Array<Int>.0[0]
+}
+fn g(-> @Int) requires(true) ensures(true) effects(pure) {
+  42
+}
+"""
+        result = _compile_ok(src)
+        # f should be skipped, g should compile
+        assert "$g" in result.wat

--- a/vera/README.md
+++ b/vera/README.md
@@ -77,13 +77,13 @@ execute(compile_result, ...)    # → run WASM via wasmtime
 | `checker.py` | 1,668 | Type check | Two-pass type checker | `typecheck()` |
 | `smt.py` | 485 | Verify | Z3 translation layer | `SmtContext`, `SlotEnv` |
 | `verifier.py` | 601 | Verify | Contract verification | `verify()` |
-| `wasm.py` | 1,707 | Compile | WASM translation layer | `WasmContext`, `WasmSlotEnv` |
-| `codegen.py` | 1,634 | Compile | Codegen orchestrator | `compile()`, `execute()` |
+| `wasm.py` | 1,965 | Compile | WASM translation layer | `WasmContext`, `WasmSlotEnv` |
+| `codegen.py` | 1,646 | Compile | Codegen orchestrator | `compile()`, `execute()` |
 | `errors.py` | 354 | All | Diagnostic class, error hierarchy | `Diagnostic`, `VeraError` |
 | `cli.py` | 563 | All | CLI commands | `main()` |
 | `registration.py` | 56 | Type check | Shared function registration | `register_fn()` |
 
-Total: ~9,489 lines of Python + 328 lines of grammar.
+Total: ~9,762 lines of Python + 328 lines of grammar.
 
 ## Parsing
 
@@ -346,7 +346,7 @@ Error at line 3, column 3:
 
 ## Code Generation
 
-**Files:** `codegen.py` (1,376 lines), `wasm.py` (1,250 lines)
+**Files:** `codegen.py` (1,646 lines), `wasm.py` (1,965 lines)
 
 ### Compilation pipeline
 
@@ -462,14 +462,14 @@ Every diagnostic includes a description (what went wrong), rationale (which lang
 | `test_ast.py` | 84 | 896 | AST transformation, node structure, serialisation |
 | `test_checker.py` | 108 | 1,203 | Type synthesis, slot resolution, effects, contracts, exhaustiveness |
 | `test_verifier.py` | 68 | 894 | Z3 verification, counterexamples, tier classification, Int→Nat enforcement, call-site preconditions |
-| `test_codegen.py` | 251 | 3,240 | WASM compilation, arithmetic, Float64, ADTs, match, generics, closures, State\<T\>, control flow, strings, IO, contracts, example round-trips |
+| `test_codegen.py` | 277 | 3,521 | WASM compilation, arithmetic, Float64, Byte, arrays, ADTs, match, generics, closures, State\<T\>, control flow, strings, IO, contracts, bounds checking, length, example round-trips |
 | `test_cli.py` | 76 | 932 | CLI commands (check, verify, compile, run), subprocess integration, JSON error paths, runtime traps, arg validation |
 | `test_types.py` | 55 | 279 | Type operations: subtyping, equality, substitution, pretty-printing, canonical names |
 | `test_wasm.py` | 22 | 255 | WASM internals: StringPool, WasmSlotEnv, translation edge cases via full pipeline |
 | `test_readme.py` | 2 | 68 | README code sample parsing |
 | `test_errors.py` | 34 | 287 | Diagnostic formatting, serialisation, error patterns, SourceLocation, diagnose_lark_error |
 
-Total: 8,845 lines of test code.
+Total: 9,126 lines of test code.
 
 ### Round-trip testing
 

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.20"
+__version__ = "0.0.21"

--- a/vera/codegen.py
+++ b/vera/codegen.py
@@ -1017,6 +1017,18 @@ class CodeGenerator:
             )
             return None
 
+        # Propagate resource flags from WasmContext (e.g. array allocation)
+        if ctx.needs_alloc:
+            self._needs_alloc = True
+            self._needs_memory = True
+
+        # Coerce body result if return type is i32 but body produces i64
+        # (e.g. IntLit in a Byte-returning function)
+        if ret_wt == "i32":
+            body_result_type = ctx._infer_block_result_type(decl.body)
+            if body_result_type == "i64":
+                body_instrs.append("i32.wrap_i64")
+
         # Collect closures created during body compilation and lift them
         self._lift_pending_closures(ctx)
 
@@ -1571,11 +1583,11 @@ class CodeGenerator:
                 return "i64"
             if name in ("Float64", "Float"):
                 return "f64"
-            if name == "Bool":
+            if name in ("Bool", "Byte"):
                 return "i32"
             if name == "Unit":
                 return None
-            if name == "String":
+            if name in ("String", "Array"):
                 return "unsupported"
             # ADT types compile to i32 (heap pointer)
             if name in self._adt_layouts:

--- a/vera/wasm.py
+++ b/vera/wasm.py
@@ -130,7 +130,7 @@ def wasm_type(t: Type) -> str | None:
             return "i64"
         if t.name in ("Float64", "Float"):
             return "f64"
-        if t.name == "Bool":
+        if t.name in ("Bool", "Byte"):
             return "i32"
         if t.name == "Unit":
             return None
@@ -153,6 +153,63 @@ def wasm_type_or_none(t: Type) -> str | None:
 def is_compilable_type(t: Type) -> bool:
     """Check if a type can be compiled to WASM."""
     return wasm_type(t) != "unsupported"
+
+
+# =====================================================================
+# Array helpers — element sizing, load/store ops
+# =====================================================================
+
+def _element_mem_size(elem_type: str) -> int | None:
+    """Return byte size of an array element given a Vera type name.
+
+    Returns None for unsupported element types.
+    """
+    if elem_type == "Byte":
+        return 1
+    if elem_type == "Bool":
+        return 4  # i32
+    if elem_type in ("Int", "Nat"):
+        return 8  # i64
+    if elem_type in ("Float64", "Float"):
+        return 8  # f64
+    return None
+
+
+def _element_load_op(elem_type: str) -> str | None:
+    """Return the WASM load instruction for an array element type."""
+    if elem_type == "Byte":
+        return "i32.load8_u"
+    if elem_type == "Bool":
+        return "i32.load"
+    if elem_type in ("Int", "Nat"):
+        return "i64.load"
+    if elem_type in ("Float64", "Float"):
+        return "f64.load"
+    return None
+
+
+def _element_store_op(elem_type: str) -> str | None:
+    """Return the WASM store instruction for an array element type."""
+    if elem_type == "Byte":
+        return "i32.store8"
+    if elem_type == "Bool":
+        return "i32.store"
+    if elem_type in ("Int", "Nat"):
+        return "i64.store"
+    if elem_type in ("Float64", "Float"):
+        return "f64.store"
+    return None
+
+
+def _element_wasm_type(elem_type: str) -> str | None:
+    """Return the WASM value type for an array element."""
+    if elem_type in ("Byte", "Bool"):
+        return "i32"
+    if elem_type in ("Int", "Nat"):
+        return "i64"
+    if elem_type in ("Float64", "Float"):
+        return "f64"
+    return None
 
 
 # =====================================================================
@@ -209,6 +266,8 @@ class WasmContext:
         self._type_aliases: dict[str, ast.TypeExpr] = {}
         # Closure signature registry: sig_key -> (type_name, param/result WAT)
         self._closure_sigs: dict[str, str] = {}
+        # Flags for resource requirements detected during translation
+        self.needs_alloc: bool = False
         # Next closure id (may be overwritten by codegen)
         self._next_closure_id: int = 0
 
@@ -319,7 +378,13 @@ class WasmContext:
         if isinstance(expr, ast.HandleExpr):
             return self._translate_handle_expr(expr, env)
 
-        # Unsupported: quantifiers, old/new, assert/assume, arrays, etc.
+        if isinstance(expr, ast.ArrayLit):
+            return self._translate_array_lit(expr, env)
+
+        if isinstance(expr, ast.IndexExpr):
+            return self._translate_index_expr(expr, env)
+
+        # Unsupported: quantifiers, old/new, assert/assume, etc.
         return None
 
     # -----------------------------------------------------------------
@@ -343,6 +408,9 @@ class WasmContext:
         local_idx = env.resolve(type_name, ref.index)
         if local_idx is None:
             return None
+        # Array types push (ptr, len) — two locals
+        if self._is_array_type_name(type_name):
+            return [f"local.get {local_idx}", f"local.get {local_idx + 1}"]
         return [f"local.get {local_idx}"]
 
     # -----------------------------------------------------------------
@@ -413,7 +481,14 @@ class WasmContext:
             if ltype == "f64" or rtype == "f64":
                 return left + right + [self._CMP_OPS_F64[op]]
             if ltype == "i32" and rtype == "i32":
-                # Bool operands — use i32 comparison
+                # Byte operands use unsigned i32 comparison
+                lv = self._infer_vera_type(expr.left)
+                rv = self._infer_vera_type(expr.right)
+                if lv == "Byte" or rv == "Byte":
+                    i32_op = self._CMP_OPS[op].replace("i64.", "i32.")
+                    i32_op = i32_op.replace("_s", "_u")
+                    return left + right + [i32_op]
+                # Bool operands — use i32 comparison (signed)
                 i32_op = self._CMP_OPS[op].replace("i64.", "i32.")
                 return left + right + [i32_op]
             return left + right + [self._CMP_OPS[op]]
@@ -450,7 +525,7 @@ class WasmContext:
                 return "i64"
             if expr.type_name in ("Float64", "Float"):
                 return "f64"
-            if expr.type_name == "Bool":
+            if expr.type_name in ("Bool", "Byte"):
                 return "i32"
             base = (expr.type_name.split("<")[0]
                     if "<" in expr.type_name else expr.type_name)
@@ -466,7 +541,7 @@ class WasmContext:
                 return "i64"
             if expr.type_name in ("Float64", "Float"):
                 return "f64"
-            if expr.type_name == "Bool":
+            if expr.type_name in ("Bool", "Byte"):
                 return "i32"
             return None
         if isinstance(expr, ast.BinaryExpr):
@@ -499,6 +574,11 @@ class WasmContext:
             if expr.body.expr:
                 return self._infer_expr_wasm_type(expr.body.expr)
             return None
+        if isinstance(expr, ast.IndexExpr):
+            elem_type = self._infer_index_element_type(expr)
+            return _element_wasm_type(elem_type) if elem_type else None
+        if isinstance(expr, ast.ArrayLit):
+            return None  # arrays are (i32, i32) — handled specially
         return None
 
     def _infer_fncall_wasm_type(self, expr: ast.FnCall) -> str | None:
@@ -509,6 +589,9 @@ class WasmContext:
         registered return type directly.  For apply_fn, infers from
         the closure's function type.
         """
+        # length(array) → Int (i64)
+        if expr.name == "length":
+            return "i64"
         # apply_fn(closure, args...) — infer from closure type
         if expr.name == "apply_fn" and len(expr.args) >= 1:
             return self._infer_apply_fn_return_type(expr.args[0])
@@ -598,7 +681,7 @@ class WasmContext:
                 return "i64"
             if name in ("Float64", "Float"):
                 return "f64"
-            if name == "Bool":
+            if name in ("Bool", "Byte"):
                 return "i32"
             base = name.split("<")[0] if "<" in name else name
             if base in self._adt_type_names:
@@ -636,6 +719,11 @@ class WasmContext:
             if expr.arms:
                 return self._infer_expr_wasm_type(expr.arms[0].body)
             return None
+        if isinstance(expr, ast.IndexExpr):
+            elem_type = self._infer_index_element_type(expr)
+            return _element_wasm_type(elem_type) if elem_type else None
+        if isinstance(expr, ast.ArrayLit):
+            return None  # arrays are (i32, i32) — handled specially
         return None
 
     # -----------------------------------------------------------------
@@ -658,6 +746,15 @@ class WasmContext:
                 type_name = self._type_expr_to_slot_name(stmt.type_expr)
                 if type_name is None:
                     return None
+                # Array bindings need two locals: (ptr, len)
+                if self._is_array_type_name(type_name):
+                    ptr_idx = self.alloc_local("i32")
+                    len_idx = self.alloc_local("i32")
+                    instructions.extend(val_instrs)
+                    instructions.append(f"local.set {len_idx}")
+                    instructions.append(f"local.set {ptr_idx}")
+                    current_env = current_env.push(type_name, ptr_idx)
+                    continue
                 wat_t = self._slot_name_to_wasm_type(type_name)
                 if wat_t is None:
                     return None
@@ -698,6 +795,10 @@ class WasmContext:
         If the call name matches an effect operation (e.g. get/put for
         State<T>), redirects to the corresponding host import.
         """
+        # Built-in: length(array) → Int
+        if call.name == "length" and len(call.args) == 1:
+            return self._translate_length(call.args[0], env)
+
         # Check if this is a closure application: apply_fn(closure, args...)
         if call.name == "apply_fn" and len(call.args) >= 2:
             return self._translate_apply_fn(call, env)
@@ -846,6 +947,8 @@ class WasmContext:
         the return TypeExpr.  For non-generic calls, maps from WASM
         return type back to Vera type name.
         """
+        if call.name == "length":
+            return "Int"
         if call.name in self._generic_fn_info:
             forall_vars, param_types = self._generic_fn_info[call.name]
             mapping: dict[str, str] = {}
@@ -884,6 +987,31 @@ class WasmContext:
         """Find the ADT type name for a constructor name."""
         return self._ctor_to_adt.get(ctor_name)
 
+    @staticmethod
+    def _is_array_type_name(type_name: str) -> bool:
+        """Check if a slot type name is an Array<T> type."""
+        return type_name.startswith("Array<")
+
+    def _infer_array_element_type(self, expr: ast.ArrayLit) -> str | None:
+        """Infer the Vera element type name from an array literal."""
+        if not expr.elements:
+            return None
+        return self._infer_vera_type(expr.elements[0])
+
+    def _infer_index_element_type(self, expr: ast.IndexExpr) -> str | None:
+        """Infer the Vera element type from an index expression's collection.
+
+        The collection should be a slot ref like @Array<Int>.0, whose
+        type_name is "Array" with type_args (NamedType("Int"),).
+        """
+        coll = expr.collection
+        if isinstance(coll, ast.SlotRef):
+            if coll.type_name == "Array" and coll.type_args:
+                ta = coll.type_args[0]
+                if isinstance(ta, ast.NamedType):
+                    return ta.name
+        return None
+
     def _get_arg_type_info_wasm(
         self, expr: ast.Expr,
     ) -> tuple[str, tuple[str, ...]] | None:
@@ -920,6 +1048,136 @@ class WasmContext:
         """Translate a string literal to (ptr, len) on the stack."""
         offset, length = self.string_pool.intern(expr.value)
         return [f"i32.const {offset}", f"i32.const {length}"]
+
+    # -----------------------------------------------------------------
+    # Array literals
+    # -----------------------------------------------------------------
+
+    def _translate_array_lit(
+        self, expr: ast.ArrayLit, env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """Translate an array literal to (ptr, len) on the stack.
+
+        Allocates heap memory via $alloc, stores each element, then
+        pushes (ptr, len) as an i32 pair.  Empty arrays push (0, 0).
+        """
+        n = len(expr.elements)
+        if n == 0:
+            return ["i32.const 0", "i32.const 0"]
+
+        elem_type = self._infer_array_element_type(expr)
+        if elem_type is None:
+            return None
+        elem_size = _element_mem_size(elem_type)
+        store_op = _element_store_op(elem_type)
+        if elem_size is None or store_op is None:
+            return None
+
+        self.needs_alloc = True
+        total_bytes = n * elem_size
+        tmp_ptr = self.alloc_local("i32")
+
+        instructions: list[str] = []
+        # Allocate
+        instructions.append(f"i32.const {total_bytes}")
+        instructions.append("call $alloc")
+        instructions.append(f"local.set {tmp_ptr}")
+
+        # Store each element
+        for i, elem in enumerate(expr.elements):
+            elem_instrs = self.translate_expr(elem, env)
+            if elem_instrs is None:
+                return None
+            offset = i * elem_size
+            instructions.append(f"local.get {tmp_ptr}")
+            instructions.extend(elem_instrs)
+            instructions.append(f"{store_op} offset={offset}")
+
+        # Push (ptr, len)
+        instructions.append(f"local.get {tmp_ptr}")
+        instructions.append(f"i32.const {n}")
+        return instructions
+
+    def _translate_index_expr(
+        self, expr: ast.IndexExpr, env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """Translate array indexing with bounds check.
+
+        Evaluates collection → (ptr, len), evaluates index,
+        performs bounds check (trap on OOB), then loads the element.
+        """
+        elem_type = self._infer_index_element_type(expr)
+        if elem_type is None:
+            return None
+        elem_size = _element_mem_size(elem_type)
+        load_op = _element_load_op(elem_type)
+        if elem_size is None or load_op is None:
+            return None
+
+        # Evaluate collection → (ptr, len) on stack
+        coll_instrs = self.translate_expr(expr.collection, env)
+        if coll_instrs is None:
+            return None
+
+        # Evaluate index (Int → i64)
+        idx_instrs = self.translate_expr(expr.index, env)
+        if idx_instrs is None:
+            return None
+
+        # Temp locals for ptr, len, index
+        tmp_ptr = self.alloc_local("i32")
+        tmp_len = self.alloc_local("i32")
+        tmp_idx = self.alloc_local("i32")
+
+        instructions: list[str] = []
+        # Save (ptr, len)
+        instructions.extend(coll_instrs)
+        instructions.append(f"local.set {tmp_len}")
+        instructions.append(f"local.set {tmp_ptr}")
+        # Evaluate and wrap index from i64 to i32
+        instructions.extend(idx_instrs)
+        instructions.append("i32.wrap_i64")
+        instructions.append(f"local.set {tmp_idx}")
+        # Bounds check: if (u32)idx >= (u32)len then trap
+        instructions.append(f"local.get {tmp_idx}")
+        instructions.append(f"local.get {tmp_len}")
+        instructions.append("i32.ge_u")
+        instructions.append("if")
+        instructions.append("  unreachable")
+        instructions.append("end")
+        # Compute address: ptr + idx * elem_size
+        instructions.append(f"local.get {tmp_ptr}")
+        if elem_size == 1:
+            instructions.append(f"local.get {tmp_idx}")
+            instructions.append("i32.add")
+        else:
+            instructions.append(f"local.get {tmp_idx}")
+            instructions.append(f"i32.const {elem_size}")
+            instructions.append("i32.mul")
+            instructions.append("i32.add")
+        # Load element
+        instructions.append(load_op)
+        return instructions
+
+    def _translate_length(
+        self, arg: ast.Expr, env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """Translate length(array) → Int (i64).
+
+        Evaluates the array → (ptr, len), drops ptr, extends len to i64.
+        """
+        arg_instrs = self.translate_expr(arg, env)
+        if arg_instrs is None:
+            return None
+        tmp_len = self.alloc_local("i32")
+        instructions: list[str] = []
+        instructions.extend(arg_instrs)
+        # Stack has (ptr, len); save len, drop ptr
+        instructions.append(f"local.set {tmp_len}")
+        instructions.append("drop")
+        instructions.append(f"local.get {tmp_len}")
+        instructions.append("i64.extend_i32_u")
+        return instructions
 
     # -----------------------------------------------------------------
     # Closures — anonymous function compilation
@@ -1234,7 +1492,7 @@ class WasmContext:
             return "i64"
         if type_name in ("Float64", "Float"):
             return "f64"
-        if type_name == "Bool":
+        if type_name in ("Bool", "Byte"):
             return "i32"
         if type_name == "Unit":
             return "i32"  # shouldn't appear, safe fallback
@@ -1690,7 +1948,7 @@ class WasmContext:
             return "i64"
         if name in ("Float64", "Float"):
             return "f64"
-        if name == "Bool":
+        if name in ("Bool", "Byte"):
             return "i32"
         # ADT types are heap pointers
         base = name.split("<")[0] if "<" in name else name


### PR DESCRIPTION
## Summary
- **Byte type codegen**: `Byte` maps to `i32` with unsigned comparison operators (`i32.lt_u`, `i32.gt_u`, etc.) and `i32.wrap_i64` coercion for Byte-returning functions
- **Array compilation**: `Array<T>` literals, indexing with bounds checking, and `length()` built-in via linear memory `(ptr, len)` pairs
- **26 new tests** (821 total): Byte identity/zero/max/let/comparisons, array literals, indexing, bounds-check traps, length, WAT inspection

Closes #30

## Test plan
- [x] All 821 tests pass (`pytest tests/ -v`)
- [x] mypy clean (`mypy vera/`)
- [x] All 14 examples pass (`check_examples.py`)
- [x] Spec code blocks parse (`check_spec_examples.py`)
- [x] README code blocks parse (`check_readme_examples.py`)
- [x] Version sync (`check_version_sync.py`)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)