### PR TITLE
C7b: cross-module type checking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,7 +108,7 @@ Each stage is a module with a single public API function (`parse_file`, `transfo
 ### Testing
 
 ```bash
-pytest tests/ -v                       # Run all tests (900 tests)
+pytest tests/ -v                       # Run all tests (913 tests)
 mypy vera/                             # Type-check the compiler
 python scripts/check_examples.py       # All 14 examples must pass
 ```
@@ -119,7 +119,7 @@ Test helpers follow a pattern: `_check_ok(source)` / `_check_err(source, match)`
 
 - All 14 examples in `examples/` must pass `vera check` and `vera verify`
 - `mypy vera/` must be clean
-- `pytest tests/ -v` must pass (currently 900 tests)
+- `pytest tests/ -v` must pass (currently 913 tests)
 - Version must be in sync across `vera/__init__.py`, `pyproject.toml`, and `CHANGELOG.md`
 
 ### Contributing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 - **Project website** ([veralang.dev](https://veralang.dev)): single-page site deployed via GitHub Pages ([#81](https://github.com/aallan/vera/pull/81))
 
+## [0.0.32] - 2026-02-27
+
+### Added
+- **Cross-module type checking** (C7b — partial [#14](https://github.com/aallan/vera/issues/14)):
+  - Imported function signatures are now registered and type-checked: arity checking, argument type checking, generic inference, and effect propagation all work across module boundaries
+  - **Bare calls**: `import vera.math(abs); abs(-5)` resolves `abs` from the imported module — immediately usable from source files
+  - **Module-qualified calls**: `ModuleCall` AST nodes type-checked against imported module declarations (grammar limitation [#95](https://github.com/aallan/vera/issues/95) prevents parsing `path.fn(args)` from source)
+  - Selective import enforcement: `import m(f)` restricts available names to `f` only; calls to unimported names produce errors with fix suggestions
+  - Wildcard imports: `import m;` makes all module declarations available
+  - Local declarations shadow imported names (standard rule)
+  - Imported ADT constructors available via bare calls: `import col(List); Cons(1, Nil)` works
+  - Module declarations registered in isolated `TypeChecker` instances to avoid namespace pollution
+  - `examples/modules.vera` now exercises bare cross-module calls (`abs`, `max` from `vera.math`)
+- LALR grammar limitation for module-qualified call syntax tracked as [#95](https://github.com/aallan/vera/issues/95)
+- 13 new tests (913 total, up from 900)
+
 ## [0.0.31] - 2026-02-26
 
 ### Added
@@ -473,6 +489,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `pyproject.toml`: corrected build backend, package discovery, PEP 639 compliance
 
 [Unreleased]: https://github.com/aallan/vera/compare/v0.0.31...HEAD
+[0.0.32]: https://github.com/aallan/vera/compare/v0.0.31...v0.0.32
 [0.0.31]: https://github.com/aallan/vera/compare/v0.0.30...v0.0.31
 [0.0.30]: https://github.com/aallan/vera/compare/v0.0.29...v0.0.30
 [0.0.29]: https://github.com/aallan/vera/compare/v0.0.28...v0.0.29

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ vera parse file.vera              # Print the parse tree
 vera ast file.vera                # Print the typed AST
 vera ast --json file.vera         # Print the AST as JSON
 
-pytest tests/ -v                  # Run the test suite (900 tests)
+pytest tests/ -v                  # Run the test suite (913 tests)
 mypy vera/                        # Type-check the compiler itself
 
 python scripts/check_examples.py      # Verify all 14 examples parse + check + verify

--- a/README.md
+++ b/README.md
@@ -224,8 +224,8 @@ Tracked in [#14](https://github.com/aallan/vera/issues/14) (type-checking) and [
 
 | Sub-phase | Scope | Status |
 |-----------|-------|--------|
-| C7a | Module resolution — map `import` paths to source files and parse them | v0.0.31 |
-| C7b | Cross-module type environment — merge public declarations across files | Planned |
+| C7a | Module resolution — map `import` paths to source files and parse them | [v0.0.31](https://github.com/aallan/vera/releases/tag/v0.0.31) |
+| C7b | Cross-module type environment — merge public declarations across files | In progress |
 | C7c | Visibility enforcement — `public`/`private` access control in the checker | Planned |
 | C7d | Cross-module verification — verify contracts that reference imported symbols | Planned |
 | C7e | Multi-module codegen — WASM import/export tables linking multiple modules | Planned |
@@ -241,7 +241,7 @@ Open issues grouped by area. These are tracked for future phases beyond C7.
 
 **Type system** — [#20](https://github.com/aallan/vera/issues/20) TypeVar subtyping, [#21](https://github.com/aallan/vera/issues/21) effect row unification, [#55](https://github.com/aallan/vera/issues/55) minimal type inference
 
-**Tooling** — [#56](https://github.com/aallan/vera/issues/56) incremental compilation, [#75](https://github.com/aallan/vera/issues/75) `vera fmt` canonical formatter, [#79](https://github.com/aallan/vera/issues/79) `vera test` contract-driven testing, [#80](https://github.com/aallan/vera/issues/80) stable error code taxonomy
+**Tooling** — [#56](https://github.com/aallan/vera/issues/56) incremental compilation, [#75](https://github.com/aallan/vera/issues/75) `vera fmt` canonical formatter, [#79](https://github.com/aallan/vera/issues/79) `vera test` contract-driven testing, [#80](https://github.com/aallan/vera/issues/80) stable error code taxonomy, [#95](https://github.com/aallan/vera/issues/95) LALR grammar fix for module-qualified call syntax
 
 **Language design (spec §0.8)** — [#57](https://github.com/aallan/vera/issues/57) `<Http>` network access effect, [#58](https://github.com/aallan/vera/issues/58) JSON standard library type, [#59](https://github.com/aallan/vera/issues/59) `<Async>` futures and promises, [#60](https://github.com/aallan/vera/issues/60) abilities and type constraints, [#61](https://github.com/aallan/vera/issues/61) `<Inference>` LLM inference effect, [#62](https://github.com/aallan/vera/issues/62) standard library collections (Set, Map, Decimal), [#76](https://github.com/aallan/vera/issues/76) Float alias vs Float64 canonical form
 

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -476,6 +476,10 @@ Functions are private by default. Add `public` for external visibility.
 
 Import paths resolve to files on disk: `import vera.math;` looks for `vera/math.vera` relative to the importing file's directory (or the project root). Imported files are parsed and cached automatically. Circular imports are detected and reported as errors.
 
+Imported functions can be called by name (bare calls): `import vera.math(abs); abs(-5)` resolves `abs` from the imported module. Selective imports restrict available names; wildcard imports (`import m;`) make all declarations available. Local definitions shadow imported names. Imported ADT constructors are also available: `import col(List); Cons(1, Nil)`.
+
+Note: module-qualified call syntax (`vera.math.abs(42)`) is not yet parseable due to an LALR grammar limitation. Use bare calls instead.
+
 ## Comments
 
 ```vera

--- a/examples/modules.vera
+++ b/examples/modules.vera
@@ -23,6 +23,15 @@ public fn clamp(@Int, @Int, @Int -> @Int)
   }
 }
 
