### PR TITLE
C6l: Quantifier + assert/assume compilation (v0.0.22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.22] - 2026-02-26
+
+### Added
+- **Quantifier compilation** (C6l): compile `forall`/`exists` as runtime loops with short-circuit evaluation
+  - Counted loop over `[0, domain)` with predicate inlined (no closure overhead)
+  - `forall` returns true if all iterations satisfy predicate, short-circuits on first false
+  - `exists` returns true if any iteration satisfies predicate, short-circuits on first true
+  - Empty domain: `forall` → true (vacuously), `exists` → false
+- **Assert compilation** (C6l): `assert(expr)` compiles to conditional `unreachable` trap
+- **Assume compilation** (C6l): `assume(expr)` compiles to no-op at runtime (verifier-only construct)
+- **Spec Sections 11.13-11.14**: new "Quantifier Compilation" and "Assert and Assume Compilation" sections
+- **Codegen tests**: 20 new tests — assert/assume, forall, exists, WAT inspection (841 total, up from 821)
+
 ## [0.0.21] - 2026-02-26
 
 ### Added
@@ -357,7 +370,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Grammar: handler body simplified to avoid LALR reduce/reduce conflict
 - `pyproject.toml`: corrected build backend, package discovery, PEP 639 compliance
 
-[Unreleased]: https://github.com/aallan/vera/compare/v0.0.21...HEAD
+[Unreleased]: https://github.com/aallan/vera/compare/v0.0.22...HEAD
+[0.0.22]: https://github.com/aallan/vera/compare/v0.0.21...v0.0.22
 [0.0.21]: https://github.com/aallan/vera/compare/v0.0.20...v0.0.21
 [0.0.20]: https://github.com/aallan/vera/compare/v0.0.19...v0.0.20
 [0.0.19]: https://github.com/aallan/vera/compare/v0.0.18...v0.0.19

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ vera parse file.vera              # Print the parse tree
 vera ast file.vera                # Print the typed AST
 vera ast --json file.vera         # Print the AST as JSON
 
