### PR TITLE
C6.5a: bind resume in handler clause scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 - **Project website** ([veralang.dev](https://veralang.dev)): single-page site deployed via GitHub Pages ([#81](https://github.com/aallan/vera/pull/81))
 
+## [0.0.25] - 2026-02-26
+
+### Fixed
+- **`resume` recognized in handler scope** (C6.5a — closes [#74](https://github.com/aallan/vera/issues/74)): the type checker now binds `resume` as a function in handler clause bodies with the correct type (takes operation return type, returns Unit), eliminating spurious "Unresolved function 'resume'" warnings
+- `effect_handler.vera` example now type-checks cleanly (moved from warn to clean examples)
+
+### Added
+- `_check_clean()` test helper asserts zero errors AND zero warnings
+- 3 new tests: `test_resume_wrong_arg_type`, `test_resume_wrong_arity`, `test_resume_outside_handler` (852 total, up from 849)
+
 ## [0.0.24] - 2026-02-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Development follows an **interleaved spiral** — each phase adds a complete com
 | C4 | [v0.0.8](https://github.com/aallan/vera/releases/tag/v0.0.8) | **Contract verifier** — Z3 integration, refinement types, counterexamples | Done |
 | C5 | [v0.0.9](https://github.com/aallan/vera/releases/tag/v0.0.9) | **WASM codegen** — compile to WebAssembly, `vera compile` / `vera run` | Done |
 | C6 | [v0.0.10](https://github.com/aallan/vera/releases/tag/v0.0.10)–[v0.0.24](https://github.com/aallan/vera/releases/tag/v0.0.24) | **Codegen completeness** — ADTs, match, closures, effects, generics in WASM | Done |
-| C6.5 | — | **Codegen cleanup** — handler fixes, missing operators, String/Array support | In Progress |
+| C6.5 | [v0.0.25](https://github.com/aallan/vera/releases/tag/v0.0.25)– | **Codegen cleanup** — handler fixes, missing operators, String/Array support | In Progress |
 | C7 | — | **Module system** — cross-file imports, public/private visibility | Planned |
 | C8 | v0.1.0 | **End-to-end** — all examples compile and run, spec complete, polish | Planned |
 
@@ -182,7 +182,7 @@ Before starting the module system, C6.5 addresses residual gaps in single-file c
 
 | Sub-phase | Scope | Issue |
 |-----------|-------|-------|
-| C6.5a | `resume` not recognized as built-in in handler scope | [#74](https://github.com/aallan/vera/issues/74) |
+| C6.5a | `resume` not recognized as built-in in handler scope | [#74](https://github.com/aallan/vera/issues/74) ✓ |
 | C6.5b | Handler `with` clause for state updates not in grammar | [#72](https://github.com/aallan/vera/issues/72) |
 | C6.5c | Pipe operator (`\|>`) compilation | [#44](https://github.com/aallan/vera/issues/44) |
 | C6.5d | Float64 modulo (`%`) — WASM has no `f64.rem` | [#46](https://github.com/aallan/vera/issues/46) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.24"
+version = "0.0.25"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -24,6 +24,7 @@ EXAMPLE_FILES = sorted(f.name for f in EXAMPLES_DIR.glob("*.vera"))
 # Self-contained examples (no unresolved external references)
 CLEAN_EXAMPLES = [
     "absolute_value.vera",
+    "effect_handler.vera",
     "factorial.vera",
     "generics.vera",
     "increment.vera",
@@ -39,7 +40,6 @@ CLEAN_EXAMPLES = [
 # Examples with unresolved external references (warnings expected)
 WARN_EXAMPLES = [
     "closures.vera",
-    "effect_handler.vera",
 ]
 
 
@@ -64,6 +64,13 @@ def _check_ok(source: str) -> None:
     errs = _errors(source)
     assert errs == [], \
         f"Expected no errors, got: {[e.description for e in errs]}"
+
+
+def _check_clean(source: str) -> None:
+    """Assert the source type-checks with no errors AND no warnings."""
+    diags = _check(source)
+    assert diags == [], \
+        f"Expected no diagnostics, got: {[d.description for d in diags]}"
 
 
 def _check_err(source: str, match: str) -> list[Diagnostic]:
@@ -644,7 +651,8 @@ fn bad(@String -> @Unit)
 """, "Pure function")
 
     def test_handler_basic(self) -> None:
-        _check_ok("""
+        """Handler with resume produces no errors or warnings."""
+        _check_clean("""
 fn foo(@Unit -> @Int)
   requires(true) ensures(true) effects(pure)
 {
@@ -656,6 +664,52 @@ fn foo(@Unit -> @Int)
   }
 }
 """)
+
+    def test_resume_wrong_arg_type(self) -> None:
+        """resume() type-checks its argument against operation return type."""
+        # get(Unit) -> Int, so resume expects Int; passing Unit is a mismatch
+        _check_err("""
+fn foo(@Unit -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  handle[State<Int>](@Int = 0) {
+    get(@Unit) -> { resume(()) },
+    put(@Int) -> { resume(()) }
+  } in {
+    get(())
+  }
+}
+""", "has type Unit, expected Int")
+
+    def test_resume_wrong_arity(self) -> None:
+        """resume() takes exactly one argument."""
+        _check_err("""
+fn foo(@Unit -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  handle[State<Int>](@Int = 0) {
+    get(@Unit) -> { resume(@Int.0, @Int.1) },
+    put(@Int) -> { resume(()) }
+  } in {
+    get(())
+  }
+}
+""", "expects 1 argument")
+
+    def test_resume_outside_handler(self) -> None:
+        """resume() outside a handler scope is unresolved."""
+        diags = _check("""
+fn foo(@Unit -> @Unit)
+  requires(true) ensures(true) effects(pure)
+{
+  resume(42)
+}
+""")
+        warns = [d for d in diags if d.severity == "warning"]
+        assert any("Unresolved function 'resume'" in w.description
+                    for w in warns), \
+            f"Expected unresolved resume warning, got: " \
+            f"{[w.description for w in warns]}"
 
     def test_state_effect_builtin(self) -> None:
         """The built-in State<T> effect is available."""

--- a/vera/README.md
+++ b/vera/README.md
@@ -260,6 +260,8 @@ Context flags (`in_ensures`, `in_contract`, `current_return_type`, `current_effe
 | `IO` | Effect | No operations exposed at type level |
 | `length` | Function | `forall<T> Array<T> → Int`, pure |
 
+Additionally, `resume` is bound as a temporary function inside handler clause bodies (in `_check_handle()`). Its type is derived from the operation: for `op(params) → ReturnType`, `resume` has type `fn(ReturnType) → Unit effects(pure)`. The binding is added to `env.functions` before checking the clause body and removed afterward.
+
 ## Contract Verification
 
 **Files:** `verifier.py` (601 lines), `smt.py` (485 lines)

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.24"
+__version__ = "0.0.25"

--- a/vera/checker.py
+++ b/vera/checker.py
@@ -1489,7 +1489,26 @@ class TypeChecker:
                     expr.state.type_expr) if expr.state else "?"
                 self.env.bind(state_tname, state_type, "handler")
 
+            # Bind resume — takes the operation's return type, returns Unit.
+            # resume is only available inside handler clause bodies.
+            op_return_type = substitute(op_info.return_type, mapping)
+            saved_resume = self.env.functions.get("resume")
+            self.env.functions["resume"] = FunctionInfo(
+                name="resume",
+                forall_vars=None,
+                param_types=(op_return_type,),
+                return_type=UNIT,
+                effect=PureEffectRow(),
+            )
+
             self._synth_expr(clause.body)
+
+            # Restore previous resume binding (if any)
+            if saved_resume is not None:
+                self.env.functions["resume"] = saved_resume
+            else:
+                del self.env.functions["resume"]
+
             self.env.pop_scope()
 
         # Check handler body — temporarily add handled effect to context


### PR DESCRIPTION
## Summary

- Fixes `resume` not being recognized as a built-in function inside handler clause bodies, eliminating spurious "Unresolved function 'resume'" warnings
- In `_check_handle()`, `resume` is now temporarily bound in `env.functions` with the correct type (`fn(ReturnType) -> Unit`) for each operation clause
- `effect_handler.vera` now type-checks cleanly (zero warnings)

Closes #74

## Changes

| File | Change |
|------|--------|
| `vera/checker.py` | Bind `resume` with save/restore in handler clause loop |
| `tests/test_checker.py` | Add `_check_clean()` helper, strengthen `test_handler_basic`, add 3 new tests |
| `tests/test_checker.py` | Move `effect_handler.vera` from WARN to CLEAN examples |
| `vera/README.md` | Document `resume` binding in built-ins section |
| `CHANGELOG.md` | v0.0.25 entry |
| `README.md` | Mark C6.5a done, add v0.0.25 to C6.5 version range |

## Test plan

- [x] `vera check --json examples/effect_handler.vera` returns zero diagnostics and zero warnings
- [x] `pytest tests/ -v` -- 852 passed (up from 849)
- [x] `mypy vera/` -- clean
- [x] All validation scripts pass (examples, spec, README, version sync)
- [x] New tests verify: correct arg type checking, arity checking, resume outside handler still warns

Generated with [Claude Code](https://claude.com/claude-code)