### PR TITLE
docs: post-C6.5a consistency fixup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,7 +108,7 @@ Each stage is a module with a single public API function (`parse_file`, `transfo
 ### Testing
 
 ```bash
-pytest tests/ -v                       # Run all tests (849 tests)
+pytest tests/ -v                       # Run all tests (852 tests)
 mypy vera/                             # Type-check the compiler
 python scripts/check_examples.py       # All 14 examples must pass
 ```
@@ -119,7 +119,7 @@ Test helpers follow a pattern: `_check_ok(source)` / `_check_err(source, match)`
 
 - All 14 examples in `examples/` must pass `vera check` and `vera verify`
 - `mypy vera/` must be clean
-- `pytest tests/ -v` must pass (currently 849 tests)
+- `pytest tests/ -v` must pass (currently 852 tests)
 - Version must be in sync across `vera/__init__.py`, `pyproject.toml`, and `CHANGELOG.md`
 
 ### Contributing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ vera parse file.vera              # Print the parse tree
 vera ast file.vera                # Print the typed AST
 vera ast --json file.vera         # Print the AST as JSON
 
-pytest tests/ -v                  # Run the test suite (849 tests)
+pytest tests/ -v                  # Run the test suite (852 tests)
 mypy vera/                        # Type-check the compiler itself
 
 python scripts/check_examples.py      # Verify all 14 examples parse + check + verify

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Before starting the module system, C6.5 addresses residual gaps in single-file c
 
 | Sub-phase | Scope | Issue |
 |-----------|-------|-------|
-| C6.5a | `resume` not recognized as built-in in handler scope | [#74](https://github.com/aallan/vera/issues/74) ✓ |
+| ~~C6.5a~~ | ~~`resume` not recognized as built-in in handler scope~~ | [v0.0.25](https://github.com/aallan/vera/releases/tag/v0.0.25) |
 | C6.5b | Handler `with` clause for state updates not in grammar | [#72](https://github.com/aallan/vera/issues/72) |
 | C6.5c | Pipe operator (`\|>`) compilation | [#44](https://github.com/aallan/vera/issues/44) |
 | C6.5d | Float64 modulo (`%`) — WASM has no `f64.rem` | [#46](https://github.com/aallan/vera/issues/46) |
@@ -466,7 +466,7 @@ vera/
 │   ├── errors.py                  # LLM-oriented diagnostics
 │   └── cli.py                     # Command-line interface
 ├── examples/                      # 14 example Vera programs
-├── tests/                         # Test suite (849 tests)
+├── tests/                         # Test suite (852 tests)
 ├── scripts/                       # CI and validation scripts
 │   ├── check_examples.py          # Verify all .vera examples
 │   ├── check_spec_examples.py     # Verify spec code blocks parse

--- a/vera/README.md
+++ b/vera/README.md
@@ -454,7 +454,7 @@ Every diagnostic includes a description (what went wrong), rationale (which lang
 
 ## Test Suite
 
-**849 tests** across 10 files, plus 4 validation scripts and CI infrastructure.
+**852 tests** across 10 files, plus 4 validation scripts and CI infrastructure.
 
 ### Test files
 
@@ -462,7 +462,7 @@ Every diagnostic includes a description (what went wrong), rationale (which lang
 |------|------:|------:|----------------|
 | `test_parser.py` | 95 | 791 | Grammar rules, operator precedence, parse errors |
 | `test_ast.py` | 84 | 896 | AST transformation, node structure, serialisation |
-| `test_checker.py` | 108 | 1,203 | Type synthesis, slot resolution, effects, contracts, exhaustiveness |
+| `test_checker.py` | 111 | 1,257 | Type synthesis, slot resolution, effects, contracts, exhaustiveness |
 | `test_verifier.py` | 68 | 894 | Z3 verification, counterexamples, tier classification, Int→Nat enforcement, call-site preconditions |
 | `test_codegen.py` | 305 | 3,871 | WASM compilation, arithmetic, Float64, Byte, arrays, ADTs, match, generics, closures, State\<T\>, control flow, strings, IO, contracts, bounds checking, length, quantifiers, assert/assume, refinement type aliases, example round-trips |
 | `test_cli.py` | 76 | 932 | CLI commands (check, verify, compile, run), subprocess integration, JSON error paths, runtime traps, arg validation |
@@ -471,7 +471,7 @@ Every diagnostic includes a description (what went wrong), rationale (which lang
 | `test_readme.py` | 2 | 68 | README code sample parsing |
 | `test_errors.py` | 34 | 287 | Diagnostic formatting, serialisation, error patterns, SourceLocation, diagnose_lark_error |
 
-Total: 9,476 lines of test code.
+Total: 9,530 lines of test code.
 
 ### Round-trip testing
 


### PR DESCRIPTION
## Summary

- Strikethrough completed C6.5a row in README roadmap table, replace issue link with linked version tag (v0.0.25) -- matches the pattern used in the C6 table
- Update test count 849 -> 852 across all docs (CLAUDE.md, AGENTS.md, README.md, vera/README.md)
- Update test_checker.py per-file stats in vera/README.md

No code changes. Docs-only fixup to prepare for the v0.0.25 tag.

Generated with [Claude Code](https://claude.com/claude-code)