### PR TITLE
C6.5c: pipe operator compilation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,7 +108,7 @@ Each stage is a module with a single public API function (`parse_file`, `transfo
 ### Testing
 
 ```bash
-pytest tests/ -v                       # Run all tests (858 tests)
+pytest tests/ -v                       # Run all tests (862 tests)
 mypy vera/                             # Type-check the compiler
 python scripts/check_examples.py       # All 14 examples must pass
 ```
@@ -119,7 +119,7 @@ Test helpers follow a pattern: `_check_ok(source)` / `_check_err(source, match)`
 
 - All 14 examples in `examples/` must pass `vera check` and `vera verify`
 - `mypy vera/` must be clean
-- `pytest tests/ -v` must pass (currently 858 tests)
+- `pytest tests/ -v` must pass (currently 862 tests)
 - Version must be in sync across `vera/__init__.py`, `pyproject.toml`, and `CHANGELOG.md`
 
 ### Contributing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 - **Project website** ([veralang.dev](https://veralang.dev)): single-page site deployed via GitHub Pages ([#81](https://github.com/aallan/vera/pull/81))
 
+## [0.0.27] - 2026-02-26
+
+### Added
+- **Pipe operator compilation** (C6.5c — closes [#44](https://github.com/aallan/vera/issues/44)): `a |> f(x, y)` now compiles to WASM and verifies via Z3, desugaring to `f(a, x, y)` in both backends
+  - WASM codegen: intercept `BinOp.PIPE` in `_translate_binary()`, construct synthetic `FnCall`, delegate to `_translate_call()`
+  - SMT verifier: same desugaring pattern in `_translate_binary()`
+  - No grammar, AST, transformer, or checker changes needed (pipe already parsed and type-checked)
+- 4 new tests: 3 codegen, 1 verifier (862 total, up from 858)
+
 ## [0.0.26] - 2026-02-26
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ vera parse file.vera              # Print the parse tree
 vera ast file.vera                # Print the typed AST
 vera ast --json file.vera         # Print the AST as JSON
 
-pytest tests/ -v                  # Run the test suite (858 tests)
+pytest tests/ -v                  # Run the test suite (862 tests)
 mypy vera/                        # Type-check the compiler itself
 
 python scripts/check_examples.py      # Verify all 14 examples parse + check + verify

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Before starting the module system, C6.5 addresses residual gaps in single-file c
 |-----------|-------|-------|
 | ~~C6.5a~~ | ~~`resume` not recognized as built-in in handler scope~~ | [v0.0.25](https://github.com/aallan/vera/releases/tag/v0.0.25) |
 | ~~C6.5b~~ | ~~Handler `with` clause for state updates not in grammar~~ | [v0.0.26](https://github.com/aallan/vera/releases/tag/v0.0.26) |
-| C6.5c | Pipe operator (`\|>`) compilation | [#44](https://github.com/aallan/vera/issues/44) |
+| ~~C6.5c~~ | ~~Pipe operator (`\|>`) compilation~~ | [v0.0.27](https://github.com/aallan/vera/releases/tag/v0.0.27) |
 | C6.5d | Float64 modulo (`%`) — WASM has no `f64.rem` | [#46](https://github.com/aallan/vera/issues/46) |
 | C6.5e | String and Array types in function signatures | [#69](https://github.com/aallan/vera/issues/69) |
 | C6.5f | `old()`/`new()` state expressions in contracts | [#70](https://github.com/aallan/vera/issues/70) |
@@ -466,7 +466,7 @@ vera/
 │   ├── errors.py                  # LLM-oriented diagnostics
 │   └── cli.py                     # Command-line interface
 ├── examples/                      # 14 example Vera programs
-├── tests/                         # Test suite (858 tests)
+├── tests/                         # Test suite (862 tests)
 ├── scripts/                       # CI and validation scripts
 │   ├── check_examples.py          # Verify all .vera examples
 │   ├── check_spec_examples.py     # Verify spec code blocks parse

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.26"
+version = "0.0.27"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -753,6 +753,51 @@ fn fib(@Nat -> @Nat)
 
 
 # =====================================================================
+# 5d-pipe: Pipe operator compilation
+# =====================================================================
+
+
+class TestPipeOperator:
+    """Pipe operator |> desugars to function call in codegen."""
+
+    def test_pipe_basic(self) -> None:
+        source = """\
+fn inc(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 + 1 }
+
+fn main(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 |> inc() }
+"""
+        assert _run(source, fn="main", args=[42]) == 43
+
+    def test_pipe_chain(self) -> None:
+        source = """\
+fn inc(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 + 1 }
+
+fn main(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 |> inc() |> inc() }
+"""
+        assert _run(source, fn="main", args=[10]) == 12
+
+    def test_pipe_multi_arg(self) -> None:
+        source = """\
+fn add(@Int, @Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 + @Int.1 }
+
+fn main(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 |> add(10) }
+"""
+        assert _run(source, fn="main", args=[42]) == 52
+
+
+# =====================================================================
 # 5e: String literals + IO host bindings
 # =====================================================================
 

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -892,3 +892,27 @@ fn bad(@Int -> @Int)
 """, "precondition")
         # Check that the error mentions the callee name
         assert any("non_zero" in e.description for e in errors)
+
+
+# =====================================================================
+# Pipe operator verification
+# =====================================================================
+
+class TestPipeVerification:
+    """Pipe operator desugars correctly in SMT translation."""
+
+    def test_pipe_verifies(self) -> None:
+        """Pipe expression in verified function."""
+        _verify_ok("""
+fn inc(@Int -> @Int)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{ @Int.0 + 1 }
+
+fn main(@Int -> @Int)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{ @Int.0 |> inc() }
+""")

--- a/vera/README.md
+++ b/vera/README.md
@@ -454,7 +454,7 @@ Every diagnostic includes a description (what went wrong), rationale (which lang
 
 ## Test Suite
 
-**858 tests** across 10 files, plus 4 validation scripts and CI infrastructure.
+**862 tests** across 10 files, plus 4 validation scripts and CI infrastructure.
 
 ### Test files
 
@@ -463,15 +463,15 @@ Every diagnostic includes a description (what went wrong), rationale (which lang
 | `test_parser.py` | 97 | 829 | Grammar rules, operator precedence, parse errors |
 | `test_ast.py` | 84 | 896 | AST transformation, node structure, serialisation |
 | `test_checker.py` | 115 | 1,320 | Type synthesis, slot resolution, effects, contracts, exhaustiveness |
-| `test_verifier.py` | 68 | 894 | Z3 verification, counterexamples, tier classification, Int→Nat enforcement, call-site preconditions |
-| `test_codegen.py` | 305 | 3,871 | WASM compilation, arithmetic, Float64, Byte, arrays, ADTs, match, generics, closures, State\<T\>, control flow, strings, IO, contracts, bounds checking, length, quantifiers, assert/assume, refinement type aliases, example round-trips |
+| `test_verifier.py` | 69 | 918 | Z3 verification, counterexamples, tier classification, Int→Nat enforcement, call-site preconditions, pipe operator |
+| `test_codegen.py` | 308 | 3,916 | WASM compilation, arithmetic, Float64, Byte, arrays, ADTs, match, generics, closures, State\<T\>, control flow, strings, IO, contracts, bounds checking, length, quantifiers, assert/assume, refinement type aliases, pipe operator, example round-trips |
 | `test_cli.py` | 76 | 932 | CLI commands (check, verify, compile, run), subprocess integration, JSON error paths, runtime traps, arg validation |
 | `test_types.py` | 55 | 279 | Type operations: subtyping, equality, substitution, pretty-printing, canonical names |
 | `test_wasm.py` | 22 | 255 | WASM internals: StringPool, WasmSlotEnv, translation edge cases via full pipeline |
 | `test_readme.py` | 2 | 68 | README code sample parsing |
 | `test_errors.py` | 34 | 287 | Diagnostic formatting, serialisation, error patterns, SourceLocation, diagnose_lark_error |
 
-Total: 9,631 lines of test code.
+Total: 9,700 lines of test code.
 
 ### Round-trip testing
 

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.26"
+__version__ = "0.0.27"

--- a/vera/smt.py
+++ b/vera/smt.py
@@ -222,6 +222,17 @@ class SmtContext:
         self, expr: ast.BinaryExpr, env: SlotEnv
     ) -> z3.ExprRef | None:
         """Translate binary operators."""
+        # Pipe: a |> f(x, y) → f(a, x, y)
+        if expr.op == ast.BinOp.PIPE:
+            if isinstance(expr.right, ast.FnCall):
+                desugared = ast.FnCall(
+                    name=expr.right.name,
+                    args=(expr.left,) + expr.right.args,
+                    span=expr.span,
+                )
+                return self._translate_call(desugared, env)
+            return None  # non-FnCall RHS — unsupported
+
         left = self.translate_expr(expr.left, env)
         right = self.translate_expr(expr.right, env)
         if left is None or right is None:
@@ -262,7 +273,6 @@ class SmtContext:
         if op == ast.BinOp.IMPLIES:
             return z3.Implies(left, right)
 
-        # Pipe — unsupported in verification context
         return None
 
     def _translate_unary(

--- a/vera/wasm.py
+++ b/vera/wasm.py
@@ -473,6 +473,17 @@ class WasmContext:
         self, expr: ast.BinaryExpr, env: WasmSlotEnv
     ) -> list[str] | None:
         """Translate binary operators to WAT."""
+        # Pipe: a |> f(x, y) → f(a, x, y)
+        if expr.op == ast.BinOp.PIPE:
+            if isinstance(expr.right, ast.FnCall):
+                desugared = ast.FnCall(
+                    name=expr.right.name,
+                    args=(expr.left,) + expr.right.args,
+                    span=expr.span,
+                )
+                return self._translate_call(desugared, env)
+            return None  # non-FnCall RHS — unsupported
+
         left = self.translate_expr(expr.left, env)
         right = self.translate_expr(expr.right, env)
         if left is None or right is None:
@@ -517,7 +528,6 @@ class WasmContext:
         if op == ast.BinOp.IMPLIES:
             return left + ["i32.eqz"] + right + ["i32.or"]
 
-        # Pipe — unsupported
         return None
 
     def _infer_expr_wasm_type(self, expr: ast.Expr) -> str | None:


### PR DESCRIPTION
## Summary

- Desugar `a |> f(x, y)` to `f(a, x, y)` in both WASM codegen and Z3 verification backends, matching the existing checker desugaring
- Intercept `BinOp.PIPE` at the top of `_translate_binary()` before eager left/right translation, construct a synthetic `FnCall` with the left operand prepended, and delegate to the existing `_translate_call()`
- No grammar, AST, transformer, or checker changes needed (pipe already parsed and type-checked)

Closes #44

## Changes

| File | What changed |
|------|-------------|
| `vera/wasm.py` | Pipe desugaring in `_translate_binary()` (~8 lines) |
| `vera/smt.py` | Same desugaring pattern (~8 lines) |
| `tests/test_codegen.py` | 3 new tests: basic, chain, multi-arg |
| `tests/test_verifier.py` | 1 new test: pipe verifies |
| Docs | CHANGELOG, README roadmap, test counts (858 to 862), version bump to 0.0.27 |

## Test plan

- [x] 862 tests pass (`pytest tests/ -v`)
- [x] mypy clean (`mypy vera/`)
- [x] All 14 examples pass (`python scripts/check_examples.py`)
- [x] Version sync check passes
- [x] Pre-commit hooks pass
- [x] Tagged v0.0.27 on branch

Generated with [Claude Code](https://claude.com/claude-code)