### PR TITLE
Remove Float alias, enforce Float64 as sole canonical form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.33] - 2026-02-27
+
+### Removed
+- **`Float` type alias** (closes [#76](https://github.com/aallan/vera/issues/76)): `Float` is no longer accepted as a type name — use `Float64` exclusively
+  - Enforces design principle 3 ("one canonical form") from spec §1.8
+  - Removed `"Float": FLOAT64` alias from `vera/types.py` PRIMITIVES dict
+  - Simplified ~12 dual-name checks in `wasm.py` and `codegen.py`
+  - Updated `examples/pattern_matching.vera` to use `Float64`
+  - Updated spec chapters 4 and 11 to remove `Float` references
+  - Decomposition issues tracked: [#99](https://github.com/aallan/vera/issues/99) (checker.py), [#100](https://github.com/aallan/vera/issues/100) (wasm.py)
+- 1 new test (914 total, up from 913)
+
 ## [0.0.32] - 2026-02-27
 
 ### Added
@@ -486,7 +498,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Grammar: handler body simplified to avoid LALR reduce/reduce conflict
 - `pyproject.toml`: corrected build backend, package discovery, PEP 639 compliance
 
-[Unreleased]: https://github.com/aallan/vera/compare/v0.0.32...HEAD
+[Unreleased]: https://github.com/aallan/vera/compare/v0.0.33...HEAD
+[0.0.33]: https://github.com/aallan/vera/compare/v0.0.32...v0.0.33
 [0.0.32]: https://github.com/aallan/vera/compare/v0.0.31...v0.0.32
 [0.0.31]: https://github.com/aallan/vera/compare/v0.0.30...v0.0.31
 [0.0.30]: https://github.com/aallan/vera/compare/v0.0.29...v0.0.30

--- a/README.md
+++ b/README.md
@@ -231,6 +231,10 @@ Tracked in [#14](https://github.com/aallan/vera/issues/14) (type-checking) and [
 | C7e | Multi-module codegen — WASM import/export tables linking multiple modules | Planned |
 | C7f | Spec Chapter 8 — formal module semantics, resolution algorithm, examples | Planned |
 
+### Next after C7: refactoring
+
+[#99](https://github.com/aallan/vera/issues/99) decompose `checker.py` into `checker/` submodules, [#100](https://github.com/aallan/vera/issues/100) decompose `wasm.py` into `wasm/` submodules
+
 ### Longer term
 
 Open issues grouped by area. These are tracked for future phases beyond C7.
@@ -243,7 +247,7 @@ Open issues grouped by area. These are tracked for future phases beyond C7.
 
 **Tooling** — [#56](https://github.com/aallan/vera/issues/56) incremental compilation, [#75](https://github.com/aallan/vera/issues/75) `vera fmt` canonical formatter, [#79](https://github.com/aallan/vera/issues/79) `vera test` contract-driven testing, [#80](https://github.com/aallan/vera/issues/80) stable error code taxonomy, [#95](https://github.com/aallan/vera/issues/95) LALR grammar fix for module-qualified call syntax
 
-**Language design (spec §0.8)** — [#57](https://github.com/aallan/vera/issues/57) `<Http>` network access effect, [#58](https://github.com/aallan/vera/issues/58) JSON standard library type, [#59](https://github.com/aallan/vera/issues/59) `<Async>` futures and promises, [#60](https://github.com/aallan/vera/issues/60) abilities and type constraints, [#61](https://github.com/aallan/vera/issues/61) `<Inference>` LLM inference effect, [#62](https://github.com/aallan/vera/issues/62) standard library collections (Set, Map, Decimal), [#76](https://github.com/aallan/vera/issues/76) Float alias vs Float64 canonical form
+**Language design (spec §0.8)** — [#57](https://github.com/aallan/vera/issues/57) `<Http>` network access effect, [#58](https://github.com/aallan/vera/issues/58) JSON standard library type, [#59](https://github.com/aallan/vera/issues/59) `<Async>` futures and promises, [#60](https://github.com/aallan/vera/issues/60) abilities and type constraints, [#61](https://github.com/aallan/vera/issues/61) `<Inference>` LLM inference effect, [#62](https://github.com/aallan/vera/issues/62) standard library collections (Set, Map, Decimal)
 
 ## Getting Started
 

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -169,7 +169,7 @@ fn abs(@Int -> @Nat)
 - `Bool` — `true`, `false`
 - `Int` — signed integers (arbitrary precision)
 - `Nat` — natural numbers (non-negative)
-- `Float64` / `Float` — 64-bit floating-point
+- `Float64` — 64-bit IEEE 754 floating-point
 - `String` — text
 - `Unit` — singleton type, value is `()`
 

--- a/examples/pattern_matching.vera
+++ b/examples/pattern_matching.vera
@@ -43,9 +43,9 @@ fn to_string(@Bool -> @String)
 
 -- Multi-variant ADT with exhaustive matching
 data Shape {
-  Circle(Float),
-  Rectangle(Float, Float),
-  Triangle(Float, Float, Float)
+  Circle(Float64),
+  Rectangle(Float64, Float64),
+  Triangle(Float64, Float64, Float64)
 }
 
 fn describe(@Shape -> @String)
@@ -54,8 +54,8 @@ fn describe(@Shape -> @String)
   effects(pure)
 {
   match @Shape.0 {
-    Circle(@Float) -> "circle",
-    Rectangle(@Float, @Float) -> "rectangle",
-    Triangle(@Float, @Float, @Float) -> "triangle"
+    Circle(@Float64) -> "circle",
+    Rectangle(@Float64, @Float64) -> "rectangle",
+    Triangle(@Float64, @Float64, @Float64) -> "triangle"
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.32"
+version = "0.0.33"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/spec/04-expressions.md
+++ b/spec/04-expressions.md
@@ -13,7 +13,7 @@ Literal expressions produce values of the corresponding primitive type:
 | Literal | Type | Examples |
 |---------|------|----------|
 | Integer | `Int` | `0`, `42`, `-17` |
-| Float | `Float64` | `3.14`, `-0.5`, `100.0` |
+| Floating-point | `Float64` | `3.14`, `-0.5`, `100.0` |
 | String | `String` | `"hello"`, `""`, `"line\nbreak"` |
 | Boolean | `Bool` | `true`, `false` |
 | Unit | `Unit` | `()` |

--- a/spec/11-compilation.md
+++ b/spec/11-compilation.md
@@ -30,7 +30,7 @@ Vera types map to WASM value types as follows:
 | `Nat` | `i64` | Non-negativity enforced by contracts, not by WASM type |
 | `Bool` | `i32` | `0` = `false`, `1` = `true` |
 | `Byte` | `i32` | Unsigned 0-255; uses unsigned comparison ops (`i32.lt_u`, etc.) |
-| `Float64` / `Float` | `f64` | 64-bit IEEE 754 floating point |
+| `Float64` | `f64` | 64-bit IEEE 754 floating point |
 | `Unit` | *(none)* | Functions returning `Unit` have no WASM result type |
 | `String` | `i32, i32` | Pointer and length pair (UTF-8 bytes in linear memory) |
 | `Array<T>` | `i32, i32` | Pointer and length pair (elements in linear memory); see Section 11.13 |

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -159,6 +159,14 @@ fn foo(@Unit -> @Unit)
 { () }
 """)
 
+    def test_float_alias_rejected(self) -> None:
+        """'Float' is not a type — only 'Float64' is accepted (#76)."""
+        _check_err("""
+fn foo(@Unit -> @Float)
+  requires(true) ensures(true) effects(pure)
+{ 3.14 }
+""", "'Float' is not a type. Did you mean 'Float64'?")
+
 
 # =====================================================================
 # Slot references

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -632,7 +632,7 @@ class TestFunctionTypes:
 class TestFloatLiterals:
     def test_float_in_expression(self) -> None:
         parse("""
-        fn f(@Unit -> @Float)
+        fn f(@Unit -> @Float64)
           requires(true)
           ensures(true)
           effects(pure)
@@ -643,12 +643,12 @@ class TestFloatLiterals:
 
     def test_float_arithmetic(self) -> None:
         parse("""
-        fn f(@Float -> @Float)
+        fn f(@Float64 -> @Float64)
           requires(true)
           ensures(true)
           effects(pure)
         {
-          @Float.0 * 2.0 + 1.5
+          @Float64.0 * 2.0 + 1.5
         }
         """)
 

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.32"
+__version__ = "0.0.33"

--- a/vera/checker.py
+++ b/vera/checker.py
@@ -36,6 +36,7 @@ from vera.types import (
     NUMERIC_TYPES,
     ORDERABLE_TYPES,
     PRIMITIVES,
+    REMOVED_ALIASES,
     STRING,
     UNIT,
     AdtType,
@@ -126,6 +127,8 @@ class TypeChecker:
         self._import_names: dict[
             tuple[str, ...], set[str] | None
         ] = {}
+        # De-dup removed-alias errors (emitted once per alias name).
+        self._reported_alias_errors: set[str] = set()
 
     # -----------------------------------------------------------------
     # C7b: cross-module registration
@@ -277,6 +280,21 @@ class TypeChecker:
                 args = tuple(self._resolve_type(a) for a in te.type_args)
                 return AdtType(name, args)
             return AdtType(name, ())
+
+        # Removed alias? — produce a helpful "did you mean" error.
+        canonical = REMOVED_ALIASES.get(name)
+        if canonical is not None:
+            if name not in self._reported_alias_errors:
+                self._reported_alias_errors.add(name)
+                self._error(
+                    te,
+                    f"'{name}' is not a type. Did you mean '{canonical}'?",
+                    rationale=(f"'{name}' was removed; "
+                               f"use '{canonical}' instead."),
+                    fix=f"Replace '{name}' with '{canonical}'.",
+                    spec_ref="Chapter 2 — Primitive Types",
+                )
+            return UnknownType()
 
         # Unknown — might be a type from an unresolved import
         return AdtType(name, tuple(

--- a/vera/codegen.py
+++ b/vera/codegen.py
@@ -1710,7 +1710,7 @@ class CodeGenerator:
             name = te.name
             if name in ("Int", "Nat"):
                 return "i64"
-            if name in ("Float64", "Float"):
+            if name == "Float64":
                 return "f64"
             if name in ("Bool", "Byte"):
                 return "i32"

--- a/vera/types.py
+++ b/vera/types.py
@@ -116,11 +116,16 @@ PRIMITIVES: dict[str, Type] = {
     "Nat": NAT,
     "Bool": BOOL,
     "Float64": FLOAT64,
-    "Float": FLOAT64,  # common alias used in examples
     "String": STRING,
     "Byte": BYTE,
     "Unit": UNIT,
     "Never": NEVER,
+}
+
+# Removed aliases — used by the checker to produce helpful error messages
+# when a user writes an old alias name instead of the canonical type.
+REMOVED_ALIASES: dict[str, str] = {
+    "Float": "Float64",
 }
 
 # Numeric types (for operator checking)

--- a/vera/wasm.py
+++ b/vera/wasm.py
@@ -129,7 +129,7 @@ def wasm_type(t: Type) -> str | None:
     if isinstance(t, PrimitiveType):
         if t.name in ("Int", "Nat"):
             return "i64"
-        if t.name in ("Float64", "Float"):
+        if t.name == "Float64":
             return "f64"
         if t.name in ("Bool", "Byte"):
             return "i32"
@@ -171,7 +171,7 @@ def _element_mem_size(elem_type: str) -> int | None:
         return 4  # i32
     if elem_type in ("Int", "Nat"):
         return 8  # i64
-    if elem_type in ("Float64", "Float"):
+    if elem_type == "Float64":
         return 8  # f64
     return None
 
@@ -184,7 +184,7 @@ def _element_load_op(elem_type: str) -> str | None:
         return "i32.load"
     if elem_type in ("Int", "Nat"):
         return "i64.load"
-    if elem_type in ("Float64", "Float"):
+    if elem_type == "Float64":
         return "f64.load"
     return None
 
@@ -197,7 +197,7 @@ def _element_store_op(elem_type: str) -> str | None:
         return "i32.store"
     if elem_type in ("Int", "Nat"):
         return "i64.store"
-    if elem_type in ("Float64", "Float"):
+    if elem_type == "Float64":
         return "f64.store"
     return None
 
@@ -208,7 +208,7 @@ def _element_wasm_type(elem_type: str) -> str | None:
         return "i32"
     if elem_type in ("Int", "Nat"):
         return "i64"
-    if elem_type in ("Float64", "Float"):
+    if elem_type == "Float64":
         return "f64"
     return None
 
@@ -594,7 +594,7 @@ class WasmContext:
             resolved = self._resolve_base_type_name(expr.type_name)
             if resolved in ("Int", "Nat"):
                 return "i64"
-            if resolved in ("Float64", "Float"):
+            if resolved == "Float64":
                 return "f64"
             if resolved in ("Bool", "Byte"):
                 return "i32"
@@ -612,7 +612,7 @@ class WasmContext:
         if isinstance(expr, ast.ResultRef):
             if expr.type_name in ("Int", "Nat"):
                 return "i64"
-            if expr.type_name in ("Float64", "Float"):
+            if expr.type_name == "Float64":
                 return "f64"
             if expr.type_name in ("Bool", "Byte"):
                 return "i32"
@@ -764,7 +764,7 @@ class WasmContext:
             name = self._resolve_base_type_name(expr.type_name)
             if name in ("Int", "Nat"):
                 return "i64"
-            if name in ("Float64", "Float"):
+            if name == "Float64":
                 return "f64"
             if name in ("Bool", "Byte"):
                 return "i32"
@@ -1646,7 +1646,7 @@ class WasmContext:
             name = ret.name
             if name in ("Int", "Nat"):
                 return "i64"
-            if name in ("Float64", "Float"):
+            if name == "Float64":
                 return "f64"
             if name == "Bool":
                 return "i32"
@@ -1665,7 +1665,7 @@ class WasmContext:
                 name = p.name
                 if name in ("Int", "Nat"):
                     types.append("i64")
-                elif name in ("Float64", "Float"):
+                elif name == "Float64":
                     types.append("f64")
                 elif name == "Bool":
                     types.append("i32")
@@ -1800,7 +1800,7 @@ class WasmContext:
         """Map a Vera type name string to a WASM type string."""
         if type_name in ("Int", "Nat"):
             return "i64"
-        if type_name in ("Float64", "Float"):
+        if type_name == "Float64":
             return "f64"
         if type_name in ("Bool", "Byte"):
             return "i32"
@@ -2298,7 +2298,7 @@ class WasmContext:
         name = self._resolve_base_type_name(name)
         if name in ("Int", "Nat"):
             return "i64"
-        if name in ("Float64", "Float"):
+        if name == "Float64":
             return "f64"
         if name in ("Bool", "Byte"):
             return "i32"


### PR DESCRIPTION
Closes #76

## Summary

- Removes the `Float` alias from `PRIMITIVES` -- `Float64` is now the only accepted floating-point type name, enforcing design principle 3 (one canonical form, spec 1.8)
- Adds a helpful "did you mean Float64?" error when `Float` is used as a type name, with deduplication so it only fires once per check run
- Simplifies ~12 dual-name checks in `wasm.py` and 1 in `codegen.py` to single-name comparisons
- Updates examples, spec chapters, tests, and agent-facing docs
- Adds post-C7 refactoring section to README roadmap (#99 decompose checker.py, #100 decompose wasm.py)
- Version bump to 0.0.33

## Files changed (14)

| File | What changed |
|------|-------------|
| `vera/types.py` | Remove `Float` from PRIMITIVES, add `REMOVED_ALIASES` dict |
| `vera/checker.py` | Detect removed aliases with helpful error + dedup |
| `vera/wasm.py` | Simplify ~12 dual-name checks to `== "Float64"` |
| `vera/codegen.py` | Simplify 1 dual-name check |
| `examples/pattern_matching.vera` | `Float` -> `Float64` (6 occurrences) |
| `spec/04-expressions.md` | Update literals table |
| `spec/11-compilation.md` | Remove `/ Float` from type mapping |
| `tests/test_checker.py` | Add `test_float_alias_rejected` |
| `tests/test_parser.py` | `@Float` -> `@Float64` in float tests |
| `SKILLS.md` | Update type list |
| `README.md` | Add refactoring section, remove #76 from roadmap |
| `CHANGELOG.md` | v0.0.33 entry |
| `vera/__init__.py` | Version 0.0.33 |
| `pyproject.toml` | Version 0.0.33 |

## Test plan

- [x] 914 tests pass (`pytest tests/ -v`)
- [x] mypy clean (`mypy vera/`)
- [x] All 14 examples pass (`python scripts/check_examples.py`)
- [x] Version sync clean (`python scripts/check_version_sync.py`)
- [x] `vera check` on a file using `@Float` produces: "'Float' is not a type. Did you mean 'Float64'?"

Generated with [Claude Code](https://claude.com/claude-code)