### PR TITLE
C6.5f: old()/new() state expressions in postconditions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,7 +108,7 @@ Each stage is a module with a single public API function (`parse_file`, `transfo
 ### Testing
 
 ```bash
-pytest tests/ -v                       # Run all tests (874 tests)
+pytest tests/ -v                       # Run all tests (880 tests)
 mypy vera/                             # Type-check the compiler
 python scripts/check_examples.py       # All 14 examples must pass
 ```
@@ -119,7 +119,7 @@ Test helpers follow a pattern: `_check_ok(source)` / `_check_err(source, match)`
 
 - All 14 examples in `examples/` must pass `vera check` and `vera verify`
 - `mypy vera/` must be clean
-- `pytest tests/ -v` must pass (currently 874 tests)
+- `pytest tests/ -v` must pass (currently 880 tests)
 - Version must be in sync across `vera/__init__.py`, `pyproject.toml`, and `CHANGELOG.md`
 
 ### Contributing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 - **Project website** ([veralang.dev](https://veralang.dev)): single-page site deployed via GitHub Pages ([#81](https://github.com/aallan/vera/pull/81))
 
+## [0.0.30] - 2026-02-26
+
+### Added
+- **old()/new() state expressions in postconditions** (C6.5f — closes [#70](https://github.com/aallan/vera/issues/70)): postconditions containing `old(State<T>)` and `new(State<T>)` now compile to WASM runtime checks
+  - `old(State<T>)` snapshots the state value at function entry into a temp local
+  - `new(State<T>)` reads the current state value at postcondition check time via `state_get`
+  - `_snapshot_old_state()` in codegen.py walks ensures clauses to detect `OldExpr` nodes and emits snapshot instructions
+  - `WasmContext._translate_old_expr()` and `_translate_new_expr()` handle the AST→WAT translation
+  - Snapshot is only emitted when ensures clauses actually reference `old()` (trivial contracts skip it)
+  - Completes the C6.5 codegen cleanup phase
+- README restructured: C7 (Module System) is now the "What's next" section with sub-phase plan; C6.5 and C6 are collapsed
+- 6 new codegen tests (880 total, up from 874)
+
 ## [0.0.29] - 2026-02-26
 
 ### Added
@@ -444,7 +457,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Grammar: handler body simplified to avoid LALR reduce/reduce conflict
 - `pyproject.toml`: corrected build backend, package discovery, PEP 639 compliance
 
-[Unreleased]: https://github.com/aallan/vera/compare/v0.0.29...HEAD
+[Unreleased]: https://github.com/aallan/vera/compare/v0.0.30...HEAD
+[0.0.30]: https://github.com/aallan/vera/compare/v0.0.29...v0.0.30
 [0.0.29]: https://github.com/aallan/vera/compare/v0.0.28...v0.0.29
 [0.0.28]: https://github.com/aallan/vera/compare/v0.0.27...v0.0.28
 [0.0.27]: https://github.com/aallan/vera/compare/v0.0.26...v0.0.27

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ vera parse file.vera              # Print the parse tree
 vera ast file.vera                # Print the typed AST
 vera ast --json file.vera         # Print the AST as JSON
 
-pytest tests/ -v                  # Run the test suite (874 tests)
+pytest tests/ -v                  # Run the test suite (880 tests)
 mypy vera/                        # Type-check the compiler itself
 
 python scripts/check_examples.py      # Verify all 14 examples parse + check + verify

--- a/README.md
+++ b/README.md
@@ -172,22 +172,40 @@ Development follows an **interleaved spiral** — each phase adds a complete com
 | C4 | [v0.0.8](https://github.com/aallan/vera/releases/tag/v0.0.8) | **Contract verifier** — Z3 integration, refinement types, counterexamples | Done |
 | C5 | [v0.0.9](https://github.com/aallan/vera/releases/tag/v0.0.9) | **WASM codegen** — compile to WebAssembly, `vera compile` / `vera run` | Done |
 | C6 | [v0.0.10](https://github.com/aallan/vera/releases/tag/v0.0.10)–[v0.0.24](https://github.com/aallan/vera/releases/tag/v0.0.24) | **Codegen completeness** — ADTs, match, closures, effects, generics in WASM | Done |
-| C6.5 | [v0.0.25](https://github.com/aallan/vera/releases/tag/v0.0.25)– | **Codegen cleanup** — handler fixes, missing operators, String/Array support | In Progress |
+| C6.5 | [v0.0.25](https://github.com/aallan/vera/releases/tag/v0.0.25)–[v0.0.30](https://github.com/aallan/vera/releases/tag/v0.0.30) | **Codegen cleanup** — handler fixes, missing operators, String/Array support | Done |
 | C7 | — | **Module system** — cross-file imports, public/private visibility | Planned |
 | C8 | v0.1.0 | **End-to-end** — all examples compile and run, spec complete, polish | Planned |
 
-### What's next: C6.5 — Codegen & Checker Cleanup
+### What's next: C7 — Module System
 
-Before starting the module system, C6.5 addresses residual gaps in single-file compilation — handler bugs, missing operators, and type support limits. Each sub-phase closes a tracked issue.
+C7 implements cross-file imports, public/private visibility, and multi-module compilation. The grammar already parses `module`, `import`, `public`, `private`, and module-qualified calls — the checker currently returns `UnknownType()` for cross-module references. C7 builds out the infrastructure to resolve those references end-to-end.
 
-| Sub-phase | Scope | Issue |
-|-----------|-------|-------|
-| ~~C6.5a~~ | ~~`resume` not recognized as built-in in handler scope~~ | [v0.0.25](https://github.com/aallan/vera/releases/tag/v0.0.25) |
-| ~~C6.5b~~ | ~~Handler `with` clause for state updates not in grammar~~ | [v0.0.26](https://github.com/aallan/vera/releases/tag/v0.0.26) |
-| ~~C6.5c~~ | ~~Pipe operator (`\|>`) compilation~~ | [v0.0.27](https://github.com/aallan/vera/releases/tag/v0.0.27) |
-| ~~C6.5d~~ | ~~Float64 modulo (`%`) — WASM has no `f64.rem`~~ | [v0.0.28](https://github.com/aallan/vera/releases/tag/v0.0.28) |
-| ~~C6.5e~~ | ~~String and Array types in function signatures~~ | [v0.0.29](https://github.com/aallan/vera/releases/tag/v0.0.29) |
-| C6.5f | `old()`/`new()` state expressions in contracts | [#70](https://github.com/aallan/vera/issues/70) |
+Tracked in [#14](https://github.com/aallan/vera/issues/14) (type-checking) and [#50](https://github.com/aallan/vera/issues/50) (code generation). Spec Chapter 8 (Modules) will be written alongside the implementation.
+
+| Sub-phase | Scope |
+|-----------|-------|
+| C7a | Module resolution — map `import` paths to source files and parse them |
+| C7b | Cross-module type environment — merge public declarations across files |
+| C7c | Visibility enforcement — `public`/`private` access control in the checker |
+| C7d | Cross-module verification — verify contracts that reference imported symbols |
+| C7e | Multi-module codegen — WASM import/export tables linking multiple modules |
+| C7f | Spec Chapter 8 — formal module semantics, resolution algorithm, examples |
+
+<details>
+<summary>C6.5 — Codegen & Checker Cleanup (<a href="https://github.com/aallan/vera/releases/tag/v0.0.25">v0.0.25</a>–<a href="https://github.com/aallan/vera/releases/tag/v0.0.30">v0.0.30</a>) ✓</summary>
+
+Before starting the module system, C6.5 addressed residual gaps in single-file compilation — handler bugs, missing operators, and type support limits. Each sub-phase closed a tracked issue.
+
+| Sub-phase | Scope | Version |
+|-----------|-------|---------|
+| C6.5a | `resume` not recognized as built-in in handler scope | [v0.0.25](https://github.com/aallan/vera/releases/tag/v0.0.25) |
+| C6.5b | Handler `with` clause for state updates not in grammar | [v0.0.26](https://github.com/aallan/vera/releases/tag/v0.0.26) |
+| C6.5c | Pipe operator (`\|>`) compilation | [v0.0.27](https://github.com/aallan/vera/releases/tag/v0.0.27) |
+| C6.5d | Float64 modulo (`%`) — WASM has no `f64.rem` | [v0.0.28](https://github.com/aallan/vera/releases/tag/v0.0.28) |
+| C6.5e | String and Array types in function signatures | [v0.0.29](https://github.com/aallan/vera/releases/tag/v0.0.29) |
+| C6.5f | `old()`/`new()` state expressions in contracts | [v0.0.30](https://github.com/aallan/vera/releases/tag/v0.0.30) |
+
+</details>
 
 <details>
 <summary>C6 — Codegen Completeness (<a href="https://github.com/aallan/vera/releases/tag/v0.0.10">v0.0.10</a>–<a href="https://github.com/aallan/vera/releases/tag/v0.0.24">v0.0.24</a>) ✓</summary>
@@ -212,10 +230,6 @@ C6 extended WASM compilation to all language constructs, working through the dep
 | C6n | Spec chapters 9 (Standard library) and 12 (Runtime) | [v0.0.24](https://github.com/aallan/vera/releases/tag/v0.0.24) |
 
 </details>
-
-### Coming next: C7 — Module System
-
-C7 will implement cross-file imports, public/private visibility, and multi-module compilation. Tracked in [#14](https://github.com/aallan/vera/issues/14) and [#50](https://github.com/aallan/vera/issues/50). Spec Chapter 8 (Modules) will be written alongside the implementation.
 
 ## Getting Started
 
@@ -466,7 +480,7 @@ vera/
 │   ├── errors.py                  # LLM-oriented diagnostics
 │   └── cli.py                     # Command-line interface
 ├── examples/                      # 14 example Vera programs
-├── tests/                         # Test suite (874 tests)
+├── tests/                         # Test suite (880 tests)
 ├── scripts/                       # CI and validation scripts
 │   ├── check_examples.py          # Verify all .vera examples
 │   ├── check_spec_examples.py     # Verify spec code blocks parse

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.29"
+version = "0.0.30"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/spec/11-compilation.md
+++ b/spec/11-compilation.md
@@ -292,7 +292,34 @@ local.get $result    ;; push result back for return
 
 The body's return value is stored in a temporary local. The `@T.result` reference in the ensures clause resolves to this local. After the check passes, the result is pushed back onto the stack for return.
 
-### 11.8.4 Trap Handling
+### 11.8.4 State Expressions in Postconditions
+
+Postconditions may reference `old(State<T>)` (the state value before the function body) and `new(State<T>)` (the state value after). The compiler handles these by snapshotting state at function entry.
+
+For a function with `ensures(new(State<Int>) == old(State<Int>) + 1)`:
+
+```wat
+;; Snapshot old state at function entry (after preconditions)
+call $vera.state_get_Int
+local.set $old_state    ;; save pre-execution value
+
+;; [function body — may call state_get/state_put]
+
+;; Postcondition check
+call $vera.state_get_Int   ;; new(State<Int>) — reads current value
+local.get $old_state       ;; old(State<Int>) — reads snapshot
+i64.const 1
+i64.add
+i64.eq
+i32.eqz
+if
+  unreachable              ;; trap: postcondition violated
+end
+```
+
+`old(State<T>)` resolves to a `local.get` of the saved snapshot. `new(State<T>)` resolves to a fresh `call $vera.state_get_<Type>` that reads the current value. The snapshot local is allocated only when the function's ensures clauses actually reference `old()`.
+
+### 11.8.5 Trap Handling
 
 When a runtime contract check fails, the WASM `unreachable` instruction causes a trap. The host runtime catches the trap and reports it as a contract violation.
 

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -4061,3 +4061,138 @@ fn hello(-> @String)
         exec_result = execute(result, fn_name="hello")
         # Returns the data pointer (an integer)
         assert isinstance(exec_result.value, int)
+
+
+# =====================================================================
+# 6.5f: old()/new() state expressions in postconditions
+# =====================================================================
+
+
+class TestOldNewContracts:
+    """Tests for old()/new() state expression compilation in postconditions."""
+
+    def test_old_new_postcondition_compiles(self) -> None:
+        """Function with old()/new() in ensures clause compiles to WASM."""
+        src = """
+fn increment(@Unit -> @Unit)
+  requires(true)
+  ensures(new(State<Int>) == old(State<Int>) + 1)
+  effects(<State<Int>>)
+{
+  let @Int = get(());
+  put(@Int.0 + 1);
+  ()
+}
+"""
+        result = _compile_ok(src)
+        assert "increment" in result.exports
+
+    def test_old_new_postcondition_passes(self) -> None:
+        """Postcondition holds — no trap when new == old + 1."""
+        src = """
+fn increment(@Unit -> @Unit)
+  requires(true)
+  ensures(new(State<Int>) == old(State<Int>) + 1)
+  effects(<State<Int>>)
+{
+  let @Int = get(());
+  put(@Int.0 + 1);
+  ()
+}
+"""
+        result = _compile_ok(src)
+        exec_result = execute(
+            result, fn_name="increment",
+            initial_state={"State_Int": 10},
+        )
+        # Should complete without trap
+        assert exec_result.value is None  # Unit return
+
+    def test_old_new_postcondition_traps(self) -> None:
+        """Postcondition violated — traps when increment is wrong."""
+        src = """
+fn bad_increment(@Unit -> @Unit)
+  requires(true)
+  ensures(new(State<Int>) == old(State<Int>) + 1)
+  effects(<State<Int>>)
+{
+  let @Int = get(());
+  put(@Int.0 + 2);
+  ()
+}
+"""
+        result = _compile_ok(src)
+        with pytest.raises((wasmtime.WasmtimeError, wasmtime.Trap)):
+            execute(
+                result, fn_name="bad_increment",
+                initial_state={"State_Int": 5},
+            )
+
+    def test_trivial_ensures_no_snapshot(self) -> None:
+        """ensures(true) with State effect does NOT emit a snapshot."""
+        src = """
+fn inc(@Unit -> @Unit)
+  requires(true) ensures(true)
+  effects(<State<Int>>)
+{
+  let @Int = get(());
+  put(@Int.0 + 1);
+  ()
+}
+"""
+        result = _compile_ok(src)
+        wat = result.wat
+        assert "inc" in result.exports
+        # Body should call state_get for the let binding,
+        # but no snapshot local.set before the body
+        lines = wat.split("\n")
+        # Find the function body — there should be exactly one
+        # state_get call (the let binding), not two (snapshot + let)
+        state_get_count = sum(
+            1 for l in lines if "call $vera.state_get_Int" in l
+        )
+        # Only the body's get() call — no snapshot
+        assert state_get_count == 1
+
+    def test_old_new_wat_structure(self) -> None:
+        """WAT contains state_get snapshot before body and new() in postcondition."""
+        src = """
+fn increment(@Unit -> @Unit)
+  requires(true)
+  ensures(new(State<Int>) == old(State<Int>) + 1)
+  effects(<State<Int>>)
+{
+  let @Int = get(());
+  put(@Int.0 + 1);
+  ()
+}
+"""
+        result = _compile_ok(src)
+        wat = result.wat
+        lines = wat.split("\n")
+        state_get_count = sum(
+            1 for l in lines if "call $vera.state_get_Int" in l
+        )
+        # 3 calls: snapshot (old), body get(), postcondition new()
+        assert state_get_count == 3
+
+    def test_new_reads_current_state(self) -> None:
+        """new(State<T>) reads the current value, not the snapshot."""
+        # Increment by 5 but claim increment by 5 in postcondition
+        src = """
+fn add_five(@Unit -> @Unit)
+  requires(true)
+  ensures(new(State<Int>) == old(State<Int>) + 5)
+  effects(<State<Int>>)
+{
+  let @Int = get(());
+  put(@Int.0 + 5);
+  ()
+}
+"""
+        result = _compile_ok(src)
+        exec_result = execute(
+            result, fn_name="add_five",
+            initial_state={"State_Int": 100},
+        )
+        assert exec_result.value is None  # Unit, no trap

--- a/vera/README.md
+++ b/vera/README.md
@@ -77,13 +77,13 @@ execute(compile_result, ...)    # → run WASM via wasmtime
 | `checker.py` | 1,668 | Type check | Two-pass type checker | `typecheck()` |
 | `smt.py` | 485 | Verify | Z3 translation layer | `SmtContext`, `SlotEnv` |
 | `verifier.py` | 601 | Verify | Contract verification | `verify()` |
-| `wasm.py` | 2,259 | Compile | WASM translation layer | `WasmContext`, `WasmSlotEnv` |
-| `codegen.py` | 1,672 | Compile | Codegen orchestrator | `compile()`, `execute()` |
+| `wasm.py` | 2,317 | Compile | WASM translation layer | `WasmContext`, `WasmSlotEnv` |
+| `codegen.py` | 1,773 | Compile | Codegen orchestrator | `compile()`, `execute()` |
 | `errors.py` | 354 | All | Diagnostic class, error hierarchy | `Diagnostic`, `VeraError` |
 | `cli.py` | 563 | All | CLI commands | `main()` |
 | `registration.py` | 56 | Type check | Shared function registration | `register_fn()` |
 
-Total: ~9,964 lines of Python + 328 lines of grammar.
+Total: ~10,323 lines of Python + 328 lines of grammar.
 
 ## Parsing
 
@@ -348,7 +348,7 @@ Error at line 3, column 3:
 
 ## Code Generation
 
-**Files:** `codegen.py` (1,672 lines), `wasm.py` (2,259 lines)
+**Files:** `codegen.py` (1,773 lines), `wasm.py` (2,317 lines)
 
 ### Compilation pipeline
 
@@ -454,7 +454,7 @@ Every diagnostic includes a description (what went wrong), rationale (which lang
 
 ## Test Suite
 
-**874 tests** across 10 files, plus 4 validation scripts and CI infrastructure.
+**880 tests** across 10 files, plus 4 validation scripts and CI infrastructure.
 
 ### Test files
 
@@ -464,14 +464,14 @@ Every diagnostic includes a description (what went wrong), rationale (which lang
 | `test_ast.py` | 84 | 896 | AST transformation, node structure, serialisation |
 | `test_checker.py` | 115 | 1,320 | Type synthesis, slot resolution, effects, contracts, exhaustiveness |
 | `test_verifier.py` | 69 | 918 | Z3 verification, counterexamples, tier classification, Int→Nat enforcement, call-site preconditions, pipe operator |
-| `test_codegen.py` | 320 | 4,063 | WASM compilation, arithmetic, Float64 (incl. modulo), Byte, arrays, ADTs, match, generics, closures, State\<T\>, control flow, strings, IO, contracts, bounds checking, length, quantifiers, assert/assume, refinement type aliases, pipe operator, String/Array signatures, example round-trips |
+| `test_codegen.py` | 326 | 4,198 | WASM compilation, arithmetic, Float64 (incl. modulo), Byte, arrays, ADTs, match, generics, closures, State\<T\>, control flow, strings, IO, contracts, bounds checking, length, quantifiers, assert/assume, refinement type aliases, pipe operator, String/Array signatures, old/new state postconditions, example round-trips |
 | `test_cli.py` | 76 | 932 | CLI commands (check, verify, compile, run), subprocess integration, JSON error paths, runtime traps, arg validation |
 | `test_types.py` | 55 | 279 | Type operations: subtyping, equality, substitution, pretty-printing, canonical names |
 | `test_wasm.py` | 22 | 255 | WASM internals: StringPool, WasmSlotEnv, translation edge cases via full pipeline |
 | `test_readme.py` | 2 | 68 | README code sample parsing |
 | `test_errors.py` | 34 | 287 | Diagnostic formatting, serialisation, error patterns, SourceLocation, diagnose_lark_error |
 
-Total: 9,847 lines of test code.
+Total: 9,982 lines of test code.
 
 ### Round-trip testing
 

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.29"
+__version__ = "0.0.30"

--- a/vera/codegen.py
+++ b/vera/codegen.py
@@ -1022,6 +1022,9 @@ class CodeGenerator:
         # Compile precondition checks
         pre_instrs = self._compile_preconditions(ctx, decl, env)
 
+        # Snapshot old state for postcondition old() references
+        snapshot_instrs = self._snapshot_old_state(ctx, decl)
+
         # Compile body
         body_instrs = ctx.translate_block(decl.body, env)
         if body_instrs is None:
@@ -1068,6 +1071,10 @@ class CodeGenerator:
 
         # Precondition checks (at function entry)
         for instr in pre_instrs:
+            lines.append(f"    {instr}")
+
+        # Old state snapshots (for postcondition old() references)
+        for instr in snapshot_instrs:
             lines.append(f"    {instr}")
 
         # Body instructions
@@ -1371,6 +1378,100 @@ class CodeGenerator:
         if isinstance(contract, ast.Ensures):
             return isinstance(contract.expr, ast.BoolLit) and contract.expr.value
         return False
+
+    def _snapshot_old_state(
+        self,
+        ctx: WasmContext,
+        decl: ast.FnDecl,
+    ) -> list[str]:
+        """Emit instructions to snapshot state at function entry for old().
+
+        Walks ensures clauses to find old(State<T>) references.
+        For each unique State<T>, calls the host state_get import and
+        saves the result to a temp local. Registers the mapping on ctx
+        so translate_expr can resolve OldExpr later.
+
+        Returns WASM instructions (call + local.set) to insert after
+        preconditions and before the function body.
+        """
+        old_types = self._find_old_state_types(decl)
+        if not old_types:
+            return []
+
+        instrs: list[str] = []
+        old_locals: dict[str, int] = {}
+
+        for type_name in sorted(old_types):
+            # Determine the WASM type for this State<T>
+            wasm_t = self._state_type_to_wasm(type_name)
+            if wasm_t is None:
+                continue
+            # Allocate a temp local for the snapshot
+            local_idx = ctx.alloc_local(wasm_t)
+            # Emit: call $vera.state_get_<Type> ; local.set <idx>
+            instrs.append(f"call $vera.state_get_{type_name}")
+            instrs.append(f"local.set {local_idx}")
+            old_locals[type_name] = local_idx
+
+        if old_locals:
+            ctx.set_old_state_locals(old_locals)
+
+        return instrs
+
+    def _find_old_state_types(self, decl: ast.FnDecl) -> set[str]:
+        """Find all State<T> type names referenced by old() in ensures clauses.
+
+        Walks each non-trivial ensures expression looking for OldExpr nodes.
+        Returns a set of type names, e.g. {"Int"}.
+        """
+        types: set[str] = set()
+        for contract in decl.contracts:
+            if not isinstance(contract, ast.Ensures):
+                continue
+            if self._is_trivial_contract(contract):
+                continue
+            self._collect_old_types(contract.expr, types)
+        return types
+
+    def _collect_old_types(
+        self, expr: ast.Expr, types: set[str],
+    ) -> None:
+        """Recursively collect State<T> type names from OldExpr nodes."""
+        if isinstance(expr, ast.OldExpr):
+            type_name = WasmContext._extract_state_type_name(
+                expr.effect_ref,
+            )
+            if type_name is not None:
+                types.add(type_name)
+            return
+        # Walk child expressions
+        for child in self._expr_children(expr):
+            self._collect_old_types(child, types)
+
+    @staticmethod
+    def _expr_children(expr: ast.Expr) -> list[ast.Expr]:
+        """Return direct child expressions for AST walking."""
+        children: list[ast.Expr] = []
+        if isinstance(expr, ast.BinaryExpr):
+            children.extend([expr.left, expr.right])
+        elif isinstance(expr, ast.UnaryExpr):
+            children.append(expr.operand)
+        elif isinstance(expr, ast.FnCall):
+            children.extend(expr.args)
+        elif isinstance(expr, ast.IfExpr):
+            children.append(expr.condition)
+        elif isinstance(expr, ast.NewExpr):
+            pass  # No child expressions to walk
+        elif isinstance(expr, ast.OldExpr):
+            pass  # Already handled by caller
+        return children
+
+    def _state_type_to_wasm(self, type_name: str) -> str | None:
+        """Map a State type name (e.g. 'Int') to its WASM type."""
+        for registered_name, wasm_t in self._state_types:
+            if registered_name == type_name:
+                return wasm_t
+        return None
 
     # -----------------------------------------------------------------
     # Module assembly

--- a/vera/wasm.py
+++ b/vera/wasm.py
@@ -273,6 +273,8 @@ class WasmContext:
         self._next_closure_id: int = 0
         # Next quantifier label id (for unique block/loop labels)
         self._next_quant_id: int = 0
+        # Old state snapshots: type_name -> local_idx (for old() in postconditions)
+        self._old_state_locals: dict[str, int] = {}
 
     def set_fn_ret_types(
         self, ret_types: dict[str, str | None],
@@ -293,6 +295,16 @@ class WasmContext:
     def set_result_local(self, local_idx: int) -> None:
         """Set the local index used for @T.result in postconditions."""
         self._result_local = local_idx
+
+    def set_old_state_locals(
+        self, locals_map: dict[str, int],
+    ) -> None:
+        """Set old-state snapshot locals for old() in postconditions."""
+        self._old_state_locals = locals_map
+
+    def get_old_state_local(self, type_name: str) -> int | None:
+        """Get the local index holding the old() snapshot for a State type."""
+        return self._old_state_locals.get(type_name)
 
     def alloc_param(self) -> int:
         """Allocate a parameter slot (already in WASM signature).
@@ -399,7 +411,12 @@ class WasmContext:
         if isinstance(expr, ast.ExistsExpr):
             return self._translate_exists(expr, env)
 
-        # Unsupported: old/new, etc.
+        if isinstance(expr, ast.OldExpr):
+            return self._translate_old_expr(expr)
+
+        if isinstance(expr, ast.NewExpr):
+            return self._translate_new_expr(expr)
+
         return None
 
     # -----------------------------------------------------------------
@@ -1314,6 +1331,47 @@ class WasmContext:
         first true result.
         """
         return self._translate_quantifier(expr, env, is_forall=False)
+
+    # -----------------------------------------------------------------
+    # old/new state expressions (postconditions)
+    # -----------------------------------------------------------------
+
+    def _translate_old_expr(self, expr: ast.OldExpr) -> list[str] | None:
+        """Translate old(State<T>) → local.get of saved pre-execution state."""
+        type_name = self._extract_state_type_name(expr.effect_ref)
+        if type_name is None:
+            return None
+        local_idx = self.get_old_state_local(type_name)
+        if local_idx is None:
+            return None
+        return [f"local.get {local_idx}"]
+
+    def _translate_new_expr(self, expr: ast.NewExpr) -> list[str] | None:
+        """Translate new(State<T>) → call state_get to read current value."""
+        type_name = self._extract_state_type_name(expr.effect_ref)
+        if type_name is None:
+            return None
+        # Look up the state getter import
+        if "get" not in self._effect_ops:
+            return None
+        call_target, _is_void = self._effect_ops["get"]
+        return [f"call {call_target}"]
+
+    @staticmethod
+    def _extract_state_type_name(
+        effect_ref: ast.EffectRefNode,
+    ) -> str | None:
+        """Extract the type name from a State<T> effect reference."""
+        if not isinstance(effect_ref, ast.EffectRef):
+            return None
+        if effect_ref.name != "State":
+            return None
+        if not effect_ref.type_args or len(effect_ref.type_args) != 1:
+            return None
+        arg = effect_ref.type_args[0]
+        if isinstance(arg, ast.NamedType):
+            return arg.name
+        return None
 
     def _translate_quantifier(
         self,


### PR DESCRIPTION
## Summary
- Postconditions with `old(State<T>)` and `new(State<T>)` now compile to WASM runtime checks (closes #70)
- `old()` snapshots state at function entry into a temp local; `new()` reads current state via `state_get`
- Snapshot only emitted when ensures clauses actually reference `old()`
- README restructured: C7 (Module System) is now the "What's next" section with sub-phase plan; C6.5 and C6 are collapsed
- Completes the C6.5 codegen cleanup phase (v0.0.25-v0.0.30)
- 6 new codegen tests (880 total)

## Changes
- `vera/wasm.py`: `_translate_old_expr()`, `_translate_new_expr()`, `_extract_state_type_name()`, old state local storage
- `vera/codegen.py`: `_snapshot_old_state()`, `_find_old_state_types()`, `_collect_old_types()`, snapshot insertion in `_compile_fn()`
- `spec/11-compilation.md`: new Section 11.8.4 on state expressions in postconditions
- `README.md`: C7 expanded as "What's next", C6.5 collapsed without strikethrough, C6 collapsed
- Version bump to 0.0.30, CHANGELOG entry, test counts updated across all docs

## Test plan
- [x] 6 new tests in `TestOldNewContracts`: compile, pass, trap, no-snapshot, WAT structure, current-state read
- [x] All 880 tests pass
- [x] mypy clean (14 source files)
- [x] All 14 examples pass check + verify
- [x] Spec code blocks pass
- [x] Version sync check passes (0.0.30)

Generated with [Claude Code](https://claude.com/claude-code)