### PR TITLE
Consistency audit: fix stale docs, spec syntax, issue tracking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,7 +108,7 @@ Each stage is a module with a single public API function (`parse_file`, `transfo
 ### Testing
 
 ```bash
-pytest tests/ -v                       # Run all tests (660 tests)
+pytest tests/ -v                       # Run all tests (849 tests)
 mypy vera/                             # Type-check the compiler
 python scripts/check_examples.py       # All 14 examples must pass
 ```
@@ -119,7 +119,7 @@ Test helpers follow a pattern: `_check_ok(source)` / `_check_err(source, match)`
 
 - All 14 examples in `examples/` must pass `vera check` and `vera verify`
 - `mypy vera/` must be clean
-- `pytest tests/ -v` must pass (currently 660 tests)
+- `pytest tests/ -v` must pass (currently 849 tests)
 - Version must be in sync across `vera/__init__.py`, `pyproject.toml`, and `CHANGELOG.md`
 
 ### Contributing

--- a/scripts/check_spec_examples.py
+++ b/scripts/check_spec_examples.py
@@ -46,9 +46,9 @@ ALLOWLIST: dict[tuple[str, int], str] = {
     ("02-types.md", 250): "FUTURE",          # forall<T where Ord<T>> fn sort
 
     # Chapter 9 — future stdlib features and signature-only blocks
-    ("09-standard-library.md", 262): "FUTURE",   # fn classify — uses ++ (string concat)
-    ("09-standard-library.md", 276): "FRAGMENT",  # length signature (no body)
-    ("09-standard-library.md", 298): "FRAGMENT",  # similarity signature (no body)
+    ("09-standard-library.md", 269): "FUTURE",   # fn classify — uses ++ (string concat)
+    ("09-standard-library.md", 283): "FRAGMENT",  # length signature (no body)
+    ("09-standard-library.md", 305): "FRAGMENT",  # similarity signature (no body)
 
     # =================================================================
     # FRAGMENT — heuristic false positives (look like declarations but
@@ -85,20 +85,18 @@ ALLOWLIST: dict[tuple[str, int], str] = {
     ("06-contracts.md", 308): "FRAGMENT",   # type SafeDiv = fn(...) + fn apply_div
 
     # Chapter 7 — anonymous function at top level
-    ("07-effects.md", 117): "FRAGMENT",     # effect Logger + anonymous fn body
+    ("07-effects.md", 116): "FRAGMENT",     # effect Logger + anonymous fn body
 
-    # Chapter 7 — handler with-clause syntax not in parser
-    ("07-effects.md", 182): "FRAGMENT",     # handle[State] with-clause in put handler
-    ("07-effects.md", 204): "FRAGMENT",     # handle[Exn] non-resuming handler
-    ("07-effects.md", 224): "FRAGMENT",     # handle[Choice] multi-shot resume
+    # Chapter 7 — multi-shot resume + array_concat (future)
+    ("07-effects.md", 222): "FUTURE",       # handle[Choice] multi-shot resume + array_concat
 
     # Chapter 7 — inline function types in generic params
-    ("07-effects.md", 251): "FRAGMENT",     # fn(A -> B) in param position
-    ("07-effects.md", 270): "FRAGMENT",     # fn(Unit -> A) in param position
+    ("07-effects.md", 249): "FRAGMENT",     # fn(A -> B) in param position
+    ("07-effects.md", 268): "FRAGMENT",     # fn(Unit -> A) in param position
 
     # Chapter 7 — empty effect bodies (parser requires op_decl+)
-    ("07-effects.md", 312): "FRAGMENT",     # effect Diverge {} — no operations
-    ("07-effects.md", 320): "FRAGMENT",     # effect Alloc {} — no operations
+    ("07-effects.md", 309): "FRAGMENT",     # effect Diverge {} — no operations
+    ("07-effects.md", 317): "FRAGMENT",     # effect Alloc {} — no operations
 }
 
 

--- a/spec/00-introduction.md
+++ b/spec/00-introduction.md
@@ -88,7 +88,7 @@ Error in examples/bad.vera at line 5, column 1:
       ...
     }
 
-  See: Chapter 5, Section 5.1 "Function Structure"
+  See: Chapter 5, Section 5.1
 ```
 
 ### 0.5.3 Diagnostic Categories

--- a/spec/04-expressions.md
+++ b/spec/04-expressions.md
@@ -286,18 +286,19 @@ Indexing uses square brackets with an `Int` or `Nat` index. Array indexing is bo
 
 ### 4.12.3 Array Operations
 
-Array operations are provided by the standard library (`vera.array`), not by special syntax. Examples:
+The built-in `length` function returns the number of elements in an array (see Chapter 9, Section 9.6.1):
 
 ```
-array_length(@Array<Int>.0)          -- returns Nat
-array_map(@Array<Int>.0, @Fn.0)      -- returns Array<B>
-array_fold(@Array<Int>.0, @Int.0, @Fn.0)  -- returns B
-array_slice(@Array<Int>.0, @Nat.0, @Nat.1)  -- returns Array<Int>
+length(@Array<Int>.0)                -- returns Int (>= 0)
 ```
+
+Future array operations (`map`, `fold`, `slice`) will be added alongside the module system and abilities (see Chapter 9, Section 9.4.1).
 
 ## 4.13 String Operations
 
-String operations are provided by the standard library (`vera.string`):
+> **Status: Not yet implemented.** Depends on dynamic string construction ([#52](https://github.com/aallan/vera/issues/52)).
+
+String operations will be provided by the standard library:
 
 ```
 string_length(@String.0)             -- returns Nat
@@ -305,7 +306,7 @@ string_concat(@String.0, @String.1)  -- returns String
 string_slice(@String.0, @Nat.0, @Nat.1)  -- returns String
 ```
 
-String concatenation uses a function, not an operator. There is no `+` on strings.
+String concatenation will use a function, not an operator. There is no `+` on strings. Currently, only string constants (literals) are supported — see Chapter 9, Section 9.4.1 for the current state of collections and Chapter 11, Section 11.5 for the string pool implementation.
 
 ## 4.14 Expression Precedence (Complete)
 

--- a/spec/07-effects.md
+++ b/spec/07-effects.md
@@ -31,7 +31,6 @@ effect Exn<E> {
 ```
 effect IO {
   op print(String -> Unit);
-  op read_line(Unit -> String);
 }
 ```
 
@@ -99,12 +98,12 @@ fn increment(@Unit -> @Unit)
 ```
 
 ```
-fn greet(@String -> @Unit)
-  requires(length(@String.0) > 0)
+fn hello(-> @Unit)
+  requires(true)
   ensures(true)
   effects(<IO>)
 {
-  IO.print(string_concat("Hello, ", @String.0))
+  IO.print("hello, world")
 }
 ```
 
@@ -136,8 +135,8 @@ An effect handler provides implementations for an effect's operations and discha
 
 ```
 handle[State<Int>](@Int = 0) {
-  get(@Unit) -> resume(@Int.0),
-  put(@Int) -> resume(()) with @Int = @Int.0,
+  get(@Unit) -> { resume(@Int.0) },
+  put(@Int) -> { resume(()) }
 } in {
   body_expression
 }
@@ -147,8 +146,8 @@ handle[State<Int>](@Int = 0) {
 
 ```
 handle[EffectName<TypeArgs>](initial_state) {
-  operation1(params) -> handler_body1,
-  operation2(params) -> handler_body2,
+  operation1(params) -> { handler_body1 },
+  operation2(params) -> { handler_body2 }
 } in {
   handled_body
 }
@@ -158,9 +157,8 @@ Components:
 
 - `[EffectName<TypeArgs>]`: the effect being handled
 - `(initial_state)`: initial value for stateful effects (optional; only for effects that carry state)
-- Operation clauses: one per operation in the effect, each providing an implementation
-- `resume`: a built-in that continues execution of the handled body with a return value
-- `with @T = expr`: updates the handler's state before resuming
+- Operation clauses: one per operation in the effect, each providing an implementation as a block
+- `resume(value)`: a built-in that continues execution of the handled body with a return value
 - `in { ... }`: the body in which the effect is handled
 
 ### 7.5.2 Handler Semantics
@@ -186,8 +184,8 @@ fn run_stateful(@Unit -> @Int)
   effects(pure)
 {
   handle[State<Int>](@Int = 0) {
-    get(@Unit) -> resume(@Int.0),
-    put(@Int) -> resume(()) with @Int = @Int.0,
+    get(@Unit) -> { resume(@Int.0) },
+    put(@Int) -> { resume(()) }
   } in {
     let @Int = get(());           -- returns 0 (initial state)
     put(@Int.0 + 10);             -- state becomes 10
@@ -208,7 +206,7 @@ fn safe_parse(@String -> @Option<Int>)
   effects(pure)
 {
   handle[Exn<String>] {
-    throw(@String) -> None,       -- do NOT resume; return None
+    throw(@String) -> { None }    -- do NOT resume; return None
   } in {
     Some(parse_int(@String.0))    -- parse_int has effects(<Exn<String>>)
   }
@@ -289,13 +287,12 @@ This function always performs `IO` (for the logging), plus whatever effects `E` 
 ```
 effect IO {
   op print(String -> Unit);
-  op read_line(Unit -> String);
-  op write_file(String, String -> Unit);    -- path, contents
-  op read_file(String -> String);            -- path -> contents
 }
 ```
 
-IO operations interact with the outside world. They cannot be handled by user code — they are handled by the runtime.
+The `IO` effect currently exposes a single operation: `print`, which writes a UTF-8 string to standard output. IO operations interact with the outside world and are handled by the runtime (see Chapter 12, Section 12.4.1).
+
+Future operations (`read_line`, `read_file`, `write_file`) will extend the `IO` effect as the runtime grows. See Chapter 9, Section 9.5.1 for the full standard library documentation.
 
 ### 7.7.2 `Exn<E>`
 

--- a/spec/09-standard-library.md
+++ b/spec/09-standard-library.md
@@ -185,12 +185,19 @@ fn increment(-> @Unit)
 State is handled by providing an initial value and a handler that manages the mutable cell:
 
 ```
-handle {
-  increment()
-} with State<Int> {
-  initial: 0,
-  get: fn(-> @Int) effects(pure) { resume(0) },
-  put: fn(@Int -> @Unit) effects(pure) { resume(()) }
+fn run_increment(@Unit -> @Int)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  handle[State<Int>](@Int = 0) {
+    get(@Unit) -> { resume(@Int.0) },
+    put(@Int) -> { resume(()) }
+  } in {
+    let @Int = get(());
+    put(@Int.0 + 1);
+    get(())
+  }
 }
 ```
 


### PR DESCRIPTION
## Summary
- Fix AGENTS.md test count (660 -> 849)
- Fix Chapter 7 IO effect: remove unimplemented `read_line`, fix handler examples to use parseable brace syntax instead of unparseable `with` clause, replace `string_concat` example with constant string
- Fix Chapter 9 handler example to use parseable brace syntax
- Fix Chapter 4: mark string operations as future (#52), document actual `length()` built-in instead of nonexistent `array_map`/`array_fold`/`array_slice`
- Fix Chapter 0 stale section title reference
- Update spec allowlist: correct line numbers, remove 2 now-parseable entries
- Closes #15 (UnknownType doc comments already exist)
- Opened #72 (handler `with` clause not in grammar)
- Added spec reference update comments to #13, #14, #50-#53, #57-#62

## Test plan
- [x] All pre-commit hooks pass (mypy, pytest, spec check)
- [x] `check_spec_examples.py`: 0 failures, 3 more blocks now parse correctly
- [x] No compiler code changes

Generated with [Claude Code](https://claude.com/claude-code)