+-- Use imported functions via bare calls (C7b)
+public fn abs_max(@Int, @Int -> @Int)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  abs(max(@Int.0, @Int.1))
+}
+
 -- Private function — internal to this module
 private fn helper(@Int -> @Int)
   requires(true)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.31"
+version = "0.0.32"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -14,6 +14,7 @@ from vera import ast
 from vera.checker import typecheck
 from vera.errors import Diagnostic
 from vera.parser import parse_to_ast
+from vera.resolver import ResolvedModule
 
 # =====================================================================
 # Helpers
@@ -1371,8 +1372,8 @@ class TestModuleCallDiagnostics:
         warns = [d for d in diags if d.severity == "warning"]
         assert any("not found" in w.description for w in warns)
 
-    def test_module_resolved_warning(self) -> None:
-        """ModuleCall with resolved module gives 'C7b' warning."""
+    def test_module_resolved_fn_not_found(self) -> None:
+        """ModuleCall with resolved empty module gives 'not found in module'."""
         from vera.resolver import ResolvedModule
 
         prog = self._make_program_with_module_call(("foo",), "bar")
@@ -1386,5 +1387,304 @@ class TestModuleCallDiagnostics:
         )
         diags = typecheck(prog, source="", resolved_modules=[fake_mod])
         warns = [d for d in diags if d.severity == "warning"]
