### PR TITLE
C6m: Refinement type alias compilation (v0.0.23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.23] - 2026-02-26
+
+### Added
+- **Refinement type alias compilation** (C6m): type aliases like `PosInt`, `Percentage`, `Nat` that resolve through refinement types now compile to their base WASM type
+  - `_type_expr_to_wasm_type()` in codegen.py now recurses on any alias type (not just FnType)
+  - `_resolve_base_type_name()` helper in wasm.py follows alias chains through refinement types to the underlying primitive (e.g. `PosInt` → `Int` → `i64`)
+  - Applied uniformly to parameter types, return types, let bindings, and slot references
+- **Spec Section 11.15**: new "Refinement Type Alias Compilation" section
+- **Codegen tests**: 8 new tests — safe_divide, to_percentage (clamp low/pass/high), refined let bindings, refined return in expr, WAT exports (849 total, up from 841)
+
 ## [0.0.22] - 2026-02-26
 
 ### Added
@@ -370,7 +380,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Grammar: handler body simplified to avoid LALR reduce/reduce conflict
 - `pyproject.toml`: corrected build backend, package discovery, PEP 639 compliance
 
-[Unreleased]: https://github.com/aallan/vera/compare/v0.0.22...HEAD
+[Unreleased]: https://github.com/aallan/vera/compare/v0.0.23...HEAD
+[0.0.23]: https://github.com/aallan/vera/compare/v0.0.22...v0.0.23
 [0.0.22]: https://github.com/aallan/vera/compare/v0.0.21...v0.0.22
 [0.0.21]: https://github.com/aallan/vera/compare/v0.0.20...v0.0.21
 [0.0.20]: https://github.com/aallan/vera/compare/v0.0.19...v0.0.20

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ vera parse file.vera              # Print the parse tree
 vera ast file.vera                # Print the typed AST
 vera ast --json file.vera         # Print the AST as JSON
 
