### PR TITLE
CHANGELOG: note veralang.dev deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- **Project website** ([veralang.dev](https://veralang.dev)): single-page site deployed via GitHub Pages ([#81](https://github.com/aallan/vera/pull/81))
+
 ## [0.0.24] - 2026-02-26
 
 ### Added


### PR DESCRIPTION
Add entry under [Unreleased] for the website deployment (#81).