### PR TITLE
docs: mark C7a as v0.0.31 in sub-phase table

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ Tracked in [#14](https://github.com/aallan/vera/issues/14) (type-checking) and [
 
 | Sub-phase | Scope | Status |
 |-----------|-------|--------|
-| C7a | Module resolution — map `import` paths to source files and parse them | In progress |
+| C7a | Module resolution — map `import` paths to source files and parse them | v0.0.31 |
 | C7b | Cross-module type environment — merge public declarations across files | Planned |
 | C7c | Visibility enforcement — `public`/`private` access control in the checker | Planned |
 | C7d | Cross-module verification — verify contracts that reference imported symbols | Planned |


### PR DESCRIPTION
One-line fix: C7a sub-phase status was still showing "In progress" instead of the release version.

Generated with [Claude Code](https://claude.com/claude-code)