-pytest tests/ -v                  # Run the test suite (821 tests)
+pytest tests/ -v                  # Run the test suite (841 tests)
 mypy vera/                        # Type-check the compiler itself
 
 python scripts/check_examples.py      # Verify all 14 examples parse + check + verify

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ C6 extends WASM compilation to all language constructs, working through the depe
 | Sub-phase | Scope | Closes | Unlocks |
 |-----------|-------|--------|---------|
 | ~~C6k~~ | ~~Byte + arrays — linear memory arrays with bounds~~ | ~~[#30](https://github.com/aallan/vera/issues/30)~~ | ~~Done (v0.0.21)~~ |
-| C6l | Quantifiers — forall/exists as runtime loops | — | quantifiers.vera |
+| ~~C6l~~ | ~~Quantifiers — forall/exists as runtime loops~~ | ~~—~~ | ~~Done (v0.0.22)~~ |
 | C6m | Refinement returns + stdlib utilities | — | refinement_types.vera |
 | C6n | Spec chapters 9 (Standard library) and 12 (Runtime) | — | — |
 

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -305,7 +305,7 @@ fn factorial(@Nat -> @Nat)
 
 For nested recursion, use lexicographic ordering: `decreases(@Nat.0, @Nat.1)`.
 
-### Quantified expressions (in contracts only)
+### Quantified expressions
 
 ```vera
 -- For all indices in [0, bound):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.21"
+version = "0.0.22"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/spec/11-compilation.md
+++ b/spec/11-compilation.md
@@ -475,7 +475,44 @@ A `let @Array<T> = expr` binding allocates two WASM locals (ptr and len) and sto
 
 Array types are compilable within function bodies (as let bindings, literals, indexing, and `length` calls) but not yet as function parameters or return types. Functions with `Array<T>` in their signatures are skipped with a warning.
 
-## 11.13 Limitations
+## 11.13 Quantifier Compilation
+
+Bounded quantifiers (`forall` and `exists`) are compiled as runtime loops that iterate over a finite domain.
+
+### 11.13.1 Loop Structure
+
+`forall(@T, domain, predicate)` compiles to a counted loop over `[0, domain)`:
+
+1. Evaluate `domain` to an `i64` value and save to a limit local
+2. Initialize a counter local (`i64`) to 0 and a result local (`i32`) to 1 (true)
+3. Emit a WASM `block`/`loop` pair:
+   - If `counter >= limit` (`i64.ge_s`), break out of the loop
+   - Evaluate the predicate body inline with the counter as the `@T` binding
+   - If the predicate returns false, set result to 0 and break (short-circuit)
+   - Increment the counter and branch back to loop start
+4. Push the result local onto the stack
+
+`exists` uses the same structure but initializes result to 0 (false) and short-circuits on the first true result (setting result to 1).
+
+### 11.13.2 Predicate Inlining
+
+The predicate is always a syntactic anonymous function (`fn(@T -> @Bool) effects(pure) { ... }`). Rather than lifting it as a closure and using `call_indirect`, the compiler inlines the predicate body directly into the loop. The predicate's parameter is pushed into the slot environment as a local bound to the loop counter. This avoids heap allocation and indirect call overhead.
+
+### 11.13.3 Short-Circuit Evaluation
+
+Both quantifiers short-circuit: `forall` exits on the first false result, `exists` exits on the first true result. This matches the logical semantics and avoids unnecessary iterations.
+
+## 11.14 Assert and Assume Compilation
+
+### 11.14.1 Assert
+
+`assert(expr)` compiles to a conditional trap: evaluate the expression, and if it is false (`i32.eqz`), execute `unreachable` (WASM trap). Assert produces no value on the stack (Unit).
+
+### 11.14.2 Assume
+
+`assume(expr)` is a no-op at runtime. The verifier uses assumptions as axioms during contract verification, but at runtime the assumption is not checked. The compiler emits no instructions for `assume`.
+
+## 11.15 Limitations
 
 The current compilation model has the following limitations, each tracked as a GitHub issue:
 

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -3519,3 +3519,243 @@ fn g(-> @Int) requires(true) ensures(true) effects(pure) {
         result = _compile_ok(src)
         # f should be skipped, g should compile
         assert "$g" in result.wat
+
+
+# =====================================================================
+# C6l: Assert and assume
+# =====================================================================
+
+
+class TestAssertAssume:
+    def test_assert_true(self) -> None:
+        """assert(true) should not trap."""
+        assert _run("""
+fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  assert(true);
+  42
+}
+""") == 42
+
+    def test_assert_false(self) -> None:
+        """assert(false) should trap."""
+        _run_trap("""
+fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  assert(false);
+  42
+}
+""")
+
+    def test_assert_with_expression(self) -> None:
+        """assert with a computed expression."""
+        assert _run("""
+fn f(@Int -> @Int) requires(true) ensures(true) effects(pure) {
+  assert(@Int.0 > 0);
+  @Int.0 + 1
+}
+""", args=[5]) == 6
+
+    def test_assert_expression_false_traps(self) -> None:
+        """assert with expression that evaluates to false."""
+        _run_trap("""
+fn f(@Int -> @Int) requires(true) ensures(true) effects(pure) {
+  assert(@Int.0 > 0);
+  @Int.0
+}
+""", args=[0])
+
+    def test_assert_in_sequence(self) -> None:
+        """assert followed by computation."""
+        assert _run("""
+fn f(@Int, @Int -> @Int) requires(true) ensures(true) effects(pure) {
+  assert(@Int.1 > 0);
+  let @Int = @Int.1 + @Int.0;
+  assert(@Int.0 > 0);
+  @Int.0
+}
+""", args=[3, 5]) == 8
+
+    def test_assume_is_noop(self) -> None:
+        """assume should be a no-op at runtime."""
+        assert _run("""
+fn f(@Int -> @Int) requires(true) ensures(true) effects(pure) {
+  assume(@Int.0 > 0);
+  @Int.0 * 2
+}
+""", args=[5]) == 10
+
+    def test_assert_wat_contains_unreachable(self) -> None:
+        """WAT should contain unreachable for assert."""
+        result = _compile_ok("""
+fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  assert(true);
+  1
+}
+""")
+        assert "unreachable" in result.wat
+
+
+# =====================================================================
+# C6l: Forall quantifier
+# =====================================================================
+
+
+class TestForall:
+    def test_forall_all_positive(self) -> None:
+        """forall over array where all elements satisfy predicate."""
+        assert _run("""
+fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
+  let @Array<Int> = [1, 2, 3];
+  forall(@Int, length(@Array<Int>.0), fn(@Int -> @Bool) effects(pure) {
+    @Array<Int>.0[@Int.0] > 0
+  })
+}
+""") == 1
+
+    def test_forall_not_all_positive(self) -> None:
+        """forall over array where one element fails predicate."""
+        assert _run("""
+fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
+  let @Array<Int> = [1, -2, 3];
+  forall(@Int, length(@Array<Int>.0), fn(@Int -> @Bool) effects(pure) {
+    @Array<Int>.0[@Int.0] > 0
+  })
+}
+""") == 0
+
+    def test_forall_empty_domain(self) -> None:
+        """forall with empty domain should be vacuously true."""
+        assert _run("""
+fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
+  forall(@Int, 0, fn(@Int -> @Bool) effects(pure) {
+    false
+  })
+}
+""") == 1
+
+    def test_forall_single_element_true(self) -> None:
+        """forall with single element, predicate true."""
+        assert _run("""
+fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
+  let @Array<Int> = [42];
+  forall(@Int, length(@Array<Int>.0), fn(@Int -> @Bool) effects(pure) {
+    @Array<Int>.0[@Int.0] > 0
+  })
+}
+""") == 1
+
+    def test_forall_single_element_false(self) -> None:
+        """forall with single element, predicate false."""
+        assert _run("""
+fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
+  let @Array<Int> = [-1];
+  forall(@Int, length(@Array<Int>.0), fn(@Int -> @Bool) effects(pure) {
+    @Array<Int>.0[@Int.0] > 0
+  })
+}
+""") == 0
+
+    def test_forall_all_equal(self) -> None:
+        """forall checking all elements equal a value."""
+        assert _run("""
+fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
+  let @Array<Int> = [7, 7, 7];
+  forall(@Int, length(@Array<Int>.0), fn(@Int -> @Bool) effects(pure) {
+    @Array<Int>.0[@Int.0] == 7
+  })
+}
+""") == 1
+
+
+# =====================================================================
+# C6l: Exists quantifier
+# =====================================================================
+
+
+class TestExists:
+    def test_exists_has_zero(self) -> None:
+        """exists with one matching element."""
+        assert _run("""
+fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
+  let @Array<Int> = [1, 0, 3];
+  exists(@Int, length(@Array<Int>.0), fn(@Int -> @Bool) effects(pure) {
+    @Array<Int>.0[@Int.0] == 0
+  })
+}
+""") == 1
+
+    def test_exists_no_match(self) -> None:
+        """exists with no matching element."""
+        assert _run("""
+fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
+  let @Array<Int> = [1, 2, 3];
+  exists(@Int, length(@Array<Int>.0), fn(@Int -> @Bool) effects(pure) {
+    @Array<Int>.0[@Int.0] == 0
+  })
+}
+""") == 0
+
+    def test_exists_empty_domain(self) -> None:
+        """exists with empty domain should be false."""
+        assert _run("""
+fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
+  exists(@Int, 0, fn(@Int -> @Bool) effects(pure) {
+    true
+  })
+}
+""") == 0
+
+    def test_exists_single_element_true(self) -> None:
+        """exists with single matching element."""
+        assert _run("""
+fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
+  let @Array<Int> = [0];
+  exists(@Int, length(@Array<Int>.0), fn(@Int -> @Bool) effects(pure) {
+    @Array<Int>.0[@Int.0] == 0
+  })
+}
+""") == 1
+
+    def test_exists_single_element_false(self) -> None:
+        """exists with single non-matching element."""
+        assert _run("""
+fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
+  let @Array<Int> = [5];
+  exists(@Int, length(@Array<Int>.0), fn(@Int -> @Bool) effects(pure) {
+    @Array<Int>.0[@Int.0] == 0
+  })
+}
+""") == 0
+
+
+# =====================================================================
+# C6l: Quantifier WAT inspection
+# =====================================================================
+
+
+class TestQuantifierWat:
+    def test_forall_wat_has_loop(self) -> None:
+        """WAT for forall should contain loop and block."""
+        result = _compile_ok("""
+fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
+  let @Array<Int> = [1, 2, 3];
+  forall(@Int, length(@Array<Int>.0), fn(@Int -> @Bool) effects(pure) {
+    @Array<Int>.0[@Int.0] > 0
+  })
+}
+""")
+        assert "loop" in result.wat
+        assert "block" in result.wat
+        assert "br_if" in result.wat
+
+    def test_exists_wat_has_loop(self) -> None:
+        """WAT for exists should contain loop and block."""
+        result = _compile_ok("""
+fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
+  let @Array<Int> = [1, 2, 3];
+  exists(@Int, length(@Array<Int>.0), fn(@Int -> @Bool) effects(pure) {
+    @Array<Int>.0[@Int.0] == 0
+  })
+}
+""")
+        assert "loop" in result.wat
+        assert "block" in result.wat

--- a/vera/README.md
+++ b/vera/README.md
@@ -77,13 +77,13 @@ execute(compile_result, ...)    # → run WASM via wasmtime
 | `checker.py` | 1,668 | Type check | Two-pass type checker | `typecheck()` |
 | `smt.py` | 485 | Verify | Z3 translation layer | `SmtContext`, `SlotEnv` |
 | `verifier.py` | 601 | Verify | Contract verification | `verify()` |
-| `wasm.py` | 1,965 | Compile | WASM translation layer | `WasmContext`, `WasmSlotEnv` |
+| `wasm.py` | 2,151 | Compile | WASM translation layer | `WasmContext`, `WasmSlotEnv` |
 | `codegen.py` | 1,646 | Compile | Codegen orchestrator | `compile()`, `execute()` |
 | `errors.py` | 354 | All | Diagnostic class, error hierarchy | `Diagnostic`, `VeraError` |
 | `cli.py` | 563 | All | CLI commands | `main()` |
 | `registration.py` | 56 | Type check | Shared function registration | `register_fn()` |
 
-Total: ~9,762 lines of Python + 328 lines of grammar.
+Total: ~9,948 lines of Python + 328 lines of grammar.
 
 ## Parsing
 
@@ -346,7 +346,7 @@ Error at line 3, column 3:
 
 ## Code Generation
 
-**Files:** `codegen.py` (1,646 lines), `wasm.py` (1,965 lines)
+**Files:** `codegen.py` (1,646 lines), `wasm.py` (2,151 lines)
 
 ### Compilation pipeline
 
@@ -452,7 +452,7 @@ Every diagnostic includes a description (what went wrong), rationale (which lang
 
 ## Test Suite
 
-**795 tests** across 10 files, plus 4 validation scripts and CI infrastructure.
+**841 tests** across 10 files, plus 4 validation scripts and CI infrastructure.
 
 ### Test files
 
@@ -462,14 +462,14 @@ Every diagnostic includes a description (what went wrong), rationale (which lang
 | `test_ast.py` | 84 | 896 | AST transformation, node structure, serialisation |
 | `test_checker.py` | 108 | 1,203 | Type synthesis, slot resolution, effects, contracts, exhaustiveness |
 | `test_verifier.py` | 68 | 894 | Z3 verification, counterexamples, tier classification, Int→Nat enforcement, call-site preconditions |
-| `test_codegen.py` | 277 | 3,521 | WASM compilation, arithmetic, Float64, Byte, arrays, ADTs, match, generics, closures, State\<T\>, control flow, strings, IO, contracts, bounds checking, length, example round-trips |
+| `test_codegen.py` | 297 | 3,761 | WASM compilation, arithmetic, Float64, Byte, arrays, ADTs, match, generics, closures, State\<T\>, control flow, strings, IO, contracts, bounds checking, length, quantifiers, assert/assume, example round-trips |
 | `test_cli.py` | 76 | 932 | CLI commands (check, verify, compile, run), subprocess integration, JSON error paths, runtime traps, arg validation |
 | `test_types.py` | 55 | 279 | Type operations: subtyping, equality, substitution, pretty-printing, canonical names |
 | `test_wasm.py` | 22 | 255 | WASM internals: StringPool, WasmSlotEnv, translation edge cases via full pipeline |
 | `test_readme.py` | 2 | 68 | README code sample parsing |
 | `test_errors.py` | 34 | 287 | Diagnostic formatting, serialisation, error patterns, SourceLocation, diagnose_lark_error |
 
-Total: 9,126 lines of test code.
+Total: 9,366 lines of test code.
 
 ### Round-trip testing
 
@@ -537,7 +537,6 @@ Honest inventory of what the compiler cannot do, and where each limitation is ad
 
 | Limitation | Why | Planned |
 |-----------|-----|---------|
-| **No Byte type codegen** | Needs linear memory byte operations | [#30](https://github.com/aallan/vera/issues/30) |
 | **No module resolution** | `import` declarations parsed but not resolved | [#50](https://github.com/aallan/vera/issues/50) |
 | **Limited effect checking** | Pure vs effectful only; no subeffecting or row unification | [#21](https://github.com/aallan/vera/issues/21) |
 | **No termination verification** | `decreases` clauses parsed but always Tier 3 | [#45](https://github.com/aallan/vera/issues/45) |

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.21"
+__version__ = "0.0.22"

--- a/vera/wasm.py
+++ b/vera/wasm.py
@@ -270,6 +270,8 @@ class WasmContext:
         self.needs_alloc: bool = False
         # Next closure id (may be overwritten by codegen)
         self._next_closure_id: int = 0
+        # Next quantifier label id (for unique block/loop labels)
+        self._next_quant_id: int = 0
 
     def set_fn_ret_types(
         self, ret_types: dict[str, str | None],
@@ -384,7 +386,19 @@ class WasmContext:
         if isinstance(expr, ast.IndexExpr):
             return self._translate_index_expr(expr, env)
 
-        # Unsupported: quantifiers, old/new, assert/assume, etc.
+        if isinstance(expr, ast.AssertExpr):
+            return self._translate_assert(expr, env)
+
+        if isinstance(expr, ast.AssumeExpr):
+            return self._translate_assume()
+
+        if isinstance(expr, ast.ForallExpr):
+            return self._translate_forall(expr, env)
+
+        if isinstance(expr, ast.ExistsExpr):
+            return self._translate_exists(expr, env)
+
+        # Unsupported: old/new, etc.
         return None
 
     # -----------------------------------------------------------------
@@ -579,6 +593,10 @@ class WasmContext:
             return _element_wasm_type(elem_type) if elem_type else None
         if isinstance(expr, ast.ArrayLit):
             return None  # arrays are (i32, i32) — handled specially
+        if isinstance(expr, (ast.ForallExpr, ast.ExistsExpr)):
+            return "i32"  # quantifiers return Bool
+        if isinstance(expr, (ast.AssertExpr, ast.AssumeExpr)):
+            return None  # assert/assume return Unit
         return None
 
     def _infer_fncall_wasm_type(self, expr: ast.FnCall) -> str | None:
@@ -724,6 +742,10 @@ class WasmContext:
             return _element_wasm_type(elem_type) if elem_type else None
         if isinstance(expr, ast.ArrayLit):
             return None  # arrays are (i32, i32) — handled specially
+        if isinstance(expr, (ast.ForallExpr, ast.ExistsExpr)):
+            return "i32"  # quantifiers return Bool
+        if isinstance(expr, (ast.AssertExpr, ast.AssumeExpr)):
+            return None  # assert/assume return Unit
         return None
 
     # -----------------------------------------------------------------
@@ -1177,6 +1199,168 @@ class WasmContext:
         instructions.append("drop")
         instructions.append(f"local.get {tmp_len}")
         instructions.append("i64.extend_i32_u")
+        return instructions
+
+    # -----------------------------------------------------------------
+    # Assert and assume
+    # -----------------------------------------------------------------
+
+    def _translate_assert(
+        self, expr: ast.AssertExpr, env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """Translate assert(expr) → trap if false.
+
+        Evaluates the condition; if it's false (i32.eqz), executes
+        unreachable (WASM trap).  Returns no value (Unit).
+        """
+        cond = self.translate_expr(expr.expr, env)
+        if cond is None:
+            return None
+        return cond + ["i32.eqz", "if", "unreachable", "end"]
+
+    def _translate_assume(self) -> list[str]:
+        """Translate assume(expr) → no-op at runtime.
+
+        The verifier uses assume as an axiom; at runtime it has no
+        effect.  Returns empty instructions (Unit).
+        """
+        return []
+
+    # -----------------------------------------------------------------
+    # Quantifiers — forall/exists as runtime loops
+    # -----------------------------------------------------------------
+
+    def _translate_forall(
+        self, expr: ast.ForallExpr, env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """Translate forall(@T, domain, predicate) → loop returning Bool.
+
+        Iterates counter from 0 to domain-1, inlining the predicate
+        body with counter as the @T binding.  Short-circuits on the
+        first false result.
+        """
+        return self._translate_quantifier(expr, env, is_forall=True)
+
+    def _translate_exists(
+        self, expr: ast.ExistsExpr, env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """Translate exists(@T, domain, predicate) → loop returning Bool.
+
+        Iterates counter from 0 to domain-1, inlining the predicate
+        body with counter as the @T binding.  Short-circuits on the
+        first true result.
+        """
+        return self._translate_quantifier(expr, env, is_forall=False)
+
+    def _translate_quantifier(
+        self,
+        expr: ast.ForallExpr | ast.ExistsExpr,
+        env: WasmSlotEnv,
+        *,
+        is_forall: bool,
+    ) -> list[str] | None:
+        """Shared implementation for forall/exists compilation.
+
+        Layout:
+          counter (i64) = 0
+          limit   (i64) = domain
+          result  (i32) = 1 (forall) or 0 (exists)
+          block $qbreak_N
+            loop $qloop_N
+              if counter >= limit → br $qbreak_N
+              push counter as @T binding
+              evaluate predicate body → i32
+              forall: if false → result=0, br $qbreak_N
+              exists: if true  → result=1, br $qbreak_N
+              counter++
+              br $qloop_N
+            end
+          end
+          local.get result
+        """
+        # Evaluate domain
+        domain_instrs = self.translate_expr(expr.domain, env)
+        if domain_instrs is None:
+            return None
+
+        # Translate predicate body with counter as binding
+        pred = expr.predicate
+        if not pred.params:
+            return None
+        param_te = pred.params[0]
+        if not isinstance(param_te, ast.NamedType):
+            return None
+        param_type_name = param_te.name
+        counter_local = self.alloc_local("i64")
+        limit_local = self.alloc_local("i64")
+        result_local = self.alloc_local("i32")
+        inner_env = env.push(param_type_name, counter_local)
+
+        body_instrs = self.translate_block(pred.body, inner_env)
+        if body_instrs is None:
+            return None
+
+        # Unique labels
+        qid = self._next_quant_id
+        self._next_quant_id += 1
+        brk = f"$qbreak_{qid}"
+        lp = f"$qloop_{qid}"
+
+        init_val = "1" if is_forall else "0"
+        instructions: list[str] = []
+
+        # Initialize
+        instructions.extend(domain_instrs)
+        instructions.append(f"local.set {limit_local}")
+        instructions.append("i64.const 0")
+        instructions.append(f"local.set {counter_local}")
+        instructions.append(f"i32.const {init_val}")
+        instructions.append(f"local.set {result_local}")
+
+        # Loop structure
+        instructions.append(f"block {brk}")
+        instructions.append(f"  loop {lp}")
+
+        # Termination check: counter >= limit → break
+        instructions.append(f"    local.get {counter_local}")
+        instructions.append(f"    local.get {limit_local}")
+        instructions.append("    i64.ge_s")
+        instructions.append(f"    br_if {brk}")
+
+        # Evaluate predicate body (counter is in env as @T)
+        for instr in body_instrs:
+            instructions.append(f"    {instr}")
+
+        # Short-circuit check
+        if is_forall:
+            # forall: if predicate is false → result=0, break
+            instructions.append("    i32.eqz")
+            instructions.append("    if")
+            instructions.append(f"      i32.const 0")
+            instructions.append(f"      local.set {result_local}")
+            instructions.append(f"      br {brk}")
+            instructions.append("    end")
+        else:
+            # exists: if predicate is true → result=1, break
+            instructions.append("    if")
+            instructions.append(f"      i32.const 1")
+            instructions.append(f"      local.set {result_local}")
+            instructions.append(f"      br {brk}")
+            instructions.append("    end")
+
+        # Increment counter
+        instructions.append(f"    local.get {counter_local}")
+        instructions.append("    i64.const 1")
+        instructions.append("    i64.add")
+        instructions.append(f"    local.set {counter_local}")
+        instructions.append(f"    br {lp}")
+
+        instructions.append("  end")  # loop
+        instructions.append("end")    # block
+
+        # Push result
+        instructions.append(f"local.get {result_local}")
+
         return instructions
 
     # -----------------------------------------------------------------
@@ -1924,6 +2108,8 @@ class WasmContext:
         if isinstance(expr, ast.FnCall) and expr.name in self._effect_ops:
             _name, is_void = self._effect_ops[expr.name]
             return is_void
+        if isinstance(expr, (ast.AssertExpr, ast.AssumeExpr)):
+            return True  # assert/assume return Unit (void)
         return False
 
     def _type_expr_to_slot_name(self, te: ast.TypeExpr) -> str | None:


### PR DESCRIPTION
## Summary
- Compile `forall`/`exists` quantifiers as runtime loops with short-circuit evaluation and inlined predicate bodies (no closure overhead)
- Compile `assert(expr)` as conditional `unreachable` trap; `assume(expr)` as no-op
- 20 new codegen tests (841 total); spec sections 11.13-11.14; docs and version updates

## Test plan
- [x] 841 tests pass (`pytest tests/ -v`)
- [x] mypy clean (`mypy vera/`)
- [x] All 14 examples pass (`check_examples.py`)
- [x] Spec/README code blocks parse (`check_spec_examples.py`, `check_readme_examples.py`)
- [x] Version sync (`check_version_sync.py`)
- [x] `vera compile examples/quantifiers.vera` — `process` compiles; `all_positive`/`has_zero` skipped (known Array param limitation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)