### PR TITLE
C7a: module resolution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,7 +108,7 @@ Each stage is a module with a single public API function (`parse_file`, `transfo
 ### Testing
 
 ```bash
-pytest tests/ -v                       # Run all tests (880 tests)
+pytest tests/ -v                       # Run all tests (900 tests)
 mypy vera/                             # Type-check the compiler
 python scripts/check_examples.py       # All 14 examples must pass
 ```
@@ -119,7 +119,7 @@ Test helpers follow a pattern: `_check_ok(source)` / `_check_err(source, match)`
 
 - All 14 examples in `examples/` must pass `vera check` and `vera verify`
 - `mypy vera/` must be clean
-- `pytest tests/ -v` must pass (currently 880 tests)
+- `pytest tests/ -v` must pass (currently 900 tests)
 - Version must be in sync across `vera/__init__.py`, `pyproject.toml`, and `CHANGELOG.md`
 
 ### Contributing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 - **Project website** ([veralang.dev](https://veralang.dev)): single-page site deployed via GitHub Pages ([#81](https://github.com/aallan/vera/pull/81))
 
+## [0.0.31] - 2026-02-26
+
+### Added
+- **Module resolution** (C7a — partial [#14](https://github.com/aallan/vera/issues/14), [#50](https://github.com/aallan/vera/issues/50)): `import` paths now resolve to source files on disk
+  - New `vera/resolver.py`: `ModuleResolver` maps import paths (e.g., `vera.math`) to `.vera` files relative to the importing file or project root
+  - `ResolvedModule` dataclass: path tuple, file path, parsed Program AST, source text
+  - Parse cache: each imported module parsed at most once per compilation session
+  - Circular import detection via in-progress tracking set
+  - Resolver wired into all CLI commands (`check`, `verify`, `compile`, `run`)
+  - `typecheck()` accepts optional `resolved_modules` parameter; improved diagnostic messages distinguish "module resolved but type merging not yet implemented (C7b)" from "module not found"
+  - `verify()` accepts `resolved_modules` for forward-compatibility with C7d
+  - Stub modules `examples/vera/math.vera` and `examples/vera/collections.vera` for the `modules.vera` example
+- README restructured: C6/C6.5 collapsed sections moved above "What's next"; new "Longer term" section with all 19 open issues linked by category
+- 20 new tests (900 total, up from 880)
+
 ## [0.0.30] - 2026-02-26
 
 ### Added
@@ -457,7 +472,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Grammar: handler body simplified to avoid LALR reduce/reduce conflict
 - `pyproject.toml`: corrected build backend, package discovery, PEP 639 compliance
 
-[Unreleased]: https://github.com/aallan/vera/compare/v0.0.30...HEAD
+[Unreleased]: https://github.com/aallan/vera/compare/v0.0.31...HEAD
+[0.0.31]: https://github.com/aallan/vera/compare/v0.0.30...v0.0.31
 [0.0.30]: https://github.com/aallan/vera/compare/v0.0.29...v0.0.30
 [0.0.29]: https://github.com/aallan/vera/compare/v0.0.28...v0.0.29
 [0.0.28]: https://github.com/aallan/vera/compare/v0.0.27...v0.0.28

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ vera parse file.vera              # Print the parse tree
 vera ast file.vera                # Print the typed AST
 vera ast --json file.vera         # Print the AST as JSON
 
-pytest tests/ -v                  # Run the test suite (880 tests)
+pytest tests/ -v                  # Run the test suite (900 tests)
 mypy vera/                        # Type-check the compiler itself
 
 python scripts/check_examples.py      # Verify all 14 examples parse + check + verify

--- a/README.md
+++ b/README.md
@@ -173,23 +173,8 @@ Development follows an **interleaved spiral** — each phase adds a complete com
 | C5 | [v0.0.9](https://github.com/aallan/vera/releases/tag/v0.0.9) | **WASM codegen** — compile to WebAssembly, `vera compile` / `vera run` | Done |
 | C6 | [v0.0.10](https://github.com/aallan/vera/releases/tag/v0.0.10)–[v0.0.24](https://github.com/aallan/vera/releases/tag/v0.0.24) | **Codegen completeness** — ADTs, match, closures, effects, generics in WASM | Done |
 | C6.5 | [v0.0.25](https://github.com/aallan/vera/releases/tag/v0.0.25)–[v0.0.30](https://github.com/aallan/vera/releases/tag/v0.0.30) | **Codegen cleanup** — handler fixes, missing operators, String/Array support | Done |
-| C7 | — | **Module system** — cross-file imports, public/private visibility | Planned |
+| C7 | — | **Module system** — cross-file imports, public/private visibility | In progress |
 | C8 | v0.1.0 | **End-to-end** — all examples compile and run, spec complete, polish | Planned |
-
-### What's next: C7 — Module System
-
-C7 implements cross-file imports, public/private visibility, and multi-module compilation. The grammar already parses `module`, `import`, `public`, `private`, and module-qualified calls — the checker currently returns `UnknownType()` for cross-module references. C7 builds out the infrastructure to resolve those references end-to-end.
-
-Tracked in [#14](https://github.com/aallan/vera/issues/14) (type-checking) and [#50](https://github.com/aallan/vera/issues/50) (code generation). Spec Chapter 8 (Modules) will be written alongside the implementation.
-
-| Sub-phase | Scope |
-|-----------|-------|
-| C7a | Module resolution — map `import` paths to source files and parse them |
-| C7b | Cross-module type environment — merge public declarations across files |
-| C7c | Visibility enforcement — `public`/`private` access control in the checker |
-| C7d | Cross-module verification — verify contracts that reference imported symbols |
-| C7e | Multi-module codegen — WASM import/export tables linking multiple modules |
-| C7f | Spec Chapter 8 — formal module semantics, resolution algorithm, examples |
 
 <details>
 <summary>C6.5 — Codegen & Checker Cleanup (<a href="https://github.com/aallan/vera/releases/tag/v0.0.25">v0.0.25</a>–<a href="https://github.com/aallan/vera/releases/tag/v0.0.30">v0.0.30</a>) ✓</summary>
@@ -230,6 +215,35 @@ C6 extended WASM compilation to all language constructs, working through the dep
 | C6n | Spec chapters 9 (Standard library) and 12 (Runtime) | [v0.0.24](https://github.com/aallan/vera/releases/tag/v0.0.24) |
 
 </details>
+
+### What's next: C7 — Module System
+
+C7 implements cross-file imports, public/private visibility, and multi-module compilation. The grammar already parses `module`, `import`, `public`, `private`, and module-qualified calls — the checker currently returns `UnknownType()` for cross-module references. C7 builds out the infrastructure to resolve those references end-to-end.
+
+Tracked in [#14](https://github.com/aallan/vera/issues/14) (type-checking) and [#50](https://github.com/aallan/vera/issues/50) (code generation). Spec Chapter 8 (Modules) will be written alongside the implementation.
+
+| Sub-phase | Scope | Status |
+|-----------|-------|--------|
+| C7a | Module resolution — map `import` paths to source files and parse them | In progress |
+| C7b | Cross-module type environment — merge public declarations across files | Planned |
+| C7c | Visibility enforcement — `public`/`private` access control in the checker | Planned |
+| C7d | Cross-module verification — verify contracts that reference imported symbols | Planned |
+| C7e | Multi-module codegen — WASM import/export tables linking multiple modules | Planned |
+| C7f | Spec Chapter 8 — formal module semantics, resolution algorithm, examples | Planned |
+
+### Longer term
+
+Open issues grouped by area. These are tracked for future phases beyond C7.
+
+**Codegen gaps** — [#51](https://github.com/aallan/vera/issues/51) garbage collection for WASM linear memory, [#52](https://github.com/aallan/vera/issues/52) dynamic string construction, [#53](https://github.com/aallan/vera/issues/53) `Exn<E>` and custom effect handler compilation
+
+**Verification** — [#13](https://github.com/aallan/vera/issues/13) expand SMT decidable fragment (Tier 2), [#45](https://github.com/aallan/vera/issues/45) decreases clause termination verification
+
+**Type system** — [#20](https://github.com/aallan/vera/issues/20) TypeVar subtyping, [#21](https://github.com/aallan/vera/issues/21) effect row unification, [#55](https://github.com/aallan/vera/issues/55) minimal type inference
+
+**Tooling** — [#56](https://github.com/aallan/vera/issues/56) incremental compilation, [#75](https://github.com/aallan/vera/issues/75) `vera fmt` canonical formatter, [#79](https://github.com/aallan/vera/issues/79) `vera test` contract-driven testing, [#80](https://github.com/aallan/vera/issues/80) stable error code taxonomy
+
+**Language design (spec §0.8)** — [#57](https://github.com/aallan/vera/issues/57) `<Http>` network access effect, [#58](https://github.com/aallan/vera/issues/58) JSON standard library type, [#59](https://github.com/aallan/vera/issues/59) `<Async>` futures and promises, [#60](https://github.com/aallan/vera/issues/60) abilities and type constraints, [#61](https://github.com/aallan/vera/issues/61) `<Inference>` LLM inference effect, [#62](https://github.com/aallan/vera/issues/62) standard library collections (Set, Map, Decimal), [#76](https://github.com/aallan/vera/issues/76) Float alias vs Float64 canonical form
 
 ## Getting Started
 
@@ -477,10 +491,11 @@ vera/
 │   ├── verifier.py                # Contract verifier
 │   ├── wasm.py                    # WASM translation layer
 │   ├── codegen.py                 # Code generation orchestrator
+│   ├── resolver.py                # Module resolver (C7a)
 │   ├── errors.py                  # LLM-oriented diagnostics
 │   └── cli.py                     # Command-line interface
 ├── examples/                      # 14 example Vera programs
-├── tests/                         # Test suite (880 tests)
+├── tests/                         # Test suite (900 tests)
 ├── scripts/                       # CI and validation scripts
 │   ├── check_examples.py          # Verify all .vera examples
 │   ├── check_spec_examples.py     # Verify spec code blocks parse

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -474,6 +474,8 @@ public fn exported(@Int -> @Int)
 
 Functions are private by default. Add `public` for external visibility.
 
+Import paths resolve to files on disk: `import vera.math;` looks for `vera/math.vera` relative to the importing file's directory (or the project root). Imported files are parsed and cached automatically. Circular imports are detected and reported as errors.
+
 ## Comments
 
 ```vera

--- a/examples/vera/collections.vera
+++ b/examples/vera/collections.vera
@@ -1,0 +1,8 @@
+-- Stub module: vera.collections
+-- Provides collection type declarations for cross-module examples.
+
+module vera.collections;
+
+data List<T> { Nil, Cons(T, List<T>) }
+
+data Option<T> { None, Some(T) }

--- a/examples/vera/math.vera
+++ b/examples/vera/math.vera
@@ -1,0 +1,21 @@
+-- Stub module: vera.math
+-- Provides basic math utilities for cross-module examples.
+
+module vera.math;
+
+public fn abs(@Int -> @Int)
+  requires(true)
+  ensures(@Int.result >= 0)
+  effects(pure)
+{
+  if @Int.0 < 0 then { 0 - @Int.0 } else { @Int.0 }
+}
+
+public fn max(@Int, @Int -> @Int)
+  requires(true)
+  ensures(@Int.result >= @Int.0)
+  ensures(@Int.result >= @Int.1)
+  effects(pure)
+{
+  if @Int.0 >= @Int.1 then { @Int.0 } else { @Int.1 }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.30"
+version = "0.0.31"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import pytest
 
+from vera import ast
 from vera.checker import typecheck
 from vera.errors import Diagnostic
 from vera.parser import parse_to_ast
@@ -1318,3 +1319,72 @@ fn classify(@Int -> @String)
   }
 }
 """, "Non-exhaustive")
+
+
+# =====================================================================
+# Module call diagnostics (C7a)
+# =====================================================================
+
+class TestModuleCallDiagnostics:
+    """Test improved module-call diagnostic messages (C7a).
+
+    Module call syntax has a known LALR limitation (grammar eats the
+    function name as part of the module_path). These tests construct
+    AST nodes manually to exercise the checker logic.
+    """
+
+    @staticmethod
+    def _make_program_with_module_call(
+        mod_path: tuple[str, ...],
+        fn_name: str,
+    ) -> ast.Program:
+        """Build a minimal Program with a module call in the body."""
+        call = ast.ModuleCall(
+            path=mod_path,
+            name=fn_name,
+            args=(ast.IntLit(value=42),),
+        )
+        fn = ast.FnDecl(
+            name="main",
+            forall_vars=None,
+            params=(),
+            return_type=ast.NamedType(name="Unit", type_args=None),
+            contracts=(
+                ast.Requires(expr=ast.BoolLit(value=True)),
+                ast.Ensures(expr=ast.BoolLit(value=True)),
+            ),
+            effect=ast.PureEffect(),
+            body=ast.Block(statements=(), expr=call),
+            where_fns=None,
+        )
+        tld = ast.TopLevelDecl(visibility=None, decl=fn)
+        return ast.Program(
+            module=None,
+            imports=(),
+            declarations=(tld,),
+        )
+
+    def test_module_not_found_warning(self) -> None:
+        """ModuleCall without resolved_modules gives 'not found' warning."""
+        prog = self._make_program_with_module_call(("foo",), "bar")
+        diags = typecheck(prog, source="")
+        warns = [d for d in diags if d.severity == "warning"]
+        assert any("not found" in w.description for w in warns)
+
+    def test_module_resolved_warning(self) -> None:
+        """ModuleCall with resolved module gives 'C7b' warning."""
+        from vera.resolver import ResolvedModule
+
+        prog = self._make_program_with_module_call(("foo",), "bar")
+        fake_mod = ResolvedModule(
+            path=("foo",),
+            file_path=Path("/fake/foo.vera"),
+            program=ast.Program(
+                module=None, imports=(), declarations=(),
+            ),
+            source="",
+        )
+        diags = typecheck(prog, source="", resolved_modules=[fake_mod])
+        warns = [d for d in diags if d.severity == "warning"]
+        assert any("C7b" in w.description for w in warns)
+        assert not any("not found" in w.description for w in warns)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -930,3 +930,73 @@ fn id(@Int -> @Int)
         data = json.loads(result.stdout)
         assert data["ok"] is False
         assert "Invalid integer" in data["diagnostics"][0]["description"]
+
+
+# =====================================================================
+# Multi-file resolution (C7a)
+# =====================================================================
+
+class TestMultiFileResolution:
+    """Test CLI commands with import resolution."""
+
+    def test_check_with_resolved_import(self, tmp_path: Path) -> None:
+        """vera check resolves imports from sibling files."""
+        main_src = """\
+import lib;
+
+fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+"""
+        lib_src = """\
+fn helper(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+"""
+        main_file = tmp_path / "main.vera"
+        lib_file = tmp_path / "lib.vera"
+        main_file.write_text(main_src, encoding="utf-8")
+        lib_file.write_text(lib_src, encoding="utf-8")
+
+        result = subprocess.run(
+            [sys.executable, "-m", "vera.cli", "check", str(main_file)],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0
+        assert "OK:" in result.stdout
+
+    def test_check_unresolved_import_error(self, tmp_path: Path) -> None:
+        """vera check reports error for unresolved imports."""
+        main_src = """\
+import missing;
+
+fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+"""
+        main_file = tmp_path / "main.vera"
+        main_file.write_text(main_src, encoding="utf-8")
+
+        result = subprocess.run(
+            [sys.executable, "-m", "vera.cli", "check", str(main_file)],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 1
+        assert "Cannot resolve import" in result.stderr
+
+    def test_check_json_with_unresolved_import(self, tmp_path: Path) -> None:
+        """vera check --json includes resolver diagnostics."""
+        main_src = """\
+import missing;
+
+fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+"""
+        main_file = tmp_path / "main.vera"
+        main_file.write_text(main_src, encoding="utf-8")
+
+        result = subprocess.run(
+            [sys.executable, "-m", "vera.cli", "check", "--json",
+             str(main_file)],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 1
+        data = json.loads(result.stdout)
+        assert data["ok"] is False
+        assert any(
+            "Cannot resolve import" in d["description"]
+            for d in data["diagnostics"]
+        )

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,0 +1,412 @@
+"""Tests for vera.resolver — module resolution.
+
+Test helpers use tmp_path (pytest fixture) to create temporary
+file hierarchies for multi-module resolution testing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from vera.resolver import ModuleResolver, ResolvedModule
+
+
+# =====================================================================
+# Helpers
+# =====================================================================
+
+
+def _write_file(base: Path, rel_path: str, content: str) -> Path:
+    """Write a .vera file into a temp directory structure."""
+    p = base / rel_path
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def _resolve_ok(
+    tmp_path: Path,
+    main_source: str,
+    modules: dict[str, str] | None = None,
+) -> list[ResolvedModule]:
+    """Write files, resolve, assert no errors. Returns resolved modules."""
+    main_file = _write_file(tmp_path, "main.vera", main_source)
+    if modules:
+        for rel_path, content in modules.items():
+            _write_file(tmp_path, rel_path, content)
+
+    resolver = ModuleResolver(_root=tmp_path)
+    from vera.parser import parse_file
+    from vera.transform import transform
+
+    tree = parse_file(str(main_file))
+    program = transform(tree)
+    resolved = resolver.resolve_imports(program, main_file)
+    assert not resolver.errors, (
+        f"Unexpected resolution errors: "
+        f"{[e.description for e in resolver.errors]}"
+    )
+    return resolved
+
+
+def _resolve_err(
+    tmp_path: Path,
+    main_source: str,
+    match: str,
+    modules: dict[str, str] | None = None,
+) -> list[str]:
+    """Write files, resolve, assert error matching substring."""
+    main_file = _write_file(tmp_path, "main.vera", main_source)
+    if modules:
+        for rel_path, content in modules.items():
+            _write_file(tmp_path, rel_path, content)
+
+    resolver = ModuleResolver(_root=tmp_path)
+    from vera.parser import parse_file
+    from vera.transform import transform
+
+    tree = parse_file(str(main_file))
+    program = transform(tree)
+    resolver.resolve_imports(program, main_file)
+    error_msgs = [e.description for e in resolver.errors]
+    assert any(match in msg for msg in error_msgs), (
+        f"Expected error matching '{match}', got: {error_msgs}"
+    )
+    return error_msgs
+
+
+# =====================================================================
+# Path resolution
+# =====================================================================
+
+
+class TestPathResolution:
+    """Test import path → file path resolution."""
+
+    def test_simple_single_segment(self, tmp_path: Path) -> None:
+        """import math; → math.vera in same directory."""
+        main = """
+import math;
+
+fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+"""
+        lib = """
+fn add(@Int, @Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 + @Int.1 }
+"""
+        resolved = _resolve_ok(tmp_path, main, {"math.vera": lib})
+        assert len(resolved) == 1
+        assert resolved[0].path == ("math",)
+
+    def test_nested_path(self, tmp_path: Path) -> None:
+        """import vera.math; → vera/math.vera relative to file."""
+        main = """
+import vera.math;
+
+fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+"""
+        lib = """
+fn add(@Int, @Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 + @Int.1 }
+"""
+        resolved = _resolve_ok(
+            tmp_path, main, {"vera/math.vera": lib},
+        )
+        assert len(resolved) == 1
+        assert resolved[0].path == ("vera", "math")
+
+    def test_file_not_found(self, tmp_path: Path) -> None:
+        """import nonexistent; → error diagnostic."""
+        main = """
+import nonexistent;
+
+fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+"""
+        _resolve_err(tmp_path, main, "Cannot resolve import")
+
+    def test_file_not_found_nested(self, tmp_path: Path) -> None:
+        """import deeply.nested.missing; → error with full path."""
+        main = """
+import deeply.nested.missing;
+
+fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+"""
+        errors = _resolve_err(tmp_path, main, "Cannot resolve import")
+        assert any("deeply.nested.missing" in msg for msg in errors)
+
+    def test_resolve_relative_to_importing_file(
+        self, tmp_path: Path,
+    ) -> None:
+        """Resolution is relative to the importing file, not cwd."""
+        # main.vera is in a subdirectory
+        main = """
+import sibling;
+
+fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+"""
+        lib = """
+fn helper(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+"""
+        # main.vera in subdir/, sibling.vera also in subdir/
+        main_file = _write_file(tmp_path, "subdir/main.vera", main)
+        _write_file(tmp_path, "subdir/sibling.vera", lib)
+
+        from vera.parser import parse_file
+        from vera.transform import transform
+
+        resolver = ModuleResolver(_root=tmp_path)
+        tree = parse_file(str(main_file))
+        program = transform(tree)
+        resolved = resolver.resolve_imports(program, main_file)
+        assert not resolver.errors
+        assert len(resolved) == 1
+        assert resolved[0].path == ("sibling",)
+
+
+# =====================================================================
+# Parse caching
+# =====================================================================
+
+
+class TestParseCaching:
+    """Test that modules are parsed at most once."""
+
+    def test_same_module_imported_twice(self, tmp_path: Path) -> None:
+        """Two imports of the same path → resolved only once in cache."""
+        # Two different files both import the same module
+        main = """
+import utils;
+
+fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+"""
+        utils_src = """
+fn helper(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+"""
+        main_file = _write_file(tmp_path, "main.vera", main)
+        _write_file(tmp_path, "utils.vera", utils_src)
+
+        from vera.parser import parse_file
+        from vera.transform import transform
+
+        resolver = ModuleResolver(_root=tmp_path)
+        tree = parse_file(str(main_file))
+        program = transform(tree)
+
+        # Resolve twice (simulating being called from two files)
+        resolved1 = resolver.resolve_imports(program, main_file)
+        resolved2 = resolver.resolve_imports(program, main_file)
+        assert len(resolved1) == 1
+        assert len(resolved2) == 1
+        # Same object from cache
+        assert resolved1[0] is resolved2[0]
+
+    def test_transitive_shared_import(self, tmp_path: Path) -> None:
+        """A imports B and C, both B and C import D → D parsed once."""
+        main_src = """
+import b;
+import c;
+
+fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+"""
+        b_src = """
+import d;
+
+fn fb(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+"""
+        c_src = """
+import d;
+
+fn fc(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+"""
+        d_src = """
+fn fd(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+"""
+        main_file = _write_file(tmp_path, "main.vera", main_src)
+        _write_file(tmp_path, "b.vera", b_src)
+        _write_file(tmp_path, "c.vera", c_src)
+        _write_file(tmp_path, "d.vera", d_src)
+
+        from vera.parser import parse_file
+        from vera.transform import transform
+
+        resolver = ModuleResolver(_root=tmp_path)
+        tree = parse_file(str(main_file))
+        program = transform(tree)
+        resolved = resolver.resolve_imports(program, main_file)
+        assert not resolver.errors
+        # main directly imports b and c
+        assert len(resolved) == 2
+        # d should be in cache (resolved transitively)
+        assert ("d",) in resolver._cache
+
+
+# =====================================================================
+# Circular imports
+# =====================================================================
+
+
+class TestCircularImports:
+    """Test circular import detection."""
+
+    def test_direct_circular(self, tmp_path: Path) -> None:
+        """A imports B, B imports A → error."""
+        a_src = """
+import b;
+
+fn fa(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+"""
+        b_src = """
+import a;
+
+fn fb(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+"""
+        # a.vera imports b.vera, b.vera imports a.vera
+        a_file = _write_file(tmp_path, "a.vera", a_src)
+        _write_file(tmp_path, "b.vera", b_src)
+
+        from vera.parser import parse_file
+        from vera.transform import transform
+
+        resolver = ModuleResolver(_root=tmp_path)
+        tree = parse_file(str(a_file))
+        program = transform(tree)
+        resolver.resolve_imports(program, a_file)
+        error_msgs = [e.description for e in resolver.errors]
+        assert any("Circular import" in msg for msg in error_msgs)
+
+    def test_self_import(self, tmp_path: Path) -> None:
+        """A imports itself → error."""
+        a_src = """
+import a;
+
+fn fa(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+"""
+        a_file = _write_file(tmp_path, "a.vera", a_src)
+
+        from vera.parser import parse_file
+        from vera.transform import transform
+
+        resolver = ModuleResolver(_root=tmp_path)
+        tree = parse_file(str(a_file))
+        program = transform(tree)
+        # Mark 'a' as the current file being resolved
+        resolver._in_progress.add(("a",))
+        resolver.resolve_imports(program, a_file)
+        error_msgs = [e.description for e in resolver.errors]
+        assert any("Circular import" in msg for msg in error_msgs)
+
+    def test_transitive_circular(self, tmp_path: Path) -> None:
+        """A imports B, B imports C, C imports A → error."""
+        a_src = """
+import b;
+
+fn fa(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+"""
+        b_src = """
+import c;
+
+fn fb(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+"""
+        c_src = """
+import a;
+
+fn fc(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+"""
+        a_file = _write_file(tmp_path, "a.vera", a_src)
+        _write_file(tmp_path, "b.vera", b_src)
+        _write_file(tmp_path, "c.vera", c_src)
+
+        from vera.parser import parse_file
+        from vera.transform import transform
+
+        resolver = ModuleResolver(_root=tmp_path)
+        tree = parse_file(str(a_file))
+        program = transform(tree)
+        resolver.resolve_imports(program, a_file)
+        error_msgs = [e.description for e in resolver.errors]
+        assert any("Circular import" in msg for msg in error_msgs)
+
+
+# =====================================================================
+# Import validation
+# =====================================================================
+
+
+class TestImportValidation:
+    """Test that resolved files are correctly parsed."""
+
+    def test_import_parses_correctly(self, tmp_path: Path) -> None:
+        """Resolved file is a valid Vera program with declarations."""
+        main = """
+import lib;
+
+fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+"""
+        lib = """
+fn add(@Int, @Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 + @Int.1 }
+
+fn sub(@Int, @Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 - @Int.1 }
+"""
+        resolved = _resolve_ok(tmp_path, main, {"lib.vera": lib})
+        assert len(resolved) == 1
+        # The resolved program should have 2 function declarations
+        assert len(resolved[0].program.declarations) == 2
+
+    def test_import_with_parse_error(self, tmp_path: Path) -> None:
+        """Resolved file has syntax errors → error diagnostic."""
+        main = """
+import broken;
+
+fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+"""
+        broken = "this is not valid vera syntax {{{"
+        _resolve_err(
+            tmp_path, main, "Error parsing imported module",
+            modules={"broken.vera": broken},
+        )
+
+    def test_import_with_names(self, tmp_path: Path) -> None:
+        """import lib(add, sub); → resolves same file as bare import."""
+        main = """
+import lib(add, sub);
+
+fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+"""
+        lib = """
+fn add(@Int, @Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 + @Int.1 }
+
+fn sub(@Int, @Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 - @Int.1 }
+"""
+        resolved = _resolve_ok(tmp_path, main, {"lib.vera": lib})
+        assert len(resolved) == 1
+        assert resolved[0].path == ("lib",)
+
+    def test_no_imports(self, tmp_path: Path) -> None:
+        """File with no imports → empty resolved list."""
+        main = """
+fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+"""
+        resolved = _resolve_ok(tmp_path, main)
+        assert resolved == []
+
+    def test_module_decl_only(self, tmp_path: Path) -> None:
+        """File with module decl but no imports → empty resolved list."""
+        main = """
+module my.app;
+
+fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+"""
+        resolved = _resolve_ok(tmp_path, main)
+        assert resolved == []

--- a/vera/README.md
+++ b/vera/README.md
@@ -10,7 +10,7 @@ For other documentation:
 
 ## Pipeline Overview
 
-The compiler is a six-stage pipeline. Each stage consumes the output of the previous one. Each stage has a single public entry point and is independently testable.
+The compiler is a seven-stage pipeline. Each stage consumes the output of the previous one. Each stage has a single public entry point and is independently testable.
 
 ```
 Source (.vera)
@@ -24,6 +24,12 @@ Source (.vera)
 ┌──────────────────────────────────────────────────────────┐
 │  2. Transform                          transform.py      │
 │     Lark parse tree → typed AST (ast.py)                 │
+└────────────────────────┬─────────────────────────────────┘
+                         ▼
+┌──────────────────────────────────────────────────────────┐
+│  2b. Resolve                           resolver.py       │
+│      Map import paths → source files, parse + cache      │
+│      Circular import detection                           │
 └────────────────────────┬─────────────────────────────────┘
                          ▼
 ┌──────────────────────────────────────────────────────────┐
@@ -74,16 +80,17 @@ execute(compile_result, ...)    # → run WASM via wasmtime
 | `ast.py` | 682 | Transform | Frozen dataclass AST nodes | `Program`, `Node`, `Expr` |
 | `types.py` | 302 | Type check | Semantic type representation | `Type`, `is_subtype()` |
 | `environment.py` | 300 | Type check | Type environment, scope stacks | `TypeEnv` |
-| `checker.py` | 1,668 | Type check | Two-pass type checker | `typecheck()` |
+| `checker.py` | 1,768 | Type check | Two-pass type checker | `typecheck()` |
+| `resolver.py` | 213 | Resolve | Module path resolution, parse cache | `ModuleResolver` |
 | `smt.py` | 485 | Verify | Z3 translation layer | `SmtContext`, `SlotEnv` |
-| `verifier.py` | 601 | Verify | Contract verification | `verify()` |
+| `verifier.py` | 605 | Verify | Contract verification | `verify()` |
 | `wasm.py` | 2,317 | Compile | WASM translation layer | `WasmContext`, `WasmSlotEnv` |
 | `codegen.py` | 1,773 | Compile | Codegen orchestrator | `compile()`, `execute()` |
 | `errors.py` | 354 | All | Diagnostic class, error hierarchy | `Diagnostic`, `VeraError` |
-| `cli.py` | 563 | All | CLI commands | `main()` |
+| `cli.py` | 594 | All | CLI commands | `main()` |
 | `registration.py` | 56 | Type check | Shared function registration | `register_fn()` |
 
-Total: ~10,323 lines of Python + 328 lines of grammar.
+Total: ~10,636 lines of Python + 328 lines of grammar.
 
 ## Parsing
 
@@ -454,7 +461,7 @@ Every diagnostic includes a description (what went wrong), rationale (which lang
 
 ## Test Suite
 
-**880 tests** across 10 files, plus 4 validation scripts and CI infrastructure.
+**900 tests** across 11 files, plus 4 validation scripts and CI infrastructure.
 
 ### Test files
 
@@ -462,10 +469,11 @@ Every diagnostic includes a description (what went wrong), rationale (which lang
 |------|------:|------:|----------------|
 | `test_parser.py` | 97 | 829 | Grammar rules, operator precedence, parse errors |
 | `test_ast.py` | 84 | 896 | AST transformation, node structure, serialisation |
-| `test_checker.py` | 115 | 1,320 | Type synthesis, slot resolution, effects, contracts, exhaustiveness |
+| `test_checker.py` | 117 | 1,390 | Type synthesis, slot resolution, effects, contracts, exhaustiveness, module call diagnostics |
 | `test_verifier.py` | 69 | 918 | Z3 verification, counterexamples, tier classification, Int→Nat enforcement, call-site preconditions, pipe operator |
 | `test_codegen.py` | 326 | 4,198 | WASM compilation, arithmetic, Float64 (incl. modulo), Byte, arrays, ADTs, match, generics, closures, State\<T\>, control flow, strings, IO, contracts, bounds checking, length, quantifiers, assert/assume, refinement type aliases, pipe operator, String/Array signatures, old/new state postconditions, example round-trips |
-| `test_cli.py` | 76 | 932 | CLI commands (check, verify, compile, run), subprocess integration, JSON error paths, runtime traps, arg validation |
+| `test_cli.py` | 79 | 1,002 | CLI commands (check, verify, compile, run), subprocess integration, JSON error paths, runtime traps, arg validation, multi-file resolution |
+| `test_resolver.py` | 15 | 412 | Module resolution, path lookup, parse caching, circular import detection |
 | `test_types.py` | 55 | 279 | Type operations: subtyping, equality, substitution, pretty-printing, canonical names |
 | `test_wasm.py` | 22 | 255 | WASM internals: StringPool, WasmSlotEnv, translation edge cases via full pipeline |
 | `test_readme.py` | 2 | 68 | README code sample parsing |
@@ -539,7 +547,7 @@ Honest inventory of what the compiler cannot do, and where each limitation is ad
 
 | Limitation | Why | Planned |
 |-----------|-----|---------|
-| **No module resolution** | `import` declarations parsed but not resolved | [#50](https://github.com/aallan/vera/issues/50) |
+| **Partial module resolution** | `import` paths resolve to files (C7a), but cross-module types not merged (C7b) | [#14](https://github.com/aallan/vera/issues/14), [#50](https://github.com/aallan/vera/issues/50) |
 | **Limited effect checking** | Pure vs effectful only; no subeffecting or row unification | [#21](https://github.com/aallan/vera/issues/21) |
 | **No termination verification** | `decreases` clauses parsed but always Tier 3 | [#45](https://github.com/aallan/vera/issues/45) |
 | **No quantifier verification** | `forall`/`exists` in contracts always Tier 3 | [#13](https://github.com/aallan/vera/issues/13) |

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.30"
+__version__ = "0.0.31"

--- a/vera/checker.py
+++ b/vera/checker.py
@@ -10,6 +10,11 @@ by the contract verifier (vera/verifier.py) via Z3.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from vera.resolver import ResolvedModule
+
 from vera import ast
 from vera.errors import Diagnostic, SourceLocation
 from vera.environment import (
@@ -59,14 +64,24 @@ from vera.types import (
 # Public API
 # =====================================================================
 
-def typecheck(program: ast.Program,
-              source: str = "",
-              file: str | None = None) -> list[Diagnostic]:
+def typecheck(
+    program: ast.Program,
+    source: str = "",
+    file: str | None = None,
+    resolved_modules: list[ResolvedModule] | None = None,
+) -> list[Diagnostic]:
     """Type-check a Vera Program AST.
 
     Returns a list of Diagnostics (empty = no errors).
+
+    *resolved_modules* — modules resolved from ``import`` declarations
+    (see :class:`~vera.resolver.ModuleResolver`).  Used in C7a to
+    improve diagnostics for cross-module calls; actual type merging
+    is deferred to C7b.
     """
-    checker = TypeChecker(source=source, file=file)
+    checker = TypeChecker(
+        source=source, file=file, resolved_modules=resolved_modules,
+    )
     checker.check_program(program)
     return checker.errors
 
@@ -78,12 +93,22 @@ def typecheck(program: ast.Program,
 class TypeChecker:
     """Top-down type checker with error accumulation."""
 
-    def __init__(self, source: str = "", file: str | None = None) -> None:
+    def __init__(
+        self,
+        source: str = "",
+        file: str | None = None,
+        resolved_modules: list[ResolvedModule] | None = None,
+    ) -> None:
         self.env = TypeEnv()
         self.errors: list[Diagnostic] = []
         self.source = source
         self.file = file
         self._effect_ops_used: set[str] = set()
+        # Resolved module paths for improved diagnostics (C7a).
+        # Actual type merging is deferred to C7b.
+        self._resolved_module_paths: set[tuple[str, ...]] = {
+            m.path for m in (resolved_modules or [])
+        }
 
     # -----------------------------------------------------------------
     # Diagnostics
@@ -1077,12 +1102,33 @@ class TypeChecker:
 
     def _check_module_call(self, expr: ast.ModuleCall) -> Type | None:
         """Type-check a module call: path.to.fn(args)."""
-        self._error(
-            expr,
-            f"Module call '{'.'.join(expr.path)}.{expr.name}' cannot be "
-            f"resolved (cross-module resolution not yet implemented).",
-            severity="warning",
-        )
+        mod_path = tuple(expr.path)
+        if mod_path in self._resolved_module_paths:
+            # Module was resolved by the resolver (C7a) but cross-module
+            # type merging is not yet implemented (C7b).
+            self._error(
+                expr,
+                f"Module '{'.'.join(expr.path)}' resolved, but "
+                f"cross-module type checking is not yet implemented "
+                f"(C7b). Call to '{expr.name}' is unchecked.",
+                severity="warning",
+                rationale=(
+                    "The module was found and parsed successfully. "
+                    "Type merging across module boundaries will be "
+                    "available in a future release (C7b)."
+                ),
+            )
+        else:
+            self._error(
+                expr,
+                f"Module '{'.'.join(expr.path)}' not found. "
+                f"Cannot resolve call to '{expr.name}'.",
+                severity="warning",
+                rationale=(
+                    "No module matching this import path was resolved. "
+                    "Check that the file exists and is imported."
+                ),
+            )
         for arg in expr.args:
             self._synth_expr(arg)
         return UnknownType()

--- a/vera/cli.py
+++ b/vera/cli.py
@@ -54,13 +54,22 @@ def cmd_parse(path: str) -> int:
 def cmd_check(path: str, as_json: bool = False) -> int:
     """Parse, transform, and type-check a .vera file."""
     from vera.checker import typecheck
+    from vera.resolver import ModuleResolver
 
     try:
         p = Path(path)
         source = p.read_text(encoding="utf-8")
         tree = parse_file(path)
         ast = transform(tree)
-        diagnostics = typecheck(ast, source, file=str(p))
+
+        # Resolve imports (C7a)
+        resolver = ModuleResolver(_root=p.parent)
+        resolved = resolver.resolve_imports(ast, p)
+        resolve_diags = resolver.errors
+
+        diagnostics = resolve_diags + typecheck(
+            ast, source, file=str(p), resolved_modules=resolved,
+        )
 
         errors = [d for d in diagnostics if d.severity == "error"]
         warnings = [d for d in diagnostics if d.severity == "warning"]
@@ -108,6 +117,7 @@ def cmd_check(path: str, as_json: bool = False) -> int:
 def cmd_verify(path: str, as_json: bool = False) -> int:
     """Parse, transform, type-check, and verify a .vera file."""
     from vera.checker import typecheck
+    from vera.resolver import ModuleResolver
     from vera.verifier import verify
 
     try:
@@ -116,8 +126,14 @@ def cmd_verify(path: str, as_json: bool = False) -> int:
         tree = parse_file(path)
         ast = transform(tree)
 
+        # Resolve imports (C7a)
+        resolver = ModuleResolver(_root=p.parent)
+        resolved = resolver.resolve_imports(ast, p)
+
         # First type-check
-        type_diags = typecheck(ast, source, file=str(p))
+        type_diags = resolver.errors + typecheck(
+            ast, source, file=str(p), resolved_modules=resolved,
+        )
         type_errors = [d for d in type_diags if d.severity == "error"]
         type_warnings = [d for d in type_diags if d.severity == "warning"]
 
@@ -136,7 +152,8 @@ def cmd_verify(path: str, as_json: bool = False) -> int:
             return 1
 
         # Then verify contracts
-        result = verify(ast, source, file=str(p))
+        result = verify(ast, source, file=str(p),
+                        resolved_modules=resolved)
 
         errors = [d for d in result.diagnostics if d.severity == "error"]
         warnings = [d for d in result.diagnostics if d.severity == "warning"]
@@ -208,6 +225,7 @@ def cmd_compile(
     """Parse, type-check, and compile a .vera file to WebAssembly."""
     from vera.checker import typecheck
     from vera.codegen import compile as codegen_compile
+    from vera.resolver import ModuleResolver
 
     try:
         p = Path(path)
@@ -215,8 +233,14 @@ def cmd_compile(
         tree = parse_file(path)
         ast = transform(tree)
 
+        # Resolve imports (C7a)
+        resolver = ModuleResolver(_root=p.parent)
+        resolved = resolver.resolve_imports(ast, p)
+
         # Type-check first
-        type_diags = typecheck(ast, source, file=str(p))
+        type_diags = resolver.errors + typecheck(
+            ast, source, file=str(p), resolved_modules=resolved,
+        )
         type_errors = [d for d in type_diags if d.severity == "error"]
         type_warnings = [d for d in type_diags if d.severity == "warning"]
 
@@ -313,6 +337,7 @@ def cmd_run(
     """Parse, type-check, compile, and execute a .vera file."""
     from vera.checker import typecheck
     from vera.codegen import compile as codegen_compile, execute
+    from vera.resolver import ModuleResolver
 
     try:
         p = Path(path)
@@ -320,8 +345,14 @@ def cmd_run(
         tree = parse_file(path)
         ast = transform(tree)
 
+        # Resolve imports (C7a)
+        resolver = ModuleResolver(_root=p.parent)
+        resolved = resolver.resolve_imports(ast, p)
+
         # Type-check
-        type_diags = typecheck(ast, source, file=str(p))
+        type_diags = resolver.errors + typecheck(
+            ast, source, file=str(p), resolved_modules=resolved,
+        )
         type_errors = [d for d in type_diags if d.severity == "error"]
 
         if type_errors:

--- a/vera/resolver.py
+++ b/vera/resolver.py
@@ -1,0 +1,213 @@
+"""Vera module resolver — map import paths to source files.
+
+C7a: Resolve import declarations to files on disk, parse them into
+ASTs, cache results, and detect circular imports. Does NOT merge
+types across modules (C7b) or enforce visibility (C7c).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from vera import ast
+from vera.errors import Diagnostic, SourceLocation
+from vera.parser import parse_file
+from vera.transform import transform
+
+
+@dataclass(frozen=True)
+class ResolvedModule:
+    """A resolved and parsed module."""
+
+    path: tuple[str, ...]  # e.g., ("vera", "math")
+    file_path: Path  # absolute path to the .vera file
+    program: ast.Program  # parsed + transformed AST
+    source: str  # raw source text
+
+
+@dataclass
+class ModuleResolver:
+    """Resolves import paths to source files and parses them.
+
+    Resolution algorithm (C7a, simple):
+    1. Convert module path to directory separators + ".vera" suffix
+       e.g., ``vera.math`` → ``vera/math.vera``
+    2. Resolve relative to the importing file's parent directory
+    3. If the importing file's parent differs from the root, also
+       try relative to the root directory
+
+    Circular imports are detected and reported as diagnostics.
+    Parsed modules are cached so each file is parsed at most once.
+    """
+
+    _root: Path
+    _cache: dict[tuple[str, ...], ResolvedModule] = field(
+        default_factory=dict,
+    )
+    _in_progress: set[tuple[str, ...]] = field(default_factory=set)
+    _errors: list[Diagnostic] = field(default_factory=list)
+
+    @property
+    def errors(self) -> list[Diagnostic]:
+        """Accumulated resolution diagnostics."""
+        return list(self._errors)
+
+    # -----------------------------------------------------------------
+    # Public API
+    # -----------------------------------------------------------------
+
+    def resolve_imports(
+        self,
+        program: ast.Program,
+        file: Path,
+    ) -> list[ResolvedModule]:
+        """Resolve all imports in a program.
+
+        Returns a list of successfully resolved modules.
+        Errors are accumulated in ``self.errors``.
+        """
+        resolved: list[ResolvedModule] = []
+        for imp in program.imports:
+            mod = self._resolve_single(imp, file)
+            if mod is not None:
+                resolved.append(mod)
+        return resolved
+
+    # -----------------------------------------------------------------
+    # Internal
+    # -----------------------------------------------------------------
+
+    def _resolve_single(
+        self,
+        imp: ast.ImportDecl,
+        importing_file: Path,
+    ) -> ResolvedModule | None:
+        """Resolve a single import declaration.
+
+        Returns the ResolvedModule or None on failure (error recorded).
+        """
+        mod_path = imp.path
+
+        # Check cache first
+        if mod_path in self._cache:
+            return self._cache[mod_path]
+
+        # Circular import detection
+        if mod_path in self._in_progress:
+            self._errors.append(
+                Diagnostic(
+                    description=(
+                        f"Circular import detected: "
+                        f"'{'.'.join(mod_path)}' is already being "
+                        f"resolved."
+                    ),
+                    location=self._location_from_node(imp),
+                    rationale=(
+                        "Circular imports are not allowed. Restructure "
+                        "the modules to break the dependency cycle."
+                    ),
+                    severity="error",
+                ),
+            )
+            return None
+
+        # Resolve path to file on disk
+        file_path = self._resolve_path(mod_path, importing_file)
+        if file_path is None:
+            self._errors.append(
+                Diagnostic(
+                    description=(
+                        f"Cannot resolve import "
+                        f"'{'.'.join(mod_path)}': no file found."
+                    ),
+                    location=self._location_from_node(imp),
+                    rationale=(
+                        f"Looked for "
+                        f"'{'/'.join(mod_path)}.vera' relative to "
+                        f"the importing file and project root."
+                    ),
+                    fix=(
+                        f"Create the file "
+                        f"'{'/'.join(mod_path)}.vera' or check the "
+                        f"import path."
+                    ),
+                    severity="error",
+                ),
+            )
+            return None
+
+        # Mark as in-progress (circular detection)
+        self._in_progress.add(mod_path)
+
+        try:
+            # Parse and transform
+            source = file_path.read_text(encoding="utf-8")
+            tree = parse_file(str(file_path))
+            program = transform(tree)
+
+            mod = ResolvedModule(
+                path=mod_path,
+                file_path=file_path,
+                program=program,
+                source=source,
+            )
+
+            # Recursively resolve imports of the imported module
+            # BEFORE adding to cache — so circular imports are caught
+            # by the _in_progress check rather than short-circuited
+            # by the cache.
+            for sub_imp in program.imports:
+                self._resolve_single(sub_imp, file_path)
+
+            self._cache[mod_path] = mod
+            return mod
+        except Exception as exc:
+            self._errors.append(
+                Diagnostic(
+                    description=(
+                        f"Error parsing imported module "
+                        f"'{'.'.join(mod_path)}': {exc}"
+                    ),
+                    location=self._location_from_node(imp),
+                    severity="error",
+                ),
+            )
+            return None
+        finally:
+            self._in_progress.discard(mod_path)
+
+    def _resolve_path(
+        self,
+        mod_path: tuple[str, ...],
+        importing_file: Path,
+    ) -> Path | None:
+        """Map a module path to a file on disk.
+
+        Tries:
+        1. Relative to the importing file's parent directory
+        2. Relative to the project root (if different)
+        """
+        relative = Path(*mod_path).with_suffix(".vera")
+
+        # Try relative to importing file's directory
+        candidate = importing_file.parent / relative
+        if candidate.is_file():
+            return candidate.resolve()
+
+        # Try relative to the project root
+        root_candidate = self._root / relative
+        if root_candidate.is_file():
+            return root_candidate.resolve()
+
+        return None
+
+    @staticmethod
+    def _location_from_node(node: ast.Node) -> SourceLocation:
+        """Extract a SourceLocation from an AST node's span."""
+        if node.span:
+            return SourceLocation(
+                line=node.span.line,
+                column=node.span.column,
+            )
+        return SourceLocation()

--- a/vera/verifier.py
+++ b/vera/verifier.py
@@ -61,11 +61,15 @@ def verify(
     source: str = "",
     file: str | None = None,
     timeout_ms: int = 10_000,
+    resolved_modules: object | None = None,
 ) -> VerifyResult:
     """Verify contracts in a type-checked Vera Program AST.
 
     Returns a VerifyResult with diagnostics and a verification summary.
     The program must already have passed type checking (C3).
+
+    *resolved_modules* is accepted for forward-compatibility with C7d
+    (cross-module verification) but is unused in this release.
     """
     verifier = ContractVerifier(source=source, file=file, timeout_ms=timeout_ms)
     verifier.verify_program(program)


### PR DESCRIPTION
## Summary
- Add `vera/resolver.py` with `ModuleResolver` and `ResolvedModule` -- maps import paths to `.vera` files on disk, parses and caches them, detects circular imports
- Wire resolver into `checker.py` (improved module-call diagnostics), `cli.py` (all four commands), and `verifier.py` (pass-through for C7d)
- Create stub modules `examples/vera/math.vera` and `examples/vera/collections.vera`
- Restructure README roadmap: collapse C6/C6.5 above What's next, add Longer term section with 19 open issues
- 900 tests, mypy clean, 14 examples pass

Partial #14, partial #50

## Test plan
- [x] `pytest tests/ -v` -- 900 tests pass (15 new resolver + 2 checker + 3 CLI)
- [x] `mypy vera/` -- clean
- [x] `python scripts/check_examples.py` -- 14/14 pass
- [x] `python scripts/check_spec_examples.py` -- all pass
- [x] `python scripts/check_readme_examples.py` -- all pass
- [x] `python scripts/check_version_sync.py` -- 0.0.31 consistent

Generated with [Claude Code](https://claude.com/claude-code)