-pytest tests/ -v                  # Run the test suite (841 tests)
+pytest tests/ -v                  # Run the test suite (849 tests)
 mypy vera/                        # Type-check the compiler itself
 
 python scripts/check_examples.py      # Verify all 14 examples parse + check + verify

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ C6 extends WASM compilation to all language constructs, working through the depe
 |-----------|-------|--------|---------|
 | ~~C6k~~ | ~~Byte + arrays — linear memory arrays with bounds~~ | ~~[#30](https://github.com/aallan/vera/issues/30)~~ | ~~Done (v0.0.21)~~ |
 | ~~C6l~~ | ~~Quantifiers — forall/exists as runtime loops~~ | ~~—~~ | ~~Done (v0.0.22)~~ |
-| C6m | Refinement returns + stdlib utilities | — | refinement_types.vera |
+| ~~C6m~~ | ~~Refinement type alias compilation~~ | ~~—~~ | ~~Done (v0.0.23)~~ |
 | C6n | Spec chapters 9 (Standard library) and 12 (Runtime) | — | — |
 
 ### Specification chapters
@@ -465,7 +465,7 @@ vera/
 │   ├── errors.py                  # LLM-oriented diagnostics
 │   └── cli.py                     # Command-line interface
 ├── examples/                      # 14 example Vera programs
-├── tests/                         # Test suite (660 tests)
+├── tests/                         # Test suite (849 tests)
 ├── scripts/                       # CI and validation scripts
 │   ├── check_examples.py          # Verify all .vera examples
 │   ├── check_spec_examples.py     # Verify spec code blocks parse

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.22"
+version = "0.0.23"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/spec/11-compilation.md
+++ b/spec/11-compilation.md
@@ -37,7 +37,7 @@ Vera types map to WASM value types as follows:
 | ADTs | `i32` | Heap pointer to tagged union (see Section 11.6) |
 | Function types | `i32` | Heap pointer to closure struct (see Section 11.11) |
 
-Generic type variables are resolved via monomorphization — each concrete instantiation of a `forall<T>` function produces a specialized copy with type variables replaced by concrete types (e.g. `identity$Int`). Type aliases for function types (e.g. `type IntToInt = fn(Int -> Int) effects(pure)`) are also resolved to `i32` closure pointers. Array and String types are compilable within function bodies (as let bindings and expressions) but not yet as function parameters or return types. Functions using non-compilable types in their signatures are skipped with a warning.
+Generic type variables are resolved via monomorphization — each concrete instantiation of a `forall<T>` function produces a specialized copy with type variables replaced by concrete types (e.g. `identity$Int`). Type aliases are resolved through their definitions: function type aliases (e.g. `type IntToInt = fn(Int -> Int) effects(pure)`) resolve to `i32` closure pointers, and refinement type aliases (e.g. `type PosInt = { @Int | @Int.0 > 0 }`) resolve to their base WASM type (see Section 11.15). Array and String types are compilable within function bodies (as let bindings and expressions) but not yet as function parameters or return types. Functions using non-compilable types in their signatures are skipped with a warning.
 
 ### 11.2.1 Nat as i64
 
@@ -512,7 +512,19 @@ Both quantifiers short-circuit: `forall` exits on the first false result, `exist
 
 `assume(expr)` is a no-op at runtime. The verifier uses assumptions as axioms during contract verification, but at runtime the assumption is not checked. The compiler emits no instructions for `assume`.
 
-## 11.15 Limitations
+## 11.15 Refinement Type Alias Compilation
+
+Refinement type aliases (e.g. `type PosInt = { @Int | @Int.0 > 0 }`) are compiled by resolving through the alias and refinement to the underlying base type. The refinement predicate is a verification-only construct — it constrains the type statically but produces no runtime code.
+
+When the compiler encounters a type alias in a function signature or slot reference, it resolves the alias chain: if the alias target is a `RefinementType`, the compiler recurses into its base type. This continues until a concrete primitive or ADT type is reached. For example:
+
+- `PosInt` → `{ @Int | @Int.0 > 0 }` → `Int` → `i64`
+- `Percentage` → `{ @Int | @Int.0 >= 0 && @Int.0 <= 100 }` → `Int` → `i64`
+- `NonEmptyArray` → `{ @Array<Int> | length(...) > 0 }` → `Array<Int>` → skipped (Array param limitation)
+
+This resolution applies uniformly to parameter types, return types, let bindings, and slot references within function bodies.
+
+## 11.16 Limitations
 
 The current compilation model has the following limitations, each tracked as a GitHub issue:
 

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -3759,3 +3759,113 @@ fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
 """)
         assert "loop" in result.wat
         assert "block" in result.wat
+
+
+# =====================================================================
+# Refinement type alias compilation
+# =====================================================================
+
+
+class TestRefinementTypeAlias:
+    """Refined type aliases (e.g. PosInt, Percentage) resolve to their
+    base WASM type for params, returns, and let bindings."""
+
+    _PREAMBLE = """
+type PosInt = { @Int | @Int.0 > 0 };
+type Nat = { @Int | @Int.0 >= 0 };
+type Percentage = { @Int | @Int.0 >= 0 && @Int.0 <= 100 };
+"""
+
+    def test_safe_divide_basic(self) -> None:
+        val = _run(self._PREAMBLE + """
+fn safe_divide(@Int, @PosInt -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 / @PosInt.0 }
+""", fn="safe_divide", args=[10, 2])
+        assert val == 5
+
+    def test_safe_divide_integer_division(self) -> None:
+        val = _run(self._PREAMBLE + """
+fn safe_divide(@Int, @PosInt -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 / @PosInt.0 }
+""", fn="safe_divide", args=[7, 3])
+        assert val == 2
+
+    def test_to_percentage_clamp_low(self) -> None:
+        val = _run(self._PREAMBLE + """
+fn to_percentage(@Int -> @Percentage)
+  requires(true) ensures(true) effects(pure)
+{
+  if @Int.0 < 0 then { 0 }
+  else { if @Int.0 > 100 then { 100 } else { @Int.0 } }
+}
+""", fn="to_percentage", args=[-5])
+        assert val == 0
+
+    def test_to_percentage_passthrough(self) -> None:
+        val = _run(self._PREAMBLE + """
+fn to_percentage(@Int -> @Percentage)
+  requires(true) ensures(true) effects(pure)
+{
+  if @Int.0 < 0 then { 0 }
+  else { if @Int.0 > 100 then { 100 } else { @Int.0 } }
+}
+""", fn="to_percentage", args=[50])
+        assert val == 50
+
+    def test_to_percentage_clamp_high(self) -> None:
+        val = _run(self._PREAMBLE + """
+fn to_percentage(@Int -> @Percentage)
+  requires(true) ensures(true) effects(pure)
+{
+  if @Int.0 < 0 then { 0 }
+  else { if @Int.0 > 100 then { 100 } else { @Int.0 } }
+}
+""", fn="to_percentage", args=[150])
+        assert val == 100
+
+    def test_refined_type_let_binding(self) -> None:
+        """Let binding to a refined type alias resolves correctly."""
+        val = _run(self._PREAMBLE + """
+fn f(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  let @PosInt = @Int.0;
+  @PosInt.0 + 1
+}
+""", fn="f", args=[10])
+        assert val == 11
+
+    def test_refined_return_in_expr(self) -> None:
+        """Function returning a refined type works in expressions."""
+        val = _run(self._PREAMBLE + """
+fn clamp(@Int -> @Percentage)
+  requires(true) ensures(true) effects(pure)
+{
+  if @Int.0 < 0 then { 0 }
+  else { if @Int.0 > 100 then { 100 } else { @Int.0 } }
+}
+
+fn main(-> @Int) requires(true) ensures(true) effects(pure) {
+  clamp(200) + clamp(50)
+}
+""")
+        assert val == 150
+
+    def test_refined_type_exports_in_wat(self) -> None:
+        """WAT should contain function exports for refined-type fns."""
+        result = _compile_ok(self._PREAMBLE + """
+fn safe_divide(@Int, @PosInt -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 / @PosInt.0 }
+
+fn to_percentage(@Int -> @Percentage)
+  requires(true) ensures(true) effects(pure)
+{
+  if @Int.0 < 0 then { 0 }
+  else { if @Int.0 > 100 then { 100 } else { @Int.0 } }
+}
+""")
+        assert '(export "safe_divide"' in result.wat
+        assert '(export "to_percentage"' in result.wat

--- a/vera/README.md
+++ b/vera/README.md
@@ -77,13 +77,13 @@ execute(compile_result, ...)    # → run WASM via wasmtime
 | `checker.py` | 1,668 | Type check | Two-pass type checker | `typecheck()` |
 | `smt.py` | 485 | Verify | Z3 translation layer | `SmtContext`, `SlotEnv` |
 | `verifier.py` | 601 | Verify | Contract verification | `verify()` |
-| `wasm.py` | 2,151 | Compile | WASM translation layer | `WasmContext`, `WasmSlotEnv` |
-| `codegen.py` | 1,646 | Compile | Codegen orchestrator | `compile()`, `execute()` |
+| `wasm.py` | 2,169 | Compile | WASM translation layer | `WasmContext`, `WasmSlotEnv` |
+| `codegen.py` | 1,644 | Compile | Codegen orchestrator | `compile()`, `execute()` |
 | `errors.py` | 354 | All | Diagnostic class, error hierarchy | `Diagnostic`, `VeraError` |
 | `cli.py` | 563 | All | CLI commands | `main()` |
 | `registration.py` | 56 | Type check | Shared function registration | `register_fn()` |
 
-Total: ~9,948 lines of Python + 328 lines of grammar.
+Total: ~9,964 lines of Python + 328 lines of grammar.
 
 ## Parsing
 
@@ -346,7 +346,7 @@ Error at line 3, column 3:
 
 ## Code Generation
 
-**Files:** `codegen.py` (1,646 lines), `wasm.py` (2,151 lines)
+**Files:** `codegen.py` (1,644 lines), `wasm.py` (2,169 lines)
 
 ### Compilation pipeline
 
@@ -452,7 +452,7 @@ Every diagnostic includes a description (what went wrong), rationale (which lang
 
 ## Test Suite
 
-**841 tests** across 10 files, plus 4 validation scripts and CI infrastructure.
+**849 tests** across 10 files, plus 4 validation scripts and CI infrastructure.
 
 ### Test files
 
@@ -462,14 +462,14 @@ Every diagnostic includes a description (what went wrong), rationale (which lang
 | `test_ast.py` | 84 | 896 | AST transformation, node structure, serialisation |
 | `test_checker.py` | 108 | 1,203 | Type synthesis, slot resolution, effects, contracts, exhaustiveness |
 | `test_verifier.py` | 68 | 894 | Z3 verification, counterexamples, tier classification, Int→Nat enforcement, call-site preconditions |
-| `test_codegen.py` | 297 | 3,761 | WASM compilation, arithmetic, Float64, Byte, arrays, ADTs, match, generics, closures, State\<T\>, control flow, strings, IO, contracts, bounds checking, length, quantifiers, assert/assume, example round-trips |
+| `test_codegen.py` | 305 | 3,871 | WASM compilation, arithmetic, Float64, Byte, arrays, ADTs, match, generics, closures, State\<T\>, control flow, strings, IO, contracts, bounds checking, length, quantifiers, assert/assume, refinement type aliases, example round-trips |
 | `test_cli.py` | 76 | 932 | CLI commands (check, verify, compile, run), subprocess integration, JSON error paths, runtime traps, arg validation |
 | `test_types.py` | 55 | 279 | Type operations: subtyping, equality, substitution, pretty-printing, canonical names |
 | `test_wasm.py` | 22 | 255 | WASM internals: StringPool, WasmSlotEnv, translation edge cases via full pipeline |
 | `test_readme.py` | 2 | 68 | README code sample parsing |
 | `test_errors.py` | 34 | 287 | Diagnostic formatting, serialisation, error patterns, SourceLocation, diagnose_lark_error |
 
-Total: 9,366 lines of test code.
+Total: 9,476 lines of test code.
 
 ### Round-trip testing
 

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.22"
+__version__ = "0.0.23"

--- a/vera/codegen.py
+++ b/vera/codegen.py
@@ -1592,11 +1592,9 @@ class CodeGenerator:
             # ADT types compile to i32 (heap pointer)
             if name in self._adt_layouts:
                 return "i32"
-            # Function type aliases compile to i32 (closure pointer)
+            # Type aliases — recurse to resolve the underlying type
             if name in self._type_aliases:
-                alias_te = self._type_aliases[name]
-                if isinstance(alias_te, ast.FnType):
-                    return "i32"
+                return self._type_expr_to_wasm_type(self._type_aliases[name])
             return "unsupported"
         if isinstance(te, ast.RefinementType):
             return self._type_expr_to_wasm_type(te.base_type)

--- a/vera/wasm.py
+++ b/vera/wasm.py
@@ -535,14 +535,15 @@ class WasmContext:
         if isinstance(expr, ast.UnitLit):
             return None
         if isinstance(expr, ast.SlotRef):
-            if expr.type_name in ("Int", "Nat"):
+            resolved = self._resolve_base_type_name(expr.type_name)
+            if resolved in ("Int", "Nat"):
                 return "i64"
-            if expr.type_name in ("Float64", "Float"):
+            if resolved in ("Float64", "Float"):
                 return "f64"
-            if expr.type_name in ("Bool", "Byte"):
+            if resolved in ("Bool", "Byte"):
                 return "i32"
-            base = (expr.type_name.split("<")[0]
-                    if "<" in expr.type_name else expr.type_name)
+            base = (resolved.split("<")[0]
+                    if "<" in resolved else resolved)
             if base in self._adt_type_names:
                 return "i32"
             # Function type aliases → i32 (closure pointer)
@@ -694,7 +695,7 @@ class WasmContext:
             return None
         if isinstance(expr, ast.SlotRef):
             # Check type name to infer WAT type
-            name = expr.type_name
+            name = self._resolve_base_type_name(expr.type_name)
             if name in ("Int", "Nat"):
                 return "i64"
             if name in ("Float64", "Float"):
@@ -2128,8 +2129,25 @@ class WasmContext:
             return self._type_expr_to_slot_name(te.base_type)
         return None
 
+    def _resolve_base_type_name(self, name: str) -> str:
+        """Resolve a type alias to its base type name.
+
+        Follows alias chains through refinement types to the underlying
+        primitive or ADT name.  E.g. "PosInt" -> "Int".
+        """
+        if name not in self._type_aliases:
+            return name
+        alias = self._type_aliases[name]
+        if isinstance(alias, ast.RefinementType):
+            if isinstance(alias.base_type, ast.NamedType):
+                return self._resolve_base_type_name(alias.base_type.name)
+        if isinstance(alias, ast.NamedType):
+            return self._resolve_base_type_name(alias.name)
+        return name
+
     def _slot_name_to_wasm_type(self, name: str) -> str | None:
         """Map a slot type name to a WAT type string."""
+        name = self._resolve_base_type_name(name)
         if name in ("Int", "Nat"):
             return "i64"
         if name in ("Float64", "Float"):


### PR DESCRIPTION
## Summary
- Fix type alias resolution so refinement type aliases (e.g. `PosInt`, `Percentage`) compile to their base WASM type
- `_type_expr_to_wasm_type()` in codegen.py now recurses on any alias type, not just FnType
- Added `_resolve_base_type_name()` helper in wasm.py to follow alias chains through refinement types
- `safe_divide` and `to_percentage` from `examples/refinement_types.vera` now compile and run correctly
- 8 new codegen tests (849 total), spec Section 11.15, version 0.0.23

## Test plan
- [x] `pytest tests/ -v` — 849 tests pass
- [x] `mypy vera/` — clean
- [x] `python scripts/check_examples.py` — all 14 examples pass
- [x] `python scripts/check_spec_examples.py` — all spec blocks pass
- [x] `python scripts/check_version_sync.py` — version consistent
- [x] `vera run examples/refinement_types.vera --fn safe_divide -- 10 2` → 5
- [x] `vera run examples/refinement_types.vera --fn to_percentage -- 150` → 100

🤖 Generated with [Claude Code](https://claude.com/claude-code)