-        assert any("C7b" in w.description for w in warns)
+        assert any("not found in module" in w.description for w in warns)
+
+
+# =====================================================================
+# C7b: Cross-module type checking
+# =====================================================================
+
+
+class TestCrossModuleTyping:
+    """Test cross-module type merging (C7b).
+
+    These tests verify that imported function signatures are registered
+    and used for type-checking.  Due to the LALR grammar limitation (#95),
+    ModuleCall tests construct AST nodes manually.  Bare-call tests use
+    ``parse_to_ast`` since ``fn_call`` parses fine.
+    """
+
+    # Reusable module sources
+    MATH_MODULE = """\
+fn abs(@Int -> @Int)
+  requires(true)
+  ensures(@Int.result >= 0)
+  effects(pure)
+{ if @Int.0 < 0 then { 0 - @Int.0 } else { @Int.0 } }
+
+fn max(@Int, @Int -> @Int)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{ if @Int.0 >= @Int.1 then { @Int.0 } else { @Int.1 } }
+"""
+
+    GENERIC_MODULE = """\
+forall<T> fn identity(@T -> @T)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{ @T.0 }
+"""
+
+    COLLECTIONS_MODULE = """\
+data List<T> { Nil, Cons(T, List<T>) }
+data Option<T> { None, Some(T) }
+"""
+
+    @staticmethod
+    def _resolved(
+        path: tuple[str, ...], source: str,
+    ) -> ResolvedModule:
+        """Build a ResolvedModule from source text."""
+        from vera.resolver import ResolvedModule as RM
+        prog = parse_to_ast(source)
+        return RM(
+            path=path,
+            file_path=Path(f"/fake/{'/'.join(path)}.vera"),
+            program=prog,
+            source=source,
+        )
+
+    # -- Bare calls (parsed normally) -----------------------------------
+
+    def test_bare_call_resolves_type(self) -> None:
+        """import m(abs); abs(42) -> no errors."""
+        mod = self._resolved(("math",), self.MATH_MODULE)
+        prog = parse_to_ast("""\
+import math(abs);
+fn main(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ abs(@Int.0) }
+""")
+        diags = typecheck(prog, source="", resolved_modules=[mod])
+        errors = [d for d in diags if d.severity == "error"]
+        assert errors == [], [e.description for e in errors]
+
+    def test_bare_call_arity_mismatch(self) -> None:
+        """abs(1, 2) where abs takes 1 arg -> arity error."""
+        mod = self._resolved(("math",), self.MATH_MODULE)
+        prog = parse_to_ast("""\
+import math(abs);
+fn main(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ abs(@Int.0, @Int.0) }
+""")
+        diags = typecheck(prog, source="", resolved_modules=[mod])
+        errors = [d for d in diags if d.severity == "error"]
+        assert any("expects 1" in e.description for e in errors)
+
+    def test_bare_call_type_mismatch(self) -> None:
+        """abs(true) where abs expects Int -> type error."""
+        mod = self._resolved(("math",), self.MATH_MODULE)
+        prog = parse_to_ast("""\
+import math(abs);
+fn main(@Bool -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ abs(@Bool.0) }
+""")
+        diags = typecheck(prog, source="", resolved_modules=[mod])
+        errors = [d for d in diags if d.severity == "error"]
+        assert any("Bool" in e.description and "Int" in e.description
+                    for e in errors)
+
+    def test_bare_call_generic_inference(self) -> None:
+        """import m(identity); identity(42) -> infers Int, no errors."""
+        mod = self._resolved(("gen",), self.GENERIC_MODULE)
+        prog = parse_to_ast("""\
+import gen(identity);
+fn main(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ identity(@Int.0) }
+""")
+        diags = typecheck(prog, source="", resolved_modules=[mod])
+        errors = [d for d in diags if d.severity == "error"]
+        assert errors == [], [e.description for e in errors]
+
+    def test_wildcard_import_allows_all(self) -> None:
+        """import math (no names) -> all functions available."""
+        mod = self._resolved(("math",), self.MATH_MODULE)
+        prog = parse_to_ast("""\
+import math;
+fn main(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ max(@Int.0, abs(@Int.0)) }
+""")
+        diags = typecheck(prog, source="", resolved_modules=[mod])
+        errors = [d for d in diags if d.severity == "error"]
+        assert errors == [], [e.description for e in errors]
+
+    def test_local_shadows_import(self) -> None:
+        """Local fn abs shadows imported abs."""
+        mod = self._resolved(("math",), self.MATH_MODULE)
+        prog = parse_to_ast("""\
+import math(abs);
+fn abs(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 + 1 }
+fn main(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ abs(@Int.0) }
+""")
+        diags = typecheck(prog, source="", resolved_modules=[mod])
+        errors = [d for d in diags if d.severity == "error"]
+        assert errors == [], [e.description for e in errors]
+
+    def test_imported_adt_constructors(self) -> None:
+        """import m(List) -> Cons and Nil constructors available."""
+        mod = self._resolved(("col",), self.COLLECTIONS_MODULE)
+        prog = parse_to_ast("""\
+import col(List);
+fn main(@Int -> @List<Int>)
+  requires(true) ensures(true) effects(pure)
+{ Cons(@Int.0, Nil) }
+""")
+        diags = typecheck(prog, source="", resolved_modules=[mod])
+        errors = [d for d in diags if d.severity == "error"]
+        assert errors == [], [e.description for e in errors]
+
+    # -- Module-qualified calls (manual AST) ----------------------------
+
+    def test_module_call_resolves_type(self) -> None:
+        """ModuleCall to resolved function -> correct type, no errors."""
+        mod = self._resolved(("math",), self.MATH_MODULE)
+        call = ast.ModuleCall(
+            path=("math",), name="abs",
+            args=(ast.IntLit(value=42),),
+        )
+        imp = ast.ImportDecl(path=("math",), names=("abs",))
+        fn = ast.FnDecl(
+            name="main", forall_vars=None, params=(),
+            return_type=ast.NamedType(name="Int", type_args=None),
+            contracts=(
+                ast.Requires(expr=ast.BoolLit(value=True)),
+                ast.Ensures(expr=ast.BoolLit(value=True)),
+            ),
+            effect=ast.PureEffect(),
+            body=ast.Block(statements=(), expr=call),
+            where_fns=None,
+        )
+        prog = ast.Program(
+            module=None,
+            imports=(imp,),
+            declarations=(ast.TopLevelDecl(visibility=None, decl=fn),),
+        )
+        diags = typecheck(prog, source="", resolved_modules=[mod])
+        errors = [d for d in diags if d.severity == "error"]
+        warns = [d for d in diags if d.severity == "warning"]
+        assert errors == [], [e.description for e in errors]
         assert not any("not found" in w.description for w in warns)
