### PR TITLE
C6n: spec chapters 9 + 12, roadmap cleanup (v0.0.24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.24] - 2026-02-26
+
+### Added
+- **Spec Chapter 9: Standard Library** (C6n): documents all built-in types (`Option<T>`, `Result<T, E>`), collections (`Array<T>`), effects (`IO`, `State<T>`), and functions (`length`, future `similarity`); includes future features (Http, Async, Inference effects; Json, Decimal types; Set, Map collections; Abilities) with issue cross-references
+- **Spec Chapter 12: Runtime and Execution** (C6n — closes [#63](https://github.com/aallan/vera/issues/63)): documents WASM module structure, wasmtime host runtime, host function bindings (IO.print, State\<T\>), linear memory model, bump allocator, execution flow, argument passing, error handling, and runtime limitations
+
+### Changed
+- **Spec Chapter 0**: condensed Section 0.8 design notes to a cross-reference table pointing to Chapter 9 sections (previously contained full feature designs inline)
+
 ## [0.0.23] - 2026-02-26
 
 ### Added
@@ -380,7 +389,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Grammar: handler body simplified to avoid LALR reduce/reduce conflict
 - `pyproject.toml`: corrected build backend, package discovery, PEP 639 compliance
 
-[Unreleased]: https://github.com/aallan/vera/compare/v0.0.23...HEAD
+[Unreleased]: https://github.com/aallan/vera/compare/v0.0.24...HEAD
+[0.0.24]: https://github.com/aallan/vera/compare/v0.0.23...v0.0.24
 [0.0.23]: https://github.com/aallan/vera/compare/v0.0.22...v0.0.23
 [0.0.22]: https://github.com/aallan/vera/compare/v0.0.21...v0.0.22
 [0.0.21]: https://github.com/aallan/vera/compare/v0.0.20...v0.0.21

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ python scripts/check_version_sync.py  # Verify version consistency
 
 ## Project layout
 
-- `spec/` — Language specification (Chapters 0-7, 10-11)
+- `spec/` — Language specification (Chapters 0-7, 9-12)
 - `vera/` — Reference compiler: grammar, parser, AST, transformer, type checker, verifier, codegen, CLI
 - `examples/` — 14 example Vera programs (all must pass `vera check` and `vera verify`)
 - `tests/` — Test suite

--- a/README.md
+++ b/README.md
@@ -139,8 +139,8 @@ Vera is in **active development**. The language specification, parser, AST, type
 
 | Component | Status |
 |-----------|--------|
-| Language specification (Chapters 0-7, 10-11) | Draft |
-| Language specification (Chapters 8-9, 12) | Not started |
+| Language specification (Chapters 0-7, 9-12) | Draft |
+| Language specification (Chapter 8) | Not started |
 | Parser (Lark LALR(1)) | Working |
 | AST (typed syntax tree) | Working |
 | Type checker | Working |
@@ -159,58 +159,37 @@ Development follows an **interleaved spiral** — each phase adds a complete com
 | C3 | v0.0.5 | **Type checker** — decidable type checking, slot resolution, effect tracking | Done |
 | C4 | v0.0.8 | **Contract verifier** — Z3 integration, refinement types, counterexamples | Done |
 | C5 | v0.0.9 | **WASM codegen** — compile to WebAssembly, `vera compile` / `vera run` | Done |
-| C6 | v0.0.10–0.0.23 | **Codegen completeness** — ADTs, match, closures, effects, generics in WASM | **In progress** (C6a–C6j done) |
+| C6 | v0.0.10–0.0.24 | **Codegen completeness** — ADTs, match, closures, effects, generics in WASM | Done |
 | C7 | — | **Module system** — cross-file imports, public/private visibility | Planned |
 | C8 | v0.1.0 | **End-to-end** — all examples compile and run, spec complete, polish | Planned |
 
-### What's next: C6 — Codegen Completeness (v0.0.10–v0.0.23)
+### What's next: C7 — Module System
 
-C6 extends WASM compilation to all language constructs, working through the dependency graph from simplest to most complex. All 14 examples now compile.
+C7 will implement cross-file imports, public/private visibility, and multi-module compilation. Tracked in [#14](https://github.com/aallan/vera/issues/14) and [#50](https://github.com/aallan/vera/issues/50). Spec Chapter 8 (Modules) will be written alongside the implementation.
 
-**Independent tasks (no dependencies on each other):**
+<details>
+<summary>C6 — Codegen Completeness (v0.0.10–v0.0.24) ✓</summary>
 
-| Sub-phase | Scope | Closes | Unlocks |
-|-----------|-------|--------|---------|
-| ~~C6a~~ | ~~Float64 — `f64` literals, arithmetic, comparisons~~ | ~~[#25](https://github.com/aallan/vera/issues/25)~~ | ~~Done (v0.0.10, [#35](https://github.com/aallan/vera/pull/35))~~ |
-| ~~C6b~~ | ~~Callee preconditions — verify `requires()` at call sites~~ | ~~[#19](https://github.com/aallan/vera/issues/19)~~ | ~~Done (v0.0.11, [#36](https://github.com/aallan/vera/pull/36))~~ |
-| ~~C6c~~ | ~~Match exhaustiveness — verify all constructors covered~~ | ~~[#18](https://github.com/aallan/vera/issues/18)~~ | ~~Done (v0.0.12, [#37](https://github.com/aallan/vera/pull/37))~~ |
-| ~~C6d~~ | ~~State\<T\> operations — get/put as host imports~~ | — | ~~Done (v0.0.13, [#38](https://github.com/aallan/vera/pull/38))~~ |
+C6 extended WASM compilation to all language constructs, working through the dependency graph from simplest to most complex. All 14 examples now compile.
 
-**Allocator and data types (sequential chain):**
+| Sub-phase | Scope | Version |
+|-----------|-------|---------|
+| C6a | Float64 — `f64` literals, arithmetic, comparisons | v0.0.10 |
+| C6b | Callee preconditions — verify `requires()` at call sites | v0.0.11 |
+| C6c | Match exhaustiveness — verify all constructors covered | v0.0.12 |
+| C6d | State\<T\> operations — get/put as host imports | v0.0.13 |
+| C6e | Bump allocator — heap allocation for tagged values | v0.0.14 |
+| C6f | ADT constructors — heap-allocated tagged unions | v0.0.15 |
+| C6g | Match expressions — tag dispatch, field extraction | v0.0.16 |
+| C6h | Closures — closure conversion, `call_indirect` | v0.0.18 |
+| C6i | Generics — monomorphization of `forall<T>` functions | v0.0.17 |
+| C6j | Effect handlers — handle/resume compilation | v0.0.19 |
+| C6k | Byte + arrays — linear memory arrays with bounds | v0.0.21 |
+| C6l | Quantifiers — forall/exists as runtime loops | v0.0.22 |
+| C6m | Refinement type alias compilation | v0.0.23 |
+| C6n | Spec chapters 9 (Standard library) and 12 (Runtime) | v0.0.24 |
 
-| Sub-phase | Scope | Closes | Unlocks |
-|-----------|-------|--------|---------|
-| ~~C6e~~ | ~~Bump allocator — heap allocation for tagged values~~ | — | ~~Done (v0.0.14, [#39](https://github.com/aallan/vera/pull/39))~~ |
-| ~~C6f~~ | ~~ADT constructors — heap-allocated tagged unions~~ | — | ~~Done (v0.0.15, [#40](https://github.com/aallan/vera/pull/40))~~ |
-| ~~C6g~~ | ~~Match expressions — tag dispatch, field extraction~~ | ~~[#26](https://github.com/aallan/vera/issues/26)~~ | ~~Done (v0.0.16, [#41](https://github.com/aallan/vera/pull/41))~~ |
-| ~~C6i~~ | ~~Generics — monomorphization of `forall<T>` functions~~ | ~~[#29](https://github.com/aallan/vera/issues/29)~~ | ~~Done (v0.0.17, [#42](https://github.com/aallan/vera/pull/42))~~ |
-
-**Higher-order and effects:**
-
-| Sub-phase | Scope | Closes | Unlocks |
-|-----------|-------|--------|---------|
-| ~~C6h~~ | ~~Closures — closure conversion, `call_indirect`~~ | ~~[#27](https://github.com/aallan/vera/issues/27)~~ | ~~Done (v0.0.18)~~ |
-| ~~C6j~~ | ~~Effect handlers — handle/resume compilation~~ | ~~[#28](https://github.com/aallan/vera/issues/28)~~ | ~~Done (v0.0.19)~~ |
-
-**Collections, runtime, and documentation:**
-
-| Sub-phase | Scope | Closes | Unlocks |
-|-----------|-------|--------|---------|
-| ~~C6k~~ | ~~Byte + arrays — linear memory arrays with bounds~~ | ~~[#30](https://github.com/aallan/vera/issues/30)~~ | ~~Done (v0.0.21)~~ |
-| ~~C6l~~ | ~~Quantifiers — forall/exists as runtime loops~~ | ~~—~~ | ~~Done (v0.0.22)~~ |
-| ~~C6m~~ | ~~Refinement type alias compilation~~ | ~~—~~ | ~~Done (v0.0.23)~~ |
-| C6n | Spec chapters 9 (Standard library) and 12 (Runtime) | — | — |
-
-### Specification chapters
-
-The language specification grows alongside the compiler. Chapters 0–7 and 10 are drafted. The remaining chapters will be written with their corresponding compiler phases:
-
-| Chapter | Topic | Written with |
-|---------|-------|-------------|
-| 8 | Modules and imports | C7 |
-| 9 | Standard library | C6n |
-| 11 | Compilation model | C5 ✓ |
-| 12 | Runtime and execution | C6n |
+</details>
 
 ## Getting Started
 

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -758,5 +758,7 @@ The full language specification is in `spec/`:
 | 5 | `spec/05-functions.md` | Functions and contracts |
 | 6 | `spec/06-contracts.md` | Verification system |
 | 7 | `spec/07-effects.md` | Algebraic effect system |
+| 9 | `spec/09-standard-library.md` | Built-in types, effects, functions |
 | 10 | `spec/10-grammar.md` | Formal EBNF grammar |
 | 11 | `spec/11-compilation.md` | Compilation model and WASM target |
+| 12 | `spec/12-runtime.md` | Runtime execution, host bindings, memory model |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.23"
+version = "0.0.24"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/scripts/check_spec_examples.py
+++ b/scripts/check_spec_examples.py
@@ -42,16 +42,13 @@ ALLOWLIST: dict[tuple[str, int], str] = {
     # FUTURE — design notes using syntax not yet in the parser
     # =================================================================
 
-    # Chapter 0 — Section 0.8 design notes (abilities, async, inference)
-    ("00-introduction.md", 158): "FUTURE",   # JSON ADT
-    ("00-introduction.md", 175): "FUTURE",   # fetch_both async example
-    # Note: 00-introduction.md abilities block (~line 203) starts with
-    # "ability" keyword, which the heuristic correctly skips as a fragment
-    # since abilities aren't in the parser yet.
-    ("00-introduction.md", 238): "FUTURE",   # effect Inference + fn classify
-
     # Chapter 2 — type constraint syntax (post-v0.1)
     ("02-types.md", 250): "FUTURE",          # forall<T where Ord<T>> fn sort
+
+    # Chapter 9 — future stdlib features and signature-only blocks
+    ("09-standard-library.md", 262): "FUTURE",   # fn classify — uses ++ (string concat)
+    ("09-standard-library.md", 276): "FRAGMENT",  # length signature (no body)
+    ("09-standard-library.md", 298): "FRAGMENT",  # similarity signature (no body)
 
     # =================================================================
     # FRAGMENT — heuristic false positives (look like declarations but

--- a/spec/00-introduction.md
+++ b/spec/00-introduction.md
@@ -143,133 +143,15 @@ Throughout this specification:
 | 11 | Compilation Model |
 | 12 | Runtime and Execution |
 
-## 0.8 Design Notes (Future Chapters)
+## 0.8 Design Notes (Future Features)
 
-The following design decisions are noted here for future specification work:
+The following features are planned for future versions. Each is specified in its target chapter with full design details; this section provides a brief index.
 
-### Network Access as an Effect ([#57](https://github.com/aallan/vera/issues/57))
-
-Network I/O SHOULD be modelled as an algebraic effect (e.g., `<Http>` or `<Net>`) with operations like `get`, `post`, etc. Functions performing network access declare `effects(<Http>)`. Handlers provide the implementation — real HTTP in production, mocks in tests. This fits naturally with Vera's algebraic effect system and makes network I/O explicit and testable. Almost all practical programs need network access; this should be a first-class part of the standard library (Chapter 9).
-
-### JSON as a Standard Library Type ([#58](https://github.com/aallan/vera/issues/58))
-
-JSON SHOULD be a standard library ADT, not a primitive type:
-
-```vera
-data Json {
-  JNull,
-  JBool(Bool),
-  JNumber(Float),
-  JString(String),
-  JArray(Array<Json>),
-  JObject(Map<String, Json>)
-}
-```
-
-Parse and serialize operations belong in the standard library. Refinement types can express JSON schemas (e.g., `type ApiResponse = { @Json | has_field(@Json.0, "status") }`). This approach keeps the core language small while providing ergonomic JSON support.
-
-### Asynchronous Promises/Futures ([#59](https://github.com/aallan/vera/issues/59))
-
-Async operations SHOULD be first-class citizens in Vera, modelled as an algebraic effect. An `<Async>` effect with an `await` operation fits naturally:
-
-```vera
-fn fetch_both(@String, @String -> @Tuple<Json, Json>)
-  requires(true)
-  ensures(true)
-  effects(<Http, Async>)
-{
-  let @Future<Json> = async(http_get(@String.0));
-  let @Future<Json> = async(http_get(@String.1));
-  let @Json = await(@Future<Json>.1);
-  let @Json = await(@Future<Json>.0);
-  Tuple(@Json.1, @Json.0)
-}
-```
-
-Key design points:
-- `async(expr)` wraps an effectful computation in a `Future<T>`, starting it concurrently
-- `await(@Future<T>.n)` suspends until the future resolves, yielding the result
-- Futures can be passed around, stored in data structures, and composed
-- The `<Async>` effect must be declared, making concurrency explicit and trackable
-- Handlers can provide different scheduling strategies (thread pool, event loop, sequential)
-- This integrates with the `<Http>` effect: network calls are naturally async
-
-This avoids coloured-function problems (async vs sync) because algebraic effects already separate the description of an operation from its execution. A handler can run `<Http>` operations sequentially or concurrently — the function code is the same either way.
-
-### Abilities (Restricted Type Constraints) ([#60](https://github.com/aallan/vera/issues/60))
-
-Vera's type variables are currently unconstrained (`forall<T>`). To support practical generic programming — sorting, hashing, serialisation — type variables need constraints. Vera SHOULD adopt **Roc-style restricted abilities** rather than full Haskell-style typeclasses:
-
-```vera
-ability Eq<T> {
-  op eq(@T, @T -> @Bool);
-}
-
-ability Ord<T> {
-  op compare(@T, @T -> @Ordering);
-}
-
-forall<T where Eq<T>> fn contains(@Array<T>, @T -> @Bool)
-  requires(true)
-  ensures(true)
-  effects(pure)
-{
-  exists(@Nat, length(@Array<T>.0), fn(@Nat -> @Bool) effects(pure) {
-    eq(@Array<T>.0[@Nat.0], @T.0)
-  })
-}
-```
-
-Key design points:
-- **No higher-kinded types.** No `Functor`, `Monad`, or `Applicative`. Abilities are first-order only: `Eq<T>`, not `Mappable<F>` where F is a type constructor. This preserves decidable type checking and prevents the abstraction hierarchy that makes code harder for LLMs to generate correctly.
-- **Built-in abilities** auto-derivable for ADTs composed of types that already support them: `Eq`, `Ord`, `Hash`, `Encode`, `Decode`, `Show`. If all fields of an ADT support `Eq`, the ADT supports `Eq` automatically — the LLM writes less, and there are fewer things to get wrong.
-- **User-defined abilities** are permitted but restricted to first-order type parameters. This allows library authors to define domain-specific abilities (e.g., `Serializable<T>`) without the complexity of higher-kinded polymorphism.
-- **`ability` declarations** look like `effect` declarations (using `op` for operations), keeping the language syntactically consistent.
-- **Constraint syntax** uses `forall<T where Ability<T>>`, consistent with the placeholder noted in Chapter 2, Section 2.7.1.
-
-This design draws on Roc's abilities (deliberately no HKTs, auto-derivable), Gleam's validation that useful languages need not have typeclasses, and Unison's abilities system. The consensus among modern functional languages is that restricted abilities provide sufficient extensibility for practical programming without the complexity explosion of full typeclasses.
-
-Abilities are a post-v0.1 feature. They will be specified in Chapter 2 when implemented.
-
-### LLM Inference as an Effect ([#61](https://github.com/aallan/vera/issues/61))
-
-Vera is designed for LLMs to write. It SHOULD also support LLMs as a runtime component, modelled as an algebraic effect:
-
-```vera
-effect Inference {
-  op complete(@String -> @String);
-  op embed(@String -> @Array<Float64>);
-}
-
-fn classify(@String -> @Category)
-  requires(length(@String.0) > 0)
-  ensures(true)
-  effects(<Inference>)
-{
-  let @String = complete("Classify as Spam or Ham: " ++ @String.0);
-  match parse_category(@String.0) {
-    Some(@Category) -> @Category.0,
-    None -> Category.Unknown
-  }
-}
-```
-
-Key design points:
-- **Effect, not primitive.** LLM inference is inherently side-effectful, non-deterministic, and requires external resources. The effect system models this naturally.
-- **Testability.** A mock handler returns canned responses. No API calls in tests.
-- **Handler flexibility.** One handler uses the Anthropic API, another uses a local model, another uses cached replay for deterministic testing.
-- **Explicit in the type.** Any function that calls an LLM declares `effects(<Inference>)`. Pure functions cannot secretly call models.
-- **Contracts still apply.** Preconditions on inference inputs are verified normally. Postconditions on outputs can use refinement types to constrain response format.
-- **Constrained decoding potential.** Refinement types on the return type (e.g., `{ @String | is_json(@String.0) }`) could eventually guide model output, similar to LMQL's constrained decoding approach.
-
-The `Inference` effect belongs in the standard library (Chapter 9). The WASM runtime provides handler implementations that bind to HTTP APIs or local model runtimes. No language changes are needed — the existing effect system supports this directly.
-
-### Standard Library Collections ([#62](https://github.com/aallan/vera/issues/62))
-
-The standard library (Chapter 9) SHOULD include:
-
-- **`Set<T>`** — an unordered collection of unique elements. Requires `Eq` and `Hash` abilities on `T`. Supports union, intersection, difference.
-- **`Map<K, V>`** — a key-value mapping. Requires `Eq` and `Hash` abilities on `K`. Already implicitly needed by the JSON ADT (`JObject(Map<String, Json>)`).
-- **`Decimal`** — exact decimal arithmetic for financial and precision-sensitive applications. Implemented as a library type (not a primitive) since WebAssembly does not have native decimal floating-point. Software implementation in the runtime.
-
-These types depend on the abilities system for their type constraints. `Set` and `Map` are standard library ADTs, not primitives — keeping the core language small while providing the collections that practical programs need.
+| Feature | Issue | Specification |
+|---------|-------|---------------|
+| Network access (`Http` effect) | [#57](https://github.com/aallan/vera/issues/57) | Chapter 9, Section 9.5.3 |
+| JSON standard library type | [#58](https://github.com/aallan/vera/issues/58) | Chapter 9, Section 9.7.1 |
+| Async futures and promises | [#59](https://github.com/aallan/vera/issues/59) | Chapter 9, Section 9.5.4 |
+| Abilities (type constraints) | [#60](https://github.com/aallan/vera/issues/60) | Chapter 9, Section 9.8 |
+| LLM inference effect | [#61](https://github.com/aallan/vera/issues/61) | Chapter 9, Section 9.5.5 |
+| Collections (`Set`, `Map`, `Decimal`) | [#62](https://github.com/aallan/vera/issues/62) | Chapter 9, Sections 9.4.2-3, 9.7.2 |

--- a/spec/09-standard-library.md
+++ b/spec/09-standard-library.md
@@ -1,0 +1,380 @@
+# Chapter 9: Standard Library
+
+## 9.1 Overview
+
+Vera's standard library provides built-in types, effects, and functions that are available in every Vera program without explicit import. The library is deliberately small — it includes only the types and operations that are universally needed and cannot be expressed purely in user code.
+
+The standard library comprises:
+
+- **Built-in ADTs**: `Option<T>` and `Result<T, E>` for representing partiality and fallibility.
+- **Built-in collections**: `Array<T>` for fixed-size homogeneous sequences, plus future collections (`Set<T>`, `Map<K, V>`).
+- **Built-in effects**: `IO` for output, `State<T>` for mutable state, plus future effects for networking, concurrency, and LLM inference.
+- **Built-in functions**: `length` for arrays, plus future functions for vector similarity.
+- **Future types**: `Json` for structured data interchange, `Decimal` for exact arithmetic.
+- **Future abilities**: Type constraints for generic programming (post-v0.1).
+
+All built-in types participate fully in the type system: they can appear in contracts, be verified by the SMT solver, and be used with refinement types and pattern matching. Built-in effects follow the same algebraic effect semantics as user-defined effects (see Chapter 7).
+
+## 9.2 Primitive Types
+
+The primitive types (`Int`, `Nat`, `Bool`, `Byte`, `Float64`, `String`, `Unit`, `Never`) are documented in Chapter 2, Section 2.2. They are not part of the standard library per se — they are built into the language core.
+
+## 9.3 Built-in ADTs
+
+### 9.3.1 Option\<T\>
+
+```
+data Option<T> {
+  Some(T),
+  None
+}
+```
+
+`Option<T>` represents a value that may or may not be present. It is the standard way to express partiality in Vera — functions that might not produce a result return `Option<T>` rather than using null pointers or sentinel values.
+
+Constructors:
+- `Some(@T)` — wraps a present value.
+- `None` — represents absence.
+
+Pattern matching on `Option<T>` is exhaustive: both `Some` and `None` must be handled.
+
+```
+fn safe_head(@Array<Int> -> @Option<Int>)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  if length(@Array<Int>.0) > 0 then {
+    Some(@Array<Int>.0[0])
+  } else {
+    None
+  }
+}
+```
+
+### 9.3.2 Result\<T, E\>
+
+```
+data Result<T, E> {
+  Ok(T),
+  Err(E)
+}
+```
+
+`Result<T, E>` represents a computation that may succeed with a value of type `T` or fail with an error of type `E`. It is the standard way to express fallible operations without using exceptions.
+
+Constructors:
+- `Ok(@T)` — wraps a successful result.
+- `Err(@E)` — wraps an error value.
+
+Pattern matching on `Result<T, E>` is exhaustive: both `Ok` and `Err` must be handled.
+
+```
+fn parse_nat(@Int -> @Result<Nat, String>)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  if @Int.0 >= 0 then {
+    Ok(@Int.0)
+  } else {
+    Err("negative")
+  }
+}
+```
+
+## 9.4 Built-in Collections
+
+### 9.4.1 Array\<T\>
+
+`Array<T>` is a fixed-size, homogeneous, immutable ordered collection. Arrays are created with array literal syntax and accessed by integer index.
+
+**Syntax:**
+
+```
+let @Array<Int> = [1, 2, 3];
+@Array<Int>.0[0]
+```
+
+**Properties:**
+- Fixed size: the length is determined at creation and cannot change.
+- Immutable: elements cannot be modified after creation.
+- Zero-indexed: the first element is at index 0.
+- Bounds-checked: indexing with an out-of-range index causes a runtime trap (see Chapter 12).
+
+**Element types:** Arrays can contain any type for which a WASM representation exists: `Int`, `Nat`, `Bool`, `Byte`, `Float64`. Arrays of compound types (`Array<Array<Int>>`, `Array<Option<Int>>`) are not yet supported (see Section 11.16).
+
+**Length:** The `length` built-in function returns the number of elements (see Section 9.6.1).
+
+For the compilation model of arrays, see Chapter 11, Section 11.12.
+
+### 9.4.2 Set\<T\> (Future)
+
+> **Status: Not yet implemented.** Tracked in [#62](https://github.com/aallan/vera/issues/62). Depends on Abilities ([#60](https://github.com/aallan/vera/issues/60)).
+
+`Set<T>` will be an unordered collection of unique elements. It will require the `Eq` and `Hash` abilities on `T` (see Section 9.8).
+
+Operations will include union, intersection, difference, membership testing, and size.
+
+### 9.4.3 Map\<K, V\> (Future)
+
+> **Status: Not yet implemented.** Tracked in [#62](https://github.com/aallan/vera/issues/62). Depends on Abilities ([#60](https://github.com/aallan/vera/issues/60)).
+
+`Map<K, V>` will be a key-value mapping. It will require the `Eq` and `Hash` abilities on `K`.
+
+`Map` is already implicitly needed by the proposed `Json` ADT (Section 9.7.1), where `JObject` wraps a `Map<String, Json>`.
+
+## 9.5 Built-in Effects
+
+### 9.5.1 IO
+
+```
+effect IO {
+  op print(String -> Unit);
+}
+```
+
+The `IO` effect provides output operations. Functions that print to stdout must declare `effects(<IO>)`.
+
+Currently, `IO` exposes a single operation:
+- `print(@String)` — writes a UTF-8 string to standard output.
+
+The `IO` effect has no type parameters. At the type level, `IO.print` is invoked as a qualified call:
+
+```
+fn hello(-> @Unit)
+  requires(true)
+  ensures(true)
+  effects(<IO>)
+{
+  IO.print("hello, world")
+}
+```
+
+For the runtime implementation of `IO.print`, see Chapter 12, Section 12.4.1.
+
+### 9.5.2 State\<T\>
+
+```
+effect State<T> {
+  op get(Unit -> T);
+  op put(T -> Unit);
+}
+```
+
+The `State<T>` effect provides mutable state operations. Functions that read or write state must declare the specific state type in their effect row: `effects(<State<Int>>)`.
+
+Operations:
+- `State<T>.get()` — reads the current state value. The `Unit` parameter is implicit.
+- `State<T>.put(@T)` — writes a new state value.
+
+Multiple independent state types can be used in the same function by declaring them in the effect row. State operations (`get`, `put`) are called without qualification — the type checker resolves which state cell is targeted from the types:
+
+```
+fn increment(-> @Unit)
+  requires(true)
+  ensures(new(State<Int>) == old(State<Int>) + 1)
+  effects(<State<Int>>)
+{
+  let @Int = get(());
+  put(@Int.0 + 1);
+  ()
+}
+```
+
+State is handled by providing an initial value and a handler that manages the mutable cell:
+
+```
+handle {
+  increment()
+} with State<Int> {
+  initial: 0,
+  get: fn(-> @Int) effects(pure) { resume(0) },
+  put: fn(@Int -> @Unit) effects(pure) { resume(()) }
+}
+```
+
+For the runtime implementation of `State<T>`, see Chapter 12, Section 12.4.2.
+
+### 9.5.3 Http (Future)
+
+> **Status: Not yet implemented.** Tracked in [#57](https://github.com/aallan/vera/issues/57).
+
+Network I/O will be modelled as an algebraic effect with operations like `get` and `post`. Functions performing network access will declare `effects(<Http>)`. Handlers will provide the implementation: real HTTP in production, mocks in tests.
+
+```
+effect Http {
+  op get(String -> String);
+  op post(String, String -> String);
+}
+```
+
+This fits naturally with Vera's algebraic effect system and makes network I/O explicit and testable.
+
+### 9.5.4 Async (Future)
+
+> **Status: Not yet implemented.** Tracked in [#59](https://github.com/aallan/vera/issues/59).
+
+Asynchronous operations will be modelled as an algebraic effect. An `<Async>` effect with `async` and `await` operations will allow concurrent computation:
+
+```
+fn fetch_both(@String, @String -> @Tuple<Json, Json>)
+  requires(true)
+  ensures(true)
+  effects(<Http, Async>)
+{
+  let @Future<Json> = async(http_get(@String.0));
+  let @Future<Json> = async(http_get(@String.1));
+  let @Json = await(@Future<Json>.1);
+  let @Json = await(@Future<Json>.0);
+  Tuple(@Json.1, @Json.0)
+}
+```
+
+Key design points:
+- `async(expr)` wraps an effectful computation in a `Future<T>`, starting it concurrently.
+- `await(@Future<T>.n)` suspends until the future resolves, yielding the result.
+- The `<Async>` effect must be declared, making concurrency explicit and trackable.
+- Handlers can provide different scheduling strategies (thread pool, event loop, sequential).
+- This avoids coloured-function problems because algebraic effects already separate the description of an operation from its execution.
+
+### 9.5.5 Inference (Future)
+
+> **Status: Not yet implemented.** Tracked in [#61](https://github.com/aallan/vera/issues/61).
+
+LLM inference will be modelled as an algebraic effect, making model calls explicit in the type system:
+
+```
+effect Inference {
+  op complete(String -> String);
+  op embed(String -> Array<Float64>);
+}
+```
+
+Operations:
+- `complete(@String)` — sends a prompt to a language model and returns the completion.
+- `embed(@String)` — computes a vector embedding of the input string.
+
+Any function that calls an LLM declares `effects(<Inference>)`. Pure functions cannot secretly call models. Contracts still apply: preconditions on inference inputs are verified normally. Postconditions on outputs can use refinement types to constrain response format.
+
+Handlers provide the implementation: one handler uses an HTTP API, another uses a local model, another uses cached replay for deterministic testing.
+
+```
+fn classify(@String -> @String)
+  requires(length(@String.0) > 0)
+  ensures(true)
+  effects(<Inference>)
+{
+  Inference.complete("Classify as Spam or Ham: " ++ @String.0)
+}
+```
+
+## 9.6 Built-in Functions
+
+### 9.6.1 length
+
+```
+forall<T> fn length(@Array<T> -> @Int)
+  requires(true)
+  ensures(@Int.result >= 0)
+  effects(pure)
+```
+
+Returns the number of elements in an array. The result is always non-negative. `length` is generic over the element type.
+
+```
+let @Array<Int> = [10, 20, 30];
+length(@Array<Int>.0)
+```
+
+This expression evaluates to `3`.
+
+For the compilation of `length`, see Chapter 11, Section 11.12.
+
+### 9.6.2 similarity (Future)
+
+> **Status: Not yet implemented.** Will be introduced alongside the `Inference` effect ([#61](https://github.com/aallan/vera/issues/61)).
+
+```
+fn similarity(@Array<Float64>, @Array<Float64> -> @Float64)
+  requires(length(@Array<Float64>.0) == length(@Array<Float64>.1))
+  ensures(@Float64.result >= -1.0 && @Float64.result <= 1.0)
+  effects(pure)
+```
+
+Computes the cosine similarity between two vectors (embeddings). The arrays must have equal length (enforced by precondition). The result is in the range \[-1, 1\], where 1 indicates identical direction, 0 indicates orthogonality, and -1 indicates opposite direction.
+
+This function is pure — it performs no effects. It is intended for use with the `Inference.embed` operation to compare semantic similarity of text.
+
+## 9.7 Built-in Types (Future)
+
+### 9.7.1 Json (Future)
+
+> **Status: Not yet implemented.** Tracked in [#58](https://github.com/aallan/vera/issues/58). Depends on `Map<K, V>` ([#62](https://github.com/aallan/vera/issues/62)).
+
+JSON will be a standard library ADT, not a primitive type:
+
+```
+data Json {
+  JNull,
+  JBool(Bool),
+  JNumber(Float64),
+  JString(String),
+  JArray(Array<Json>),
+  JObject(Map<String, Json>)
+}
+```
+
+Parse and serialize operations will belong in the standard library. Refinement types can express JSON schemas:
+
+```
+type ApiResponse = { @Json | has_field(@Json.0, "status") };
+```
+
+This approach keeps the core language small while providing ergonomic JSON support.
+
+### 9.7.2 Decimal (Future)
+
+> **Status: Not yet implemented.** Tracked in [#62](https://github.com/aallan/vera/issues/62).
+
+`Decimal` will provide exact decimal arithmetic for financial and precision-sensitive applications. It will be implemented as a library type (not a primitive) since WebAssembly does not have native decimal floating-point. The runtime will provide a software implementation.
+
+## 9.8 Abilities (Future)
+
+> **Status: Not yet implemented.** Tracked in [#60](https://github.com/aallan/vera/issues/60). Post-v0.1 feature.
+
+Vera's type variables are currently unconstrained (`forall<T>`). To support practical generic programming — sorting, hashing, serialisation — type variables will need constraints. Vera will adopt restricted abilities rather than full typeclasses:
+
+```
+ability Eq<T> {
+  op eq(T, T -> Bool);
+}
+
+ability Ord<T> {
+  op compare(T, T -> Ordering);
+}
+
+forall<T where Eq<T>> fn contains(@Array<T>, @T -> @Bool)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  exists(@Nat, length(@Array<T>.0), fn(@Nat -> @Bool) effects(pure) {
+    eq(@Array<T>.0[@Nat.0], @T.0)
+  })
+}
+```
+
+Key design points:
+
+1. **No higher-kinded types.** No `Functor`, `Monad`, or `Applicative`. Abilities are first-order only: `Eq<T>`, not `Mappable<F>` where `F` is a type constructor. This preserves decidable type checking and prevents the abstraction hierarchy that makes code harder for LLMs to generate correctly.
+
+2. **Built-in abilities** will be auto-derivable for ADTs composed of types that already support them: `Eq`, `Ord`, `Hash`, `Encode`, `Decode`, `Show`. If all fields of an ADT support `Eq`, the ADT supports `Eq` automatically.
+
+3. **User-defined abilities** are permitted but restricted to first-order type parameters. This allows library authors to define domain-specific abilities without the complexity of higher-kinded polymorphism.
+
+4. **`ability` declarations** look like `effect` declarations (using `op` for operations), keeping the language syntactically consistent.
+
+5. **Constraint syntax** uses `forall<T where Ability<T>>`, consistent with the placeholder noted in Chapter 2, Section 2.7.1.
+
+This design draws on Roc's abilities (deliberately no HKTs, auto-derivable) and Gleam's validation that useful languages need not have typeclasses.

--- a/spec/12-runtime.md
+++ b/spec/12-runtime.md
@@ -1,0 +1,260 @@
+# Chapter 12: Runtime and Execution
+
+## 12.1 Overview
+
+Vera programs compile to WebAssembly (WASM) modules and execute in a host runtime. The reference implementation uses [wasmtime](https://wasmtime.dev/) as the WASM engine. The runtime is responsible for:
+
+- Instantiating compiled WASM modules
+- Providing host function implementations for effects (`IO`, `State<T>`)
+- Managing linear memory (for string constants, heap-allocated ADTs, and arrays)
+- Capturing output and state for the caller
+- Handling traps and runtime errors
+
+The runtime is deliberately minimal. It provides only what is needed to execute the compiled WASM — there is no garbage collector, no scheduler, and no standard I/O beyond `print`. Future runtime features (networking, async, inference) will extend this model without changing its fundamentals.
+
+## 12.2 WASM Module Structure
+
+A compiled Vera module is a standalone WASM module containing:
+
+### 12.2.1 Exports
+
+Every compilable top-level function is exported by name. The entry point for `vera run` is resolved as follows:
+
+1. If `--fn <name>` is provided, call that function.
+2. Otherwise, if a function named `main` exists, call `main`.
+3. Otherwise, call the first exported function.
+
+Functions with unsupported parameter or return types (e.g., `String`, `Array<T>` in signatures) are skipped during compilation with a warning — they do not appear in the module's exports.
+
+### 12.2.2 Imports
+
+The module imports host functions for effects that the program uses:
+
+| Import | Signature | Condition |
+|--------|-----------|-----------|
+| `vera.print` | `(i32, i32) -> ()` | Program uses `IO.print` |
+| `vera.state_get_{T}` | `() -> {wasm_t}` | Program uses `State<T>.get` |
+| `vera.state_put_{T}` | `({wasm_t}) -> ()` | Program uses `State<T>.put` |
+
+Imports are only emitted when the program actually uses the corresponding effect operations. A pure program produces a module with no imports.
+
+### 12.2.3 Linear Memory
+
+The module exports one page (64 KiB) of linear memory as `"memory"`. The host runtime uses this export to read string data for `IO.print` operations.
+
+For the memory layout, see Section 12.5.
+
+### 12.2.4 Data Section
+
+String constants are stored in the WASM data section at the start of linear memory (offset 0). The string pool deduplicates identical strings. Each string is stored as raw UTF-8 bytes with no null terminator.
+
+For the string pool implementation, see Chapter 11, Section 11.5.
+
+## 12.3 Host Runtime
+
+### 12.3.1 Wasmtime Integration
+
+The reference runtime uses wasmtime's Python bindings. The execution pipeline is:
+
+```
+Engine → Module(engine, wat) → Linker(engine) → Store(engine)
+  → linker.define_func(...)   [register host functions]
+  → linker.instantiate(store, module)
+  → instance.exports(store).get(fn_name)
+  → func(store, *args)
+```
+
+Each execution creates a fresh engine, module, linker, and store. There is no persistent state between invocations.
+
+### 12.3.2 Module Instantiation
+
+The linker resolves all imports before instantiation. If the module imports a host function that the linker has not defined, instantiation fails with an error.
+
+The linker registers host functions before instantiation:
+1. `vera.print` — always registered (even if unused, for simplicity).
+2. `vera.state_get_{T}` / `vera.state_put_{T}` — registered for each concrete `State<T>` type used by the program.
+
+### 12.3.3 Entry Point Resolution
+
+After instantiation, the runtime resolves the function to call:
+
+1. If `--fn <name>` is specified, look up `name` in the module's exports.
+2. Otherwise, look up `main`.
+3. Otherwise, use the first export.
+4. If no exports exist, raise an error.
+
+Arguments are passed as WASM values. The CLI parses string arguments to integers or floats based on the function's WASM parameter types.
+
+## 12.4 Host Function Bindings
+
+### 12.4.1 IO.print
+
+**Import:** `(import "vera" "print" (func $vera.print (param i32 i32)))`
+
+**Parameters:**
+- `ptr` (i32): byte offset into linear memory where the string data begins.
+- `len` (i32): length of the string in bytes.
+
+**Behaviour:**
+1. Read `len` bytes from linear memory starting at offset `ptr`.
+2. Decode the bytes as UTF-8.
+3. Write the decoded string to standard output.
+
+The output is captured in a buffer so the caller can inspect it programmatically (e.g., in tests). The `ExecuteResult` returned by `execute()` includes a `stdout` field containing all captured output.
+
+### 12.4.2 State\<T\>
+
+**Imports:** One pair per concrete state type:
+
+```wat
+(import "vera" "state_get_Int" (func $vera.state_get_Int (result i64)))
+(import "vera" "state_put_Int" (func $vera.state_put_Int (param i64)))
+```
+
+**State cells:** The host runtime maintains one mutable cell per concrete `State<T>` type. Cells are initialized to zero (0 for integers, 0.0 for floats). The `execute()` function accepts an optional `initial_state` parameter to override initial values for testing.
+
+**Type mapping:**
+| Vera State Type | WASM Type | Default |
+|----------------|-----------|---------|
+| `State<Int>` | `i64` | `0` |
+| `State<Nat>` | `i64` | `0` |
+| `State<Bool>` | `i32` | `0` |
+| `State<Byte>` | `i32` | `0` |
+| `State<Float64>` | `f64` | `0.0` |
+
+**get:** Returns the current value of the state cell.
+
+**put:** Replaces the value of the state cell with the argument.
+
+Multiple independent state types can coexist — each has its own cell and its own pair of host functions.
+
+## 12.5 Memory Model
+
+### 12.5.1 Linear Memory Layout
+
+```
+┌──────────────────────────────────┐  offset 0
+│  String constants (data section) │
+├──────────────────────────────────┤  $heap_ptr (initial)
+│  Heap-allocated data             │
+│  (ADTs, closures, arrays)        │
+│          ↓ grows downward        │
+├──────────────────────────────────┤
+│  (unused)                        │
+└──────────────────────────────────┘  65536 (64 KiB)
+```
+
+String constants occupy the lowest addresses. The heap grows upward from the first byte after the string data section.
+
+### 12.5.2 Bump Allocator
+
+The heap uses a bump allocator. A mutable WASM global `$heap_ptr` tracks the next free byte. The internal `$alloc` function:
+
+1. Reads `$heap_ptr`.
+2. Aligns the pointer up to the required alignment.
+3. Advances `$heap_ptr` by the requested size.
+4. Returns the original (aligned) pointer.
+
+The allocator and `$heap_ptr` global are only emitted when the program actually allocates heap data (ADTs, closures, or arrays).
+
+### 12.5.3 Alignment
+
+All heap allocations are 8-byte aligned. This ensures correct access for all WASM value types:
+
+| WASM Type | Size | Alignment |
+|-----------|------|-----------|
+| `i32` | 4 bytes | 4 bytes |
+| `i64` | 8 bytes | 8 bytes |
+| `f64` | 8 bytes | 8 bytes |
+
+8-byte alignment satisfies all requirements.
+
+### 12.5.4 No Garbage Collection
+
+> **Limitation.** Tracked in [#51](https://github.com/aallan/vera/issues/51).
+
+The bump allocator does not reclaim memory. Once allocated, heap memory is never freed. This is acceptable for short-lived computations but will not scale to long-running programs.
+
+Future work: a tracing garbage collector or region-based memory management.
+
+## 12.6 Execution Flow
+
+### 12.6.1 Compilation, Instantiation, and Call
+
+The full pipeline from source to result:
+
+```
+Source (.vera)
+  → parse_file()           Lark parse tree
+  → transform()            Typed AST
+  → typecheck()            Type diagnostics
+  → compile()              CompileResult (WAT + WASM bytes)
+  → execute()              ExecuteResult (value + stdout + state)
+```
+
+The `compile()` step produces WAT text and assembles it to WASM bytes via `wasmtime.wat2wasm()`. The `execute()` step instantiates the WASM module and calls the specified function.
+
+### 12.6.2 Argument Passing
+
+Arguments are passed to the WASM function as typed values:
+
+- `Int` / `Nat` arguments → `i64` values
+- `Bool` / `Byte` arguments → `i32` values
+- `Float64` arguments → `f64` values
+
+The CLI (`vera run file.vera --fn f -- 42 3.14`) parses string arguments to the appropriate types. Integer arguments become `i64`; arguments containing a decimal point become `f64`.
+
+### 12.6.3 Return Value Extraction
+
+The raw WASM return value is extracted and returned as a Python `int` or `float`:
+
+- `i64` results → Python `int`
+- `i32` results → Python `int`
+- `f64` results → Python `float`
+- Void results (Unit) → `None`
+
+### 12.6.4 Stdout Capture
+
+All `IO.print` calls during execution write to an in-memory buffer. The buffer contents are returned in `ExecuteResult.stdout`. This allows programmatic inspection of output without interfering with the host process's stdout.
+
+The CLI prints `ExecuteResult.stdout` to the terminal after execution completes. If the function also returns a value, the value is printed after the captured output.
+
+## 12.7 Error Handling
+
+### 12.7.1 WASM Traps
+
+WASM traps are unrecoverable runtime errors. The following conditions cause traps:
+
+| Condition | WASM Instruction | Source |
+|-----------|-----------------|--------|
+| Integer division by zero | `i64.div_s` | `/` operator on Int |
+| Unreachable code | `unreachable` | `assert` failure, bounds check failure |
+| Out-of-bounds memory access | `i64.load`, etc. | Invalid pointer dereference |
+| Integer overflow (in `i64.div_s`) | — | `Int.min_value / -1` |
+
+When a trap occurs, the wasmtime engine raises a `WasmtimeError` or `Trap` exception. The CLI reports this as a runtime error and exits with a non-zero status.
+
+### 12.7.2 Runtime Contract Violations
+
+Contracts that the verifier could not prove statically (Tier 3) are compiled as runtime assertions. A failed runtime precondition or postcondition executes `unreachable`, causing a WASM trap.
+
+For the contract insertion strategy, see Chapter 11, Section 11.8.
+
+The `assert` expression also compiles to a conditional trap: if the condition is false, the program traps (see Chapter 11, Section 11.14).
+
+### 12.7.3 Array Bounds Checking
+
+Array index expressions are bounds-checked at runtime. If the index is negative or greater than or equal to the array length, the program traps via `unreachable`.
+
+For the bounds checking implementation, see Chapter 11, Section 11.12.
+
+## 12.8 Limitations
+
+The current runtime has the following limitations, each tracked as a GitHub issue:
+
+| Limitation | Issue | Notes |
+|-----------|-------|-------|
+| No garbage collection | [#51](https://github.com/aallan/vera/issues/51) | Bump allocator only; linear memory is not reclaimed |
+| String constants only | [#52](https://github.com/aallan/vera/issues/52) | No dynamic string construction or concatenation at runtime |
+| Single-module execution | [#50](https://github.com/aallan/vera/issues/50) | Each file compiles and executes independently; no cross-module linking |
+| State\<T\> only | [#53](https://github.com/aallan/vera/issues/53) | Only `State<T>` effect handlers are compiled; `Exn<E>` and custom effects use in-WASM handlers |

--- a/vera/README.md
+++ b/vera/README.md
@@ -5,7 +5,7 @@ Architecture documentation for the Vera compiler (`vera/` package). This is for 
 For other documentation:
 - [Root README](../README.md) — project overview, getting started, language examples
 - [SKILLS.md](../SKILLS.md) — language reference for LLM agents writing Vera code
-- [spec/](../spec/) — formal language specification (10 chapters)
+- [spec/](../spec/) — formal language specification (12 chapters)
 - [CONTRIBUTING.md](../CONTRIBUTING.md) — contributor workflow and conventions
 
 ## Pipeline Overview

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.23"
+__version__ = "0.0.24"


### PR DESCRIPTION
## Summary
- Write spec Chapter 9 (Standard Library): built-in ADTs, collections, effects, functions, and future features with issue cross-references
- Write spec Chapter 12 (Runtime and Execution): WASM module structure, host runtime, memory model, execution flow, error handling
- Condense Chapter 0 Section 0.8 design notes to cross-reference table pointing to Chapter 9
- Mark C6 phase complete in roadmap, collapse sub-phase tables, update next milestone to C7
- Closes #63

## Test plan
- [x] All pre-commit hooks pass (mypy, pytest, examples, spec check)
- [x] `python scripts/check_spec_examples.py` passes (new spec code blocks parse or are allowlisted)
- [x] `python scripts/check_version_sync.py` passes (version 0.0.24 consistent)
- [x] No compiler code changes — pure spec/docs/roadmap update

Generated with [Claude Code](https://claude.com/claude-code)