### PR TITLE
C6.5d: float64 modulo compilation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,7 +108,7 @@ Each stage is a module with a single public API function (`parse_file`, `transfo
 ### Testing
 
 ```bash
-pytest tests/ -v                       # Run all tests (862 tests)
+pytest tests/ -v                       # Run all tests (866 tests)
 mypy vera/                             # Type-check the compiler
 python scripts/check_examples.py       # All 14 examples must pass
 ```
@@ -119,7 +119,7 @@ Test helpers follow a pattern: `_check_ok(source)` / `_check_err(source, match)`
 
 - All 14 examples in `examples/` must pass `vera check` and `vera verify`
 - `mypy vera/` must be clean
-- `pytest tests/ -v` must pass (currently 862 tests)
+- `pytest tests/ -v` must pass (currently 866 tests)
 - Version must be in sync across `vera/__init__.py`, `pyproject.toml`, and `CHANGELOG.md`
 
 ### Contributing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 - **Project website** ([veralang.dev](https://veralang.dev)): single-page site deployed via GitHub Pages ([#81](https://github.com/aallan/vera/pull/81))
 
+## [0.0.28] - 2026-02-26
+
+### Added
+- **Float64 modulo compilation** (C6.5d — closes [#46](https://github.com/aallan/vera/issues/46)): `%` on Float64 operands now compiles to WASM via the decomposition `a % b = a - trunc(a / b) * b`
+  - Uses `f64.trunc` (truncation toward zero), matching C `fmod` semantics and consistent with `i64.rem_s` for integer modulo
+  - Multi-instruction WAT sequence with temporary locals (same pattern as array indexing, closures)
+  - WASM has no native `f64.rem` instruction; this was previously unsupported (function silently skipped)
+- 4 new codegen tests: exact division, remainder, negative operand, parameterized (866 total, up from 862)
+
 ## [0.0.27] - 2026-02-26
 
 ### Added
@@ -421,7 +430,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Grammar: handler body simplified to avoid LALR reduce/reduce conflict
 - `pyproject.toml`: corrected build backend, package discovery, PEP 639 compliance
 
-[Unreleased]: https://github.com/aallan/vera/compare/v0.0.27...HEAD
+[Unreleased]: https://github.com/aallan/vera/compare/v0.0.28...HEAD
+[0.0.28]: https://github.com/aallan/vera/compare/v0.0.27...v0.0.28
 [0.0.27]: https://github.com/aallan/vera/compare/v0.0.26...v0.0.27
 [0.0.26]: https://github.com/aallan/vera/compare/v0.0.25...v0.0.26
 [0.0.25]: https://github.com/aallan/vera/compare/v0.0.24...v0.0.25

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ vera parse file.vera              # Print the parse tree
 vera ast file.vera                # Print the typed AST
 vera ast --json file.vera         # Print the AST as JSON
 
-pytest tests/ -v                  # Run the test suite (862 tests)
+pytest tests/ -v                  # Run the test suite (866 tests)
 mypy vera/                        # Type-check the compiler itself
 
 python scripts/check_examples.py      # Verify all 14 examples parse + check + verify

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Before starting the module system, C6.5 addresses residual gaps in single-file c
 | ~~C6.5a~~ | ~~`resume` not recognized as built-in in handler scope~~ | [v0.0.25](https://github.com/aallan/vera/releases/tag/v0.0.25) |
 | ~~C6.5b~~ | ~~Handler `with` clause for state updates not in grammar~~ | [v0.0.26](https://github.com/aallan/vera/releases/tag/v0.0.26) |
 | ~~C6.5c~~ | ~~Pipe operator (`\|>`) compilation~~ | [v0.0.27](https://github.com/aallan/vera/releases/tag/v0.0.27) |
-| C6.5d | Float64 modulo (`%`) — WASM has no `f64.rem` | [#46](https://github.com/aallan/vera/issues/46) |
+| ~~C6.5d~~ | ~~Float64 modulo (`%`) — WASM has no `f64.rem`~~ | [v0.0.28](https://github.com/aallan/vera/releases/tag/v0.0.28) |
 | C6.5e | String and Array types in function signatures | [#69](https://github.com/aallan/vera/issues/69) |
 | C6.5f | `old()`/`new()` state expressions in contracts | [#70](https://github.com/aallan/vera/issues/70) |
 
@@ -466,7 +466,7 @@ vera/
 │   ├── errors.py                  # LLM-oriented diagnostics
 │   └── cli.py                     # Command-line interface
 ├── examples/                      # 14 example Vera programs
-├── tests/                         # Test suite (862 tests)
+├── tests/                         # Test suite (866 tests)
 ├── scripts/                       # CI and validation scripts
 │   ├── check_examples.py          # Verify all .vera examples
 │   ├── check_spec_examples.py     # Verify spec code blocks parse

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.27"
+version = "0.0.28"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/spec/11-compilation.md
+++ b/spec/11-compilation.md
@@ -80,7 +80,7 @@ Binary operators compile to their WASM equivalents:
 | `-` | `i64.sub` | `f64.sub` | — |
 | `*` | `i64.mul` | `f64.mul` | — |
 | `/` | `i64.div_s` | `f64.div` | — |
-| `%` | `i64.rem_s` | *(unsupported)* | — |
+| `%` | `i64.rem_s` | `a - trunc(a/b) * b` | — |
 | `==` | `i64.eq` | `f64.eq` | `i32.eq` |
 | `!=` | `i64.ne` | `f64.ne` | `i32.ne` |
 | `<` | `i64.lt_s` | `f64.lt` | `i32.lt_s` |
@@ -89,6 +89,8 @@ Binary operators compile to their WASM equivalents:
 | `>=` | `i64.ge_s` | `f64.ge` | `i32.ge_s` |
 | `&&` | — | — | `i32.and` |
 | `\|\|` | — | — | `i32.or` |
+
+Float64 modulo uses the decomposition `a % b = a - trunc(a / b) * b`, where `trunc` is `f64.trunc` (truncation toward zero). This matches C's `fmod` semantics and is consistent with integer `%` (which uses `i64.rem_s`, also truncated toward zero). WASM has no native `f64.rem` instruction, so the compiler emits a multi-instruction sequence using temporary locals.
 
 Float64 comparisons return `i32` (0 or 1), matching WASM's native comparison semantics.
 

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -209,6 +209,38 @@ class TestFloatArithmetic:
             "{ (1.0 + 2.0) * 3.0 }"
         ) == 9.0
 
+    def test_mod(self) -> None:
+        """7.5 % 2.5 = 0.0 (exact division)."""
+        assert _run_float(
+            "fn f(-> @Float64) requires(true) ensures(true) effects(pure) "
+            "{ 7.5 % 2.5 }"
+        ) == 0.0
+
+    def test_mod_remainder(self) -> None:
+        """10.0 % 3.0 = 1.0."""
+        assert _run_float(
+            "fn f(-> @Float64) requires(true) ensures(true) effects(pure) "
+            "{ 10.0 % 3.0 }"
+        ) == 1.0
+
+    def test_mod_negative(self) -> None:
+        """-7.0 % 3.0 = -1.0 (truncation toward zero, matching fmod)."""
+        assert _run_float(
+            "fn f(-> @Float64) requires(true) ensures(true) effects(pure) "
+            "{ -7.0 % 3.0 }"
+        ) == -1.0
+
+    def test_mod_with_params(self) -> None:
+        """Float mod with slot-ref operands (not just literals)."""
+        source = (
+            "fn fmod(@Float64, @Float64 -> @Float64) requires(true) "
+            "ensures(true) effects(pure) { @Float64.1 % @Float64.0 }"
+        )
+        result = _compile_ok(source)
+        # @Float64.1 = first arg (10.0), @Float64.0 = second arg (3.0)
+        exec_result = execute(result, fn_name="fmod", args=[10.0, 3.0])
+        assert exec_result.value == 1.0
+
 
 class TestFloatComparison:
     def test_eq_true(self) -> None:

--- a/tests/test_wasm.py
+++ b/tests/test_wasm.py
@@ -165,8 +165,8 @@ fn hello(@Unit -> @Unit)
         result = _compile_ok(source)
         assert b"hello world" in result.wasm_bytes
 
-    def test_float_mod_skipped(self) -> None:
-        """Float MOD is unsupported — function should be skipped."""
+    def test_float_mod_compiles(self) -> None:
+        """Float MOD compiles to f64 instruction sequence (not skipped)."""
         source = """\
 fn fmod(@Float64, @Float64 -> @Float64)
   requires(true) ensures(true) effects(pure)
@@ -174,9 +174,9 @@ fn fmod(@Float64, @Float64 -> @Float64)
   @Float64.1 % @Float64.0
 }
 """
-        result = _compile(source)
-        # Function should be skipped (WASM has no f64.rem)
-        assert "fmod" not in (result.exports or [])
+        result = _compile_ok(source)
+        assert "fmod" in (result.exports or [])
+        assert "f64.trunc" in result.wat
 
     def test_call_helper_function(self) -> None:
         """Calling a helper function compiles correctly."""

--- a/vera/README.md
+++ b/vera/README.md
@@ -454,7 +454,7 @@ Every diagnostic includes a description (what went wrong), rationale (which lang
 
 ## Test Suite
 
-**862 tests** across 10 files, plus 4 validation scripts and CI infrastructure.
+**866 tests** across 10 files, plus 4 validation scripts and CI infrastructure.
 
 ### Test files
 
@@ -464,14 +464,14 @@ Every diagnostic includes a description (what went wrong), rationale (which lang
 | `test_ast.py` | 84 | 896 | AST transformation, node structure, serialisation |
 | `test_checker.py` | 115 | 1,320 | Type synthesis, slot resolution, effects, contracts, exhaustiveness |
 | `test_verifier.py` | 69 | 918 | Z3 verification, counterexamples, tier classification, Int→Nat enforcement, call-site preconditions, pipe operator |
-| `test_codegen.py` | 308 | 3,916 | WASM compilation, arithmetic, Float64, Byte, arrays, ADTs, match, generics, closures, State\<T\>, control flow, strings, IO, contracts, bounds checking, length, quantifiers, assert/assume, refinement type aliases, pipe operator, example round-trips |
+| `test_codegen.py` | 312 | 3,948 | WASM compilation, arithmetic, Float64 (incl. modulo), Byte, arrays, ADTs, match, generics, closures, State\<T\>, control flow, strings, IO, contracts, bounds checking, length, quantifiers, assert/assume, refinement type aliases, pipe operator, example round-trips |
 | `test_cli.py` | 76 | 932 | CLI commands (check, verify, compile, run), subprocess integration, JSON error paths, runtime traps, arg validation |
 | `test_types.py` | 55 | 279 | Type operations: subtyping, equality, substitution, pretty-printing, canonical names |
 | `test_wasm.py` | 22 | 255 | WASM internals: StringPool, WasmSlotEnv, translation edge cases via full pipeline |
 | `test_readme.py` | 2 | 68 | README code sample parsing |
 | `test_errors.py` | 34 | 287 | Diagnostic formatting, serialisation, error patterns, SourceLocation, diagnose_lark_error |
 
-Total: 9,700 lines of test code.
+Total: 9,732 lines of test code.
 
 ### Round-trip testing
 

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.27"
+__version__ = "0.0.28"

--- a/vera/wasm.py
+++ b/vera/wasm.py
@@ -446,7 +446,7 @@ class WasmContext:
         ast.BinOp.SUB: "f64.sub",
         ast.BinOp.MUL: "f64.mul",
         ast.BinOp.DIV: "f64.div",
-        # MOD: WASM has no f64.rem — unsupported for floats
+        # MOD: handled by _translate_f64_mod() — WASM has no f64.rem
     }
 
     # Comparison: i64 → i32 (default)
@@ -495,8 +495,10 @@ class WasmContext:
         # Arithmetic
         if op in self._ARITH_OPS:
             if ltype == "f64":
+                if op == ast.BinOp.MOD:
+                    return self._translate_f64_mod(left, right)
                 if op not in self._ARITH_OPS_F64:
-                    return None  # MOD unsupported for f64
+                    return None  # unsupported float op
                 return left + right + [self._ARITH_OPS_F64[op]]
             return left + right + [self._ARITH_OPS[op]]
 
@@ -529,6 +531,32 @@ class WasmContext:
             return left + ["i32.eqz"] + right + ["i32.or"]
 
         return None
+
+    def _translate_f64_mod(
+        self, left: list[str], right: list[str]
+    ) -> list[str]:
+        """Translate f64 modulo: a % b = a - trunc(a / b) * b.
+
+        WASM has no f64.rem instruction, so we decompose using
+        f64.trunc (truncation toward zero), matching C fmod semantics
+        and consistent with i64.rem_s for integer modulo.
+        """
+        tmp_a = self.alloc_local("f64")
+        tmp_b = self.alloc_local("f64")
+        return [
+            *left,
+            f"local.set {tmp_a}",
+            *right,
+            f"local.set {tmp_b}",
+            f"local.get {tmp_a}",          # a
+            f"local.get {tmp_a}",          # a  (for a / b)
+            f"local.get {tmp_b}",          # b  (for a / b)
+            "f64.div",                      # a / b
+            "f64.trunc",                    # trunc(a / b)
+            f"local.get {tmp_b}",          # b  (for * b)
+            "f64.mul",                      # trunc(a / b) * b
+            "f64.sub",                      # a - trunc(a / b) * b
+        ]
 
     def _infer_expr_wasm_type(self, expr: ast.Expr) -> str | None:
         """Infer the WAT result type of an expression.


### PR DESCRIPTION
## Summary

- Compile `%` on Float64 operands to WASM via `a % b = a - trunc(a / b) * b`
- Uses `f64.trunc` (truncation toward zero), matching C `fmod` semantics and consistent with `i64.rem_s` for integer modulo
- WASM has no native `f64.rem` instruction; previously `%` on floats caused the function to be silently skipped

Closes #46

## Changes

| File | What changed |
|------|-------------|
| `vera/wasm.py` | `_translate_f64_mod()` helper + dispatch in `_translate_binary()` |
| `tests/test_wasm.py` | `test_float_mod_skipped` renamed to `test_float_mod_compiles` |
| `tests/test_codegen.py` | 4 new tests: exact division, remainder, negative operand, parameterized |
| `spec/11-compilation.md` | Updated operator table + added explanatory note |
| Docs | CHANGELOG, README roadmap, test counts (862 to 866), version bump to 0.0.28 |

## Test plan

- [x] 866 tests pass (`pytest tests/ -v`)
- [x] mypy clean
- [x] All 14 examples pass
- [x] Version sync check passes
- [x] Spec code blocks pass
- [x] Pre-commit hooks pass
- [x] Tagged v0.0.28 on branch

Generated with [Claude Code](https://claude.com/claude-code)