+
+    def test_module_call_arity_mismatch(self) -> None:
+        """Module-qualified call with wrong arity -> error."""
+        mod = self._resolved(("math",), self.MATH_MODULE)
+        call = ast.ModuleCall(
+            path=("math",), name="abs",
+            args=(ast.IntLit(value=1), ast.IntLit(value=2)),
+        )
+        imp = ast.ImportDecl(path=("math",), names=("abs",))
+        fn = ast.FnDecl(
+            name="main", forall_vars=None, params=(),
+            return_type=ast.NamedType(name="Int", type_args=None),
+            contracts=(
+                ast.Requires(expr=ast.BoolLit(value=True)),
+                ast.Ensures(expr=ast.BoolLit(value=True)),
+            ),
+            effect=ast.PureEffect(),
+            body=ast.Block(statements=(), expr=call),
+            where_fns=None,
+        )
+        prog = ast.Program(
+            module=None,
+            imports=(imp,),
+            declarations=(ast.TopLevelDecl(visibility=None, decl=fn),),
+        )
+        diags = typecheck(prog, source="", resolved_modules=[mod])
+        errors = [d for d in diags if d.severity == "error"]
+        assert any("expects 1" in e.description for e in errors)
+
+    def test_selective_import_rejects_unimported(self) -> None:
+        """Module call to name not in selective import -> error."""
+        mod = self._resolved(("math",), self.MATH_MODULE)
+        call = ast.ModuleCall(
+            path=("math",), name="max",
+            args=(ast.IntLit(value=1), ast.IntLit(value=2)),
+        )
+        # Only import "abs", not "max"
+        imp = ast.ImportDecl(path=("math",), names=("abs",))
+        fn = ast.FnDecl(
+            name="main", forall_vars=None, params=(),
+            return_type=ast.NamedType(name="Int", type_args=None),
+            contracts=(
+                ast.Requires(expr=ast.BoolLit(value=True)),
+                ast.Ensures(expr=ast.BoolLit(value=True)),
+            ),
+            effect=ast.PureEffect(),
+            body=ast.Block(statements=(), expr=call),
+            where_fns=None,
+        )
+        prog = ast.Program(
+            module=None,
+            imports=(imp,),
+            declarations=(ast.TopLevelDecl(visibility=None, decl=fn),),
+        )
+        diags = typecheck(prog, source="", resolved_modules=[mod])
+        errors = [d for d in diags if d.severity == "error"]
+        assert any("not imported" in e.description for e in errors)
+
+    def test_fn_not_in_module(self) -> None:
+        """Module call to nonexistent function -> warning with available list."""
+        mod = self._resolved(("math",), self.MATH_MODULE)
+        call = ast.ModuleCall(
+            path=("math",), name="nonexistent",
+            args=(ast.IntLit(value=42),),
+        )
+        imp = ast.ImportDecl(path=("math",), names=None)  # wildcard
+        fn = ast.FnDecl(
+            name="main", forall_vars=None, params=(),
+            return_type=ast.NamedType(name="Unit", type_args=None),
+            contracts=(
+                ast.Requires(expr=ast.BoolLit(value=True)),
+                ast.Ensures(expr=ast.BoolLit(value=True)),
+            ),
+            effect=ast.PureEffect(),
+            body=ast.Block(statements=(), expr=call),
+            where_fns=None,
+        )
+        prog = ast.Program(
+            module=None,
+            imports=(imp,),
+            declarations=(ast.TopLevelDecl(visibility=None, decl=fn),),
+        )
+        diags = typecheck(prog, source="", resolved_modules=[mod])
+        warns = [d for d in diags if d.severity == "warning"]
+        assert any("not found in module" in w.description for w in warns)
+        assert any("abs" in w.description for w in warns)  # available list
+
+    def test_multi_segment_path(self) -> None:
+        """Multi-segment module path (vera.math) works."""
+        mod = self._resolved(("vera", "math"), self.MATH_MODULE)
+        call = ast.ModuleCall(
+            path=("vera", "math"), name="abs",
+            args=(ast.IntLit(value=42),),
+        )
+        imp = ast.ImportDecl(path=("vera", "math"), names=("abs",))
+        fn = ast.FnDecl(
+            name="main", forall_vars=None, params=(),
+            return_type=ast.NamedType(name="Int", type_args=None),
+            contracts=(
+                ast.Requires(expr=ast.BoolLit(value=True)),
+                ast.Ensures(expr=ast.BoolLit(value=True)),
+            ),
+            effect=ast.PureEffect(),
+            body=ast.Block(statements=(), expr=call),
+            where_fns=None,
+        )
+        prog = ast.Program(
+            module=None,
+            imports=(imp,),
+            declarations=(ast.TopLevelDecl(visibility=None, decl=fn),),
+        )
+        diags = typecheck(prog, source="", resolved_modules=[mod])
+        errors = [d for d in diags if d.severity == "error"]
+        assert errors == [], [e.description for e in errors]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1000,3 +1000,28 @@ fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
             "Cannot resolve import" in d["description"]
             for d in data["diagnostics"]
         )
