### PR TITLE
C6.5b: handler with clause for state updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,7 +108,7 @@ Each stage is a module with a single public API function (`parse_file`, `transfo
 ### Testing
 
 ```bash
-pytest tests/ -v                       # Run all tests (852 tests)
+pytest tests/ -v                       # Run all tests (858 tests)
 mypy vera/                             # Type-check the compiler
 python scripts/check_examples.py       # All 14 examples must pass
 ```
@@ -119,7 +119,7 @@ Test helpers follow a pattern: `_check_ok(source)` / `_check_err(source, match)`
 
 - All 14 examples in `examples/` must pass `vera check` and `vera verify`
 - `mypy vera/` must be clean
-- `pytest tests/ -v` must pass (currently 852 tests)
+- `pytest tests/ -v` must pass (currently 858 tests)
 - Version must be in sync across `vera/__init__.py`, `pyproject.toml`, and `CHANGELOG.md`
 
 ### Contributing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 - **Project website** ([veralang.dev](https://veralang.dev)): single-page site deployed via GitHub Pages ([#81](https://github.com/aallan/vera/pull/81))
 
+## [0.0.26] - 2026-02-26
+
+### Added
+- **Handler `with` clause** (C6.5b — closes [#72](https://github.com/aallan/vera/issues/72)): handler operation clauses can now update handler state via `with @T = expr` after the clause body
+  - Grammar: `with_clause` rule added to `handler_clause`
+  - AST: `state_update` field on `HandlerClause`
+  - Type checker: validates state update type matches handler state declaration
+  - No codegen changes (handler clauses remain specifications per spec 11.11.2)
+- 6 new tests: 2 parser, 4 checker (858 total, up from 852)
+
 ## [0.0.25] - 2026-02-26
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ vera parse file.vera              # Print the parse tree
 vera ast file.vera                # Print the typed AST
 vera ast --json file.vera         # Print the AST as JSON
 
-pytest tests/ -v                  # Run the test suite (852 tests)
+pytest tests/ -v                  # Run the test suite (858 tests)
 mypy vera/                        # Type-check the compiler itself
 
 python scripts/check_examples.py      # Verify all 14 examples parse + check + verify

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Before starting the module system, C6.5 addresses residual gaps in single-file c
 | Sub-phase | Scope | Issue |
 |-----------|-------|-------|
 | ~~C6.5a~~ | ~~`resume` not recognized as built-in in handler scope~~ | [v0.0.25](https://github.com/aallan/vera/releases/tag/v0.0.25) |
-| C6.5b | Handler `with` clause for state updates not in grammar | [#72](https://github.com/aallan/vera/issues/72) |
+| ~~C6.5b~~ | ~~Handler `with` clause for state updates not in grammar~~ | [v0.0.26](https://github.com/aallan/vera/releases/tag/v0.0.26) |
 | C6.5c | Pipe operator (`\|>`) compilation | [#44](https://github.com/aallan/vera/issues/44) |
 | C6.5d | Float64 modulo (`%`) — WASM has no `f64.rem` | [#46](https://github.com/aallan/vera/issues/46) |
 | C6.5e | String and Array types in function signatures | [#69](https://github.com/aallan/vera/issues/69) |
@@ -466,7 +466,7 @@ vera/
 │   ├── errors.py                  # LLM-oriented diagnostics
 │   └── cli.py                     # Command-line interface
 ├── examples/                      # 14 example Vera programs
-├── tests/                         # Test suite (852 tests)
+├── tests/                         # Test suite (858 tests)
 ├── scripts/                       # CI and validation scripts
 │   ├── check_examples.py          # Verify all .vera examples
 │   ├── check_spec_examples.py     # Verify spec code blocks parse

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -396,13 +396,20 @@ Handler syntax:
 ```vera
 handle[EffectName<TypeArgs>](@StateType = initial_value) {
   operation(@ParamType) -> { handler_body },
+  operation(@ParamType) -> { handler_body } with @StateType = new_value,
   ...
 } in {
   handled_body
 }
 ```
 
-Use `resume(value)` in a handler clause to continue the handled computation with the given return value.
+Use `resume(value)` in a handler clause to continue the handled computation with the given return value. Optionally update handler state with a `with` clause:
+
+```vera
+put(@Int) -> { resume(()) } with @Int = @Int.0
+```
+
+The `with @T = expr` clause updates the handler's state when resuming. The type must match the handler's state type declaration.
 
 ### Qualified operation calls
 

--- a/examples/effect_handler.vera
+++ b/examples/effect_handler.vera
@@ -19,6 +19,7 @@ fn count_to_three(@Unit -> @Unit)
 
 -- Handle State<Int> to implement a counter
 -- The handle expression discharges the effect: run_counter is pure
+-- The put clause uses 'with' to explicitly update handler state
 fn run_counter(@Unit -> @Int)
   requires(true)
   ensures(true)
@@ -26,7 +27,7 @@ fn run_counter(@Unit -> @Int)
 {
   handle[State<Int>](@Int = 0) {
     get(@Unit) -> { resume(@Int.0) },
-    put(@Int) -> { resume(()) }
+    put(@Int) -> { resume(()) } with @Int = @Int.0
   } in {
     put(0);
     put(get(()) + 1);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.25"
+version = "0.0.26"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/scripts/check_spec_examples.py
+++ b/scripts/check_spec_examples.py
@@ -66,8 +66,8 @@ ALLOWLIST: dict[tuple[str, int], str] = {
 
     # =================================================================
     # FRAGMENT — spec examples using syntax the parser doesn't support
-    # (generics without forall, empty effects, handler with-clauses,
-    # anonymous top-level functions, inline function types in params)
+    # (generics without forall, empty effects, anonymous top-level
+    # functions, inline function types in params)
     # =================================================================
 
     # Chapter 3 — generic functions without forall keyword

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -711,6 +711,69 @@ fn foo(@Unit -> @Unit)
             f"Expected unresolved resume warning, got: " \
             f"{[w.description for w in warns]}"
 
+    def test_with_clause_valid(self) -> None:
+        """Handler with-clause with correct type produces no errors."""
+        _check_ok("""
+fn foo(@Unit -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  handle[State<Int>](@Int = 0) {
+    get(@Unit) -> { resume(@Int.0) },
+    put(@Int) -> { resume(()) } with @Int = @Int.0
+  } in {
+    put(42);
+    get(())
+  }
+}
+""")
+
+    def test_with_clause_type_mismatch(self) -> None:
+        """Handler with-clause value must match state type."""
+        _check_err("""
+fn foo(@Unit -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  handle[State<Int>](@Int = 0) {
+    get(@Unit) -> { resume(@Int.0) },
+    put(@Int) -> { resume(()) } with @Int = true
+  } in {
+    get(())
+  }
+}
+""", "expected Int")
+
+    def test_with_clause_no_state(self) -> None:
+        """Handler with-clause without handler state is an error."""
+        _check_err("""
+effect Exn<E> {
+  op throw(E -> Never);
+}
+fn bar(@Unit -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  handle[Exn<String>] {
+    throw(@String) -> { 0 } with @String = @String.0
+  } in {
+    42
+  }
+}
+""", "no state declaration")
+
+    def test_with_clause_wrong_slot_type(self) -> None:
+        """Handler with-clause type must match handler state type."""
+        _check_err("""
+fn foo(@Unit -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  handle[State<Int>](@Int = 0) {
+    get(@Unit) -> { resume(@Int.0) },
+    put(@Int) -> { resume(()) } with @Bool = true
+  } in {
+    get(())
+  }
+}
+""", "does not match handler state type")
+
     def test_state_effect_builtin(self) -> None:
         """The built-in State<T> effect is available."""
         _check_ok("""

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -740,6 +740,44 @@ class TestHandlerVariations:
         """)
 
 
+    def test_handler_with_clause(self) -> None:
+        """Handler clause with state update parses."""
+        parse("""
+        fn f(@Unit -> @Int)
+          requires(true) ensures(true) effects(pure)
+        {
+          handle[State<Int>](@Int = 0) {
+            get(@Unit) -> { resume(@Int.0) },
+            put(@Int) -> { resume(()) } with @Int = @Int.0
+          } in {
+            get(())
+          }
+        }
+        """)
+
+    def test_handler_with_clause_ast(self) -> None:
+        """Handler with-clause populates state_update on HandlerClause."""
+        from vera.parser import parse_to_ast
+        prog = parse_to_ast("""
+fn f(@Unit -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  handle[State<Int>](@Int = 0) {
+    get(@Unit) -> { resume(@Int.0) },
+    put(@Int) -> { resume(()) } with @Int = @Int.0
+  } in {
+    get(())
+  }
+}
+""")
+        fn = prog.declarations[0].decl
+        clauses = fn.body.expr.clauses
+        assert clauses[0].state_update is None
+        assert clauses[1].state_update is not None
+        upd_te, upd_expr = clauses[1].state_update
+        assert upd_te.name == "Int"
+
+
 class TestImpliesOperator:
     def test_implies_in_contract(self) -> None:
         parse("""

--- a/vera/README.md
+++ b/vera/README.md
@@ -454,15 +454,15 @@ Every diagnostic includes a description (what went wrong), rationale (which lang
 
 ## Test Suite
 
-**852 tests** across 10 files, plus 4 validation scripts and CI infrastructure.
+**858 tests** across 10 files, plus 4 validation scripts and CI infrastructure.
 
 ### Test files
 
 | File | Tests | Lines | What it covers |
 |------|------:|------:|----------------|
-| `test_parser.py` | 95 | 791 | Grammar rules, operator precedence, parse errors |
+| `test_parser.py` | 97 | 829 | Grammar rules, operator precedence, parse errors |
 | `test_ast.py` | 84 | 896 | AST transformation, node structure, serialisation |
-| `test_checker.py` | 111 | 1,257 | Type synthesis, slot resolution, effects, contracts, exhaustiveness |
+| `test_checker.py` | 115 | 1,320 | Type synthesis, slot resolution, effects, contracts, exhaustiveness |
 | `test_verifier.py` | 68 | 894 | Z3 verification, counterexamples, tier classification, Int→Nat enforcement, call-site preconditions |
 | `test_codegen.py` | 305 | 3,871 | WASM compilation, arithmetic, Float64, Byte, arrays, ADTs, match, generics, closures, State\<T\>, control flow, strings, IO, contracts, bounds checking, length, quantifiers, assert/assume, refinement type aliases, example round-trips |
 | `test_cli.py` | 76 | 932 | CLI commands (check, verify, compile, run), subprocess integration, JSON error paths, runtime traps, arg validation |
@@ -471,7 +471,7 @@ Every diagnostic includes a description (what went wrong), rationale (which lang
 | `test_readme.py` | 2 | 68 | README code sample parsing |
 | `test_errors.py` | 34 | 287 | Diagnostic formatting, serialisation, error patterns, SourceLocation, diagnose_lark_error |
 
-Total: 9,530 lines of test code.
+Total: 9,631 lines of test code.
 
 ### Round-trip testing
 

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.25"
+__version__ = "0.0.26"

--- a/vera/ast.py
+++ b/vera/ast.py
@@ -459,10 +459,18 @@ class HandlerState(Node):
 
 @dataclass(frozen=True)
 class HandlerClause(Node):
-    """Handler operation clause: op_name(params) -> body."""
+    """Handler operation clause: op_name(params) -> body [with @T = expr]."""
     op_name: str
     params: tuple[TypeExpr, ...]
     body: Expr
+    state_update: tuple[TypeExpr, Expr] | None = None
+
+
+@dataclass(frozen=True)
+class _WithClause:
+    """Internal sentinel for transformer: carries parsed with-clause data."""
+    type_expr: TypeExpr
+    init_expr: Expr
 
 
 # -- Contract expressions --

--- a/vera/checker.py
+++ b/vera/checker.py
@@ -1464,6 +1464,12 @@ class TypeChecker:
                         f"{pretty_type(state_type)}.",
                     )
 
+        # Compute handler state canonical type name (for with-clause checks)
+        state_tname_outer: str | None = None
+        if state_type and expr.state:
+            state_tname_outer = self._type_expr_to_slot_name(
+                expr.state.type_expr)
+
         # Check handler clauses
         for clause in expr.clauses:
             op_info = eff_info.operations.get(clause.op_name)
@@ -1502,6 +1508,35 @@ class TypeChecker:
             )
 
             self._synth_expr(clause.body)
+
+            # Type-check with clause (state update) if present
+            if clause.state_update is not None:
+                upd_te, upd_expr = clause.state_update
+                if state_type is None:
+                    self._error(
+                        clause,
+                        "Handler clause has 'with' state update but "
+                        "handler has no state declaration.",
+                    )
+                else:
+                    upd_slot = self._type_expr_to_slot_name(upd_te)
+                    if upd_slot != state_tname_outer:
+                        self._error(
+                            clause,
+                            f"State update type '{upd_slot}' does not "
+                            f"match handler state type "
+                            f"'{state_tname_outer}'.",
+                        )
+                    upd_type = self._synth_expr(upd_expr)
+                    if (upd_type and state_type
+                            and not isinstance(upd_type, UnknownType)
+                            and not is_subtype(upd_type, state_type)):
+                        self._error(
+                            upd_expr,
+                            f"State update expression has type "
+                            f"{pretty_type(upd_type)}, expected "
+                            f"{pretty_type(state_type)}.",
+                        )
 
             # Restore previous resume binding (if any)
             if saved_resume is not None:

--- a/vera/grammar.lark
+++ b/vera/grammar.lark
@@ -274,12 +274,14 @@ handle_expr: "handle" "[" effect_ref "]" handler_state? "{" handler_clause ("," 
 
 handler_state: "(" "@" type_expr "=" expr ")"
 
-handler_clause: LOWER_IDENT "(" handler_params? ")" "->" handler_body
+handler_clause: LOWER_IDENT "(" handler_params? ")" "->" handler_body with_clause?
 
 handler_params: "@" type_expr ("," "@" type_expr)*
 
 // handler_body is just an expr — block_expr is already reachable via expr
 ?handler_body: expr
+
+with_clause: "with" "@" type_expr "=" expr
 
 // =====================================================================
 // Array Literals

--- a/vera/transform.py
+++ b/vera/transform.py
@@ -88,6 +88,7 @@ from vera.ast import (
     _TupleDestruct,
     _TypeParams,
     _WhereFns,
+    _WithClause,
 )
 from vera.errors import Diagnostic, SourceLocation, TransformError
 
@@ -815,8 +816,13 @@ class VeraTransformer(Transformer):
 
     @v_args(meta=True)
     def handler_clause(self, meta, children):
-        # children: [str, tuple[TypeExpr, ...]?, Expr]
+        # children: [str, tuple[TypeExpr, ...]?, Expr, _WithClause?]
         name = children[0]
+        state_update = None
+        if isinstance(children[-1], _WithClause):
+            wc = children[-1]
+            state_update = (wc.type_expr, wc.init_expr)
+            children = children[:-1]
         if len(children) == 3:
             params = children[1]
             body = children[2]
@@ -825,8 +831,12 @@ class VeraTransformer(Transformer):
             body = children[1]
         return HandlerClause(
             op_name=name, params=params, body=body,
-            span=_span_from_meta(meta),
+            state_update=state_update, span=_span_from_meta(meta),
         )
+
+    def with_clause(self, children):
+        # children: [TypeExpr, Expr]
+        return _WithClause(type_expr=children[0], init_expr=children[1])
 
     def handler_params(self, children):
         return tuple(children)


### PR DESCRIPTION
## Summary

- Adds `resume(expr) with @T = expr` syntax for updating handler state in operation clauses
- Grammar, AST, transformer, and type checker all updated; no codegen changes needed (handler clauses are specifications per spec 11.11.2)
- Type checker validates: state update type matches handler state, update expression type matches, `with` without state declaration is an error

Closes #72

## Changes

| File | Change |
|------|--------|
| `vera/grammar.lark` | Add `with_clause` rule, optional in `handler_clause` |
| `vera/ast.py` | Add `state_update` field to `HandlerClause`, `_WithClause` sentinel |
| `vera/transform.py` | Add `with_clause` method, update `handler_clause` extraction |
| `vera/checker.py` | Validate `with` clause type + value in handler clause loop |
| `tests/test_parser.py` | 2 new tests (parse + AST verification) |
| `tests/test_checker.py` | 4 new tests (valid, type mismatch, no state, wrong slot type) |
| `examples/effect_handler.vera` | Add `with` clause to `put` handler |
| `SKILLS.md` | Document `with` clause syntax |
| Docs | CHANGELOG v0.0.26, README roadmap, test counts (858) |

## Test plan

- [x] `pytest tests/ -v` -- 858 passed (up from 852)
- [x] `mypy vera/` -- clean
- [x] All 14 examples pass check + verify
- [x] All validation scripts pass
- [x] v0.0.26 tagged on branch

Generated with [Claude Code](https://claude.com/claude-code)