### PR TITLE
C6.5e: String and Array types in function signatures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,7 +108,7 @@ Each stage is a module with a single public API function (`parse_file`, `transfo
 ### Testing
 
 ```bash
-pytest tests/ -v                       # Run all tests (866 tests)
+pytest tests/ -v                       # Run all tests (874 tests)
 mypy vera/                             # Type-check the compiler
 python scripts/check_examples.py       # All 14 examples must pass
 ```
@@ -119,7 +119,7 @@ Test helpers follow a pattern: `_check_ok(source)` / `_check_err(source, match)`
 
 - All 14 examples in `examples/` must pass `vera check` and `vera verify`
 - `mypy vera/` must be clean
-- `pytest tests/ -v` must pass (currently 866 tests)
+- `pytest tests/ -v` must pass (currently 874 tests)
 - Version must be in sync across `vera/__init__.py`, `pyproject.toml`, and `CHANGELOG.md`
 
 ### Contributing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 - **Project website** ([veralang.dev](https://veralang.dev)): single-page site deployed via GitHub Pages ([#81](https://github.com/aallan/vera/pull/81))
 
+## [0.0.29] - 2026-02-26
+
+### Added
+- **String and Array types in function signatures** (C6.5e — closes [#69](https://github.com/aallan/vera/issues/69)): functions with `String` or `Array<T>` parameters and return types now compile to WASM
+  - Each String/Array parameter expands to two consecutive `i32` WASM parameters (pointer and length)
+  - String/Array return types use WASM multi-value return `(result i32 i32)`
+  - `_type_expr_to_wasm_type()` returns `"i32_pair"` sentinel instead of `"unsupported"` for String/Array
+  - Generalised `_is_pair_type_name()` helper for String and Array<T> across slot refs, let bindings, and drop logic
+  - `execute()` handles multi-value (list) returns from wasmtime
+  - Postcondition checks skipped for pair return types (single-local save/restore pattern incompatible with two-value results)
+  - `if` and `match` blocks emit `(result i32 i32)` for pair-typed branches
+  - Functions previously skipped in `examples/pattern_matching.vera` and `examples/quantifiers.vera` now compile
+- 8 new codegen tests (874 total, up from 866)
+
 ## [0.0.28] - 2026-02-26
 
 ### Added
@@ -430,7 +444,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Grammar: handler body simplified to avoid LALR reduce/reduce conflict
 - `pyproject.toml`: corrected build backend, package discovery, PEP 639 compliance
 
-[Unreleased]: https://github.com/aallan/vera/compare/v0.0.28...HEAD
+[Unreleased]: https://github.com/aallan/vera/compare/v0.0.29...HEAD
+[0.0.29]: https://github.com/aallan/vera/compare/v0.0.28...v0.0.29
 [0.0.28]: https://github.com/aallan/vera/compare/v0.0.27...v0.0.28
 [0.0.27]: https://github.com/aallan/vera/compare/v0.0.26...v0.0.27
 [0.0.26]: https://github.com/aallan/vera/compare/v0.0.25...v0.0.26

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ vera parse file.vera              # Print the parse tree
 vera ast file.vera                # Print the typed AST
 vera ast --json file.vera         # Print the AST as JSON
 
-pytest tests/ -v                  # Run the test suite (866 tests)
+pytest tests/ -v                  # Run the test suite (874 tests)
 mypy vera/                        # Type-check the compiler itself
 
 python scripts/check_examples.py      # Verify all 14 examples parse + check + verify

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Before starting the module system, C6.5 addresses residual gaps in single-file c
 | ~~C6.5b~~ | ~~Handler `with` clause for state updates not in grammar~~ | [v0.0.26](https://github.com/aallan/vera/releases/tag/v0.0.26) |
 | ~~C6.5c~~ | ~~Pipe operator (`\|>`) compilation~~ | [v0.0.27](https://github.com/aallan/vera/releases/tag/v0.0.27) |
 | ~~C6.5d~~ | ~~Float64 modulo (`%`) — WASM has no `f64.rem`~~ | [v0.0.28](https://github.com/aallan/vera/releases/tag/v0.0.28) |
-| C6.5e | String and Array types in function signatures | [#69](https://github.com/aallan/vera/issues/69) |
+| ~~C6.5e~~ | ~~String and Array types in function signatures~~ | [v0.0.29](https://github.com/aallan/vera/releases/tag/v0.0.29) |
 | C6.5f | `old()`/`new()` state expressions in contracts | [#70](https://github.com/aallan/vera/issues/70) |
 
 <details>
@@ -466,7 +466,7 @@ vera/
 │   ├── errors.py                  # LLM-oriented diagnostics
 │   └── cli.py                     # Command-line interface
 ├── examples/                      # 14 example Vera programs
-├── tests/                         # Test suite (866 tests)
+├── tests/                         # Test suite (874 tests)
 ├── scripts/                       # CI and validation scripts
 │   ├── check_examples.py          # Verify all .vera examples
 │   ├── check_spec_examples.py     # Verify spec code blocks parse

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.28"
+version = "0.0.29"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/spec/11-compilation.md
+++ b/spec/11-compilation.md
@@ -37,7 +37,7 @@ Vera types map to WASM value types as follows:
 | ADTs | `i32` | Heap pointer to tagged union (see Section 11.6) |
 | Function types | `i32` | Heap pointer to closure struct (see Section 11.11) |
 
-Generic type variables are resolved via monomorphization — each concrete instantiation of a `forall<T>` function produces a specialized copy with type variables replaced by concrete types (e.g. `identity$Int`). Type aliases are resolved through their definitions: function type aliases (e.g. `type IntToInt = fn(Int -> Int) effects(pure)`) resolve to `i32` closure pointers, and refinement type aliases (e.g. `type PosInt = { @Int | @Int.0 > 0 }`) resolve to their base WASM type (see Section 11.15). Array and String types are compilable within function bodies (as let bindings and expressions) but not yet as function parameters or return types. Functions using non-compilable types in their signatures are skipped with a warning.
+Generic type variables are resolved via monomorphization — each concrete instantiation of a `forall<T>` function produces a specialized copy with type variables replaced by concrete types (e.g. `identity$Int`). Type aliases are resolved through their definitions: function type aliases (e.g. `type IntToInt = fn(Int -> Int) effects(pure)`) resolve to `i32` closure pointers, and refinement type aliases (e.g. `type PosInt = { @Int | @Int.0 > 0 }`) resolve to their base WASM type (see Section 11.15). String and Array types compile to `(i32, i32)` pairs in function signatures — each Vera parameter expands to two WASM parameters (pointer and length), and String/Array return types use WASM multi-value return `(result i32 i32)`. Functions using non-compilable types in their signatures are skipped with a warning.
 
 ### 11.2.1 Nat as i64
 
@@ -475,7 +475,7 @@ A `let @Array<T> = expr` binding allocates two WASM locals (ptr and len) and sto
 
 ### 11.12.6 Scope
 
-Array types are compilable within function bodies (as let bindings, literals, indexing, and `length` calls) but not yet as function parameters or return types. Functions with `Array<T>` in their signatures are skipped with a warning.
+Array and String types are compilable both within function bodies (as let bindings, literals, indexing, and `length` calls) and as function parameters and return types. Each Array or String parameter expands to two WASM parameters `(i32, i32)` for the pointer and length, and Array/String return types use WASM multi-value return `(result i32 i32)`.
 
 ## 11.13 Quantifier Compilation
 
@@ -522,7 +522,7 @@ When the compiler encounters a type alias in a function signature or slot refere
 
 - `PosInt` → `{ @Int | @Int.0 > 0 }` → `Int` → `i64`
 - `Percentage` → `{ @Int | @Int.0 >= 0 && @Int.0 <= 100 }` → `Int` → `i64`
-- `NonEmptyArray` → `{ @Array<Int> | length(...) > 0 }` → `Array<Int>` → skipped (Array param limitation)
+- `NonEmptyArray` → `{ @Array<Int> | length(...) > 0 }` → `Array<Int>` → `(i32, i32)` pair
 
 This resolution applies uniformly to parameter types, return types, let bindings, and slot references within function bodies.
 

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -3583,8 +3583,8 @@ fn f(-> @Int) requires(true) ensures(true) effects(pure) {
 """
         assert _run(src) == 5
 
-    def test_array_fn_param_skipped(self) -> None:
-        """Functions with Array params should be skipped with warning."""
+    def test_array_fn_param_compiles(self) -> None:
+        """Functions with Array params should compile with pair params."""
         src = """
 fn f(@Array<Int> -> @Int) requires(true) ensures(true) effects(pure) {
   @Array<Int>.0[0]
@@ -3594,8 +3594,12 @@ fn g(-> @Int) requires(true) ensures(true) effects(pure) {
 }
 """
         result = _compile_ok(src)
-        # f should be skipped, g should compile
+        # Both f and g should compile
+        assert "$f" in result.wat
         assert "$g" in result.wat
+        # f should have pair params
+        assert "(param $p0_ptr i32)" in result.wat
+        assert "(param $p0_len i32)" in result.wat
 
 
 # =====================================================================
@@ -3946,3 +3950,114 @@ fn to_percentage(@Int -> @Percentage)
 """)
         assert '(export "safe_divide"' in result.wat
         assert '(export "to_percentage"' in result.wat
+
+
+# =====================================================================
+# C6.5e: String and Array types in function signatures
+# =====================================================================
+
+
+class TestStringArraySignatures:
+    """Tests for String and Array types in function parameters and returns."""
+
+    def test_string_param(self) -> None:
+        """Function taking a String param compiles with pair params."""
+        src = """
+fn say(@String -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{ IO.print(@String.0) }
+"""
+        result = _compile_ok(src)
+        assert "say" in result.exports
+        assert "(param $p0_ptr i32)" in result.wat
+        assert "(param $p0_len i32)" in result.wat
+
+    def test_string_return(self) -> None:
+        """Function returning a String compiles with (result i32 i32)."""
+        src = '''
+fn greeting(-> @String)
+  requires(true) ensures(true) effects(pure)
+{ "hello" }
+'''
+        result = _compile_ok(src)
+        assert "greeting" in result.exports
+        assert "(result i32 i32)" in result.wat
+
+    def test_string_param_and_return(self) -> None:
+        """String param + String return: identity-like function."""
+        src = """
+fn echo(@String -> @String)
+  requires(true) ensures(true) effects(pure)
+{ @String.0 }
+"""
+        result = _compile_ok(src)
+        assert "echo" in result.exports
+        assert "(param $p0_ptr i32)" in result.wat
+        assert "(result i32 i32)" in result.wat
+
+    def test_string_call_chain(self) -> None:
+        """String-returning fn called by another fn via IO.print."""
+        src = '''
+fn greeting(-> @String)
+  requires(true) ensures(true) effects(pure)
+{ "hello world" }
+
+fn main(-> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{ IO.print(greeting()) }
+'''
+        result = _compile_ok(src)
+        exec_result = execute(result)
+        assert exec_result.stdout == "hello world"
+
+    def test_array_param(self) -> None:
+        """Function taking an Array<Int> param compiles with pair params."""
+        src = """
+fn get_len(@Array<Int> -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ length(@Array<Int>.0) }
+"""
+        result = _compile_ok(src)
+        assert "get_len" in result.exports
+        assert "(param $p0_ptr i32)" in result.wat
+        assert "(param $p0_len i32)" in result.wat
+
+    def test_array_return(self) -> None:
+        """Function returning an Array literal compiles."""
+        src = """
+fn nums(-> @Array<Int>)
+  requires(true) ensures(true) effects(pure)
+{ [1, 2, 3] }
+"""
+        result = _compile_ok(src)
+        assert "nums" in result.exports
+        assert "(result i32 i32)" in result.wat
+
+    def test_mixed_params(self) -> None:
+        """Function with both pair and primitive params."""
+        src = """
+fn add_to(@Int, @String -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 + 1 }
+"""
+        result = _compile_ok(src)
+        assert "add_to" in result.exports
+        # Int param is plain i64, String param is pair
+        assert "(param $p0 i64)" in result.wat
+        assert "(param $p1_ptr i32)" in result.wat
+        assert "(param $p1_len i32)" in result.wat
+        # Can execute with Int=10, String ptr=0, len=0
+        exec_result = execute(result, fn_name="add_to", args=[10, 0, 0])
+        assert exec_result.value == 11
+
+    def test_string_return_execution(self) -> None:
+        """Executing a String-returning function returns a pointer."""
+        src = '''
+fn hello(-> @String)
+  requires(true) ensures(true) effects(pure)
+{ "hello" }
+'''
+        result = _compile_ok(src)
+        exec_result = execute(result, fn_name="hello")
+        # Returns the data pointer (an integer)
+        assert isinstance(exec_result.value, int)

--- a/vera/README.md
+++ b/vera/README.md
@@ -77,8 +77,8 @@ execute(compile_result, ...)    # → run WASM via wasmtime
 | `checker.py` | 1,668 | Type check | Two-pass type checker | `typecheck()` |
 | `smt.py` | 485 | Verify | Z3 translation layer | `SmtContext`, `SlotEnv` |
 | `verifier.py` | 601 | Verify | Contract verification | `verify()` |
-| `wasm.py` | 2,169 | Compile | WASM translation layer | `WasmContext`, `WasmSlotEnv` |
-| `codegen.py` | 1,644 | Compile | Codegen orchestrator | `compile()`, `execute()` |
+| `wasm.py` | 2,259 | Compile | WASM translation layer | `WasmContext`, `WasmSlotEnv` |
+| `codegen.py` | 1,672 | Compile | Codegen orchestrator | `compile()`, `execute()` |
 | `errors.py` | 354 | All | Diagnostic class, error hierarchy | `Diagnostic`, `VeraError` |
 | `cli.py` | 563 | All | CLI commands | `main()` |
 | `registration.py` | 56 | Type check | Shared function registration | `register_fn()` |
@@ -348,7 +348,7 @@ Error at line 3, column 3:
 
 ## Code Generation
 
-**Files:** `codegen.py` (1,644 lines), `wasm.py` (2,169 lines)
+**Files:** `codegen.py` (1,672 lines), `wasm.py` (2,259 lines)
 
 ### Compilation pipeline
 
@@ -454,7 +454,7 @@ Every diagnostic includes a description (what went wrong), rationale (which lang
 
 ## Test Suite
 
-**866 tests** across 10 files, plus 4 validation scripts and CI infrastructure.
+**874 tests** across 10 files, plus 4 validation scripts and CI infrastructure.
 
 ### Test files
 
@@ -464,14 +464,14 @@ Every diagnostic includes a description (what went wrong), rationale (which lang
 | `test_ast.py` | 84 | 896 | AST transformation, node structure, serialisation |
 | `test_checker.py` | 115 | 1,320 | Type synthesis, slot resolution, effects, contracts, exhaustiveness |
 | `test_verifier.py` | 69 | 918 | Z3 verification, counterexamples, tier classification, Int→Nat enforcement, call-site preconditions, pipe operator |
-| `test_codegen.py` | 312 | 3,948 | WASM compilation, arithmetic, Float64 (incl. modulo), Byte, arrays, ADTs, match, generics, closures, State\<T\>, control flow, strings, IO, contracts, bounds checking, length, quantifiers, assert/assume, refinement type aliases, pipe operator, example round-trips |
+| `test_codegen.py` | 320 | 4,063 | WASM compilation, arithmetic, Float64 (incl. modulo), Byte, arrays, ADTs, match, generics, closures, State\<T\>, control flow, strings, IO, contracts, bounds checking, length, quantifiers, assert/assume, refinement type aliases, pipe operator, String/Array signatures, example round-trips |
 | `test_cli.py` | 76 | 932 | CLI commands (check, verify, compile, run), subprocess integration, JSON error paths, runtime traps, arg validation |
 | `test_types.py` | 55 | 279 | Type operations: subtyping, equality, substitution, pretty-printing, canonical names |
 | `test_wasm.py` | 22 | 255 | WASM internals: StringPool, WasmSlotEnv, translation edge cases via full pipeline |
 | `test_readme.py` | 2 | 68 | README code sample parsing |
 | `test_errors.py` | 34 | 287 | Diagnostic formatting, serialisation, error patterns, SourceLocation, diagnose_lark_error |
 
-Total: 9,732 lines of test code.
+Total: 9,847 lines of test code.
 
 ### Round-trip testing
 

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.28"
+__version__ = "0.0.29"

--- a/vera/codegen.py
+++ b/vera/codegen.py
@@ -226,6 +226,9 @@ def execute(
     value: int | float | None
     if raw_result is None:
         value = None
+    elif isinstance(raw_result, (tuple, list)):
+        # Multi-value return (e.g. String/Array as (ptr, len))
+        value = raw_result[0] if raw_result else None
     elif isinstance(raw_result, float):
         value = raw_result
     elif isinstance(raw_result, int):
@@ -956,7 +959,7 @@ class CodeGenerator:
         # Build function return type map for FnCall type inference
         fn_ret_types: dict[str, str | None] = {}
         for fn_name, (_, ret_wt) in self._fn_sigs.items():
-            if ret_wt != "unsupported":
+            if ret_wt and ret_wt != "unsupported":
                 fn_ret_types[fn_name] = ret_wt
         ctx.set_fn_ret_types(fn_ret_types)
         # Provide type aliases so closures can resolve FnType return types
@@ -979,6 +982,16 @@ class CodeGenerator:
                     "are compilable in the current WASM backend.",
                 )
                 return None
+            if wt == "i32_pair":
+                # String/Array types use two consecutive i32 params (ptr, len)
+                ptr_idx = ctx.alloc_param()
+                _len_idx = ctx.alloc_param()
+                param_parts.append(f"(param $p{i}_ptr i32)")
+                param_parts.append(f"(param $p{i}_len i32)")
+                type_name = self._type_expr_to_slot_name(param_te)
+                if type_name:
+                    env = env.push(type_name, ptr_idx)
+                continue
             local_idx = ctx.alloc_param()
             param_parts.append(f"(param $p{i} {wt})")
             # Push into slot environment
@@ -996,7 +1009,12 @@ class CodeGenerator:
                 "compilable in the current WASM backend.",
             )
             return None
-        result_part = f" (result {ret_wt})" if ret_wt else ""
+        if ret_wt == "i32_pair":
+            result_part = " (result i32 i32)"
+        elif ret_wt:
+            result_part = f" (result {ret_wt})"
+        else:
+            result_part = ""
 
         # Scan body for handle[State<T>] expressions to register imports
         self._scan_body_for_state_handlers(decl.body)
@@ -1087,17 +1105,21 @@ class CodeGenerator:
                 # Register the closure signature for call_indirect
                 param_wasm: list[str] = ["i32"]  # env param
                 for p in anon_fn.params:
-                    pname = self._type_expr_to_slot_name(p)
                     pwt = self._type_expr_to_wasm_type(p)
-                    if pwt and pwt != "unsupported":
+                    if pwt == "i32_pair":
+                        param_wasm.extend(["i32", "i32"])
+                    elif pwt and pwt != "unsupported":
                         param_wasm.append(pwt)
                 ret_wt = self._type_expr_to_wasm_type(anon_fn.return_type)
                 param_part = " ".join(
                     f"(param {wt})" for wt in param_wasm
                 )
-                result_part = (
-                    f" (result {ret_wt})" if ret_wt else ""
-                )
+                if ret_wt == "i32_pair":
+                    result_part = " (result i32 i32)"
+                elif ret_wt:
+                    result_part = f" (result {ret_wt})"
+                else:
+                    result_part = ""
                 sig_content = f"{param_part}{result_part}"
                 if sig_content not in self._closure_sigs:
                     sig_name = (
@@ -1296,6 +1318,11 @@ class CodeGenerator:
                     ensures_clauses.append(contract)
 
         if not ensures_clauses:
+            return []
+
+        # Pair returns (String/Array) don't support postcondition checks
+        # — can't save/restore a two-value result with a single local
+        if ret_wt == "i32_pair":
             return []
 
         instrs: list[str] = []
@@ -1510,7 +1537,7 @@ class CodeGenerator:
             return False
         type_arg = eff.type_args[0]
         wt = self._type_expr_to_wasm_type(type_arg)
-        if wt is None or wt == "unsupported":
+        if wt is None or wt in ("unsupported", "i32_pair"):
             self._warning(
                 decl,
                 f"Function '{decl.name}' uses State with "
@@ -1575,7 +1602,8 @@ class CodeGenerator:
     def _type_expr_to_wasm_type(self, te: ast.TypeExpr) -> str | None:
         """Map a Vera TypeExpr to a WAT type string.
 
-        Returns None for Unit, "unsupported" for non-compilable types.
+        Returns None for Unit, "unsupported" for non-compilable types,
+        "i32_pair" for types represented as (i32, i32) pairs (String, Array).
         """
         if isinstance(te, ast.NamedType):
             name = te.name
@@ -1588,7 +1616,7 @@ class CodeGenerator:
             if name == "Unit":
                 return None
             if name in ("String", "Array"):
-                return "unsupported"
+                return "i32_pair"
             # ADT types compile to i32 (heap pointer)
             if name in self._adt_layouts:
                 return "i32"

--- a/vera/wasm.py
+++ b/vera/wasm.py
@@ -123,6 +123,7 @@ def wasm_type(t: Type) -> str | None:
 
     Returns None for types with no WASM representation (Unit).
     Returns "unsupported" for types that cannot be compiled.
+    Returns "i32_pair" for types represented as (i32, i32) pairs.
     """
     t = base_type(t)
     if isinstance(t, PrimitiveType):
@@ -135,7 +136,7 @@ def wasm_type(t: Type) -> str | None:
         if t.name == "Unit":
             return None
         if t.name == "String":
-            return "unsupported"  # handled specially in 5e
+            return "i32_pair"
     if isinstance(t, FunctionType):
         return "i32"  # closure pointer (heap-allocated struct)
     return "unsupported"
@@ -422,8 +423,8 @@ class WasmContext:
         local_idx = env.resolve(type_name, ref.index)
         if local_idx is None:
             return None
-        # Array types push (ptr, len) — two locals
-        if self._is_array_type_name(type_name):
+        # Pair types (String, Array<T>) push (ptr, len) — two locals
+        if self._is_pair_type_name(type_name):
             return [f"local.get {local_idx}", f"local.get {local_idx + 1}"]
         return [f"local.get {local_idx}"]
 
@@ -580,6 +581,8 @@ class WasmContext:
                 return "f64"
             if resolved in ("Bool", "Byte"):
                 return "i32"
+            if self._is_pair_type_name(resolved):
+                return "i32_pair"
             base = (resolved.split("<")[0]
                     if "<" in resolved else resolved)
             if base in self._adt_type_names:
@@ -631,7 +634,9 @@ class WasmContext:
             elem_type = self._infer_index_element_type(expr)
             return _element_wasm_type(elem_type) if elem_type else None
         if isinstance(expr, ast.ArrayLit):
-            return None  # arrays are (i32, i32) — handled specially
+            return "i32_pair"
+        if isinstance(expr, ast.StringLit):
+            return "i32_pair"
         if isinstance(expr, (ast.ForallExpr, ast.ExistsExpr)):
             return "i32"  # quantifiers return Bool
         if isinstance(expr, (ast.AssertExpr, ast.AssumeExpr)):
@@ -711,9 +716,15 @@ class WasmContext:
                 + ["end"]
             )
 
+        # i32_pair → two i32 results (ptr, len)
+        if result_type == "i32_pair":
+            result_annot = "if (result i32 i32)"
+        else:
+            result_annot = f"if (result {result_type})"
+
         return (
             cond
-            + [f"if (result {result_type})"]
+            + [result_annot]
             + ["  " + i for i in then]
             + ["else"]
             + ["  " + i for i in else_]
@@ -740,6 +751,8 @@ class WasmContext:
                 return "f64"
             if name in ("Bool", "Byte"):
                 return "i32"
+            if self._is_pair_type_name(name):
+                return "i32_pair"
             base = name.split("<")[0] if "<" in name else name
             if base in self._adt_type_names:
                 return "i32"
@@ -765,7 +778,7 @@ class WasmContext:
         if isinstance(expr, ast.QualifiedCall):
             return None  # effect ops return Unit (void)
         if isinstance(expr, ast.StringLit):
-            return None  # strings are (i32, i32) — handled specially
+            return "i32_pair"
         if isinstance(expr, ast.Block):
             return self._infer_block_result_type(expr)
         if isinstance(expr, ast.ConstructorCall):
@@ -780,7 +793,7 @@ class WasmContext:
             elem_type = self._infer_index_element_type(expr)
             return _element_wasm_type(elem_type) if elem_type else None
         if isinstance(expr, ast.ArrayLit):
-            return None  # arrays are (i32, i32) — handled specially
+            return "i32_pair"
         if isinstance(expr, (ast.ForallExpr, ast.ExistsExpr)):
             return "i32"  # quantifiers return Bool
         if isinstance(expr, (ast.AssertExpr, ast.AssumeExpr)):
@@ -807,8 +820,8 @@ class WasmContext:
                 type_name = self._type_expr_to_slot_name(stmt.type_expr)
                 if type_name is None:
                     return None
-                # Array bindings need two locals: (ptr, len)
-                if self._is_array_type_name(type_name):
+                # Pair bindings (String, Array<T>) need two locals: (ptr, len)
+                if self._is_pair_type_name(type_name):
                     ptr_idx = self.alloc_local("i32")
                     len_idx = self.alloc_local("i32")
                     instructions.extend(val_instrs)
@@ -832,7 +845,10 @@ class WasmContext:
                 # QualifiedCalls (effect ops like IO.print) return void.
                 # UnitLit produces nothing.
                 if stmt_instrs and not self._is_void_expr(stmt.expr):
-                    instructions.append("drop")
+                    if self._is_pair_result_expr(stmt.expr):
+                        instructions.extend(["drop", "drop"])
+                    else:
+                        instructions.append("drop")
             else:
                 # LetDestruct or unknown
                 return None
@@ -1052,6 +1068,14 @@ class WasmContext:
     def _is_array_type_name(type_name: str) -> bool:
         """Check if a slot type name is an Array<T> type."""
         return type_name.startswith("Array<")
+
+    @staticmethod
+    def _is_pair_type_name(type_name: str) -> bool:
+        """Check if a slot type name is a pair type (ptr, len).
+
+        String and Array<T> are represented as two consecutive i32 locals.
+        """
+        return type_name == "String" or type_name.startswith("Array<")
 
     def _infer_array_element_type(self, expr: ast.ArrayLit) -> str | None:
         """Infer the Vera element type name from an array literal."""
@@ -1524,7 +1548,12 @@ class WasmContext:
         param_parts = " ".join(
             f"(param {wt})" for wt in ["i32"] + arg_wasm_types
         )
-        result_part = f" (result {ret_wt})" if ret_wt else ""
+        if ret_wt == "i32_pair":
+            result_part = " (result i32 i32)"
+        elif ret_wt:
+            result_part = f" (result {ret_wt})"
+        else:
+            result_part = ""
         sig_key = f"{param_parts}{result_part}"
 
         # Register this signature for the codegen to emit as a type decl
@@ -1988,7 +2017,12 @@ class WasmContext:
             return None
 
         # Build if-else block
-        result_annot = f" (result {result_type})" if result_type else ""
+        if result_type == "i32_pair":
+            result_annot = " (result i32 i32)"
+        elif result_type:
+            result_annot = f" (result {result_type})"
+        else:
+            result_annot = ""
         instrs: list[str] = list(cond)
         instrs.append(f"if{result_annot}")
         for i in setup_instrs:
@@ -2149,6 +2183,24 @@ class WasmContext:
             return is_void
         if isinstance(expr, (ast.AssertExpr, ast.AssumeExpr)):
             return True  # assert/assume return Unit (void)
+        return False
+
+    def _is_pair_result_expr(self, expr: ast.Expr) -> bool:
+        """Check if an expression produces two values (ptr, len) on the stack.
+
+        String literals, array literals, pair-type slot refs, and function
+        calls returning i32_pair all produce two values.
+        """
+        if isinstance(expr, ast.StringLit):
+            return True
+        if isinstance(expr, ast.ArrayLit):
+            return True
+        if isinstance(expr, ast.SlotRef):
+            name = self._resolve_base_type_name(expr.type_name)
+            return self._is_pair_type_name(name)
+        if isinstance(expr, ast.FnCall):
+            ret = self._infer_fncall_wasm_type(expr)
+            return ret == "i32_pair"
         return False
 
     def _type_expr_to_slot_name(self, te: ast.TypeExpr) -> str | None:


### PR DESCRIPTION
## Summary

- Functions with `String` or `Array<T>` parameters and return types now compile to WASM instead of being silently skipped
- Each String/Array parameter expands to two consecutive `i32` WASM parameters (pointer and length)
- String/Array return types use WASM multi-value return `(result i32 i32)`
- `_type_expr_to_wasm_type()` returns `"i32_pair"` sentinel instead of `"unsupported"` for String/Array
- Generalised `_is_pair_type_name()` helper for String and Array<T> across slot refs, let bindings, drop logic, and type inference
- `if` and `match` blocks emit `(result i32 i32)` for pair-typed branches
- `execute()` handles multi-value (list) returns from wasmtime
- Postcondition checks skipped for pair return types (single-local save/restore incompatible with two-value results)
- Functions previously skipped in `examples/pattern_matching.vera` (`classify`, `to_string`, `describe`) and `examples/quantifiers.vera` (`all_positive`, `has_zero`) now compile
- 8 new codegen tests, 874 total (up from 866)

Closes #69

## Test plan

- [x] `pytest tests/ -v` -- 874 pass
- [x] `mypy vera/` -- clean
- [x] `python scripts/check_examples.py` -- 14/14 pass
- [x] `python scripts/check_spec_examples.py` -- all pass
- [x] `python scripts/check_version_sync.py` -- 0.0.29 consistent
- [x] End-to-end: `vera run examples/pattern_matching.vera --fn classify -- 42` returns result

Generated with [Claude Code](https://claude.com/claude-code)