+
+    def test_check_with_bare_imported_call(self, tmp_path: Path) -> None:
+        """vera check passes when main.vera calls an imported function."""
+        lib_src = """\
+fn double(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 + @Int.0 }
+"""
+        main_src = """\
+import lib(double);
+fn main(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ double(@Int.0) }
+"""
+        lib_dir = tmp_path / "lib.vera"
+        lib_dir.write_text(lib_src, encoding="utf-8")
+        main_file = tmp_path / "main.vera"
+        main_file.write_text(main_src, encoding="utf-8")
+
+        result = subprocess.run(
+            [sys.executable, "-m", "vera.cli", "check", str(main_file)],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "OK" in result.stdout

--- a/vera/README.md
+++ b/vera/README.md
@@ -80,7 +80,7 @@ execute(compile_result, ...)    # → run WASM via wasmtime
 | `ast.py` | 682 | Transform | Frozen dataclass AST nodes | `Program`, `Node`, `Expr` |
 | `types.py` | 302 | Type check | Semantic type representation | `Type`, `is_subtype()` |
 | `environment.py` | 300 | Type check | Type environment, scope stacks | `TypeEnv` |
-| `checker.py` | 1,768 | Type check | Two-pass type checker | `typecheck()` |
+| `checker.py` | 1,888 | Type check | Two-pass type checker, cross-module merging | `typecheck()` |
 | `resolver.py` | 213 | Resolve | Module path resolution, parse cache | `ModuleResolver` |
 | `smt.py` | 485 | Verify | Z3 translation layer | `SmtContext`, `SlotEnv` |
 | `verifier.py` | 605 | Verify | Contract verification | `verify()` |
@@ -90,7 +90,7 @@ execute(compile_result, ...)    # → run WASM via wasmtime
 | `cli.py` | 594 | All | CLI commands | `main()` |
 | `registration.py` | 56 | Type check | Shared function registration | `register_fn()` |
 
-Total: ~10,636 lines of Python + 328 lines of grammar.
+Total: ~10,737 lines of Python + 328 lines of grammar.
 
 ## Parsing
 
@@ -176,22 +176,22 @@ Node
 
 ## Type Checking
 
-**Files:** `checker.py` (1,668 lines), `types.py` (302 lines), `environment.py` (300 lines)
+**Files:** `checker.py` (1,888 lines), `types.py` (302 lines), `environment.py` (300 lines)
 
 This is the most architecturally complex stage.
 
-### Two-pass architecture
+### Three-pass architecture
 
 ```
-              Pass 1: Registration                  Pass 2: Checking
-         ┌────────────────────────┐          ┌──────────────────────────┐
-         │  Walk all declarations │          │  Walk all declarations   │
-         │                        │          │                          │
-         │  Register into TypeEnv:│          │  For each function:      │
-         │   • functions           │  TypeEnv │   • bind forall vars    │
-         │   • ADTs + constructors│ ───────▶ │   • resolve param types  │
-         │   • type aliases       │ populated│   • push scope, bind     │
-         │   • effects + ops      │          │   • check contracts      │
+ Pass 0: Module Registration       Pass 1: Local Registration         Pass 2: Checking
+  ┌──────────────────────┐          ┌────────────────────────┐          ┌──────────────────────────┐
+  │  For each resolved   │          │  Walk all declarations │          │  Walk all declarations   │
+  │  module:             │          │                        │          │                          │
+  │   • create temp      │          │  Register into TypeEnv:│          │  For each function:      │
+  │     TypeChecker      │  TypeEnv │   • functions           │  TypeEnv │   • bind forall vars    │
+  │   • register decls   │ ───────▶ │   • ADTs + constructors│ ───────▶ │   • resolve param types  │
+  │   • harvest into     │ imports  │   • type aliases       │ populated│   • push scope, bind     │
+  │     module-qual dicts│ injected │   • effects + ops      │          │   • check contracts      │
          │                        │          │   • synthesise body type │
          │  (signatures only,     │          │   • check effects        │
          │   no bodies checked)   │          │   • pop scope            │
@@ -461,7 +461,7 @@ Every diagnostic includes a description (what went wrong), rationale (which lang
 
 ## Test Suite
 
-**900 tests** across 11 files, plus 4 validation scripts and CI infrastructure.
+**913 tests** across 11 files, plus 4 validation scripts and CI infrastructure.
 
 ### Test files
 
@@ -469,10 +469,10 @@ Every diagnostic includes a description (what went wrong), rationale (which lang
 |------|------:|------:|----------------|
 | `test_parser.py` | 97 | 829 | Grammar rules, operator precedence, parse errors |
 | `test_ast.py` | 84 | 896 | AST transformation, node structure, serialisation |
-| `test_checker.py` | 117 | 1,390 | Type synthesis, slot resolution, effects, contracts, exhaustiveness, module call diagnostics |
+| `test_checker.py` | 130 | 1,690 | Type synthesis, slot resolution, effects, contracts, exhaustiveness, cross-module typing |
 | `test_verifier.py` | 69 | 918 | Z3 verification, counterexamples, tier classification, Int→Nat enforcement, call-site preconditions, pipe operator |
 | `test_codegen.py` | 326 | 4,198 | WASM compilation, arithmetic, Float64 (incl. modulo), Byte, arrays, ADTs, match, generics, closures, State\<T\>, control flow, strings, IO, contracts, bounds checking, length, quantifiers, assert/assume, refinement type aliases, pipe operator, String/Array signatures, old/new state postconditions, example round-trips |
-| `test_cli.py` | 79 | 1,002 | CLI commands (check, verify, compile, run), subprocess integration, JSON error paths, runtime traps, arg validation, multi-file resolution |
+| `test_cli.py` | 80 | 1,027 | CLI commands (check, verify, compile, run), subprocess integration, JSON error paths, runtime traps, arg validation, multi-file resolution |
 | `test_resolver.py` | 15 | 412 | Module resolution, path lookup, parse caching, circular import detection |
 | `test_types.py` | 55 | 279 | Type operations: subtyping, equality, substitution, pretty-printing, canonical names |
 | `test_wasm.py` | 22 | 255 | WASM internals: StringPool, WasmSlotEnv, translation edge cases via full pipeline |
@@ -547,7 +547,7 @@ Honest inventory of what the compiler cannot do, and where each limitation is ad
 
 | Limitation | Why | Planned |
 |-----------|-----|---------|
-| **Partial module resolution** | `import` paths resolve to files (C7a), but cross-module types not merged (C7b) | [#14](https://github.com/aallan/vera/issues/14), [#50](https://github.com/aallan/vera/issues/50) |
+| **Partial module system** | Resolution (C7a) and type merging (C7b) complete; visibility (C7c), verification (C7d), and codegen (C7e) pending | [#14](https://github.com/aallan/vera/issues/14), [#50](https://github.com/aallan/vera/issues/50), [#95](https://github.com/aallan/vera/issues/95) |
 | **Limited effect checking** | Pure vs effectful only; no subeffecting or row unification | [#21](https://github.com/aallan/vera/issues/21) |
 | **No termination verification** | `decreases` clauses parsed but always Tier 3 | [#45](https://github.com/aallan/vera/issues/45) |
 | **No quantifier verification** | `forall`/`exists` in contracts always Tier 3 | [#13](https://github.com/aallan/vera/issues/13) |

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.31"
+__version__ = "0.0.32"

--- a/vera/checker.py
+++ b/vera/checker.py
@@ -75,9 +75,9 @@ def typecheck(
     Returns a list of Diagnostics (empty = no errors).
 
     *resolved_modules* — modules resolved from ``import`` declarations
-    (see :class:`~vera.resolver.ModuleResolver`).  Used in C7a to
-    improve diagnostics for cross-module calls; actual type merging
-    is deferred to C7b.
+    (see :class:`~vera.resolver.ModuleResolver`).  Cross-module type
+    merging (C7b): imported function signatures are registered and
+    used for arity, argument-type, and effect checking.
     """
     checker = TypeChecker(
         source=source, file=file, resolved_modules=resolved_modules,
@@ -104,11 +104,93 @@ class TypeChecker:
         self.source = source
         self.file = file
         self._effect_ops_used: set[str] = set()
-        # Resolved module paths for improved diagnostics (C7a).
-        # Actual type merging is deferred to C7b.
+        # Resolved modules (C7a: paths for diagnostics, C7b: full list
+        # for cross-module type merging).
+        self._resolved_modules: list[ResolvedModule] = (
+            resolved_modules or []
+        )
         self._resolved_module_paths: set[tuple[str, ...]] = {
-            m.path for m in (resolved_modules or [])
+            m.path for m in self._resolved_modules
         }
+        # C7b: per-module declaration registries (for ModuleCall path).
+        self._module_functions: dict[
+            tuple[str, ...], dict[str, FunctionInfo]
+        ] = {}
+        self._module_data_types: dict[
+            tuple[str, ...], dict[str, AdtInfo]
+        ] = {}
+        self._module_constructors: dict[
+            tuple[str, ...], dict[str, ConstructorInfo]
+        ] = {}
+        # C7b: import-name filter from ImportDecl nodes.
+        self._import_names: dict[
+            tuple[str, ...], set[str] | None
+        ] = {}
+
+    # -----------------------------------------------------------------
+    # C7b: cross-module registration
+    # -----------------------------------------------------------------
+
+    def _register_modules(self, program: ast.Program) -> None:
+        """Register declarations from resolved modules (C7b).
+
+        1. Build an import-name filter from the program's ``import``
+           declarations (selective vs wildcard).
+        2. For each resolved module, run the registration pass in an
+           isolated TypeChecker to populate its ``TypeEnv``, then
+           harvest the declarations into per-module dicts.
+        3. Inject selectively imported names into ``self.env`` so
+           bare calls (``abs(42)`` after ``import vera.math(abs)``)
+           resolve through the normal ``_check_call_with_args`` path.
+        """
+        # 1. Build import filter
+        for imp in program.imports:
+            self._import_names[imp.path] = (
+                set(imp.names) if imp.names is not None else None
+            )
+
+        # Snapshot builtin names (TypeEnv registers builtins in __post_init__)
+        _builtins = TypeEnv()
+        builtin_fn_names = set(_builtins.functions)
+        builtin_data_names = set(_builtins.data_types)
+        builtin_ctor_names = set(_builtins.constructors)
+
+        # 2. Register each module in isolation, harvest declarations
+        for mod in self._resolved_modules:
+            temp = TypeChecker(source=mod.source)
+            temp._register_all(mod.program)
+
+            # Keep only module-declared names (builtins have span=None)
+            mod_fns = {
+                k: v for k, v in temp.env.functions.items()
+                if k not in builtin_fn_names or v.span is not None
+            }
+            mod_data = {
+                k: v for k, v in temp.env.data_types.items()
+                if k not in builtin_data_names
+            }
+            mod_ctors = {
+                k: v for k, v in temp.env.constructors.items()
+                if k not in builtin_ctor_names
+            }
+
+            self._module_functions[mod.path] = mod_fns
+            self._module_data_types[mod.path] = mod_data
+            self._module_constructors[mod.path] = mod_ctors
+
+            # 3. Inject into main env for bare calls
+            name_filter = self._import_names.get(mod.path)
+            for fn_name, fn_info in mod_fns.items():
+                if name_filter is None or fn_name in name_filter:
+                    self.env.functions.setdefault(fn_name, fn_info)
+            for dt_name, dt_info in mod_data.items():
+                if name_filter is None or dt_name in name_filter:
+                    self.env.data_types.setdefault(dt_name, dt_info)
+            for ct_name, ct_info in mod_ctors.items():
+                # Constructors: include if parent type is in import list
+                parent = ct_info.parent_type
+                if name_filter is None or parent in name_filter:
+                    self.env.constructors.setdefault(ct_name, ct_info)
 
     # -----------------------------------------------------------------
     # Diagnostics
@@ -359,8 +441,9 @@ class TypeChecker:
     # -----------------------------------------------------------------
 
     def check_program(self, program: ast.Program) -> None:
-        """Entry point: register all declarations, then check each."""
-        self._register_all(program)
+        """Entry point: register modules, then local declarations, then check."""
+        self._register_modules(program)  # C7b: cross-module imports
+        self._register_all(program)  # local declarations shadow imports
         for tld in program.declarations:
             self._check_decl(tld.decl)
 
@@ -1101,34 +1184,71 @@ class TypeChecker:
         return UnknownType()
 
     def _check_module_call(self, expr: ast.ModuleCall) -> Type | None:
-        """Type-check a module call: path.to.fn(args)."""
+        """Type-check a module-qualified call: path.to.fn(args).
+
+        Lookup order:
+        1. Module not resolved → warning (same as C7a).
+        2. Name not in selective import list → error.
+        3. Function found → delegate to ``_check_fn_call_with_info``.
+        4. Function not found in module → warning with available list.
+        """
         mod_path = tuple(expr.path)
-        if mod_path in self._resolved_module_paths:
-            # Module was resolved by the resolver (C7a) but cross-module
-            # type merging is not yet implemented (C7b).
+        fn_name = expr.name
+        mod_label = ".".join(expr.path)
+
+        # 1. Module not resolved
+        if mod_path not in self._resolved_module_paths:
             self._error(
                 expr,
-                f"Module '{'.'.join(expr.path)}' resolved, but "
-                f"cross-module type checking is not yet implemented "
-                f"(C7b). Call to '{expr.name}' is unchecked.",
-                severity="warning",
-                rationale=(
-                    "The module was found and parsed successfully. "
-                    "Type merging across module boundaries will be "
-                    "available in a future release (C7b)."
-                ),
-            )
-        else:
-            self._error(
-                expr,
-                f"Module '{'.'.join(expr.path)}' not found. "
-                f"Cannot resolve call to '{expr.name}'.",
+                f"Module '{mod_label}' not found. "
+                f"Cannot resolve call to '{fn_name}'.",
                 severity="warning",
                 rationale=(
                     "No module matching this import path was resolved. "
                     "Check that the file exists and is imported."
                 ),
             )
+            for arg in expr.args:
+                self._synth_expr(arg)
+            return UnknownType()
+
+        # 2. Selective import filter
+        import_filter = self._import_names.get(mod_path)
+        if import_filter is not None and fn_name not in import_filter:
+            self._error(
+                expr,
+                f"'{fn_name}' is not imported from module "
+                f"'{mod_label}'. "
+                f"Imported names: {sorted(import_filter)}.",
+                rationale=(
+                    "The import declaration uses selective imports. "
+                    "Add the name to the import list to use it."
+                ),
+                fix=(
+                    f"Change the import to include '{fn_name}': "
+                    f"import {mod_label}"
+                    f"({', '.join(sorted(import_filter | {fn_name}))});"
+                ),
+            )
+            for arg in expr.args:
+                self._synth_expr(arg)
+            return UnknownType()
+
+        # 3. Look up function in module's registered declarations
+        mod_fns = self._module_functions.get(mod_path, {})
+        fn_info = mod_fns.get(fn_name)
+        if fn_info is not None:
+            return self._check_fn_call_with_info(fn_info, expr.args, expr)
+
+        # 4. Function not found in module
+        available = sorted(mod_fns.keys())
+        self._error(
+            expr,
+            f"Function '{fn_name}' not found in module "
+            f"'{mod_label}'."
+            + (f" Available functions: {available}." if available else ""),
+            severity="warning",
+        )
         for arg in expr.args:
             self._synth_expr(arg)
         return UnknownType()


### PR DESCRIPTION
## Summary
- Imported function signatures are now type-checked: arity, argument types, generic inference, and effect propagation all work across module boundaries
- **Bare calls**: `import vera.math(abs); abs(-5)` resolves `abs` from the imported module -- immediately usable from source files
- **Module-qualified calls**: `ModuleCall` AST nodes type-checked against per-module registries (grammar limitation #95 prevents parsing `path.fn(args)` from source)
- Selective imports enforced; wildcard imports allow all names; local definitions shadow imports
- Imported ADT constructors available via bare calls
- `examples/modules.vera` now exercises bare cross-module calls (`abs`, `max` from `vera.math`)
- 913 tests, mypy clean, 14 examples pass

Partial #14

## Test plan
- [x] `pytest tests/ -v` -- 913 tests pass (12 new checker + 1 CLI)
- [x] `mypy vera/` -- clean
- [x] `python scripts/check_examples.py` -- 14/14 pass
- [x] `python scripts/check_spec_examples.py` -- all pass
- [x] `python scripts/check_readme_examples.py` -- all pass
- [x] `python scripts/check_version_sync.py` -- 0.0.32 consistent

Generated with [Claude Code](https://claude.com/claude-code)