### PR TITLE
docs: website copy tweaks and reference links

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -467,8 +467,8 @@
     <div class="container">
       <h2 class="section-heading">Why?</h2>
       <p>Programming languages have always co-evolved with their users. Assembly emerged from hardware constraints. C from operating system needs. Python from productivity needs. If models become the primary authors of software, it follows that languages should adapt to that.</p>
-      <p>The biggest problem models face isn't syntax — it's <strong>coherence over scale</strong>. Models struggle with maintaining invariants across a codebase, understanding the ripple effects of changes, and reasoning about state over time. They're pattern matchers optimising for local plausibility, not architects holding the entire system in mind.</p>
-      <p>Vera addresses this by making everything explicit and verifiable. The model doesn't need to be right — it needs to be <strong>checkable</strong>.</p>
+      <p>The biggest problem models face isn't syntax it's coherence over scale. Models struggle with maintaining invariants across a codebase, understanding the ripple effects of changes, and reasoning about state over time. They're pattern matchers optimising for local plausibility, not architects holding the entire system in mind.</p>
+      <p>Vera addresses this by making everything explicit and verifiable. The model doesn't need to be right, it just needs to be checkable.</p>
     </div>
   </section>
 
@@ -520,7 +520,7 @@
           <div class="feature-marker"></div>
           <div>
             <div class="feature-title">No variable names</div>
-            <div class="feature-desc">Typed De Bruijn indices (<code>@T.n</code>) replace traditional variable names</div>
+            <div class="feature-desc">Typed <a href="https://en.wikipedia.org/wiki/De_Bruijn_index">De Bruijn indices</a> (<code>@T.n</code>) replace traditional variable names</div>
           </div>
         </div>
         <div class="feature">
@@ -548,7 +548,7 @@
           <div class="feature-marker"></div>
           <div>
             <div class="feature-title">Three-tier verification</div>
-            <div class="feature-desc">Static verification via Z3, guided verification with hints, runtime fallback</div>
+            <div class="feature-desc">Static verification via <a href="https://www.microsoft.com/en-us/research/project/z3-3/">Z3</a>, guided verification with hints, runtime fallback</div>
           </div>
         </div>
         <div class="feature">


### PR DESCRIPTION
Minor text refinements to veralang.dev:

- Simplify punctuation in "Why?" section
- Link "De Bruijn indices" to Wikipedia
- Link "Z3" to Microsoft Research project page

Generated with [Claude Code](https://claude.com/claude-code)