### PR TITLE
C7c: mandatory visibility enforcement (public/private)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.34] - 2026-02-27
+
+### Added
+- **Visibility enforcement** (C7c — partial [#14](https://github.com/aallan/vera/issues/14)):
+  - Every top-level `fn` and `data` declaration now requires an explicit `public` or `private` annotation — no implicit default, enforcing design principle 3 ("one canonical form")
+  - Cross-module access control: only `public` declarations are importable; private names produce targeted "is private" errors with fix suggestions
+  - Selective imports of private names caught at import site with clear diagnostics
+  - Wildcard imports (`import m;`) automatically filter to public declarations only
+  - Constructor visibility derived from parent ADT — private ADT means private constructors
+  - `FunctionInfo` and `AdtInfo` now carry a `visibility` field threaded through the registration pipeline
+  - Updated all 14 examples, all test inline sources, spec chapters, README, SKILLS.md, and docs site — no bare `fn`/`data` declarations remain anywhere in the repo
+- 13 new tests (927 total, up from 914)
+
 ## [0.0.33] - 2026-02-27
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ effect IO {
   op print(String -> Unit);
 }
 
-fn main(@Unit -> @Unit)
+private fn main(@Unit -> @Unit)
   requires(true)
   ensures(true)
   effects(<IO>)
@@ -58,7 +58,7 @@ fn main(@Unit -> @Unit)
 There are no variable names. `@Int.0` refers to the most recent `Int` binding — a typed positional index, like De Bruijn indices but namespaced by type. The `ensures` clause is a machine-checkable promise: the result is non-negative and equals the absolute value of the input. The compiler verifies this via SMT solver.
 
 ```vera
-fn absolute_value(@Int -> @Nat)
+private fn absolute_value(@Int -> @Nat)
   requires(true)
   ensures(@Nat.result >= 0)
   ensures(@Nat.result == @Int.0 || @Nat.result == -@Int.0)
@@ -77,7 +77,7 @@ fn absolute_value(@Int -> @Nat)
 `requires(@Int.1 != 0)` means this function cannot be called with a zero divisor. The compiler checks every call site to prove the precondition holds. If it cannot prove it, the code does not compile. Division by zero is not a runtime error — it is a type error.
 
 ```vera
-fn safe_divide(@Int, @Int -> @Int)
+private fn safe_divide(@Int, @Int -> @Int)
   requires(@Int.1 != 0)
   ensures(@Int.result == @Int.0 / @Int.1)
   effects(pure)
@@ -91,7 +91,7 @@ fn safe_divide(@Int, @Int -> @Int)
 Vera is pure by default. State changes must be declared as effects. `effects(<State<Int>>)` says this function reads and writes an integer. The `ensures` clause specifies exactly how the state changes: the new value equals the old value plus one. Handlers (not shown) provide the actual state implementation — an in-memory cell in production, a mock in tests.
 
 ```vera
-fn increment(@Unit -> @Unit)
+private fn increment(@Unit -> @Unit)
   requires(true)
   ensures(new(State<Int>) == old(State<Int>) + 1)
   effects(<State<Int>>)
@@ -226,7 +226,7 @@ Tracked in [#14](https://github.com/aallan/vera/issues/14) (type-checking) and [
 |-----------|-------|--------|
 | C7a | Module resolution — map `import` paths to source files and parse them | [v0.0.31](https://github.com/aallan/vera/releases/tag/v0.0.31) |
 | C7b | Cross-module type environment — merge public declarations across files | [v0.0.32](https://github.com/aallan/vera/releases/tag/v0.0.32) |
-| C7c | Visibility enforcement — `public`/`private` access control in the checker | Planned |
+| C7c | Visibility enforcement — `public`/`private` access control in the checker | [v0.0.34](https://github.com/aallan/vera/releases/tag/v0.0.34) |
 | C7d | Cross-module verification — verify contracts that reference imported symbols | Planned |
 | C7e | Multi-module codegen — WASM import/export tables linking multiple modules | Planned |
 | C7f | Spec Chapter 8 — formal module semantics, resolution algorithm, examples | Planned |
@@ -355,7 +355,7 @@ This runs mypy, pytest, trailing whitespace checks, and validates all examples o
 Create a file `hello.vera`:
 
 ```vera
-fn double(@Int -> @Int)
+private fn double(@Int -> @Int)
   requires(true)
   ensures(@Int.result == @Int.0 * 2)
   effects(pure)

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -41,10 +41,10 @@ On error, each diagnostic includes `severity`, `description`, `location` (`file`
 
 ## Function Structure
 
-Every function has this exact structure. No part is optional except `decreases` and `where`.
+Every function has this exact structure. No part is optional except `decreases` and `where`. Visibility (`public` or `private`) is mandatory on every top-level `fn` and `data` declaration.
 
 ```vera
-fn function_name(@ParamType1, @ParamType2 -> @ReturnType)
+private fn function_name(@ParamType1, @ParamType2 -> @ReturnType)
   requires(precondition_expression)
   ensures(postcondition_expression)
   effects(effect_row)
@@ -56,7 +56,7 @@ fn function_name(@ParamType1, @ParamType2 -> @ReturnType)
 Complete example:
 
 ```vera
-fn safe_divide(@Int, @Int -> @Int)
+private fn safe_divide(@Int, @Int -> @Int)
   requires(@Int.1 != 0)
   ensures(@Int.result == @Int.0 / @Int.1)
   effects(pure)
@@ -65,10 +65,56 @@ fn safe_divide(@Int, @Int -> @Int)
 }
 ```
 
+## Function Visibility
+
+Every top-level `fn` and `data` declaration **must** have an explicit visibility modifier. There is no default visibility -- omitting it is an error.
+
+- `public` -- the declaration is visible to other modules that import this one. Use for library APIs and exported functions.
+- `private` -- the declaration is only visible within the current file/module. Use for internal helpers and standalone programs.
+
+```vera
+public fn exported_api(@Int -> @Int)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  @Int.0
+}
+
+private fn internal_helper(@Int -> @Int)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  @Int.0 + 1
+}
+
+public data Color { Red, Green, Blue }
+
+private data InternalState {
+  Ready,
+  Done(Int)
+}
+```
+
+For generic functions, visibility comes before `forall`:
+
+```vera
+private forall<T> fn identity(@T -> @T)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  @T.0
+}
+```
+
+Visibility does **not** apply to: type aliases (`type Foo = ...`), effect declarations (`effect E { ... }`), module declarations, or import statements. Functions inside `where` blocks also do not take visibility.
+
 Multiple `requires` and `ensures` clauses are allowed. They are conjunctive (AND'd together):
 
 ```vera
-fn clamp(@Int, @Int, @Int -> @Int)
+private fn clamp(@Int, @Int, @Int -> @Int)
   requires(@Int.1 <= @Int.2)
   ensures(@Int.result >= @Int.1)
   ensures(@Int.result <= @Int.2)
@@ -103,7 +149,7 @@ Vera has no variable names. Every binding is referenced by type and index:
 Parameters bind left-to-right. The **rightmost** parameter of a given type is `@T.0`:
 
 ```vera
-fn add(@Int, @Int -> @Int)
+private fn add(@Int, @Int -> @Int)
   requires(true)
   ensures(@Int.result == @Int.0 + @Int.1)
   effects(pure)
@@ -119,7 +165,7 @@ fn add(@Int, @Int -> @Int)
 Each type has its own index counter:
 
 ```vera
-fn repeat(@String, @Int -> @String)
+private fn repeat(@String, @Int -> @String)
   requires(@Int.0 >= 0)
   ensures(true)
   effects(pure)
@@ -133,7 +179,7 @@ fn repeat(@String, @Int -> @String)
 ### Let bindings push new slots
 
 ```vera
-fn example(@Int -> @Int)
+private fn example(@Int -> @Int)
   requires(true)
   ensures(true)
   effects(pure)
@@ -149,7 +195,7 @@ fn example(@Int -> @Int)
 Only valid inside `ensures` clauses. Refers to the function's return value:
 
 ```vera
-fn abs(@Int -> @Nat)
+private fn abs(@Int -> @Nat)
   requires(true)
   ensures(@Nat.result >= 0)
   effects(pure)
@@ -193,20 +239,20 @@ type Name = String;
 ## Data Types (ADTs)
 
 ```vera
-data Color { Red, Green, Blue }
+private data Color { Red, Green, Blue }
 
-data List<T> {
+private data List<T> {
   Nil,
   Cons(T, List<T>)
 }
 
-data Option<T> { None, Some(T) }
+private data Option<T> { None, Some(T) }
 ```
 
 With an invariant:
 
 ```vera
-data Positive invariant(@Int.0 > 0) {
+private data Positive invariant(@Int.0 > 0) {
   MkPositive(Int)
 }
 ```
@@ -214,7 +260,7 @@ data Positive invariant(@Int.0 > 0) {
 ## Pattern Matching
 
 ```vera
-fn to_int(@Color -> @Int)
+private fn to_int(@Color -> @Int)
   requires(true)
   ensures(true)
   effects(pure)
@@ -230,7 +276,7 @@ fn to_int(@Color -> @Int)
 Patterns can bind values:
 
 ```vera
-fn unwrap_or(@Option<Int>, @Int -> @Int)
+private fn unwrap_or(@Option<Int>, @Int -> @Int)
   requires(true)
   ensures(true)
   effects(pure)
@@ -276,7 +322,7 @@ Statements end with `;`. The final expression (no `;`) is the block's value.
 Conditions that must hold when the function is called:
 
 ```vera
-fn safe_divide(@Int, @Int -> @Int)
+private fn safe_divide(@Int, @Int -> @Int)
   requires(@Int.1 != 0)
 ```
 
@@ -293,7 +339,7 @@ Conditions guaranteed when the function returns. Use `@T.result` to refer to the
 Required on recursive functions. The expression must decrease on each recursive call:
 
 ```vera
-fn factorial(@Nat -> @Nat)
+private fn factorial(@Nat -> @Nat)
   requires(true)
   ensures(@Nat.result >= 1)
   decreases(@Nat.0)
@@ -346,7 +392,7 @@ effect Console {
 Call the effect operations directly:
 
 ```vera
-fn greet(@String -> @Unit)
+private fn greet(@String -> @Unit)
   requires(true)
   ensures(true)
   effects(<IO>)
@@ -359,7 +405,7 @@ fn greet(@String -> @Unit)
 ### State effects
 
 ```vera
-fn increment(@Unit -> @Unit)
+private fn increment(@Unit -> @Unit)
   requires(true)
   ensures(new(State<Int>) == old(State<Int>) + 1)
   effects(<State<Int>>)
@@ -377,7 +423,7 @@ In `ensures` clauses, `old(State<T>)` is the state before the call and `new(Stat
 Handlers eliminate an effect, converting effectful code to pure code:
 
 ```vera
-fn run_counter(@Unit -> @Int)
+private fn run_counter(@Unit -> @Int)
   requires(true)
   ensures(true)
   effects(pure)
@@ -423,7 +469,7 @@ Logger.put("message");
 ## Where Blocks (Mutual Recursion)
 
 ```vera
-fn is_even(@Nat -> @Bool)
+private fn is_even(@Nat -> @Bool)
   requires(true)
   ensures(true)
   decreases(@Nat.0)
@@ -446,7 +492,7 @@ where {
 ## Generic Functions
 
 ```vera
-forall<T> fn identity(@T -> @T)
+private forall<T> fn identity(@T -> @T)
   requires(true)
   ensures(true)
   effects(pure)
@@ -472,7 +518,7 @@ public fn exported(@Int -> @Int)
 }
 ```
 
-Functions are private by default. Add `public` for external visibility.
+Every top-level `fn` and `data` must have explicit `public` or `private` visibility. Use `public` for functions that other modules should be able to import.
 
 Import paths resolve to files on disk: `import vera.math;` looks for `vera/math.vera` relative to the importing file's directory (or the project root). Imported files are parsed and cached automatically. Circular imports are detected and reported as errors.
 
@@ -511,14 +557,14 @@ Note: module-qualified call syntax (`vera.math.abs(42)`) is not yet parseable du
 
 WRONG:
 ```vera
-fn add(@Int, @Int -> @Int) {
+private fn add(@Int, @Int -> @Int) {
   @Int.0 + @Int.1
 }
 ```
 
 CORRECT:
 ```vera
-fn add(@Int, @Int -> @Int)
+private fn add(@Int, @Int -> @Int)
   requires(true)
   ensures(@Int.result == @Int.0 + @Int.1)
   effects(pure)
@@ -531,7 +577,7 @@ fn add(@Int, @Int -> @Int)
 
 WRONG:
 ```vera
-fn add(@Int, @Int -> @Int)
+private fn add(@Int, @Int -> @Int)
   requires(true)
   ensures(true)
 {
@@ -541,7 +587,7 @@ fn add(@Int, @Int -> @Int)
 
 CORRECT — add `effects(pure)` (or the appropriate effect row):
 ```vera
-fn add(@Int, @Int -> @Int)
+private fn add(@Int, @Int -> @Int)
   requires(true)
   ensures(true)
   effects(pure)
@@ -554,7 +600,7 @@ fn add(@Int, @Int -> @Int)
 
 WRONG — both `@Int.0` refer to the same binding (the second parameter):
 ```vera
-fn add(@Int, @Int -> @Int)
+private fn add(@Int, @Int -> @Int)
   requires(true)
   ensures(true)
   effects(pure)
@@ -565,7 +611,7 @@ fn add(@Int, @Int -> @Int)
 
 CORRECT — `@Int.1` is the first parameter, `@Int.0` is the second:
 ```vera
-fn add(@Int, @Int -> @Int)
+private fn add(@Int, @Int -> @Int)
   requires(true)
   ensures(true)
   effects(pure)
@@ -590,7 +636,7 @@ CORRECT:
 
 WRONG:
 ```vera
-fn factorial(@Nat -> @Nat)
+private fn factorial(@Nat -> @Nat)
   requires(true)
   ensures(true)
   effects(pure)
@@ -601,7 +647,7 @@ fn factorial(@Nat -> @Nat)
 
 CORRECT:
 ```vera
-fn factorial(@Nat -> @Nat)
+private fn factorial(@Nat -> @Nat)
   requires(true)
   ensures(true)
   decreases(@Nat.0)
@@ -615,7 +661,7 @@ fn factorial(@Nat -> @Nat)
 
 WRONG — `IO.print` performs IO but function declares `pure`:
 ```vera
-fn greet(@String -> @Unit)
+private fn greet(@String -> @Unit)
   requires(true)
   ensures(true)
   effects(pure)
@@ -627,7 +673,7 @@ fn greet(@String -> @Unit)
 
 CORRECT:
 ```vera
-fn greet(@String -> @Unit)
+private fn greet(@String -> @Unit)
   requires(true)
   ensures(true)
   effects(<IO>)
@@ -641,7 +687,7 @@ fn greet(@String -> @Unit)
 
 WRONG:
 ```vera
-fn f(@Int -> @Int)
+private fn f(@Int -> @Int)
   requires(@Int.result > 0)
   ensures(true)
   effects(pure)
@@ -650,7 +696,7 @@ fn f(@Int -> @Int)
 
 CORRECT — `@T.result` is only valid in `ensures`:
 ```vera
-fn f(@Int -> @Int)
+private fn f(@Int -> @Int)
   requires(true)
   ensures(@Int.result > 0)
   effects(pure)
@@ -691,7 +737,7 @@ if @Bool.0 then { 1 } else { 0 }
 ### Pure function with postconditions
 
 ```vera
-fn absolute_value(@Int -> @Nat)
+private fn absolute_value(@Int -> @Nat)
   requires(true)
   ensures(@Nat.result >= 0)
   ensures(@Nat.result == @Int.0 || @Nat.result == -@Int.0)
@@ -708,7 +754,7 @@ fn absolute_value(@Int -> @Nat)
 ### Recursive function with termination proof
 
 ```vera
-fn factorial(@Nat -> @Nat)
+private fn factorial(@Nat -> @Nat)
   requires(true)
   ensures(@Nat.result >= 1)
   decreases(@Nat.0)
@@ -725,7 +771,7 @@ fn factorial(@Nat -> @Nat)
 ### Stateful effects with old/new
 
 ```vera
-fn increment(@Unit -> @Unit)
+private fn increment(@Unit -> @Unit)
   requires(true)
   ensures(new(State<Int>) == old(State<Int>) + 1)
   effects(<State<Int>>)
@@ -739,12 +785,12 @@ fn increment(@Unit -> @Unit)
 ### ADT with pattern matching
 
 ```vera
-data List<T> {
+private data List<T> {
   Nil,
   Cons(T, List<T>)
 }
 
-fn length(@List<Int> -> @Nat)
+private fn length(@List<Int> -> @Nat)
   requires(true)
   ensures(@Nat.result >= 0)
   decreases(@List<Int>.0)

--- a/docs/index.html
+++ b/docs/index.html
@@ -579,7 +579,7 @@
   <span class="kw">op</span> print(<span class="ty">String</span> -> <span class="ty">Unit</span>);
 }
 
-<span class="kw">fn</span> main(<span class="sl">@Unit</span> -> <span class="sl">@Unit</span>)
+<span class="kw">private</span> <span class="kw">fn</span> main(<span class="sl">@Unit</span> -> <span class="sl">@Unit</span>)
   <span class="ct">requires</span>(<span class="num">true</span>)
   <span class="ct">ensures</span>(<span class="num">true</span>)
   <span class="ct">effects</span>(&lt;<span class="ty">IO</span>&gt;)
@@ -593,7 +593,7 @@
         <div class="code-block">
 <pre><span class="err-head">Error in main.vera at line 12, column 1:</span>
 
-    <span class="err-code">fn add(@Int, @Int -> @Int)</span>
+    <span class="err-code">private fn add(@Int, @Int -> @Int)</span>
     <span class="err-caret">^</span>
 
   <span class="err-msg">Function "add" is missing its contract block. Every function in Vera
@@ -602,7 +602,7 @@
 
   <span class="err-fix">Add a contract block after the signature:
 
-    fn add(@Int, @Int -> @Int)
+    private fn add(@Int, @Int -> @Int)
       requires(true)
       ensures(@Int.result == @Int.0 + @Int.1)
       effects(pure)

--- a/examples/absolute_value.vera
+++ b/examples/absolute_value.vera
@@ -1,6 +1,6 @@
 -- Absolute value: a simple pure function with postconditions.
 
-fn absolute_value(@Int -> @Nat)
+private fn absolute_value(@Int -> @Nat)
   requires(true)
   ensures(@Nat.result >= 0)
   ensures(@Nat.result == @Int.0 || @Nat.result == -@Int.0)

--- a/examples/closures.vera
+++ b/examples/closures.vera
@@ -4,7 +4,7 @@
 type IntToInt = fn(Int -> Int) effects(pure);
 
 -- Create a closure that captures a value from the enclosing scope
-fn make_adder(@Int -> @IntToInt)
+private fn make_adder(@Int -> @IntToInt)
   requires(true)
   ensures(true)
   effects(pure)
@@ -13,7 +13,7 @@ fn make_adder(@Int -> @IntToInt)
 }
 
 -- Apply a function to a value
-fn apply(@IntToInt, @Int -> @Int)
+private fn apply(@IntToInt, @Int -> @Int)
   requires(true)
   ensures(true)
   effects(pure)
@@ -22,11 +22,11 @@ fn apply(@IntToInt, @Int -> @Int)
 }
 
 -- Map a function over an optional value
-data Option<T> { None, Some(T) }
+private data Option<T> { None, Some(T) }
 
 type IntMapper = fn(Int -> Int) effects(pure);
 
-fn map_option(@Option<Int>, @IntMapper -> @Option<Int>)
+private fn map_option(@Option<Int>, @IntMapper -> @Option<Int>)
   requires(true)
   ensures(true)
   effects(pure)
@@ -38,7 +38,7 @@ fn map_option(@Option<Int>, @IntMapper -> @Option<Int>)
 }
 
 -- End-to-end test: create a closure, apply it, return the result
-fn test_closure(@Unit -> @Int)
+private fn test_closure(@Unit -> @Int)
   requires(true)
   ensures(true)
   effects(pure)
@@ -48,7 +48,7 @@ fn test_closure(@Unit -> @Int)
 }
 
 -- Test: map a closure over an Option
-fn test_map_option(@Unit -> @Int)
+private fn test_map_option(@Unit -> @Int)
   requires(true)
   ensures(true)
   effects(pure)

--- a/examples/effect_handler.vera
+++ b/examples/effect_handler.vera
@@ -7,7 +7,7 @@ effect Counter {
 }
 
 -- Use the counter effect (not compilable — Counter is not a host effect)
-fn count_to_three(@Unit -> @Unit)
+private fn count_to_three(@Unit -> @Unit)
   requires(true)
   ensures(true)
   effects(<Counter>)
@@ -20,7 +20,7 @@ fn count_to_three(@Unit -> @Unit)
 -- Handle State<Int> to implement a counter
 -- The handle expression discharges the effect: run_counter is pure
 -- The put clause uses 'with' to explicitly update handler state
-fn run_counter(@Unit -> @Int)
+private fn run_counter(@Unit -> @Int)
   requires(true)
   ensures(true)
   effects(pure)
@@ -38,7 +38,7 @@ fn run_counter(@Unit -> @Int)
 }
 
 -- Simpler test: read the initial state value
-fn test_state_init(@Unit -> @Int)
+private fn test_state_init(@Unit -> @Int)
   requires(true)
   ensures(true)
   effects(pure)
@@ -52,7 +52,7 @@ fn test_state_init(@Unit -> @Int)
 }
 
 -- Test: put then get
-fn test_put_get(@Unit -> @Int)
+private fn test_put_get(@Unit -> @Int)
   requires(true)
   ensures(true)
   effects(pure)
@@ -71,4 +71,4 @@ effect Exn<E> {
   op throw(E -> Unit);
 }
 
-data Option<T> { None, Some(T) }
+private data Option<T> { None, Some(T) }

--- a/examples/factorial.vera
+++ b/examples/factorial.vera
@@ -1,6 +1,6 @@
 -- Factorial: demonstrates recursion with a decreases clause.
 
-fn factorial(@Nat -> @Nat)
+private fn factorial(@Nat -> @Nat)
   requires(true)
   ensures(@Nat.result >= 1)
   decreases(@Nat.0)

--- a/examples/generics.vera
+++ b/examples/generics.vera
@@ -1,7 +1,7 @@
 -- Generic functions and parameterized types
 
 -- Identity function — works for any type
-forall<T> fn identity(@T -> @T)
+private forall<T> fn identity(@T -> @T)
   requires(true)
   ensures(@T.result == @T.0)
   effects(pure)
@@ -10,7 +10,7 @@ forall<T> fn identity(@T -> @T)
 }
 
 -- Constant function — returns the first argument, ignoring the second
-forall<A, B> fn const(@A, @B -> @A)
+private forall<A, B> fn const(@A, @B -> @A)
   requires(true)
   ensures(@A.result == @A.0)
   effects(pure)
@@ -19,10 +19,10 @@ forall<A, B> fn const(@A, @B -> @A)
 }
 
 -- Generic option type
-data Option<T> { None, Some(T) }
+private data Option<T> { None, Some(T) }
 
 -- Check if an option contains a value
-forall<T> fn is_some(@Option<T> -> @Bool)
+private forall<T> fn is_some(@Option<T> -> @Bool)
   requires(true)
   ensures(true)
   effects(pure)
@@ -34,13 +34,13 @@ forall<T> fn is_some(@Option<T> -> @Bool)
 }
 
 -- Either type — two type parameters
-data Either<L, R> {
+private data Either<L, R> {
   Left(L),
   Right(R)
 }
 
 -- Extract the right value or provide a default
-fn unwrap_right(@Either<String, Int>, @Int -> @Int)
+private fn unwrap_right(@Either<String, Int>, @Int -> @Int)
   requires(true)
   ensures(true)
   effects(pure)

--- a/examples/hello_world.vera
+++ b/examples/hello_world.vera
@@ -4,7 +4,7 @@ effect IO {
   op print(String -> Unit);
 }
 
-fn main(@Unit -> @Unit)
+private fn main(@Unit -> @Unit)
   requires(true)
   ensures(true)
   effects(<IO>)

--- a/examples/increment.vera
+++ b/examples/increment.vera
@@ -1,6 +1,6 @@
 -- Increment: demonstrates stateful effects with State<Int>.
 
-fn increment(@Unit -> @Unit)
+private fn increment(@Unit -> @Unit)
   requires(true)
   ensures(new(State<Int>) == old(State<Int>) + 1)
   effects(<State<Int>>)

--- a/examples/list_ops.vera
+++ b/examples/list_ops.vera
@@ -1,11 +1,11 @@
 -- List operations: demonstrates ADTs, pattern matching, and recursion.
 
-data List<T> {
+private data List<T> {
   Nil,
   Cons(T, List<T>)
 }
 
-fn length(@List<Int> -> @Nat)
+private fn length(@List<Int> -> @Nat)
   requires(true)
   ensures(@Nat.result >= 0)
   decreases(@List<Int>.0)
@@ -17,7 +17,7 @@ fn length(@List<Int> -> @Nat)
   }
 }
 
-fn sum(@List<Int> -> @Int)
+private fn sum(@List<Int> -> @Int)
   requires(true)
   ensures(true)
   decreases(@List<Int>.0)

--- a/examples/mutual_recursion.vera
+++ b/examples/mutual_recursion.vera
@@ -1,7 +1,7 @@
 -- Mutual recursion with where blocks
 
 -- is_even and is_odd defined together
-fn is_even(@Nat -> @Bool)
+private fn is_even(@Nat -> @Bool)
   requires(true)
   ensures(true)
   decreases(@Nat.0)

--- a/examples/pattern_matching.vera
+++ b/examples/pattern_matching.vera
@@ -1,10 +1,10 @@
 -- Pattern matching — nested patterns, wildcards, multiple variants
 
-data Option<T> { None, Some(T) }
-data List<T> { Nil, Cons(T, List<T>) }
+private data Option<T> { None, Some(T) }
+private data List<T> { Nil, Cons(T, List<T>) }
 
 -- Nested pattern: match inside a list of options
-fn first_some(@List<Option<Int>> -> @Int)
+private fn first_some(@List<Option<Int>> -> @Int)
   requires(true)
   ensures(true)
   effects(pure)
@@ -17,7 +17,7 @@ fn first_some(@List<Option<Int>> -> @Int)
 }
 
 -- Literal patterns with wildcard fallback
-fn classify(@Int -> @String)
+private fn classify(@Int -> @String)
   requires(true)
   ensures(true)
   effects(pure)
@@ -30,7 +30,7 @@ fn classify(@Int -> @String)
 }
 
 -- Boolean patterns
-fn to_string(@Bool -> @String)
+private fn to_string(@Bool -> @String)
   requires(true)
   ensures(true)
   effects(pure)
@@ -42,13 +42,13 @@ fn to_string(@Bool -> @String)
 }
 
 -- Multi-variant ADT with exhaustive matching
-data Shape {
+private data Shape {
   Circle(Float64),
   Rectangle(Float64, Float64),
   Triangle(Float64, Float64, Float64)
 }
 
-fn describe(@Shape -> @String)
+private fn describe(@Shape -> @String)
   requires(true)
   ensures(true)
   effects(pure)

--- a/examples/quantifiers.vera
+++ b/examples/quantifiers.vera
@@ -1,7 +1,7 @@
 -- Quantifiers in contracts — forall and exists
 
 -- All elements in the array are positive
-fn all_positive(@Array<Int> -> @Bool)
+private fn all_positive(@Array<Int> -> @Bool)
   requires(true)
   ensures(true)
   effects(pure)
@@ -12,7 +12,7 @@ fn all_positive(@Array<Int> -> @Bool)
 }
 
 -- There exists a zero in the array
-fn has_zero(@Array<Int> -> @Bool)
+private fn has_zero(@Array<Int> -> @Bool)
   requires(true)
   ensures(true)
   effects(pure)
@@ -23,7 +23,7 @@ fn has_zero(@Array<Int> -> @Bool)
 }
 
 -- Assert and assume in function bodies
-fn process(@Int -> @Int)
+private fn process(@Int -> @Int)
   requires(@Int.0 > 0)
   ensures(@Int.result > 0)
   effects(pure)

--- a/examples/refinement_types.vera
+++ b/examples/refinement_types.vera
@@ -10,7 +10,7 @@ type Nat = { @Int | @Int.0 >= 0 };
 type Percentage = { @Int | @Int.0 >= 0 && @Int.0 <= 100 };
 
 -- Safe division — denominator must be non-zero
-fn safe_divide(@Int, @PosInt -> @Int)
+private fn safe_divide(@Int, @PosInt -> @Int)
   requires(true)
   ensures(true)
   effects(pure)
@@ -19,7 +19,7 @@ fn safe_divide(@Int, @PosInt -> @Int)
 }
 
 -- Clamp a value to a percentage
-fn to_percentage(@Int -> @Percentage)
+private fn to_percentage(@Int -> @Percentage)
   requires(true)
   ensures(true)
   effects(pure)
@@ -39,7 +39,7 @@ fn to_percentage(@Int -> @Percentage)
 type NonEmptyArray = { @Array<Int> | length(@Array<Int>.0) > 0 };
 
 -- Head of a non-empty array — always safe
-fn head(@NonEmptyArray -> @Int)
+private fn head(@NonEmptyArray -> @Int)
   requires(true)
   ensures(true)
   effects(pure)

--- a/examples/safe_divide.vera
+++ b/examples/safe_divide.vera
@@ -1,6 +1,6 @@
 -- Safe division: demonstrates a non-trivial precondition.
 
-fn safe_divide(@Int, @Int -> @Int)
+private fn safe_divide(@Int, @Int -> @Int)
   requires(@Int.1 != 0)
   ensures(@Int.result == @Int.0 / @Int.1)
   effects(pure)

--- a/examples/vera/collections.vera
+++ b/examples/vera/collections.vera
@@ -3,6 +3,6 @@
 
 module vera.collections;
 
-data List<T> { Nil, Cons(T, List<T>) }
+public data List<T> { Nil, Cons(T, List<T>) }
 
-data Option<T> { None, Some(T) }
+public data Option<T> { None, Some(T) }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.33"
+version = "0.0.34"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/scripts/check_spec_examples.py
+++ b/scripts/check_spec_examples.py
@@ -79,7 +79,7 @@ ALLOWLIST: dict[tuple[str, int], str] = {
 
     # Chapter 5 — inline function types in return/param position
     ("05-functions.md", 203): "FRAGMENT",   # fn make_adder returns fn(...) inline
-    ("05-functions.md", 277): "FRAGMENT",   # fn(A -> B) in param position
+    ("05-functions.md", 314): "FRAGMENT",   # fn(A -> B) in param position
 
     # Chapter 6 — inline function type in type alias
     ("06-contracts.md", 308): "FRAGMENT",   # type SafeDiv = fn(...) + fn apply_div

--- a/spec/02-types.md
+++ b/spec/02-types.md
@@ -60,7 +60,7 @@ Option<Int>
 `Option<T>` is a built-in algebraic data type equivalent to:
 
 ```
-data Option<T> {
+public data Option<T> {
   Some(T),
   None
 }
@@ -77,7 +77,7 @@ Result<Int, String>
 `Result<T, E>` is a built-in algebraic data type equivalent to:
 
 ```
-data Result<T, E> {
+public data Result<T, E> {
   Ok(T),
   Err(E)
 }
@@ -90,21 +90,21 @@ It represents a computation that may succeed with a value of type `T` or fail wi
 User-defined algebraic data types are declared with the `data` keyword:
 
 ```
-data List<T> {
+private data List<T> {
   Cons(T, List<T>),
   Nil
 }
 ```
 
 ```
-data Tree<T> {
+private data Tree<T> {
   Leaf(T),
   Node(Tree<T>, Tree<T>)
 }
 ```
 
 ```
-data Color {
+private data Color {
   Red,
   Green,
   Blue
@@ -127,7 +127,7 @@ Rules:
 An ADT may declare an invariant that all values must satisfy:
 
 ```
-data SortedList<T>
+private data SortedList<T>
   invariant(is_sorted(@SortedList<T>.0))
 {
   SCons(T, SortedList<T>),
@@ -228,7 +228,7 @@ However, type aliases create distinct namespaces for slot references (see Chapte
 Functions and data types may be parameterised by type variables:
 
 ```
-forall<A, B> fn swap(@Tuple<A, B> -> @Tuple<B, A>)
+private forall<A, B> fn swap(@Tuple<A, B> -> @Tuple<B, A>)
   requires(true)
   ensures(true)
   effects(pure)
@@ -248,7 +248,7 @@ Type variables:
 Type variables may be constrained (future extension, not in v0.1):
 
 ```
-forall<T where Ord<T>> fn sort(@Array<T> -> @Array<T>)
+private forall<T where Ord<T>> fn sort(@Array<T> -> @Array<T>)
 ```
 
 For v0.1, type variables are unconstrained.

--- a/spec/03-slot-references.md
+++ b/spec/03-slot-references.md
@@ -84,7 +84,7 @@ In this example:
 ### Example 1: Simple Function
 
 ```
-fn add(@Int, @Int -> @Int)
+private fn add(@Int, @Int -> @Int)
   requires(true)
   ensures(@Int.result == @Int.0 + @Int.1)
   effects(pure)
@@ -214,7 +214,7 @@ After destructuring:
 ### Example 7: Recursive Function with Decreases
 
 ```
-fn factorial(@Nat -> @Nat)
+private fn factorial(@Nat -> @Nat)
   requires(true)
   ensures(@Nat.result >= 1)
   decreases(@Nat.0)
@@ -236,7 +236,7 @@ In the else branch after the let:
 ### Example 8: Higher-Order Functions
 
 ```
-fn map_array<A, B>(@Array<A>, fn(A -> B) effects(pure) -> @Array<B>)
+private fn map_array<A, B>(@Array<A>, fn(A -> B) effects(pure) -> @Array<B>)
   requires(true)
   ensures(length(@Array<B>.result) == length(@Array<A>.0))
   effects(pure)
@@ -251,12 +251,12 @@ Here `@Array<A>.0` refers to the first argument and `@Fn<A, B>.0` is a shorthand
 ### Example 9: ADT Construction and Matching
 
 ```
-data List<T> {
+private data List<T> {
   Cons(T, List<T>),
   Nil
 }
 
-fn list_head<T>(@List<T> -> @Option<T>)
+private fn list_head<T>(@List<T> -> @Option<T>)
   requires(true)
   ensures(true)
   effects(pure)
@@ -275,7 +275,7 @@ In the `Cons` arm:
 ### Example 10: Multiple Return-Type References in Contracts
 
 ```
-fn clamp(@Int, @Int, @Int -> @Int)
+private fn clamp(@Int, @Int, @Int -> @Int)
   requires(@Int.2 <= @Int.1)
   ensures(@Int.result >= @Int.2 && @Int.result <= @Int.1)
   effects(pure)
@@ -327,7 +327,7 @@ Function-type parameters use the same `@T.n` system, where `T` is the full funct
 ```
 type IntTransform = fn(Int -> Int) effects(pure);
 
-fn apply_to_array(@Array<Int>, @IntTransform -> @Array<Int>)
+private fn apply_to_array(@Array<Int>, @IntTransform -> @Array<Int>)
   requires(length(@Array<Int>.0) > 0)
   ensures(length(@Array<Int>.result) == length(@Array<Int>.0))
   effects(pure)

--- a/spec/05-functions.md
+++ b/spec/05-functions.md
@@ -17,7 +17,7 @@ All components are mandatory. There are no defaults, no shortcuts, and no omissi
 The canonical form of a function declaration:
 
 ```
-fn function_name(@ParamType1, @ParamType2 -> @ReturnType)
+private fn function_name(@ParamType1, @ParamType2 -> @ReturnType)
   requires(precondition)
   ensures(postcondition)
   effects(effect_row)
@@ -29,7 +29,7 @@ fn function_name(@ParamType1, @ParamType2 -> @ReturnType)
 ### 5.2.1 Complete Example
 
 ```
-fn absolute_value(@Int -> @Nat)
+private fn absolute_value(@Int -> @Nat)
   requires(true)
   ensures(@Nat.result == if @Int.0 >= 0 then { @Int.0 } else { -@Int.0 })
   effects(pure)
@@ -47,7 +47,7 @@ fn absolute_value(@Int -> @Nat)
 Multiple `requires` and `ensures` clauses may be specified. They are conjunctive (all must hold):
 
 ```
-fn safe_divide(@Int, @Int -> @Int)
+private fn safe_divide(@Int, @Int -> @Int)
   requires(@Int.1 != 0)
   requires(@Int.0 >= 0)
   ensures(@Int.result >= 0)
@@ -109,7 +109,7 @@ Effect syntax and semantics are detailed in Chapter 7.
 Recursive functions are functions that call themselves (directly or mutually). A recursive function MUST declare a `decreases` clause:
 
 ```
-fn factorial(@Nat -> @Nat)
+private fn factorial(@Nat -> @Nat)
   requires(true)
   ensures(@Nat.result >= 1)
   decreases(@Nat.0)
@@ -135,7 +135,7 @@ The `decreases` clause specifies an expression that must strictly decrease (in a
 Lexicographic decrease:
 
 ```
-fn ackermann(@Nat, @Nat -> @Nat)
+private fn ackermann(@Nat, @Nat -> @Nat)
   requires(true)
   ensures(true)
   decreases(@Nat.1, @Nat.0)
@@ -160,7 +160,7 @@ The tuple `(@Nat.1, @Nat.0)` decreases lexicographically on each recursive call.
 Mutually recursive functions are declared together in a `where` block. Each must have its own `decreases` clause:
 
 ```
-fn is_even(@Nat -> @Bool)
+private fn is_even(@Nat -> @Bool)
   requires(true)
   ensures(true)
   decreases(@Nat.0)
@@ -201,7 +201,7 @@ Anonymous functions:
 Anonymous functions capture bindings from enclosing scopes by reference. The captured bindings are immutable (since all bindings in Vera are immutable):
 
 ```
-fn make_adder(@Int -> fn(Int -> Int) effects(pure))
+private fn make_adder(@Int -> fn(Int -> Int) effects(pure))
   requires(true)
   ensures(true)
   effects(pure)
@@ -219,7 +219,7 @@ When passing closures to higher-order functions:
 ```
 type IntPred = fn(Int -> Bool) effects(pure);
 
-fn filter_positive(@Array<Int> -> @Array<Int>)
+private fn filter_positive(@Array<Int> -> @Array<Int>)
   requires(true)
   ensures(true)
   effects(pure)
@@ -230,7 +230,7 @@ fn filter_positive(@Array<Int> -> @Array<Int>)
 
 ## 5.8 Function Visibility
 
-Top-level functions are `private` by default. Use `public` to export:
+Every top-level `fn` and `data` declaration MUST have an explicit visibility modifier: either `public` or `private`. There is no default visibility. Omitting the modifier is a compile error.
 
 ```
 public fn add(@Int, @Int -> @Int)
@@ -240,16 +240,53 @@ public fn add(@Int, @Int -> @Int)
 {
   @Int.0 + @Int.1
 }
+
+private fn helper(@Int -> @Int)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  @Int.0 + 1
+}
 ```
 
 `public` functions are visible to importing modules. `private` functions are visible only within their own module.
+
+The same rule applies to `data` declarations:
+
+```
+public data Color {
+  Red,
+  Green,
+  Blue
+}
+
+private data InternalState {
+  Active(Int),
+  Idle
+}
+```
+
+For generic functions, the visibility modifier precedes `forall`:
+
+```
+private forall<T> fn identity(@T -> @T)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  @T.0
+}
+```
+
+Type aliases (`type Foo = ...`), effect declarations (`effect E { ... }`), module declarations, and import statements do not take visibility modifiers. Functions declared inside `where` blocks do not take visibility modifiers (they are always local to the parent function).
 
 ## 5.9 Generic Functions
 
 Functions may be parameterised by type variables using `forall`:
 
 ```
-forall<T> fn identity(@T -> @T)
+private forall<T> fn identity(@T -> @T)
   requires(true)
   ensures(true)
   effects(pure)
@@ -259,7 +296,7 @@ forall<T> fn identity(@T -> @T)
 ```
 
 ```
-forall<A, B> fn pair(@A, @B -> @Tuple<A, B>)
+private forall<A, B> fn pair(@A, @B -> @Tuple<A, B>)
   requires(true)
   ensures(true)
   effects(pure)
@@ -275,7 +312,7 @@ Type variables are introduced by `forall<...>` and are scoped to the entire func
 Functions can be polymorphic over effects:
 
 ```
-forall<A, B> fn map_option(@Option<A>, fn(A -> B) effects(<E>) -> @Option<B>)
+private forall<A, B> fn map_option(@Option<A>, fn(A -> B) effects(<E>) -> @Option<B>)
   requires(true)
   ensures(true)
   effects(<E>)
@@ -308,7 +345,7 @@ Functions are first-class values. They can be:
 A Vera program's entry point is a function named `main`:
 
 ```
-fn main(@Unit -> @Unit)
+public fn main(@Unit -> @Unit)
   requires(true)
   ensures(true)
   effects(<IO>)

--- a/spec/06-contracts.md
+++ b/spec/06-contracts.md
@@ -13,7 +13,7 @@ Contracts serve as executable specifications. They are the source of truth about
 A precondition is a predicate that MUST hold when the function is called. It is the caller's responsibility to ensure preconditions are met.
 
 ```
-fn safe_divide(@Int, @Int -> @Int)
+private fn safe_divide(@Int, @Int -> @Int)
   requires(@Int.1 != 0)
   ensures(@Int.result == @Int.0 / @Int.1)
   effects(pure)
@@ -29,7 +29,7 @@ At every call site of `safe_divide`, the compiler verifies that the second argum
 A postcondition is a predicate that MUST hold when the function returns. It is the function's responsibility to ensure postconditions are met.
 
 ```
-fn absolute_value(@Int -> @Nat)
+private fn absolute_value(@Int -> @Nat)
   requires(true)
   ensures(@Nat.result >= 0)
   ensures(@Nat.result == @Int.0 || @Nat.result == -@Int.0)
@@ -46,7 +46,7 @@ The special reference `@T.result` (where `T` is the return type) refers to the f
 An invariant is a predicate declared on a data type that MUST hold for all values of that type:
 
 ```
-data SortedArray
+private data SortedArray
   invariant(is_sorted_impl(@SortedArray.0))
 {
   Mk(Array<Int>)
@@ -62,7 +62,7 @@ Invariants on built-in types are expressed as refinement types (Chapter 2) rathe
 A `decreases` clause specifies an expression that strictly decreases on each recursive call (see Chapter 5, Section 5.6.1):
 
 ```
-fn sum_to(@Nat -> @Nat)
+private fn sum_to(@Nat -> @Nat)
   requires(true)
   ensures(@Nat.result == @Nat.0 * (@Nat.0 + 1) / 2)
   decreases(@Nat.0)
@@ -282,7 +282,7 @@ WARNING: Cannot statically verify contract at line 3: requires(@Int.0 > 0)
 A lemma function is a `pure` function whose sole purpose is to establish a fact for the verifier. Its body must type-check and its contract must verify, but it is never called at runtime:
 
 ```
-fn lemma_sum_positive(@Nat, @Nat -> @Unit)
+private fn lemma_sum_positive(@Nat, @Nat -> @Unit)
   requires(@Nat.0 > 0 && @Nat.1 > 0)
   ensures(@Nat.0 + @Nat.1 > @Nat.0)
   effects(pure)
@@ -308,7 +308,7 @@ When a function type is used as a parameter, the caller can rely on the contract
 ```
 type SafeDiv = fn(Int, { @Int | @Int.0 != 0 } -> Int) effects(pure);
 
-fn apply_div(@Int, @Int, @SafeDiv -> @Int)
+private fn apply_div(@Int, @Int, @SafeDiv -> @Int)
   requires(@Int.1 != 0)
   ensures(true)
   effects(pure)

--- a/spec/07-effects.md
+++ b/spec/07-effects.md
@@ -86,7 +86,7 @@ The same effect with the same type parameters MUST NOT appear twice (it would be
 Within a function that declares an effect, operations are called like regular functions:
 
 ```
-fn increment(@Unit -> @Unit)
+private fn increment(@Unit -> @Unit)
   requires(true)
   ensures(true)
   effects(<State<Int>>)
@@ -98,7 +98,7 @@ fn increment(@Unit -> @Unit)
 ```
 
 ```
-fn hello(-> @Unit)
+private fn hello(-> @Unit)
   requires(true)
   ensures(true)
   effects(<IO>)
@@ -178,7 +178,7 @@ The handler may also choose NOT to call `resume`, which aborts the handled body.
 **State handler:**
 
 ```
-fn run_stateful(@Unit -> @Int)
+private fn run_stateful(@Unit -> @Int)
   requires(true)
   ensures(true)
   effects(pure)
@@ -200,7 +200,7 @@ The result is `10`. The `handle` expression's type is the type of the handled bo
 **Exception handler:**
 
 ```
-fn safe_parse(@String -> @Option<Int>)
+private fn safe_parse(@String -> @Option<Int>)
   requires(true)
   ensures(true)
   effects(pure)
@@ -220,7 +220,7 @@ Note: when the handler does not call `resume`, the handled body is abandoned. Th
 **Choice handler (non-determinism):**
 
 ```
-fn all_choices(@Unit -> @Array<Bool>)
+private fn all_choices(@Unit -> @Array<Bool>)
   requires(true)
   ensures(true)
   effects(pure)
@@ -247,7 +247,7 @@ This demonstrates that `resume` is a first-class continuation: it can be called 
 Functions can be polymorphic over effects:
 
 ```
-forall<A, B> fn map_option(@Option<A>, fn(A -> B) effects(<E>) -> @Option<B>)
+private forall<A, B> fn map_option(@Option<A>, fn(A -> B) effects(<E>) -> @Option<B>)
   requires(true)
   ensures(true)
   effects(<E>)
@@ -266,7 +266,7 @@ The effect variable `E` is unified at each call site. If the passed function is 
 Effect row variables can appear alongside concrete effects:
 
 ```
-forall<A> fn with_logging(fn(Unit -> A) effects(<E>) -> @A)
+private forall<A> fn with_logging(fn(Unit -> A) effects(<E>) -> @A)
   requires(true)
   ensures(true)
   effects(<IO, E>)
@@ -346,7 +346,7 @@ Contract predicates (`requires`, `ensures`, `invariant`, `assert`, `assume`) MUS
 Since contract predicates must be pure (Section 7.9.1), they cannot call effect operations like `get()` or `put()` directly. Instead, contracts on stateful functions use `old` and `new` to refer to the state before and after the function call:
 
 ```
-fn increment_and_return(@Unit -> @Int)
+private fn increment_and_return(@Unit -> @Int)
   requires(true)
   ensures(@Int.result == old(State<Int>) && new(State<Int>) == old(State<Int>) + 1)
   effects(<State<Int>>)
@@ -367,7 +367,7 @@ These are contract-only syntax forms that do not perform effects.
 When a function calls other functions, the effects compose via row union:
 
 ```
-fn foo(@Unit -> @Unit)
+private fn foo(@Unit -> @Unit)
   requires(true)
   ensures(true)
   effects(<IO, State<Int>>)

--- a/spec/09-standard-library.md
+++ b/spec/09-standard-library.md
@@ -24,7 +24,7 @@ The primitive types (`Int`, `Nat`, `Bool`, `Byte`, `Float64`, `String`, `Unit`, 
 ### 9.3.1 Option\<T\>
 
 ```
-data Option<T> {
+public data Option<T> {
   Some(T),
   None
 }
@@ -39,7 +39,7 @@ Constructors:
 Pattern matching on `Option<T>` is exhaustive: both `Some` and `None` must be handled.
 
 ```
-fn safe_head(@Array<Int> -> @Option<Int>)
+private fn safe_head(@Array<Int> -> @Option<Int>)
   requires(true)
   ensures(true)
   effects(pure)
@@ -55,7 +55,7 @@ fn safe_head(@Array<Int> -> @Option<Int>)
 ### 9.3.2 Result\<T, E\>
 
 ```
-data Result<T, E> {
+public data Result<T, E> {
   Ok(T),
   Err(E)
 }
@@ -70,7 +70,7 @@ Constructors:
 Pattern matching on `Result<T, E>` is exhaustive: both `Ok` and `Err` must be handled.
 
 ```
-fn parse_nat(@Int -> @Result<Nat, String>)
+private fn parse_nat(@Int -> @Result<Nat, String>)
   requires(true)
   ensures(true)
   effects(pure)
@@ -142,7 +142,7 @@ Currently, `IO` exposes a single operation:
 The `IO` effect has no type parameters. At the type level, `IO.print` is invoked as a qualified call:
 
 ```
-fn hello(-> @Unit)
+private fn hello(-> @Unit)
   requires(true)
   ensures(true)
   effects(<IO>)
@@ -171,7 +171,7 @@ Operations:
 Multiple independent state types can be used in the same function by declaring them in the effect row. State operations (`get`, `put`) are called without qualification — the type checker resolves which state cell is targeted from the types:
 
 ```
-fn increment(-> @Unit)
+private fn increment(-> @Unit)
   requires(true)
   ensures(new(State<Int>) == old(State<Int>) + 1)
   effects(<State<Int>>)
@@ -185,7 +185,7 @@ fn increment(-> @Unit)
 State is handled by providing an initial value and a handler that manages the mutable cell:
 
 ```
-fn run_increment(@Unit -> @Int)
+private fn run_increment(@Unit -> @Int)
   requires(true)
   ensures(true)
   effects(pure)
@@ -225,7 +225,7 @@ This fits naturally with Vera's algebraic effect system and makes network I/O ex
 Asynchronous operations will be modelled as an algebraic effect. An `<Async>` effect with `async` and `await` operations will allow concurrent computation:
 
 ```
-fn fetch_both(@String, @String -> @Tuple<Json, Json>)
+private fn fetch_both(@String, @String -> @Tuple<Json, Json>)
   requires(true)
   ensures(true)
   effects(<Http, Async>)
@@ -267,7 +267,7 @@ Any function that calls an LLM declares `effects(<Inference>)`. Pure functions c
 Handlers provide the implementation: one handler uses an HTTP API, another uses a local model, another uses cached replay for deterministic testing.
 
 ```
-fn classify(@String -> @String)
+private fn classify(@String -> @String)
   requires(length(@String.0) > 0)
   ensures(true)
   effects(<Inference>)
@@ -281,7 +281,7 @@ fn classify(@String -> @String)
 ### 9.6.1 length
 
 ```
-forall<T> fn length(@Array<T> -> @Int)
+public forall<T> fn length(@Array<T> -> @Int)
   requires(true)
   ensures(@Int.result >= 0)
   effects(pure)
@@ -303,7 +303,7 @@ For the compilation of `length`, see Chapter 11, Section 11.12.
 > **Status: Not yet implemented.** Will be introduced alongside the `Inference` effect ([#61](https://github.com/aallan/vera/issues/61)).
 
 ```
-fn similarity(@Array<Float64>, @Array<Float64> -> @Float64)
+public fn similarity(@Array<Float64>, @Array<Float64> -> @Float64)
   requires(length(@Array<Float64>.0) == length(@Array<Float64>.1))
   ensures(@Float64.result >= -1.0 && @Float64.result <= 1.0)
   effects(pure)
@@ -322,7 +322,7 @@ This function is pure — it performs no effects. It is intended for use with th
 JSON will be a standard library ADT, not a primitive type:
 
 ```
-data Json {
+public data Json {
   JNull,
   JBool(Bool),
   JNumber(Float64),
@@ -361,7 +361,7 @@ ability Ord<T> {
   op compare(T, T -> Ordering);
 }
 
-forall<T where Eq<T>> fn contains(@Array<T>, @T -> @Bool)
+public forall<T where Eq<T>> fn contains(@Array<T>, @T -> @Bool)
   requires(true)
   ensures(true)
   effects(pure)

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -190,7 +190,7 @@ class TestProgramStructure:
 class TestFunctions:
     def test_simple_fn(self):
         fn = _first_fn("""
-        fn inc(@Int -> @Int)
+        private fn inc(@Int -> @Int)
           requires(true)
           ensures(true)
           effects(pure)
@@ -207,7 +207,7 @@ class TestFunctions:
 
     def test_fn_with_forall(self):
         fn = _first_fn("""
-        forall<T> fn identity(@T -> @T)
+        private forall<T> fn identity(@T -> @T)
           requires(true)
           ensures(true)
           effects(pure)
@@ -217,7 +217,7 @@ class TestFunctions:
 
     def test_fn_multiple_forall_vars(self):
         fn = _first_fn("""
-        forall<A, B> fn swap(@A, @B -> @B)
+        private forall<A, B> fn swap(@A, @B -> @B)
           requires(true)
           ensures(true)
           effects(pure)
@@ -227,7 +227,7 @@ class TestFunctions:
 
     def test_fn_with_where(self):
         fn = _first_fn("""
-        fn main(@Int -> @Int)
+        private fn main(@Int -> @Int)
           requires(true)
           ensures(true)
           effects(pure)
@@ -246,7 +246,7 @@ class TestFunctions:
 
     def test_multiple_contracts(self):
         fn = _first_fn("""
-        fn clamp(@Int -> @Int)
+        private fn clamp(@Int -> @Int)
           requires(@Int.0 >= 0)
           requires(@Int.0 <= 100)
           ensures(@Int.result >= 0)
@@ -260,7 +260,7 @@ class TestFunctions:
 
     def test_decreases_clause(self):
         fn = _first_fn("""
-        fn f(@Nat -> @Nat)
+        private fn f(@Nat -> @Nat)
           requires(true)
           ensures(true)
           decreases(@Nat.0)
@@ -277,7 +277,7 @@ class TestFunctions:
 class TestDataDecls:
     def test_simple_adt(self):
         prog = _ast("""
-        data Color { Red, Green, Blue }
+        private data Color { Red, Green, Blue }
         """)
         decl = prog.declarations[0].decl
         assert isinstance(decl, DataDecl)
@@ -288,7 +288,7 @@ class TestDataDecls:
 
     def test_parameterized_adt(self):
         prog = _ast("""
-        data Option<T> { None, Some(T) }
+        private data Option<T> { None, Some(T) }
         """)
         decl = prog.declarations[0].decl
         assert decl.type_params == ("T",)
@@ -299,7 +299,7 @@ class TestDataDecls:
 
     def test_adt_with_invariant(self):
         prog = _ast("""
-        data PosInt
+        private data PosInt
           invariant(@Int.0 > 0)
         { MkPosInt(Int) }
         """)
@@ -351,7 +351,7 @@ class TestEffectDecls:
 class TestTypeExprs:
     def test_named_type_simple(self):
         fn = _first_fn("""
-        fn f(@Int -> @Int)
+        private fn f(@Int -> @Int)
           requires(true) ensures(true) effects(pure)
         { @Int.0 }
         """)
@@ -361,7 +361,7 @@ class TestTypeExprs:
 
     def test_named_type_with_args(self):
         fn = _first_fn("""
-        fn f(@Option<Int> -> @Bool)
+        private fn f(@Option<Int> -> @Bool)
           requires(true) ensures(true) effects(pure)
         { true }
         """)
@@ -393,14 +393,14 @@ class TestTypeExprs:
 class TestExpressions:
     def test_int_lit(self):
         expr = _body_expr("""
-        fn f(@Unit -> @Int) requires(true) ensures(true) effects(pure) { 42 }
+        private fn f(@Unit -> @Int) requires(true) ensures(true) effects(pure) { 42 }
         """)
         assert isinstance(expr, IntLit)
         assert expr.value == 42
 
     def test_float_lit(self):
         expr = _body_expr("""
-        fn f(@Unit -> @Float64)
+        private fn f(@Unit -> @Float64)
           requires(true) ensures(true) effects(pure)
         { 3.14 }
         """)
@@ -409,7 +409,7 @@ class TestExpressions:
 
     def test_string_lit(self):
         expr = _body_expr("""
-        fn f(@Unit -> @String)
+        private fn f(@Unit -> @String)
           requires(true) ensures(true) effects(pure)
         { "hello" }
         """)
@@ -418,20 +418,20 @@ class TestExpressions:
 
     def test_bool_lit(self):
         expr = _body_expr("""
-        fn f(@Unit -> @Bool) requires(true) ensures(true) effects(pure) { true }
+        private fn f(@Unit -> @Bool) requires(true) ensures(true) effects(pure) { true }
         """)
         assert isinstance(expr, BoolLit)
         assert expr.value is True
 
     def test_unit_lit(self):
         expr = _body_expr("""
-        fn f(@Unit -> @Unit) requires(true) ensures(true) effects(pure) { () }
+        private fn f(@Unit -> @Unit) requires(true) ensures(true) effects(pure) { () }
         """)
         assert isinstance(expr, UnitLit)
 
     def test_binary_add(self):
         expr = _body_expr("""
-        fn f(@Int -> @Int) requires(true) ensures(true) effects(pure)
+        private fn f(@Int -> @Int) requires(true) ensures(true) effects(pure)
         { @Int.0 + 1 }
         """)
         assert isinstance(expr, BinaryExpr)
@@ -441,7 +441,7 @@ class TestExpressions:
 
     def test_binary_implies(self):
         fn = _first_fn("""
-        fn f(@Bool -> @Bool)
+        private fn f(@Bool -> @Bool)
           requires(@Bool.0 ==> true)
           ensures(true)
           effects(pure)
@@ -453,7 +453,7 @@ class TestExpressions:
 
     def test_unary_not(self):
         expr = _body_expr("""
-        fn f(@Bool -> @Bool) requires(true) ensures(true) effects(pure)
+        private fn f(@Bool -> @Bool) requires(true) ensures(true) effects(pure)
         { !@Bool.0 }
         """)
         assert isinstance(expr, UnaryExpr)
@@ -461,7 +461,7 @@ class TestExpressions:
 
     def test_unary_neg(self):
         expr = _body_expr("""
-        fn f(@Int -> @Int) requires(true) ensures(true) effects(pure)
+        private fn f(@Int -> @Int) requires(true) ensures(true) effects(pure)
         { -@Int.0 }
         """)
         assert isinstance(expr, UnaryExpr)
@@ -469,7 +469,7 @@ class TestExpressions:
 
     def test_slot_ref(self):
         expr = _body_expr("""
-        fn f(@Int -> @Int) requires(true) ensures(true) effects(pure)
+        private fn f(@Int -> @Int) requires(true) ensures(true) effects(pure)
         { @Int.0 }
         """)
         assert isinstance(expr, SlotRef)
@@ -479,7 +479,7 @@ class TestExpressions:
 
     def test_result_ref(self):
         fn = _first_fn("""
-        fn f(@Int -> @Int)
+        private fn f(@Int -> @Int)
           requires(true)
           ensures(@Int.result >= 0)
           effects(pure)
@@ -491,7 +491,7 @@ class TestExpressions:
 
     def test_fn_call(self):
         expr = _body_expr("""
-        fn f(@Int -> @Int) requires(true) ensures(true) effects(pure)
+        private fn f(@Int -> @Int) requires(true) ensures(true) effects(pure)
         { add(@Int.0, 1) }
         """)
         assert isinstance(expr, FnCall)
@@ -500,7 +500,7 @@ class TestExpressions:
 
     def test_constructor_call(self):
         expr = _body_expr("""
-        fn f(@Int -> @Int) requires(true) ensures(true) effects(pure)
+        private fn f(@Int -> @Int) requires(true) ensures(true) effects(pure)
         { Some(@Int.0) }
         """)
         assert isinstance(expr, ConstructorCall)
@@ -508,7 +508,7 @@ class TestExpressions:
 
     def test_nullary_constructor(self):
         expr = _body_expr("""
-        fn f(@Unit -> @Unit) requires(true) ensures(true) effects(pure)
+        private fn f(@Unit -> @Unit) requires(true) ensures(true) effects(pure)
         { None }
         """)
         assert isinstance(expr, NullaryConstructor)
@@ -516,7 +516,7 @@ class TestExpressions:
 
     def test_qualified_call(self):
         expr = _body_expr("""
-        fn f(@Unit -> @Int) requires(true) ensures(true) effects(<Counter>)
+        private fn f(@Unit -> @Int) requires(true) ensures(true) effects(<Counter>)
         { Counter.get(()) }
         """)
         assert isinstance(expr, QualifiedCall)
@@ -525,7 +525,7 @@ class TestExpressions:
 
     def test_if_expr(self):
         expr = _body_expr("""
-        fn f(@Bool -> @Int) requires(true) ensures(true) effects(pure)
+        private fn f(@Bool -> @Int) requires(true) ensures(true) effects(pure)
         { if @Bool.0 then { 1 } else { 0 } }
         """)
         assert isinstance(expr, IfExpr)
@@ -534,7 +534,7 @@ class TestExpressions:
 
     def test_match_expr(self):
         expr = _body_expr("""
-        fn f(@Int -> @Int) requires(true) ensures(true) effects(pure)
+        private fn f(@Int -> @Int) requires(true) ensures(true) effects(pure)
         { match @Int.0 { 0 -> 1, _ -> 0 } }
         """)
         assert isinstance(expr, MatchExpr)
@@ -545,7 +545,7 @@ class TestExpressions:
 
     def test_block_with_let(self):
         expr = _body_expr("""
-        fn f(@Int -> @Int) requires(true) ensures(true) effects(pure)
+        private fn f(@Int -> @Int) requires(true) ensures(true) effects(pure)
         {
           let @Int = @Int.0 + 1;
           @Int.1
@@ -553,7 +553,7 @@ class TestExpressions:
         """)
         assert isinstance(expr, SlotRef)
         fn = _first_fn("""
-        fn f(@Int -> @Int) requires(true) ensures(true) effects(pure)
+        private fn f(@Int -> @Int) requires(true) ensures(true) effects(pure)
         {
           let @Int = @Int.0 + 1;
           @Int.1
@@ -564,7 +564,7 @@ class TestExpressions:
 
     def test_array_literal(self):
         expr = _body_expr("""
-        fn f(@Unit -> @Unit) requires(true) ensures(true) effects(pure)
+        private fn f(@Unit -> @Unit) requires(true) ensures(true) effects(pure)
         { [1, 2, 3] }
         """)
         assert isinstance(expr, ArrayLit)
@@ -572,14 +572,14 @@ class TestExpressions:
 
     def test_index_expr(self):
         expr = _body_expr("""
-        fn f(@Unit -> @Unit) requires(true) ensures(true) effects(pure)
+        private fn f(@Unit -> @Unit) requires(true) ensures(true) effects(pure)
         { [1, 2, 3][0] }
         """)
         assert isinstance(expr, IndexExpr)
 
     def test_pipe_expr(self):
         expr = _body_expr("""
-        fn f(@Int -> @Int) requires(true) ensures(true) effects(pure)
+        private fn f(@Int -> @Int) requires(true) ensures(true) effects(pure)
         { @Int.0 |> inc() }
         """)
         assert isinstance(expr, BinaryExpr)
@@ -588,7 +588,7 @@ class TestExpressions:
     def test_anonymous_fn(self):
         prog = _ast("""
         type IntToInt = fn(Int -> Int) effects(pure);
-        fn f(@Int -> @Int) requires(true) ensures(true) effects(pure)
+        private fn f(@Int -> @Int) requires(true) ensures(true) effects(pure)
         { apply(fn(@Int -> @Int) effects(pure) { @Int.0 + 1 }) }
         """)
         fn = prog.declarations[1].decl
@@ -605,7 +605,7 @@ class TestExpressions:
 class TestContractExprs:
     def test_old_new_expr(self):
         fn = _first_fn("""
-        fn f(@Unit -> @Int)
+        private fn f(@Unit -> @Int)
           requires(true)
           ensures(@Int.result == old(State<Int>) && new(State<Int>) == old(State<Int>) + 1)
           effects(<State<Int>>)
@@ -617,7 +617,7 @@ class TestContractExprs:
 
     def test_assert_assume(self):
         fn = _first_fn("""
-        fn f(@Int -> @Int) requires(true) ensures(true) effects(pure)
+        private fn f(@Int -> @Int) requires(true) ensures(true) effects(pure)
         {
           assert(@Int.0 > 0);
           assume(@Int.0 < 100);
@@ -636,7 +636,7 @@ class TestContractExprs:
 class TestQuantifiers:
     def test_forall_expr(self):
         fn = _first_fn("""
-        fn f(@Unit -> @Bool) requires(true) ensures(true) effects(pure)
+        private fn f(@Unit -> @Bool) requires(true) ensures(true) effects(pure)
         { forall(@Int, 10, fn(@Int -> @Bool) effects(pure) { @Int.0 > 0 }) }
         """)
         expr = fn.body.expr
@@ -645,7 +645,7 @@ class TestQuantifiers:
 
     def test_exists_expr(self):
         fn = _first_fn("""
-        fn f(@Unit -> @Bool) requires(true) ensures(true) effects(pure)
+        private fn f(@Unit -> @Bool) requires(true) ensures(true) effects(pure)
         { exists(@Int, 10, fn(@Int -> @Bool) effects(pure) { @Int.0 == 5 }) }
         """)
         expr = fn.body.expr
@@ -657,7 +657,7 @@ class TestQuantifiers:
 class TestHandlers:
     def test_handler_with_state(self):
         src = """
-        fn f(@Unit -> @Int) requires(true) ensures(true) effects(pure)
+        private fn f(@Unit -> @Int) requires(true) ensures(true) effects(pure)
         {
           handle[Counter] (@Int = 0) {
             get(@Unit) -> { resume(0) },
@@ -681,7 +681,7 @@ class TestHandlers:
 
     def test_handler_without_state(self):
         src = """
-        fn f(@Unit -> @Int) requires(true) ensures(true) effects(pure)
+        private fn f(@Unit -> @Int) requires(true) ensures(true) effects(pure)
         {
           handle[Abort] {
             abort(@Unit) -> { 0 }
@@ -705,7 +705,7 @@ class TestHandlers:
 class TestPatterns:
     def test_constructor_pattern(self):
         expr = _body_expr("""
-        fn f(@Int -> @Int) requires(true) ensures(true) effects(pure)
+        private fn f(@Int -> @Int) requires(true) ensures(true) effects(pure)
         { match Some(@Int.0) { Some(@Int) -> @Int.0, None -> 0 } }
         """)
         assert isinstance(expr, MatchExpr)
@@ -716,7 +716,7 @@ class TestPatterns:
 
     def test_nullary_pattern(self):
         expr = _body_expr("""
-        fn f(@Int -> @Int) requires(true) ensures(true) effects(pure)
+        private fn f(@Int -> @Int) requires(true) ensures(true) effects(pure)
         { match None { None -> 0 } }
         """)
         assert isinstance(expr.arms[0].pattern, NullaryPattern)
@@ -724,14 +724,14 @@ class TestPatterns:
 
     def test_wildcard_pattern(self):
         expr = _body_expr("""
-        fn f(@Int -> @Int) requires(true) ensures(true) effects(pure)
+        private fn f(@Int -> @Int) requires(true) ensures(true) effects(pure)
         { match @Int.0 { _ -> 0 } }
         """)
         assert isinstance(expr.arms[0].pattern, WildcardPattern)
 
     def test_literal_patterns(self):
         expr = _body_expr("""
-        fn f(@Int -> @Bool) requires(true) ensures(true) effects(pure)
+        private fn f(@Int -> @Bool) requires(true) ensures(true) effects(pure)
         { match @Int.0 { 0 -> true, 1 -> false, _ -> false } }
         """)
         assert isinstance(expr.arms[0].pattern, IntPattern)
@@ -739,7 +739,7 @@ class TestPatterns:
 
     def test_bool_pattern(self):
         expr = _body_expr("""
-        fn f(@Bool -> @Int) requires(true) ensures(true) effects(pure)
+        private fn f(@Bool -> @Int) requires(true) ensures(true) effects(pure)
         { match @Bool.0 { true -> 1, false -> 0 } }
         """)
         assert isinstance(expr.arms[0].pattern, BoolPattern)
@@ -753,7 +753,7 @@ class TestPatterns:
 class TestStatements:
     def test_let_stmt(self):
         fn = _first_fn("""
-        fn f(@Int -> @Int) requires(true) ensures(true) effects(pure)
+        private fn f(@Int -> @Int) requires(true) ensures(true) effects(pure)
         { let @Int = @Int.0 + 1; @Int.1 }
         """)
         stmt = fn.body.statements[0]
@@ -763,7 +763,7 @@ class TestStatements:
 
     def test_let_destruct(self):
         fn = _first_fn("""
-        fn f(@Int -> @Int) requires(true) ensures(true) effects(pure)
+        private fn f(@Int -> @Int) requires(true) ensures(true) effects(pure)
         { let Tuple<@Int, @String> = make_pair(); @Int.1 }
         """)
         stmt = fn.body.statements[0]
@@ -773,7 +773,7 @@ class TestStatements:
 
     def test_expr_stmt(self):
         fn = _first_fn("""
-        fn f(@Unit -> @Unit) requires(true) ensures(true) effects(<IO>)
+        private fn f(@Unit -> @Unit) requires(true) ensures(true) effects(<IO>)
         { print("hello"); () }
         """)
         stmt = fn.body.statements[0]
@@ -786,14 +786,14 @@ class TestStatements:
 class TestEffects:
     def test_pure_effect(self):
         fn = _first_fn("""
-        fn f(@Int -> @Int) requires(true) ensures(true) effects(pure)
+        private fn f(@Int -> @Int) requires(true) ensures(true) effects(pure)
         { @Int.0 }
         """)
         assert isinstance(fn.effect, PureEffect)
 
     def test_single_effect(self):
         fn = _first_fn("""
-        fn f(@Unit -> @Unit) requires(true) ensures(true) effects(<IO>)
+        private fn f(@Unit -> @Unit) requires(true) ensures(true) effects(<IO>)
         { () }
         """)
         assert isinstance(fn.effect, EffectSet)
@@ -802,7 +802,7 @@ class TestEffects:
 
     def test_multiple_effects(self):
         fn = _first_fn("""
-        fn f(@Unit -> @Unit) requires(true) ensures(true) effects(<IO, State<Int>>)
+        private fn f(@Unit -> @Unit) requires(true) ensures(true) effects(<IO, State<Int>>)
         { () }
         """)
         assert isinstance(fn.effect, EffectSet)
@@ -810,7 +810,7 @@ class TestEffects:
 
     def test_parameterized_effect(self):
         fn = _first_fn("""
-        fn f(@Unit -> @Unit) requires(true) ensures(true) effects(<State<Int>>)
+        private fn f(@Unit -> @Unit) requires(true) ensures(true) effects(<State<Int>>)
         { () }
         """)
         eff = fn.effect.effects[0]
@@ -827,13 +827,13 @@ class TestEffects:
 class TestSpans:
     def test_span_populated(self):
         prog = _ast("""
-        fn f(@Int -> @Int) requires(true) ensures(true) effects(pure) { @Int.0 }
+        private fn f(@Int -> @Int) requires(true) ensures(true) effects(pure) { @Int.0 }
         """)
         assert prog.span is not None
         assert isinstance(prog.span, Span)
 
     def test_span_correct_line(self):
-        src = "fn f(@Int -> @Int)\n  requires(true)\n  ensures(true)\n  effects(pure)\n{ @Int.0 }"
+        src = "private fn f(@Int -> @Int)\n  requires(true)\n  ensures(true)\n  effects(pure)\n{ @Int.0 }"
         prog = _ast(src)
         fn = prog.declarations[0].decl
         assert fn.span is not None
@@ -841,7 +841,7 @@ class TestSpans:
 
     def test_nested_spans(self):
         fn = _first_fn("""
-        fn f(@Int -> @Int) requires(true) ensures(true) effects(pure)
+        private fn f(@Int -> @Int) requires(true) ensures(true) effects(pure)
         { @Int.0 + 1 }
         """)
         body_expr = fn.body.expr
@@ -852,7 +852,7 @@ class TestSpans:
 class TestSerialisation:
     def test_to_dict_structure(self):
         prog = _ast("""
-        fn f(@Int -> @Int) requires(true) ensures(true) effects(pure) { @Int.0 }
+        private fn f(@Int -> @Int) requires(true) ensures(true) effects(pure) { @Int.0 }
         """)
         d = prog.to_dict()
         assert d["_type"] == "Program"
@@ -862,7 +862,7 @@ class TestSerialisation:
 
     def test_json_roundtrip(self):
         prog = _ast("""
-        fn f(@Int -> @Int) requires(true) ensures(true) effects(pure) { @Int.0 }
+        private fn f(@Int -> @Int) requires(true) ensures(true) effects(pure) { @Int.0 }
         """)
         d = prog.to_dict()
         j = json.dumps(d)
@@ -872,7 +872,7 @@ class TestSerialisation:
 
     def test_pretty_format(self):
         prog = _ast("""
-        fn f(@Int -> @Int) requires(true) ensures(true) effects(pure) { @Int.0 }
+        private fn f(@Int -> @Int) requires(true) ensures(true) effects(pure) { @Int.0 }
         """)
         text = prog.pretty()
         assert text.startswith("Program")

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -119,42 +119,42 @@ class TestLiterals:
 
     def test_int_lit(self) -> None:
         _check_ok("""
-fn foo(@Unit -> @Int)
+private fn foo(@Unit -> @Int)
   requires(true) ensures(true) effects(pure)
 { 42 }
 """)
 
     def test_negative_int_lit(self) -> None:
         _check_ok("""
-fn foo(@Unit -> @Int)
+private fn foo(@Unit -> @Int)
   requires(true) ensures(true) effects(pure)
 { 0 - 1 }
 """)
 
     def test_float_lit(self) -> None:
         _check_ok("""
-fn foo(@Unit -> @Float64)
+private fn foo(@Unit -> @Float64)
   requires(true) ensures(true) effects(pure)
 { 3.14 }
 """)
 
     def test_string_lit(self) -> None:
         _check_ok("""
-fn foo(@Unit -> @String)
+private fn foo(@Unit -> @String)
   requires(true) ensures(true) effects(pure)
 { "hello" }
 """)
 
     def test_bool_lit(self) -> None:
         _check_ok("""
-fn foo(@Unit -> @Bool)
+private fn foo(@Unit -> @Bool)
   requires(true) ensures(true) effects(pure)
 { true }
 """)
 
     def test_unit_lit(self) -> None:
         _check_ok("""
-fn foo(@Unit -> @Unit)
+private fn foo(@Unit -> @Unit)
   requires(true) ensures(true) effects(pure)
 { () }
 """)
@@ -162,7 +162,7 @@ fn foo(@Unit -> @Unit)
     def test_float_alias_rejected(self) -> None:
         """'Float' is not a type — only 'Float64' is accepted (#76)."""
         _check_err("""
-fn foo(@Unit -> @Float)
+private fn foo(@Unit -> @Float)
   requires(true) ensures(true) effects(pure)
 { 3.14 }
 """, "'Float' is not a type. Did you mean 'Float64'?")
@@ -176,42 +176,42 @@ class TestSlotRefs:
 
     def test_simple_ref(self) -> None:
         _check_ok("""
-fn id(@Int -> @Int)
+private fn id(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { @Int.0 }
 """)
 
     def test_multiple_same_type(self) -> None:
         _check_ok("""
-fn add(@Int, @Int -> @Int)
+private fn add(@Int, @Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { @Int.0 + @Int.1 }
 """)
 
     def test_different_types(self) -> None:
         _check_ok("""
-fn pick(@Int, @String -> @Int)
+private fn pick(@Int, @String -> @Int)
   requires(true) ensures(true) effects(pure)
 { @Int.0 }
 """)
 
     def test_out_of_bounds(self) -> None:
         _check_err("""
-fn bad(@Int -> @Int)
+private fn bad(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { @Int.1 }
 """, "Cannot resolve @Int.1")
 
     def test_no_bindings(self) -> None:
         _check_err("""
-fn bad(@Unit -> @Int)
+private fn bad(@Unit -> @Int)
   requires(true) ensures(true) effects(pure)
 { @Int.0 }
 """, "Cannot resolve @Int.0")
 
     def test_let_introduces_binding(self) -> None:
         _check_ok("""
-fn foo(@Unit -> @Int)
+private fn foo(@Unit -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   let @Int = 42;
@@ -221,7 +221,7 @@ fn foo(@Unit -> @Int)
 
     def test_let_shadowing(self) -> None:
         _check_ok("""
-fn foo(@Int -> @Int)
+private fn foo(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   let @Int = 99;
@@ -234,16 +234,16 @@ fn foo(@Int -> @Int)
         _check_ok("""
 type PosInt = { @Int | @Int.0 > 0 };
 
-fn foo(@PosInt, @Int -> @Int)
+private fn foo(@PosInt, @Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { @PosInt.0 + @Int.0 }
 """)
 
     def test_parameterised_slot(self) -> None:
         _check_ok("""
-data Option<T> { None, Some(T) }
+private data Option<T> { None, Some(T) }
 
-fn foo(@Option<Int> -> @Bool)
+private fn foo(@Option<Int> -> @Bool)
   requires(true) ensures(true) effects(pure)
 { true }
 """)
@@ -257,7 +257,7 @@ class TestResultRefs:
 
     def test_result_in_ensures(self) -> None:
         _check_ok("""
-fn foo(@Int -> @Int)
+private fn foo(@Int -> @Int)
   requires(true)
   ensures(@Int.result == @Int.0)
   effects(pure)
@@ -266,7 +266,7 @@ fn foo(@Int -> @Int)
 
     def test_result_outside_ensures(self) -> None:
         _check_err("""
-fn foo(@Int -> @Int)
+private fn foo(@Int -> @Int)
   requires(@Int.result > 0)
   ensures(true)
   effects(pure)
@@ -275,7 +275,7 @@ fn foo(@Int -> @Int)
 
     def test_result_in_body(self) -> None:
         _check_err("""
-fn foo(@Int -> @Int)
+private fn foo(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { @Int.result }
 """, "only valid inside ensures")
@@ -289,63 +289,63 @@ class TestBinaryOps:
 
     def test_add_int(self) -> None:
         _check_ok("""
-fn foo(@Int, @Int -> @Int)
+private fn foo(@Int, @Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { @Int.0 + @Int.1 }
 """)
 
     def test_add_float(self) -> None:
         _check_ok("""
-fn foo(@Float64, @Float64 -> @Float64)
+private fn foo(@Float64, @Float64 -> @Float64)
   requires(true) ensures(true) effects(pure)
 { @Float64.0 + @Float64.1 }
 """)
 
     def test_add_mixed_error(self) -> None:
         _check_err("""
-fn bad(@Int, @String -> @Int)
+private fn bad(@Int, @String -> @Int)
   requires(true) ensures(true) effects(pure)
 { @Int.0 + @String.0 }
 """, "requires numeric operands")
 
     def test_comparison(self) -> None:
         _check_ok("""
-fn foo(@Int, @Int -> @Bool)
+private fn foo(@Int, @Int -> @Bool)
   requires(true) ensures(true) effects(pure)
 { @Int.0 < @Int.1 }
 """)
 
     def test_equality(self) -> None:
         _check_ok("""
-fn foo(@Int, @Int -> @Bool)
+private fn foo(@Int, @Int -> @Bool)
   requires(true) ensures(true) effects(pure)
 { @Int.0 == @Int.1 }
 """)
 
     def test_logical_and(self) -> None:
         _check_ok("""
-fn foo(@Bool, @Bool -> @Bool)
+private fn foo(@Bool, @Bool -> @Bool)
   requires(true) ensures(true) effects(pure)
 { @Bool.0 && @Bool.1 }
 """)
 
     def test_logical_implies(self) -> None:
         _check_ok("""
-fn foo(@Bool, @Bool -> @Bool)
+private fn foo(@Bool, @Bool -> @Bool)
   requires(true) ensures(true) effects(pure)
 { @Bool.0 ==> @Bool.1 }
 """)
 
     def test_logical_not_bool_error(self) -> None:
         _check_err("""
-fn bad(@Int, @Bool -> @Bool)
+private fn bad(@Int, @Bool -> @Bool)
   requires(true) ensures(true) effects(pure)
 { @Int.0 && @Bool.0 }
 """, "must be Bool")
 
     def test_modulo(self) -> None:
         _check_ok("""
-fn foo(@Int, @Int -> @Int)
+private fn foo(@Int, @Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { @Int.0 % @Int.1 }
 """)
@@ -359,21 +359,21 @@ class TestUnaryOps:
 
     def test_not(self) -> None:
         _check_ok("""
-fn foo(@Bool -> @Bool)
+private fn foo(@Bool -> @Bool)
   requires(true) ensures(true) effects(pure)
 { !@Bool.0 }
 """)
 
     def test_neg(self) -> None:
         _check_ok("""
-fn foo(@Int -> @Int)
+private fn foo(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { 0 - @Int.0 }
 """)
 
     def test_not_non_bool_error(self) -> None:
         _check_err("""
-fn bad(@Int -> @Bool)
+private fn bad(@Int -> @Bool)
   requires(true) ensures(true) effects(pure)
 { !@Int.0 }
 """, "requires Bool operand")
@@ -387,40 +387,40 @@ class TestFnCalls:
 
     def test_simple_call(self) -> None:
         _check_ok("""
-fn double(@Int -> @Int)
+private fn double(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { @Int.0 + @Int.0 }
 
-fn main(@Int -> @Int)
+private fn main(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { double(@Int.0) }
 """)
 
     def test_arity_mismatch(self) -> None:
         _check_err("""
-fn double(@Int -> @Int)
+private fn double(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { @Int.0 + @Int.0 }
 
-fn main(@Int -> @Int)
+private fn main(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { double(@Int.0, @Int.0) }
 """, "expects 1 argument")
 
     def test_type_mismatch_arg(self) -> None:
         _check_err("""
-fn double(@Int -> @Int)
+private fn double(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { @Int.0 + @Int.0 }
 
-fn main(@String -> @Int)
+private fn main(@String -> @Int)
   requires(true) ensures(true) effects(pure)
 { double(@String.0) }
 """, "has type String, expected Int")
 
     def test_recursive_call(self) -> None:
         _check_ok("""
-fn factorial(@Nat -> @Nat)
+private fn factorial(@Nat -> @Nat)
   requires(true)
   ensures(@Nat.result >= 1)
   decreases(@Nat.0)
@@ -434,7 +434,7 @@ fn factorial(@Nat -> @Nat)
     def test_unresolved_function_warning(self) -> None:
         """Unresolved functions emit warnings, not errors."""
         diags = _check("""
-fn foo(@Int -> @Int)
+private fn foo(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { unknown_fn(@Int.0) }
 """)
@@ -453,18 +453,18 @@ class TestGenerics:
 
     def test_identity(self) -> None:
         _check_ok("""
-forall<T> fn identity(@T -> @T)
+private forall<T> fn identity(@T -> @T)
   requires(true) ensures(true) effects(pure)
 { @T.0 }
 """)
 
     def test_generic_call(self) -> None:
         _check_ok("""
-forall<T> fn identity(@T -> @T)
+private forall<T> fn identity(@T -> @T)
   requires(true) ensures(true) effects(pure)
 { @T.0 }
 
-fn main(@Int -> @Int)
+private fn main(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { identity(@Int.0) }
 """)
@@ -478,36 +478,36 @@ class TestConstructors:
 
     def test_nullary_constructor(self) -> None:
         _check_ok("""
-data Color { Red, Green, Blue }
+private data Color { Red, Green, Blue }
 
-fn foo(@Unit -> @Color)
+private fn foo(@Unit -> @Color)
   requires(true) ensures(true) effects(pure)
 { Red }
 """)
 
     def test_constructor_with_fields(self) -> None:
         _check_ok("""
-data Pair { MkPair(Int, String) }
+private data Pair { MkPair(Int, String) }
 
-fn foo(@Int, @String -> @Pair)
+private fn foo(@Int, @String -> @Pair)
   requires(true) ensures(true) effects(pure)
 { MkPair(@Int.0, @String.0) }
 """)
 
     def test_constructor_arity_mismatch(self) -> None:
         _check_err("""
-data Pair { MkPair(Int, String) }
+private data Pair { MkPair(Int, String) }
 
-fn foo(@Int -> @Pair)
+private fn foo(@Int -> @Pair)
   requires(true) ensures(true) effects(pure)
 { MkPair(@Int.0) }
 """, "expects 2 field")
 
     def test_parameterised_adt(self) -> None:
         _check_ok("""
-data Box<T> { MkBox(T) }
+private data Box<T> { MkBox(T) }
 
-fn foo(@Int -> @Box<Int>)
+private fn foo(@Int -> @Box<Int>)
   requires(true) ensures(true) effects(pure)
 { MkBox(@Int.0) }
 """)
@@ -521,9 +521,9 @@ class TestPatterns:
 
     def test_constructor_pattern(self) -> None:
         _check_ok("""
-data Option<T> { None, Some(T) }
+private data Option<T> { None, Some(T) }
 
-fn unwrap(@Option<Int> -> @Int)
+private fn unwrap(@Option<Int> -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   match @Option<Int>.0 {
@@ -535,7 +535,7 @@ fn unwrap(@Option<Int> -> @Int)
 
     def test_wildcard_pattern(self) -> None:
         _check_ok("""
-fn classify(@Int -> @String)
+private fn classify(@Int -> @String)
   requires(true) ensures(true) effects(pure)
 {
   match @Int.0 {
@@ -548,7 +548,7 @@ fn classify(@Int -> @String)
 
     def test_bool_pattern(self) -> None:
         _check_ok("""
-fn to_str(@Bool -> @String)
+private fn to_str(@Bool -> @String)
   requires(true) ensures(true) effects(pure)
 {
   match @Bool.0 {
@@ -560,10 +560,10 @@ fn to_str(@Bool -> @String)
 
     def test_nested_pattern(self) -> None:
         _check_ok("""
-data Option<T> { None, Some(T) }
-data List<T> { Nil, Cons(T, List<T>) }
+private data Option<T> { None, Some(T) }
+private data List<T> { Nil, Cons(T, List<T>) }
 
-fn first(@List<Option<Int>> -> @Int)
+private fn first(@List<Option<Int>> -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   match @List<Option<Int>>.0 {
@@ -583,7 +583,7 @@ class TestControlFlow:
 
     def test_if_then_else(self) -> None:
         _check_ok("""
-fn abs(@Int -> @Int)
+private fn abs(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   if @Int.0 >= 0 then { @Int.0 }
@@ -593,7 +593,7 @@ fn abs(@Int -> @Int)
 
     def test_if_condition_not_bool(self) -> None:
         _check_err("""
-fn bad(@Int -> @Int)
+private fn bad(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   if @Int.0 then { 1 } else { 2 }
@@ -602,7 +602,7 @@ fn bad(@Int -> @Int)
 
     def test_if_branch_mismatch(self) -> None:
         _check_err("""
-fn bad(@Bool -> @Int)
+private fn bad(@Bool -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   if @Bool.0 then { 42 } else { "hello" }
@@ -611,7 +611,7 @@ fn bad(@Bool -> @Int)
 
     def test_block_with_let(self) -> None:
         _check_ok("""
-fn foo(@Int -> @Int)
+private fn foo(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   let @Int = @Int.0 + 1;
@@ -629,7 +629,7 @@ class TestEffects:
 
     def test_pure_function(self) -> None:
         _check_ok("""
-fn pure_fn(@Int -> @Int)
+private fn pure_fn(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { @Int.0 }
 """)
@@ -640,7 +640,7 @@ effect Logger {
   op log(String -> Unit);
 }
 
-fn greet(@String -> @Unit)
+private fn greet(@String -> @Unit)
   requires(true) ensures(true) effects(<Logger>)
 {
   Logger.log(@String.0)
@@ -653,7 +653,7 @@ effect Logger {
   op log(String -> Unit);
 }
 
-fn bad(@String -> @Unit)
+private fn bad(@String -> @Unit)
   requires(true) ensures(true) effects(pure)
 {
   Logger.log(@String.0)
@@ -663,7 +663,7 @@ fn bad(@String -> @Unit)
     def test_handler_basic(self) -> None:
         """Handler with resume produces no errors or warnings."""
         _check_clean("""
-fn foo(@Unit -> @Int)
+private fn foo(@Unit -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   handle[State<Int>](@Int = 0) {
@@ -679,7 +679,7 @@ fn foo(@Unit -> @Int)
         """resume() type-checks its argument against operation return type."""
         # get(Unit) -> Int, so resume expects Int; passing Unit is a mismatch
         _check_err("""
-fn foo(@Unit -> @Int)
+private fn foo(@Unit -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   handle[State<Int>](@Int = 0) {
@@ -694,7 +694,7 @@ fn foo(@Unit -> @Int)
     def test_resume_wrong_arity(self) -> None:
         """resume() takes exactly one argument."""
         _check_err("""
-fn foo(@Unit -> @Int)
+private fn foo(@Unit -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   handle[State<Int>](@Int = 0) {
@@ -709,7 +709,7 @@ fn foo(@Unit -> @Int)
     def test_resume_outside_handler(self) -> None:
         """resume() outside a handler scope is unresolved."""
         diags = _check("""
-fn foo(@Unit -> @Unit)
+private fn foo(@Unit -> @Unit)
   requires(true) ensures(true) effects(pure)
 {
   resume(42)
@@ -724,7 +724,7 @@ fn foo(@Unit -> @Unit)
     def test_with_clause_valid(self) -> None:
         """Handler with-clause with correct type produces no errors."""
         _check_ok("""
-fn foo(@Unit -> @Int)
+private fn foo(@Unit -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   handle[State<Int>](@Int = 0) {
@@ -740,7 +740,7 @@ fn foo(@Unit -> @Int)
     def test_with_clause_type_mismatch(self) -> None:
         """Handler with-clause value must match state type."""
         _check_err("""
-fn foo(@Unit -> @Int)
+private fn foo(@Unit -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   handle[State<Int>](@Int = 0) {
@@ -758,7 +758,7 @@ fn foo(@Unit -> @Int)
 effect Exn<E> {
   op throw(E -> Never);
 }
-fn bar(@Unit -> @Int)
+private fn bar(@Unit -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   handle[Exn<String>] {
@@ -772,7 +772,7 @@ fn bar(@Unit -> @Int)
     def test_with_clause_wrong_slot_type(self) -> None:
         """Handler with-clause type must match handler state type."""
         _check_err("""
-fn foo(@Unit -> @Int)
+private fn foo(@Unit -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   handle[State<Int>](@Int = 0) {
@@ -787,7 +787,7 @@ fn foo(@Unit -> @Int)
     def test_state_effect_builtin(self) -> None:
         """The built-in State<T> effect is available."""
         _check_ok("""
-fn incr(@Unit -> @Unit)
+private fn incr(@Unit -> @Unit)
   requires(true) ensures(true) effects(<State<Int>>)
 {
   let @Int = get(());
@@ -803,7 +803,7 @@ effect Counter {
   op increment(Unit -> Unit);
 }
 
-fn use_counter(@Unit -> @Unit)
+private fn use_counter(@Unit -> @Unit)
   requires(true) ensures(true) effects(<Counter>)
 {
   Counter.increment(())
@@ -819,35 +819,35 @@ class TestContracts:
 
     def test_requires_bool(self) -> None:
         _check_ok("""
-fn foo(@Int -> @Int)
+private fn foo(@Int -> @Int)
   requires(@Int.0 > 0) ensures(true) effects(pure)
 { @Int.0 }
 """)
 
     def test_requires_non_bool_error(self) -> None:
         _check_err("""
-fn bad(@Int -> @Int)
+private fn bad(@Int -> @Int)
   requires(@Int.0) ensures(true) effects(pure)
 { @Int.0 }
 """, "requires() predicate must be Bool")
 
     def test_ensures_bool(self) -> None:
         _check_ok("""
-fn foo(@Int -> @Int)
+private fn foo(@Int -> @Int)
   requires(true) ensures(@Int.result >= 0) effects(pure)
 { @Int.0 }
 """)
 
     def test_ensures_non_bool_error(self) -> None:
         _check_err("""
-fn bad(@Int -> @Int)
+private fn bad(@Int -> @Int)
   requires(true) ensures(@Int.result) effects(pure)
 { @Int.0 }
 """, "ensures() predicate must be Bool")
 
     def test_decreases(self) -> None:
         _check_ok("""
-fn count(@Nat -> @Nat)
+private fn count(@Nat -> @Nat)
   requires(true) ensures(true)
   decreases(@Nat.0)
   effects(pure)
@@ -859,7 +859,7 @@ fn count(@Nat -> @Nat)
 
     def test_multiple_contracts(self) -> None:
         _check_ok("""
-fn clamp(@Int, @Int, @Int -> @Int)
+private fn clamp(@Int, @Int, @Int -> @Int)
   requires(@Int.1 <= @Int.2)
   ensures(@Int.result >= @Int.1)
   ensures(@Int.result <= @Int.2)
@@ -875,7 +875,7 @@ fn clamp(@Int, @Int, @Int -> @Int)
 
     def test_old_new_in_ensures(self) -> None:
         _check_ok("""
-fn incr(@Unit -> @Unit)
+private fn incr(@Unit -> @Unit)
   requires(true)
   ensures(new(State<Int>) == old(State<Int>) + 1)
   effects(<State<Int>>)
@@ -888,7 +888,7 @@ fn incr(@Unit -> @Unit)
 
     def test_old_outside_ensures_error(self) -> None:
         _check_err("""
-fn bad(@Unit -> @Unit)
+private fn bad(@Unit -> @Unit)
   requires(old(State<Int>) > 0)
   ensures(true)
   effects(<State<Int>>)
@@ -904,7 +904,7 @@ class TestHigherOrder:
 
     def test_anon_fn(self) -> None:
         _check_ok("""
-fn foo(@Int -> @Int)
+private fn foo(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   let @Int = 5;
@@ -916,7 +916,7 @@ fn foo(@Int -> @Int)
         _check_ok("""
 type IntToInt = fn(Int -> Int) effects(pure);
 
-fn apply(@IntToInt, @Int -> @Int)
+private fn apply(@IntToInt, @Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { @Int.0 }
 """)
@@ -932,7 +932,7 @@ class TestRefinementTypes:
         _check_ok("""
 type PosInt = { @Int | @Int.0 > 0 };
 
-fn foo(@PosInt -> @Int)
+private fn foo(@PosInt -> @Int)
   requires(true) ensures(true) effects(pure)
 { @PosInt.0 }
 """)
@@ -942,7 +942,7 @@ fn foo(@PosInt -> @Int)
         _check_ok("""
 type PosInt = { @Int | @Int.0 > 0 };
 
-fn foo(@PosInt -> @Int)
+private fn foo(@PosInt -> @Int)
   requires(true) ensures(true) effects(pure)
 { @PosInt.0 + 1 }
 """)
@@ -950,7 +950,7 @@ fn foo(@PosInt -> @Int)
     def test_int_to_nat_allowed(self) -> None:
         """Int -> Nat allowed by checker; verifier enforces >= 0 via Z3."""
         _check_ok("""
-fn foo(@Int -> @Nat)
+private fn foo(@Int -> @Nat)
   requires(true) ensures(true) effects(pure)
 { @Int.0 }
 """)
@@ -965,7 +965,7 @@ class TestErrorAccumulation:
     def test_multiple_errors(self) -> None:
         """Multiple type errors in one file are all reported."""
         errs = _errors("""
-fn bad(@Unit -> @Int)
+private fn bad(@Unit -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   let @String = 42;
@@ -982,14 +982,14 @@ fn bad(@Unit -> @Int)
     def test_data_only_program(self) -> None:
         """A program with only data declarations type-checks cleanly."""
         _check_ok("""
-data Color { Red, Green, Blue }
-data Option<T> { None, Some(T) }
+private data Color { Red, Green, Blue }
+private data Option<T> { None, Some(T) }
 """)
 
     def test_type_error_has_location(self) -> None:
         """Type errors include source location."""
         errs = _errors("""
-fn bad(@Int -> @Bool)
+private fn bad(@Int -> @Bool)
   requires(true) ensures(true) effects(pure)
 { @Int.0 }
 """)
@@ -1005,7 +1005,7 @@ class TestWhereBlocks:
 
     def test_mutual_recursion(self) -> None:
         _check_ok("""
-fn is_even(@Nat -> @Bool)
+private fn is_even(@Nat -> @Bool)
   requires(true) ensures(true)
   decreases(@Nat.0)
   effects(pure)
@@ -1034,14 +1034,14 @@ class TestArrays:
 
     def test_array_index(self) -> None:
         _check_ok("""
-fn first(@Array<Int> -> @Int)
+private fn first(@Array<Int> -> @Int)
   requires(true) ensures(true) effects(pure)
 { @Array<Int>.0[0] }
 """)
 
     def test_array_index_non_array_error(self) -> None:
         _check_err("""
-fn bad(@Int -> @Int)
+private fn bad(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { @Int.0[0] }
 """, "Cannot index")
@@ -1055,7 +1055,7 @@ class TestReturnTypes:
 
     def test_return_type_mismatch(self) -> None:
         _check_err("""
-fn bad(@Int -> @Bool)
+private fn bad(@Int -> @Bool)
   requires(true) ensures(true) effects(pure)
 { @Int.0 }
 """, "body has type")
@@ -1063,7 +1063,7 @@ fn bad(@Int -> @Bool)
     def test_nat_return_from_int_body(self) -> None:
         """Int body with Nat return: allowed in C3."""
         _check_ok("""
-fn foo(@Int -> @Nat)
+private fn foo(@Int -> @Nat)
   requires(true) ensures(true) effects(pure)
 { @Int.0 }
 """)
@@ -1071,7 +1071,7 @@ fn foo(@Int -> @Nat)
     def test_if_nat_literal_return(self) -> None:
         """Non-negative literal should satisfy Nat return."""
         _check_ok("""
-fn foo(@Unit -> @Nat)
+private fn foo(@Unit -> @Nat)
   requires(true) ensures(true) effects(pure)
 { 42 }
 """)
@@ -1088,9 +1088,9 @@ class TestExhaustiveness:
     def test_adt_exhaustive(self) -> None:
         """All constructors covered → no error."""
         _check_ok("""
-data Option<T> { None, Some(T) }
+private data Option<T> { None, Some(T) }
 
-fn unwrap(@Option<Int> -> @Int)
+private fn unwrap(@Option<Int> -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   match @Option<Int>.0 {
@@ -1103,9 +1103,9 @@ fn unwrap(@Option<Int> -> @Int)
     def test_adt_missing_constructor(self) -> None:
         """Missing None constructor → non-exhaustive error."""
         _check_err("""
-data Option<T> { None, Some(T) }
+private data Option<T> { None, Some(T) }
 
-fn unwrap(@Option<Int> -> @Int)
+private fn unwrap(@Option<Int> -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   match @Option<Int>.0 {
@@ -1117,9 +1117,9 @@ fn unwrap(@Option<Int> -> @Int)
     def test_adt_missing_multiple(self) -> None:
         """Missing both Err constructor → error mentions missing ones."""
         errs = _check_err("""
-data Result<T, E> { Ok(T), Err(E) }
+private data Result<T, E> { Ok(T), Err(E) }
 
-fn get(@Result<Int, String> -> @Int)
+private fn get(@Result<Int, String> -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   match @Result<Int, String>.0 {
@@ -1133,9 +1133,9 @@ fn get(@Result<Int, String> -> @Int)
     def test_adt_with_wildcard(self) -> None:
         """Wildcard after Some covers None → exhaustive."""
         _check_ok("""
-data Option<T> { None, Some(T) }
+private data Option<T> { None, Some(T) }
 
-fn unwrap(@Option<Int> -> @Int)
+private fn unwrap(@Option<Int> -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   match @Option<Int>.0 {
@@ -1148,9 +1148,9 @@ fn unwrap(@Option<Int> -> @Int)
     def test_adt_with_binding(self) -> None:
         """Binding pattern is a catch-all → exhaustive."""
         _check_ok("""
-data Option<T> { None, Some(T) }
+private data Option<T> { None, Some(T) }
 
-fn unwrap(@Option<Int> -> @Int)
+private fn unwrap(@Option<Int> -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   match @Option<Int>.0 {
@@ -1165,7 +1165,7 @@ fn unwrap(@Option<Int> -> @Int)
     def test_bool_exhaustive(self) -> None:
         """Both true and false covered → no error."""
         _check_ok("""
-fn to_str(@Bool -> @String)
+private fn to_str(@Bool -> @String)
   requires(true) ensures(true) effects(pure)
 {
   match @Bool.0 {
@@ -1178,7 +1178,7 @@ fn to_str(@Bool -> @String)
     def test_bool_missing_true(self) -> None:
         """Only false covered → non-exhaustive."""
         _check_err("""
-fn to_str(@Bool -> @String)
+private fn to_str(@Bool -> @String)
   requires(true) ensures(true) effects(pure)
 {
   match @Bool.0 {
@@ -1190,7 +1190,7 @@ fn to_str(@Bool -> @String)
     def test_bool_missing_false(self) -> None:
         """Only true covered → non-exhaustive."""
         _check_err("""
-fn to_str(@Bool -> @String)
+private fn to_str(@Bool -> @String)
   requires(true) ensures(true) effects(pure)
 {
   match @Bool.0 {
@@ -1202,7 +1202,7 @@ fn to_str(@Bool -> @String)
     def test_bool_with_wildcard(self) -> None:
         """true + wildcard → exhaustive."""
         _check_ok("""
-fn to_str(@Bool -> @String)
+private fn to_str(@Bool -> @String)
   requires(true) ensures(true) effects(pure)
 {
   match @Bool.0 {
@@ -1217,7 +1217,7 @@ fn to_str(@Bool -> @String)
     def test_int_with_wildcard(self) -> None:
         """Int literals + wildcard → exhaustive."""
         _check_ok("""
-fn classify(@Int -> @String)
+private fn classify(@Int -> @String)
   requires(true) ensures(true) effects(pure)
 {
   match @Int.0 {
@@ -1231,7 +1231,7 @@ fn classify(@Int -> @String)
     def test_int_without_wildcard(self) -> None:
         """Int with only literals → non-exhaustive."""
         _check_err("""
-fn classify(@Int -> @String)
+private fn classify(@Int -> @String)
   requires(true) ensures(true) effects(pure)
 {
   match @Int.0 {
@@ -1244,7 +1244,7 @@ fn classify(@Int -> @String)
     def test_string_without_wildcard(self) -> None:
         """String with only literals → non-exhaustive."""
         _check_err("""
-fn classify(@String -> @Int)
+private fn classify(@String -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   match @String.0 {
@@ -1259,7 +1259,7 @@ fn classify(@String -> @Int)
     def test_unreachable_after_wildcard(self) -> None:
         """Arm after wildcard → unreachable warning."""
         warns = _warnings("""
-fn classify(@Int -> @String)
+private fn classify(@Int -> @String)
   requires(true) ensures(true) effects(pure)
 {
   match @Int.0 {
@@ -1274,7 +1274,7 @@ fn classify(@Int -> @String)
     def test_unreachable_after_binding(self) -> None:
         """Arm after binding pattern → unreachable warning."""
         warns = _warnings("""
-fn classify(@Int -> @String)
+private fn classify(@Int -> @String)
   requires(true) ensures(true) effects(pure)
 {
   match @Int.0 {
@@ -1289,7 +1289,7 @@ fn classify(@Int -> @String)
     def test_multiple_unreachable(self) -> None:
         """Multiple arms after wildcard → multiple warnings."""
         warns = _warnings("""
-fn classify(@Int -> @String)
+private fn classify(@Int -> @String)
   requires(true) ensures(true) effects(pure)
 {
   match @Int.0 {
@@ -1307,7 +1307,7 @@ fn classify(@Int -> @String)
     def test_wildcard_only(self) -> None:
         """Single wildcard arm → exhaustive."""
         _check_ok("""
-fn identity(@Int -> @Int)
+private fn identity(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   match @Int.0 {
@@ -1319,7 +1319,7 @@ fn identity(@Int -> @Int)
     def test_refined_type_stripped(self) -> None:
         """Refined Int scrutinee still needs wildcard."""
         _check_err("""
-fn classify(@Int -> @String)
+private fn classify(@Int -> @String)
   requires(@Int.0 > 0) ensures(true) effects(pure)
 {
   match @Int.0 {
@@ -1366,7 +1366,7 @@ class TestModuleCallDiagnostics:
             body=ast.Block(statements=(), expr=call),
             where_fns=None,
         )
-        tld = ast.TopLevelDecl(visibility=None, decl=fn)
+        tld = ast.TopLevelDecl(visibility="private", decl=fn)
         return ast.Program(
             module=None,
             imports=(),
@@ -1414,13 +1414,13 @@ class TestCrossModuleTyping:
 
     # Reusable module sources
     MATH_MODULE = """\
-fn abs(@Int -> @Int)
+public fn abs(@Int -> @Int)
   requires(true)
   ensures(@Int.result >= 0)
   effects(pure)
 { if @Int.0 < 0 then { 0 - @Int.0 } else { @Int.0 } }
 
-fn max(@Int, @Int -> @Int)
+public fn max(@Int, @Int -> @Int)
   requires(true)
   ensures(true)
   effects(pure)
@@ -1428,7 +1428,7 @@ fn max(@Int, @Int -> @Int)
 """
 
     GENERIC_MODULE = """\
-forall<T> fn identity(@T -> @T)
+public forall<T> fn identity(@T -> @T)
   requires(true)
   ensures(true)
   effects(pure)
@@ -1436,8 +1436,8 @@ forall<T> fn identity(@T -> @T)
 """
 
     COLLECTIONS_MODULE = """\
-data List<T> { Nil, Cons(T, List<T>) }
-data Option<T> { None, Some(T) }
+public data List<T> { Nil, Cons(T, List<T>) }
+public data Option<T> { None, Some(T) }
 """
 
     @staticmethod
@@ -1461,7 +1461,7 @@ data Option<T> { None, Some(T) }
         mod = self._resolved(("math",), self.MATH_MODULE)
         prog = parse_to_ast("""\
 import math(abs);
-fn main(@Int -> @Int)
+private fn main(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { abs(@Int.0) }
 """)
@@ -1474,7 +1474,7 @@ fn main(@Int -> @Int)
         mod = self._resolved(("math",), self.MATH_MODULE)
         prog = parse_to_ast("""\
 import math(abs);
-fn main(@Int -> @Int)
+private fn main(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { abs(@Int.0, @Int.0) }
 """)
@@ -1487,7 +1487,7 @@ fn main(@Int -> @Int)
         mod = self._resolved(("math",), self.MATH_MODULE)
         prog = parse_to_ast("""\
 import math(abs);
-fn main(@Bool -> @Int)
+private fn main(@Bool -> @Int)
   requires(true) ensures(true) effects(pure)
 { abs(@Bool.0) }
 """)
@@ -1501,7 +1501,7 @@ fn main(@Bool -> @Int)
         mod = self._resolved(("gen",), self.GENERIC_MODULE)
         prog = parse_to_ast("""\
 import gen(identity);
-fn main(@Int -> @Int)
+private fn main(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { identity(@Int.0) }
 """)
@@ -1514,7 +1514,7 @@ fn main(@Int -> @Int)
         mod = self._resolved(("math",), self.MATH_MODULE)
         prog = parse_to_ast("""\
 import math;
-fn main(@Int -> @Int)
+private fn main(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { max(@Int.0, abs(@Int.0)) }
 """)
@@ -1527,10 +1527,10 @@ fn main(@Int -> @Int)
         mod = self._resolved(("math",), self.MATH_MODULE)
         prog = parse_to_ast("""\
 import math(abs);
-fn abs(@Int -> @Int)
+private fn abs(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { @Int.0 + 1 }
-fn main(@Int -> @Int)
+private fn main(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { abs(@Int.0) }
 """)
@@ -1543,7 +1543,7 @@ fn main(@Int -> @Int)
         mod = self._resolved(("col",), self.COLLECTIONS_MODULE)
         prog = parse_to_ast("""\
 import col(List);
-fn main(@Int -> @List<Int>)
+private fn main(@Int -> @List<Int>)
   requires(true) ensures(true) effects(pure)
 { Cons(@Int.0, Nil) }
 """)
@@ -1575,7 +1575,7 @@ fn main(@Int -> @List<Int>)
         prog = ast.Program(
             module=None,
             imports=(imp,),
-            declarations=(ast.TopLevelDecl(visibility=None, decl=fn),),
+            declarations=(ast.TopLevelDecl(visibility="private", decl=fn),),
         )
         diags = typecheck(prog, source="", resolved_modules=[mod])
         errors = [d for d in diags if d.severity == "error"]
@@ -1605,7 +1605,7 @@ fn main(@Int -> @List<Int>)
         prog = ast.Program(
             module=None,
             imports=(imp,),
-            declarations=(ast.TopLevelDecl(visibility=None, decl=fn),),
+            declarations=(ast.TopLevelDecl(visibility="private", decl=fn),),
         )
         diags = typecheck(prog, source="", resolved_modules=[mod])
         errors = [d for d in diags if d.severity == "error"]
@@ -1634,7 +1634,7 @@ fn main(@Int -> @List<Int>)
         prog = ast.Program(
             module=None,
             imports=(imp,),
-            declarations=(ast.TopLevelDecl(visibility=None, decl=fn),),
+            declarations=(ast.TopLevelDecl(visibility="private", decl=fn),),
         )
         diags = typecheck(prog, source="", resolved_modules=[mod])
         errors = [d for d in diags if d.severity == "error"]
@@ -1662,7 +1662,7 @@ fn main(@Int -> @List<Int>)
         prog = ast.Program(
             module=None,
             imports=(imp,),
-            declarations=(ast.TopLevelDecl(visibility=None, decl=fn),),
+            declarations=(ast.TopLevelDecl(visibility="private", decl=fn),),
         )
         diags = typecheck(prog, source="", resolved_modules=[mod])
         warns = [d for d in diags if d.severity == "warning"]
@@ -1691,8 +1691,232 @@ fn main(@Int -> @List<Int>)
         prog = ast.Program(
             module=None,
             imports=(imp,),
-            declarations=(ast.TopLevelDecl(visibility=None, decl=fn),),
+            declarations=(ast.TopLevelDecl(visibility="private", decl=fn),),
         )
         diags = typecheck(prog, source="", resolved_modules=[mod])
         errors = [d for d in diags if d.severity == "error"]
         assert errors == [], [e.description for e in errors]
+
+
+# =====================================================================
+# C7c: Visibility enforcement
+# =====================================================================
+
+class TestVisibilityEnforcement:
+    """Test visibility enforcement (C7c).
+
+    Verifies that the checker:
+    - Requires explicit public/private on every fn/data declaration
+    - Prevents importing private declarations across module boundaries
+    - Allows calling own file's private declarations freely
+    """
+
+    # Reusable module sources
+    MIXED_MODULE = """\
+public fn pub_fn(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 }
+
+private fn priv_fn(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 + 1 }
+
+public data Color { Red, Green, Blue }
+
+private data Secret { Hidden }
+"""
+
+    @staticmethod
+    def _resolved(
+        path: tuple[str, ...], source: str,
+    ) -> ResolvedModule:
+        """Build a ResolvedModule from source text."""
+        from vera.resolver import ResolvedModule as RM
+        prog = parse_to_ast(source)
+        return RM(
+            path=path,
+            file_path=Path(f"/fake/{'/'.join(path)}.vera"),
+            program=prog,
+            source=source,
+        )
+
+    # -- Mandatory visibility -------------------------------------------
+
+    def test_missing_visibility_on_fn(self) -> None:
+        """Bare fn (no public/private) -> error."""
+        _check_err("""
+fn foo(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 }
+""", "Missing visibility on 'foo'")
+
+    def test_missing_visibility_on_data(self) -> None:
+        """Bare data (no public/private) -> error."""
+        _check_err("""
+data Color { Red, Green, Blue }
+""", "Missing visibility on 'Color'")
+
+    def test_private_fn_ok(self) -> None:
+        """Explicit private fn -> no error."""
+        _check_ok("""
+private fn foo(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 }
+""")
+
+    def test_public_fn_ok(self) -> None:
+        """Explicit public fn -> no error."""
+        _check_ok("""
+public fn foo(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 }
+""")
+
+    # -- Cross-module visibility (bare calls) ---------------------------
+
+    def test_public_fn_importable(self) -> None:
+        """Public fn from module can be imported and called."""
+        mod = self._resolved(("mod",), self.MIXED_MODULE)
+        prog = parse_to_ast("""\
+import mod(pub_fn);
+private fn main(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ pub_fn(@Int.0) }
+""")
+        diags = typecheck(prog, source="", resolved_modules=[mod])
+        errors = [d for d in diags if d.severity == "error"]
+        assert errors == [], [e.description for e in errors]
+
+    def test_private_fn_not_importable(self) -> None:
+        """Selective import of private fn -> error."""
+        mod = self._resolved(("mod",), self.MIXED_MODULE)
+        prog = parse_to_ast("""\
+import mod(priv_fn);
+private fn main(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ priv_fn(@Int.0) }
+""")
+        diags = typecheck(prog, source="", resolved_modules=[mod])
+        errors = [d for d in diags if d.severity == "error"]
+        assert any("private" in e.description for e in errors), (
+            [e.description for e in errors]
+        )
+
+    def test_public_data_importable(self) -> None:
+        """Public data type and constructors can be imported."""
+        mod = self._resolved(("mod",), self.MIXED_MODULE)
+        prog = parse_to_ast("""\
+import mod(Color);
+private fn main(@Unit -> @Color)
+  requires(true) ensures(true) effects(pure)
+{ Red }
+""")
+        diags = typecheck(prog, source="", resolved_modules=[mod])
+        errors = [d for d in diags if d.severity == "error"]
+        assert errors == [], [e.description for e in errors]
+
+    def test_private_data_not_importable(self) -> None:
+        """Selective import of private data type -> error."""
+        mod = self._resolved(("mod",), self.MIXED_MODULE)
+        prog = parse_to_ast("""\
+import mod(Secret);
+private fn main(@Unit -> @Secret)
+  requires(true) ensures(true) effects(pure)
+{ Hidden }
+""")
+        diags = typecheck(prog, source="", resolved_modules=[mod])
+        errors = [d for d in diags if d.severity == "error"]
+        assert any("private" in e.description for e in errors), (
+            [e.description for e in errors]
+        )
+
+    def test_wildcard_import_skips_private(self) -> None:
+        """Wildcard import only injects public names."""
+        mod = self._resolved(("mod",), self.MIXED_MODULE)
+        prog = parse_to_ast("""\
+import mod;
+private fn main(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ pub_fn(@Int.0) }
+""")
+        diags = typecheck(prog, source="", resolved_modules=[mod])
+        errors = [d for d in diags if d.severity == "error"]
+        assert errors == [], [e.description for e in errors]
+
+    def test_wildcard_import_private_fn_unresolved(self) -> None:
+        """Wildcard import: calling private fn -> unresolved warning."""
+        mod = self._resolved(("mod",), self.MIXED_MODULE)
+        prog = parse_to_ast("""\
+import mod;
+private fn main(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ priv_fn(@Int.0) }
+""")
+        diags = typecheck(prog, source="", resolved_modules=[mod])
+        warns = [d for d in diags if d.severity == "warning"]
+        assert any("Unresolved" in w.description or "not found" in w.description
+                    for w in warns), [d.description for d in diags]
+
+    # -- Module-qualified call visibility (C7c + ModuleCall AST) --------
+
+    def test_module_call_private_fn_rejected(self) -> None:
+        """ModuleCall to private function -> error."""
+        mod = self._resolved(("mod",), self.MIXED_MODULE)
+        call = ast.ModuleCall(
+            path=("mod",), name="priv_fn",
+            args=(ast.IntLit(value=42),),
+        )
+        imp = ast.ImportDecl(path=("mod",), names=None)
+        fn = ast.FnDecl(
+            name="main", forall_vars=None, params=(),
+            return_type=ast.NamedType(name="Int", type_args=None),
+            contracts=(
+                ast.Requires(expr=ast.BoolLit(value=True)),
+                ast.Ensures(expr=ast.BoolLit(value=True)),
+            ),
+            effect=ast.PureEffect(),
+            body=ast.Block(statements=(), expr=call),
+            where_fns=None,
+        )
+        prog = ast.Program(
+            module=None,
+            imports=(imp,),
+            declarations=(ast.TopLevelDecl(visibility="private", decl=fn),),
+        )
+        diags = typecheck(prog, source="", resolved_modules=[mod])
+        errors = [d for d in diags if d.severity == "error"]
+        assert any("private" in e.description for e in errors), (
+            [e.description for e in errors]
+        )
+
+    # -- Own file's declarations always accessible ----------------------
+
+    def test_own_private_fn_callable(self) -> None:
+        """Private fn in own file -> callable, no errors."""
+        _check_ok("""
+private fn helper(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 + 1 }
+
+private fn main(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ helper(@Int.0) }
+""")
+
+    # -- Error message quality ------------------------------------------
+
+    def test_visibility_error_mentions_private(self) -> None:
+        """Error message includes 'private', fn name, and module name."""
+        mod = self._resolved(("mymod",), self.MIXED_MODULE)
+        prog = parse_to_ast("""\
+import mymod(priv_fn);
+private fn main(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ priv_fn(@Int.0) }
+""")
+        diags = typecheck(prog, source="", resolved_modules=[mod])
+        errors = [d for d in diags if d.severity == "error"]
+        msg = " ".join(e.description for e in errors)
+        assert "private" in msg.lower()
+        assert "priv_fn" in msg
+        assert "mymod" in msg

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,7 +33,7 @@ def _bad_vera(tmp_path: Path, content: str) -> str:
 def _type_error_source() -> str:
     """A .vera program that parses but fails type-checking."""
     return """\
-fn bad(@Int -> @Bool)
+private fn bad(@Int -> @Bool)
   requires(true) ensures(true) effects(pure)
 { @Int.0 }
 """
@@ -784,7 +784,7 @@ class TestCmdRunEdgeCases:
         # Create a temp file with a two-arg function
         import tempfile
         source = """\
-fn add(@Int, @Int -> @Int)
+private fn add(@Int, @Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { @Int.1 + @Int.0 }
 """
@@ -804,7 +804,7 @@ fn add(@Int, @Int -> @Int)
         """Run a function with negative integer arguments."""
         import tempfile
         source = """\
-fn abs(@Int -> @Int)
+private fn abs(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { if @Int.0 >= 0 then { @Int.0 } else { -@Int.0 } }
 """
@@ -824,7 +824,7 @@ fn abs(@Int -> @Int)
         """Run a function that triggers a runtime precondition trap."""
         import tempfile
         source = """\
-fn positive(@Int -> @Int)
+private fn positive(@Int -> @Int)
   requires(@Int.0 > 0) ensures(true) effects(pure)
 { @Int.0 }
 """
@@ -846,11 +846,11 @@ fn positive(@Int -> @Int)
         source = """\
 effect Counter { op inc(Unit -> Unit); }
 
-fn count(@Unit -> @Unit)
+private fn count(@Unit -> @Unit)
   requires(true) ensures(true) effects(<Counter>)
 { () }
 
-fn simple(-> @Int)
+private fn simple(-> @Int)
   requires(true) ensures(true) effects(pure)
 { 42 }
 """
@@ -870,7 +870,7 @@ fn simple(-> @Int)
         """Non-integer arguments after -- produce a clean error."""
         import tempfile
         source = """\
-fn id(@Int -> @Int)
+private fn id(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { @Int.0 }
 """
@@ -891,7 +891,7 @@ fn id(@Int -> @Int)
         """Float arguments after -- produce a clean error."""
         import tempfile
         source = """\
-fn id(@Int -> @Int)
+private fn id(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { @Int.0 }
 """
@@ -912,7 +912,7 @@ fn id(@Int -> @Int)
         """Invalid args with --json produce JSON error."""
         import tempfile
         source = """\
-fn id(@Int -> @Int)
+private fn id(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { @Int.0 }
 """
@@ -944,10 +944,10 @@ class TestMultiFileResolution:
         main_src = """\
 import lib;
 
-fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+private fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
 """
         lib_src = """\
-fn helper(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+private fn helper(-> @Unit) requires(true) ensures(true) effects(pure) { () }
 """
         main_file = tmp_path / "main.vera"
         lib_file = tmp_path / "lib.vera"
@@ -966,7 +966,7 @@ fn helper(-> @Unit) requires(true) ensures(true) effects(pure) { () }
         main_src = """\
 import missing;
 
-fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+private fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
 """
         main_file = tmp_path / "main.vera"
         main_file.write_text(main_src, encoding="utf-8")
@@ -983,7 +983,7 @@ fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
         main_src = """\
 import missing;
 
-fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+private fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
 """
         main_file = tmp_path / "main.vera"
         main_file.write_text(main_src, encoding="utf-8")
@@ -1004,13 +1004,13 @@ fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
     def test_check_with_bare_imported_call(self, tmp_path: Path) -> None:
         """vera check passes when main.vera calls an imported function."""
         lib_src = """\
-fn double(@Int -> @Int)
+public fn double(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { @Int.0 + @Int.0 }
 """
         main_src = """\
 import lib(double);
-fn main(@Int -> @Int)
+private fn main(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { double(@Int.0) }
 """

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -104,44 +104,44 @@ def _run_trap(
 
 class TestIntLit:
     def test_zero(self) -> None:
-        assert _run("fn f(-> @Int) requires(true) ensures(true) effects(pure) { 0 }") == 0
+        assert _run("private fn f(-> @Int) requires(true) ensures(true) effects(pure) { 0 }") == 0
 
     def test_positive(self) -> None:
-        assert _run("fn f(-> @Int) requires(true) ensures(true) effects(pure) { 42 }") == 42
+        assert _run("private fn f(-> @Int) requires(true) ensures(true) effects(pure) { 42 }") == 42
 
     def test_negative(self) -> None:
-        assert _run("fn f(-> @Int) requires(true) ensures(true) effects(pure) { -1 }") == -1
+        assert _run("private fn f(-> @Int) requires(true) ensures(true) effects(pure) { -1 }") == -1
 
     def test_large(self) -> None:
         assert _run(
-            "fn f(-> @Int) requires(true) ensures(true) effects(pure) "
+            "private fn f(-> @Int) requires(true) ensures(true) effects(pure) "
             "{ 9999999999 }"
         ) == 9999999999
 
 
 class TestBoolLit:
     def test_true(self) -> None:
-        assert _run("fn f(-> @Bool) requires(true) ensures(true) effects(pure) { true }") == 1
+        assert _run("private fn f(-> @Bool) requires(true) ensures(true) effects(pure) { true }") == 1
 
     def test_false(self) -> None:
-        assert _run("fn f(-> @Bool) requires(true) ensures(true) effects(pure) { false }") == 0
+        assert _run("private fn f(-> @Bool) requires(true) ensures(true) effects(pure) { false }") == 0
 
 
 class TestFloatLit:
     def test_zero(self) -> None:
         assert _run_float(
-            "fn f(-> @Float64) requires(true) ensures(true) effects(pure) { 0.0 }"
+            "private fn f(-> @Float64) requires(true) ensures(true) effects(pure) { 0.0 }"
         ) == 0.0
 
     def test_positive(self) -> None:
         result = _run_float(
-            "fn f(-> @Float64) requires(true) ensures(true) effects(pure) { 3.14 }"
+            "private fn f(-> @Float64) requires(true) ensures(true) effects(pure) { 3.14 }"
         )
         assert abs(result - 3.14) < 1e-10
 
     def test_one(self) -> None:
         assert _run_float(
-            "fn f(-> @Float64) requires(true) ensures(true) effects(pure) { 1.0 }"
+            "private fn f(-> @Float64) requires(true) ensures(true) effects(pure) { 1.0 }"
         ) == 1.0
 
 
@@ -149,7 +149,7 @@ class TestFloatSlotRef:
     def test_identity_float64(self) -> None:
         """Float64 identity function: param in, same value out."""
         source = (
-            "fn id(@Float64 -> @Float64) requires(true) ensures(true) "
+            "private fn id(@Float64 -> @Float64) requires(true) ensures(true) "
             "effects(pure) { @Float64.0 }"
         )
         result = _compile_ok(source)
@@ -159,7 +159,7 @@ class TestFloatSlotRef:
     def test_two_float_params(self) -> None:
         """@Float64.0 = most recent (second), @Float64.1 = first."""
         source = (
-            "fn second(@Float64, @Float64 -> @Float64) requires(true) "
+            "private fn second(@Float64, @Float64 -> @Float64) requires(true) "
             "ensures(true) effects(pure) { @Float64.0 }"
         )
         result = _compile_ok(source)
@@ -169,7 +169,7 @@ class TestFloatSlotRef:
     def test_float_param_arithmetic(self) -> None:
         """Float64 param used in arithmetic."""
         source = (
-            "fn add_one(@Float64 -> @Float64) requires(true) ensures(true) "
+            "private fn add_one(@Float64 -> @Float64) requires(true) ensures(true) "
             "effects(pure) { @Float64.0 + 1.0 }"
         )
         result = _compile_ok(source)
@@ -180,60 +180,60 @@ class TestFloatSlotRef:
 class TestFloatArithmetic:
     def test_add(self) -> None:
         assert _run_float(
-            "fn f(-> @Float64) requires(true) ensures(true) effects(pure) "
+            "private fn f(-> @Float64) requires(true) ensures(true) effects(pure) "
             "{ 1.5 + 2.5 }"
         ) == 4.0
 
     def test_sub(self) -> None:
         assert _run_float(
-            "fn f(-> @Float64) requires(true) ensures(true) effects(pure) "
+            "private fn f(-> @Float64) requires(true) ensures(true) effects(pure) "
             "{ 5.0 - 2.5 }"
         ) == 2.5
 
     def test_mul(self) -> None:
         assert _run_float(
-            "fn f(-> @Float64) requires(true) ensures(true) effects(pure) "
+            "private fn f(-> @Float64) requires(true) ensures(true) effects(pure) "
             "{ 3.0 * 2.5 }"
         ) == 7.5
 
     def test_div(self) -> None:
         assert _run_float(
-            "fn f(-> @Float64) requires(true) ensures(true) effects(pure) "
+            "private fn f(-> @Float64) requires(true) ensures(true) effects(pure) "
             "{ 7.5 / 2.5 }"
         ) == 3.0
 
     def test_nested(self) -> None:
         """(1.0 + 2.0) * 3.0 = 9.0"""
         assert _run_float(
-            "fn f(-> @Float64) requires(true) ensures(true) effects(pure) "
+            "private fn f(-> @Float64) requires(true) ensures(true) effects(pure) "
             "{ (1.0 + 2.0) * 3.0 }"
         ) == 9.0
 
     def test_mod(self) -> None:
         """7.5 % 2.5 = 0.0 (exact division)."""
         assert _run_float(
-            "fn f(-> @Float64) requires(true) ensures(true) effects(pure) "
+            "private fn f(-> @Float64) requires(true) ensures(true) effects(pure) "
             "{ 7.5 % 2.5 }"
         ) == 0.0
 
     def test_mod_remainder(self) -> None:
         """10.0 % 3.0 = 1.0."""
         assert _run_float(
-            "fn f(-> @Float64) requires(true) ensures(true) effects(pure) "
+            "private fn f(-> @Float64) requires(true) ensures(true) effects(pure) "
             "{ 10.0 % 3.0 }"
         ) == 1.0
 
     def test_mod_negative(self) -> None:
         """-7.0 % 3.0 = -1.0 (truncation toward zero, matching fmod)."""
         assert _run_float(
-            "fn f(-> @Float64) requires(true) ensures(true) effects(pure) "
+            "private fn f(-> @Float64) requires(true) ensures(true) effects(pure) "
             "{ -7.0 % 3.0 }"
         ) == -1.0
 
     def test_mod_with_params(self) -> None:
         """Float mod with slot-ref operands (not just literals)."""
         source = (
-            "fn fmod(@Float64, @Float64 -> @Float64) requires(true) "
+            "private fn fmod(@Float64, @Float64 -> @Float64) requires(true) "
             "ensures(true) effects(pure) { @Float64.1 % @Float64.0 }"
         )
         result = _compile_ok(source)
@@ -245,43 +245,43 @@ class TestFloatArithmetic:
 class TestFloatComparison:
     def test_eq_true(self) -> None:
         assert _run(
-            "fn f(-> @Bool) requires(true) ensures(true) effects(pure) "
+            "private fn f(-> @Bool) requires(true) ensures(true) effects(pure) "
             "{ 1.5 == 1.5 }"
         ) == 1
 
     def test_eq_false(self) -> None:
         assert _run(
-            "fn f(-> @Bool) requires(true) ensures(true) effects(pure) "
+            "private fn f(-> @Bool) requires(true) ensures(true) effects(pure) "
             "{ 1.5 == 2.5 }"
         ) == 0
 
     def test_neq(self) -> None:
         assert _run(
-            "fn f(-> @Bool) requires(true) ensures(true) effects(pure) "
+            "private fn f(-> @Bool) requires(true) ensures(true) effects(pure) "
             "{ 1.5 != 2.5 }"
         ) == 1
 
     def test_lt(self) -> None:
         assert _run(
-            "fn f(-> @Bool) requires(true) ensures(true) effects(pure) "
+            "private fn f(-> @Bool) requires(true) ensures(true) effects(pure) "
             "{ 1.5 < 2.5 }"
         ) == 1
 
     def test_gt(self) -> None:
         assert _run(
-            "fn f(-> @Bool) requires(true) ensures(true) effects(pure) "
+            "private fn f(-> @Bool) requires(true) ensures(true) effects(pure) "
             "{ 2.5 > 1.5 }"
         ) == 1
 
     def test_le(self) -> None:
         assert _run(
-            "fn f(-> @Bool) requires(true) ensures(true) effects(pure) "
+            "private fn f(-> @Bool) requires(true) ensures(true) effects(pure) "
             "{ 1.5 <= 1.5 }"
         ) == 1
 
     def test_ge(self) -> None:
         assert _run(
-            "fn f(-> @Bool) requires(true) ensures(true) effects(pure) "
+            "private fn f(-> @Bool) requires(true) ensures(true) effects(pure) "
             "{ 2.5 >= 1.5 }"
         ) == 1
 
@@ -289,13 +289,13 @@ class TestFloatComparison:
 class TestFloatNeg:
     def test_neg_literal(self) -> None:
         assert _run_float(
-            "fn f(-> @Float64) requires(true) ensures(true) effects(pure) "
+            "private fn f(-> @Float64) requires(true) ensures(true) effects(pure) "
             "{ -3.5 }"
         ) == -3.5
 
     def test_neg_expr(self) -> None:
         assert _run_float(
-            "fn f(-> @Float64) requires(true) ensures(true) effects(pure) "
+            "private fn f(-> @Float64) requires(true) ensures(true) effects(pure) "
             "{ -(1.0 + 2.5) }"
         ) == -3.5
 
@@ -304,7 +304,7 @@ class TestFloatIfExpr:
     def test_if_float_result(self) -> None:
         """If expression returning Float64."""
         source = """\
-fn f(-> @Float64)
+private fn f(-> @Float64)
   requires(true) ensures(true) effects(pure)
 { if true then { 1.5 } else { 2.5 } }
 """
@@ -312,7 +312,7 @@ fn f(-> @Float64)
 
     def test_if_float_else(self) -> None:
         source = """\
-fn f(-> @Float64)
+private fn f(-> @Float64)
   requires(true) ensures(true) effects(pure)
 { if false then { 1.5 } else { 2.5 } }
 """
@@ -323,7 +323,7 @@ class TestFloatLet:
     def test_let_float(self) -> None:
         """Let binding with Float64 type."""
         source = """\
-fn f(-> @Float64)
+private fn f(-> @Float64)
   requires(true) ensures(true) effects(pure)
 {
   let @Float64 = 1.5 + 2.5;
@@ -335,7 +335,7 @@ fn f(-> @Float64)
     def test_let_float_chain(self) -> None:
         """Multiple let bindings with Float64."""
         source = """\
-fn f(-> @Float64)
+private fn f(-> @Float64)
   requires(true) ensures(true) effects(pure)
 {
   let @Float64 = 3.0;
@@ -350,34 +350,34 @@ class TestFloatCompileResult:
     def test_wat_has_f64(self) -> None:
         """WAT output contains f64 instructions."""
         result = _compile_ok(
-            "fn f(-> @Float64) requires(true) ensures(true) effects(pure) { 3.14 }"
+            "private fn f(-> @Float64) requires(true) ensures(true) effects(pure) { 3.14 }"
         )
         assert "f64.const" in result.wat
 
     def test_float_fn_exported(self) -> None:
         """Float64 functions are exported (no longer skipped)."""
         result = _compile_ok(
-            "fn f(-> @Float64) requires(true) ensures(true) effects(pure) { 1.0 }"
+            "private fn f(-> @Float64) requires(true) ensures(true) effects(pure) { 1.0 }"
         )
         assert "f" in result.exports
 
 
 class TestCompileResult:
     def test_wat_not_empty(self) -> None:
-        result = _compile_ok("fn f(-> @Int) requires(true) ensures(true) effects(pure) { 42 }")
+        result = _compile_ok("private fn f(-> @Int) requires(true) ensures(true) effects(pure) { 42 }")
         assert "(module" in result.wat
         assert "i64.const 42" in result.wat
 
     def test_wasm_bytes_not_empty(self) -> None:
-        result = _compile_ok("fn f(-> @Int) requires(true) ensures(true) effects(pure) { 42 }")
+        result = _compile_ok("private fn f(-> @Int) requires(true) ensures(true) effects(pure) { 42 }")
         assert len(result.wasm_bytes) > 0
 
     def test_exports_list(self) -> None:
-        result = _compile_ok("fn f(-> @Int) requires(true) ensures(true) effects(pure) { 42 }")
+        result = _compile_ok("private fn f(-> @Int) requires(true) ensures(true) effects(pure) { 42 }")
         assert "f" in result.exports
 
     def test_ok_property(self) -> None:
-        result = _compile_ok("fn f(-> @Int) requires(true) ensures(true) effects(pure) { 42 }")
+        result = _compile_ok("private fn f(-> @Int) requires(true) ensures(true) effects(pure) { 42 }")
         assert result.ok is True
 
 
@@ -390,14 +390,14 @@ class TestSlotRef:
     def test_identity_int(self) -> None:
         """fn id(@Int -> @Int) { @Int.0 }"""
         assert _run(
-            "fn id(@Int -> @Int) requires(true) ensures(true) effects(pure) "
+            "private fn id(@Int -> @Int) requires(true) ensures(true) effects(pure) "
             "{ @Int.0 }",
             fn="id", args=[7],
         ) == 7
 
     def test_identity_bool(self) -> None:
         assert _run(
-            "fn id(@Bool -> @Bool) requires(true) ensures(true) effects(pure) "
+            "private fn id(@Bool -> @Bool) requires(true) ensures(true) effects(pure) "
             "{ @Bool.0 }",
             fn="id", args=[1],
         ) == 1
@@ -405,14 +405,14 @@ class TestSlotRef:
     def test_two_params_same_type(self) -> None:
         """@Int.0 = second param, @Int.1 = first param."""
         assert _run(
-            "fn first(@Int, @Int -> @Int) requires(true) ensures(true) "
+            "private fn first(@Int, @Int -> @Int) requires(true) ensures(true) "
             "effects(pure) { @Int.1 }",
             fn="first", args=[10, 20],
         ) == 10
 
     def test_second_param(self) -> None:
         assert _run(
-            "fn second(@Int, @Int -> @Int) requires(true) ensures(true) "
+            "private fn second(@Int, @Int -> @Int) requires(true) ensures(true) "
             "effects(pure) { @Int.0 }",
             fn="second", args=[10, 20],
         ) == 20
@@ -421,35 +421,35 @@ class TestSlotRef:
 class TestArithmetic:
     def test_add(self) -> None:
         assert _run(
-            "fn add(@Int, @Int -> @Int) requires(true) ensures(true) "
+            "private fn add(@Int, @Int -> @Int) requires(true) ensures(true) "
             "effects(pure) { @Int.1 + @Int.0 }",
             fn="add", args=[3, 4],
         ) == 7
 
     def test_sub(self) -> None:
         assert _run(
-            "fn sub(@Int, @Int -> @Int) requires(true) ensures(true) "
+            "private fn sub(@Int, @Int -> @Int) requires(true) ensures(true) "
             "effects(pure) { @Int.1 - @Int.0 }",
             fn="sub", args=[10, 3],
         ) == 7
 
     def test_mul(self) -> None:
         assert _run(
-            "fn mul(@Int, @Int -> @Int) requires(true) ensures(true) "
+            "private fn mul(@Int, @Int -> @Int) requires(true) ensures(true) "
             "effects(pure) { @Int.1 * @Int.0 }",
             fn="mul", args=[6, 7],
         ) == 42
 
     def test_div(self) -> None:
         assert _run(
-            "fn div(@Int, @Int -> @Int) requires(@Int.0 != 0) ensures(true) "
+            "private fn div(@Int, @Int -> @Int) requires(@Int.0 != 0) ensures(true) "
             "effects(pure) { @Int.1 / @Int.0 }",
             fn="div", args=[10, 3],
         ) == 3
 
     def test_mod(self) -> None:
         assert _run(
-            "fn rem(@Int, @Int -> @Int) requires(@Int.0 != 0) ensures(true) "
+            "private fn rem(@Int, @Int -> @Int) requires(@Int.0 != 0) ensures(true) "
             "effects(pure) { @Int.1 % @Int.0 }",
             fn="rem", args=[10, 3],
         ) == 1
@@ -457,7 +457,7 @@ class TestArithmetic:
     def test_nested_arithmetic(self) -> None:
         """(a + b) * (a - b)"""
         assert _run(
-            "fn f(@Int, @Int -> @Int) requires(true) ensures(true) "
+            "private fn f(@Int, @Int -> @Int) requires(true) ensures(true) "
             "effects(pure) { (@Int.1 + @Int.0) * (@Int.1 - @Int.0) }",
             fn="f", args=[5, 3],
         ) == (5 + 3) * (5 - 3)
@@ -466,49 +466,49 @@ class TestArithmetic:
 class TestComparison:
     def test_eq_true(self) -> None:
         assert _run(
-            "fn f(@Int, @Int -> @Bool) requires(true) ensures(true) "
+            "private fn f(@Int, @Int -> @Bool) requires(true) ensures(true) "
             "effects(pure) { @Int.1 == @Int.0 }",
             fn="f", args=[5, 5],
         ) == 1
 
     def test_eq_false(self) -> None:
         assert _run(
-            "fn f(@Int, @Int -> @Bool) requires(true) ensures(true) "
+            "private fn f(@Int, @Int -> @Bool) requires(true) ensures(true) "
             "effects(pure) { @Int.1 == @Int.0 }",
             fn="f", args=[5, 6],
         ) == 0
 
     def test_neq(self) -> None:
         assert _run(
-            "fn f(@Int, @Int -> @Bool) requires(true) ensures(true) "
+            "private fn f(@Int, @Int -> @Bool) requires(true) ensures(true) "
             "effects(pure) { @Int.1 != @Int.0 }",
             fn="f", args=[5, 6],
         ) == 1
 
     def test_lt(self) -> None:
         assert _run(
-            "fn f(@Int, @Int -> @Bool) requires(true) ensures(true) "
+            "private fn f(@Int, @Int -> @Bool) requires(true) ensures(true) "
             "effects(pure) { @Int.1 < @Int.0 }",
             fn="f", args=[3, 5],
         ) == 1
 
     def test_gt(self) -> None:
         assert _run(
-            "fn f(@Int, @Int -> @Bool) requires(true) ensures(true) "
+            "private fn f(@Int, @Int -> @Bool) requires(true) ensures(true) "
             "effects(pure) { @Int.1 > @Int.0 }",
             fn="f", args=[5, 3],
         ) == 1
 
     def test_le(self) -> None:
         assert _run(
-            "fn f(@Int, @Int -> @Bool) requires(true) ensures(true) "
+            "private fn f(@Int, @Int -> @Bool) requires(true) ensures(true) "
             "effects(pure) { @Int.1 <= @Int.0 }",
             fn="f", args=[5, 5],
         ) == 1
 
     def test_ge(self) -> None:
         assert _run(
-            "fn f(@Int, @Int -> @Bool) requires(true) ensures(true) "
+            "private fn f(@Int, @Int -> @Bool) requires(true) ensures(true) "
             "effects(pure) { @Int.1 >= @Int.0 }",
             fn="f", args=[5, 3],
         ) == 1
@@ -517,28 +517,28 @@ class TestComparison:
 class TestBooleanLogic:
     def test_and(self) -> None:
         assert _run(
-            "fn f(@Bool, @Bool -> @Bool) requires(true) ensures(true) "
+            "private fn f(@Bool, @Bool -> @Bool) requires(true) ensures(true) "
             "effects(pure) { @Bool.1 && @Bool.0 }",
             fn="f", args=[1, 1],
         ) == 1
 
     def test_and_false(self) -> None:
         assert _run(
-            "fn f(@Bool, @Bool -> @Bool) requires(true) ensures(true) "
+            "private fn f(@Bool, @Bool -> @Bool) requires(true) ensures(true) "
             "effects(pure) { @Bool.1 && @Bool.0 }",
             fn="f", args=[1, 0],
         ) == 0
 
     def test_or(self) -> None:
         assert _run(
-            "fn f(@Bool, @Bool -> @Bool) requires(true) ensures(true) "
+            "private fn f(@Bool, @Bool -> @Bool) requires(true) ensures(true) "
             "effects(pure) { @Bool.1 || @Bool.0 }",
             fn="f", args=[0, 1],
         ) == 1
 
     def test_not(self) -> None:
         assert _run(
-            "fn f(@Bool -> @Bool) requires(true) ensures(true) "
+            "private fn f(@Bool -> @Bool) requires(true) ensures(true) "
             "effects(pure) { !@Bool.0 }",
             fn="f", args=[1],
         ) == 0
@@ -546,7 +546,7 @@ class TestBooleanLogic:
     def test_implies_true(self) -> None:
         """false ==> anything is true."""
         assert _run(
-            "fn f(@Bool, @Bool -> @Bool) requires(true) ensures(true) "
+            "private fn f(@Bool, @Bool -> @Bool) requires(true) ensures(true) "
             "effects(pure) { @Bool.1 ==> @Bool.0 }",
             fn="f", args=[0, 0],
         ) == 1
@@ -554,7 +554,7 @@ class TestBooleanLogic:
     def test_implies_false(self) -> None:
         """true ==> false is false."""
         assert _run(
-            "fn f(@Bool, @Bool -> @Bool) requires(true) ensures(true) "
+            "private fn f(@Bool, @Bool -> @Bool) requires(true) ensures(true) "
             "effects(pure) { @Bool.1 ==> @Bool.0 }",
             fn="f", args=[1, 0],
         ) == 0
@@ -563,28 +563,28 @@ class TestBooleanLogic:
 class TestUnaryOps:
     def test_neg(self) -> None:
         assert _run(
-            "fn neg(@Int -> @Int) requires(true) ensures(true) "
+            "private fn neg(@Int -> @Int) requires(true) ensures(true) "
             "effects(pure) { -@Int.0 }",
             fn="neg", args=[5],
         ) == -5
 
     def test_neg_negative(self) -> None:
         assert _run(
-            "fn neg(@Int -> @Int) requires(true) ensures(true) "
+            "private fn neg(@Int -> @Int) requires(true) ensures(true) "
             "effects(pure) { -@Int.0 }",
             fn="neg", args=[-3],
         ) == 3
 
     def test_not_true(self) -> None:
         assert _run(
-            "fn f(@Bool -> @Bool) requires(true) ensures(true) "
+            "private fn f(@Bool -> @Bool) requires(true) ensures(true) "
             "effects(pure) { !@Bool.0 }",
             fn="f", args=[1],
         ) == 0
 
     def test_not_false(self) -> None:
         assert _run(
-            "fn f(@Bool -> @Bool) requires(true) ensures(true) "
+            "private fn f(@Bool -> @Bool) requires(true) ensures(true) "
             "effects(pure) { !@Bool.0 }",
             fn="f", args=[0],
         ) == 1
@@ -598,7 +598,7 @@ class TestUnaryOps:
 class TestIfExpr:
     def test_if_true(self) -> None:
         source = """\
-fn f(@Bool -> @Int)
+private fn f(@Bool -> @Int)
   requires(true) ensures(true) effects(pure)
 { if @Bool.0 then { 1 } else { 0 } }
 """
@@ -606,7 +606,7 @@ fn f(@Bool -> @Int)
 
     def test_if_false(self) -> None:
         source = """\
-fn f(@Bool -> @Int)
+private fn f(@Bool -> @Int)
   requires(true) ensures(true) effects(pure)
 { if @Bool.0 then { 1 } else { 0 } }
 """
@@ -614,7 +614,7 @@ fn f(@Bool -> @Int)
 
     def test_absolute_value(self) -> None:
         source = """\
-fn absolute_value(@Int -> @Int)
+private fn absolute_value(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { if @Int.0 >= 0 then { @Int.0 } else { -@Int.0 } }
 """
@@ -624,7 +624,7 @@ fn absolute_value(@Int -> @Int)
 
     def test_nested_if(self) -> None:
         source = """\
-fn clamp(@Int -> @Int)
+private fn clamp(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   if @Int.0 < 0 then { 0 }
@@ -637,7 +637,7 @@ fn clamp(@Int -> @Int)
 
     def test_if_bool_result(self) -> None:
         source = """\
-fn is_positive(@Int -> @Bool)
+private fn is_positive(@Int -> @Bool)
   requires(true) ensures(true) effects(pure)
 { if @Int.0 > 0 then { true } else { false } }
 """
@@ -648,7 +648,7 @@ fn is_positive(@Int -> @Bool)
 class TestLetBindings:
     def test_simple_let(self) -> None:
         source = """\
-fn f(@Int -> @Int)
+private fn f(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   let @Int = @Int.0 + 1;
@@ -659,7 +659,7 @@ fn f(@Int -> @Int)
 
     def test_multiple_lets(self) -> None:
         source = """\
-fn f(@Int -> @Int)
+private fn f(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   let @Int = @Int.0 + 1;
@@ -672,7 +672,7 @@ fn f(@Int -> @Int)
     def test_let_with_original(self) -> None:
         """After let @Int, the original param is @Int.1."""
         source = """\
-fn f(@Int -> @Int)
+private fn f(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   let @Int = @Int.0 * 2;
@@ -683,7 +683,7 @@ fn f(@Int -> @Int)
 
     def test_let_different_types(self) -> None:
         source = """\
-fn f(@Int -> @Bool)
+private fn f(@Int -> @Bool)
   requires(true) ensures(true) effects(pure)
 {
   let @Bool = @Int.0 > 0;
@@ -695,7 +695,7 @@ fn f(@Int -> @Bool)
 
     def test_let_in_if_branches(self) -> None:
         source = """\
-fn f(@Int -> @Int)
+private fn f(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   let @Int = if @Int.0 > 0 then { @Int.0 } else { -@Int.0 };
@@ -714,11 +714,11 @@ fn f(@Int -> @Int)
 class TestFnCall:
     def test_call_simple(self) -> None:
         source = """\
-fn double(@Int -> @Int)
+private fn double(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { @Int.0 * 2 }
 
-fn f(@Int -> @Int)
+private fn f(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { double(@Int.0) }
 """
@@ -726,11 +726,11 @@ fn f(@Int -> @Int)
 
     def test_call_chain(self) -> None:
         source = """\
-fn inc(@Int -> @Int)
+private fn inc(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { @Int.0 + 1 }
 
-fn double_inc(@Int -> @Int)
+private fn double_inc(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { inc(inc(@Int.0)) }
 """
@@ -738,11 +738,11 @@ fn double_inc(@Int -> @Int)
 
     def test_multiple_args(self) -> None:
         source = """\
-fn add(@Int, @Int -> @Int)
+private fn add(@Int, @Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { @Int.1 + @Int.0 }
 
-fn f(@Int -> @Int)
+private fn f(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { add(@Int.0, @Int.0) }
 """
@@ -752,7 +752,7 @@ fn f(@Int -> @Int)
 class TestRecursion:
     def test_factorial(self) -> None:
         source = """\
-fn factorial(@Nat -> @Nat)
+private fn factorial(@Nat -> @Nat)
   requires(@Nat.0 >= 0)
   ensures(true)
   decreases(@Nat.0)
@@ -769,7 +769,7 @@ fn factorial(@Nat -> @Nat)
 
     def test_fibonacci(self) -> None:
         source = """\
-fn fib(@Nat -> @Nat)
+private fn fib(@Nat -> @Nat)
   requires(@Nat.0 >= 0)
   ensures(true)
   decreases(@Nat.0)
@@ -794,11 +794,11 @@ class TestPipeOperator:
 
     def test_pipe_basic(self) -> None:
         source = """\
-fn inc(@Int -> @Int)
+private fn inc(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { @Int.0 + 1 }
 
-fn main(@Int -> @Int)
+private fn main(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { @Int.0 |> inc() }
 """
@@ -806,11 +806,11 @@ fn main(@Int -> @Int)
 
     def test_pipe_chain(self) -> None:
         source = """\
-fn inc(@Int -> @Int)
+private fn inc(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { @Int.0 + 1 }
 
-fn main(@Int -> @Int)
+private fn main(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { @Int.0 |> inc() |> inc() }
 """
@@ -818,11 +818,11 @@ fn main(@Int -> @Int)
 
     def test_pipe_multi_arg(self) -> None:
         source = """\
-fn add(@Int, @Int -> @Int)
+private fn add(@Int, @Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { @Int.0 + @Int.1 }
 
-fn main(@Int -> @Int)
+private fn main(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { @Int.0 |> add(10) }
 """
@@ -844,7 +844,7 @@ class TestStringLitIO:
     def test_hello_world(self) -> None:
         """First light: Hello, World!"""
         source = _IO_PRELUDE + """\
-fn main(@Unit -> @Unit)
+private fn main(@Unit -> @Unit)
   requires(true) ensures(true) effects(<IO>)
 { IO.print("Hello, World!") }
 """
@@ -852,7 +852,7 @@ fn main(@Unit -> @Unit)
 
     def test_empty_string(self) -> None:
         source = _IO_PRELUDE + """\
-fn main(@Unit -> @Unit)
+private fn main(@Unit -> @Unit)
   requires(true) ensures(true) effects(<IO>)
 { IO.print("") }
 """
@@ -860,7 +860,7 @@ fn main(@Unit -> @Unit)
 
     def test_multiple_prints(self) -> None:
         source = _IO_PRELUDE + """\
-fn main(@Unit -> @Unit)
+private fn main(@Unit -> @Unit)
   requires(true) ensures(true) effects(<IO>)
 {
   IO.print("Hello, ");
@@ -872,7 +872,7 @@ fn main(@Unit -> @Unit)
     def test_string_dedup(self) -> None:
         """Identical strings should be deduplicated in the data section."""
         source = _IO_PRELUDE + """\
-fn main(@Unit -> @Unit)
+private fn main(@Unit -> @Unit)
   requires(true) ensures(true) effects(<IO>)
 {
   IO.print("abc");
@@ -888,7 +888,7 @@ fn main(@Unit -> @Unit)
     def test_special_characters(self) -> None:
         """Strings with punctuation and spaces."""
         source = _IO_PRELUDE + """\
-fn main(@Unit -> @Unit)
+private fn main(@Unit -> @Unit)
   requires(true) ensures(true) effects(<IO>)
 { IO.print("Hello, World! 123 @#$") }
 """
@@ -897,11 +897,11 @@ fn main(@Unit -> @Unit)
     def test_io_with_pure_functions(self) -> None:
         """IO functions coexist with pure functions in the same module."""
         source = _IO_PRELUDE + """\
-fn add(@Int, @Int -> @Int)
+private fn add(@Int, @Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { @Int.1 + @Int.0 }
 
-fn main(@Unit -> @Unit)
+private fn main(@Unit -> @Unit)
   requires(true) ensures(true) effects(<IO>)
 { IO.print("hello") }
 """
@@ -932,7 +932,7 @@ class TestPreconditions:
     def test_requires_holds(self) -> None:
         """Non-trivial precondition that holds — no trap."""
         source = """\
-fn positive(@Int -> @Int)
+private fn positive(@Int -> @Int)
   requires(@Int.0 > 0)
   ensures(true)
   effects(pure)
@@ -943,7 +943,7 @@ fn positive(@Int -> @Int)
     def test_requires_traps(self) -> None:
         """Non-trivial precondition violated — WASM trap."""
         source = """\
-fn positive(@Int -> @Int)
+private fn positive(@Int -> @Int)
   requires(@Int.0 > 0)
   ensures(true)
   effects(pure)
@@ -954,7 +954,7 @@ fn positive(@Int -> @Int)
     def test_requires_boundary(self) -> None:
         """Precondition with exact boundary value."""
         source = """\
-fn nonneg(@Int -> @Int)
+private fn nonneg(@Int -> @Int)
   requires(@Int.0 >= 0)
   ensures(true)
   effects(pure)
@@ -966,7 +966,7 @@ fn nonneg(@Int -> @Int)
     def test_requires_neq_zero(self) -> None:
         """Precondition: denominator != 0."""
         source = """\
-fn safe_div(@Int, @Int -> @Int)
+private fn safe_div(@Int, @Int -> @Int)
   requires(@Int.0 != 0)
   ensures(true)
   effects(pure)
@@ -978,7 +978,7 @@ fn safe_div(@Int, @Int -> @Int)
     def test_trivial_requires_no_overhead(self) -> None:
         """requires(true) should not produce any trap instructions."""
         source = """\
-fn f(@Int -> @Int)
+private fn f(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { @Int.0 }
 """
@@ -989,7 +989,7 @@ fn f(@Int -> @Int)
     def test_multiple_requires(self) -> None:
         """Multiple preconditions — all must hold."""
         source = """\
-fn bounded(@Int -> @Int)
+private fn bounded(@Int -> @Int)
   requires(@Int.0 >= 0)
   requires(@Int.0 <= 100)
   ensures(true)
@@ -1005,7 +1005,7 @@ class TestPostconditions:
     def test_ensures_holds(self) -> None:
         """Postcondition that holds — no trap."""
         source = """\
-fn double(@Int -> @Int)
+private fn double(@Int -> @Int)
   requires(true)
   ensures(@Int.result >= 0)
   effects(pure)
@@ -1016,7 +1016,7 @@ fn double(@Int -> @Int)
     def test_ensures_traps(self) -> None:
         """Postcondition violated — WASM trap."""
         source = """\
-fn negate(@Int -> @Int)
+private fn negate(@Int -> @Int)
   requires(true)
   ensures(@Int.result > 0)
   effects(pure)
@@ -1028,7 +1028,7 @@ fn negate(@Int -> @Int)
     def test_ensures_with_params(self) -> None:
         """Postcondition referencing both result and parameters."""
         source = """\
-fn inc(@Int -> @Int)
+private fn inc(@Int -> @Int)
   requires(true)
   ensures(@Int.result > @Int.0)
   effects(pure)
@@ -1039,7 +1039,7 @@ fn inc(@Int -> @Int)
     def test_ensures_result_eq(self) -> None:
         """Postcondition checking exact result value."""
         source = """\
-fn always_zero(-> @Int)
+private fn always_zero(-> @Int)
   requires(true)
   ensures(@Int.result == 0)
   effects(pure)
@@ -1050,7 +1050,7 @@ fn always_zero(-> @Int)
     def test_ensures_result_traps(self) -> None:
         """Postcondition checking exact value — wrong result traps."""
         source = """\
-fn buggy(-> @Int)
+private fn buggy(-> @Int)
   requires(true)
   ensures(@Int.result == 0)
   effects(pure)
@@ -1061,7 +1061,7 @@ fn buggy(-> @Int)
     def test_trivial_ensures_no_overhead(self) -> None:
         """ensures(true) should not produce any trap instructions."""
         source = """\
-fn f(@Int -> @Int)
+private fn f(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { @Int.0 }
 """
@@ -1071,7 +1071,7 @@ fn f(@Int -> @Int)
     def test_ensures_bool_result(self) -> None:
         """Postcondition on a Bool-returning function."""
         source = """\
-fn is_pos(@Int -> @Bool)
+private fn is_pos(@Int -> @Bool)
   requires(true)
   ensures(@Bool.result == true)
   effects(pure)
@@ -1086,7 +1086,7 @@ class TestCombinedContracts:
     def test_both_hold(self) -> None:
         """Both requires and ensures hold — normal execution."""
         source = """\
-fn safe_inc(@Int -> @Int)
+private fn safe_inc(@Int -> @Int)
   requires(@Int.0 >= 0)
   ensures(@Int.result > @Int.0)
   effects(pure)
@@ -1098,7 +1098,7 @@ fn safe_inc(@Int -> @Int)
     def test_requires_fails_first(self) -> None:
         """Precondition fails before postcondition is checked."""
         source = """\
-fn safe_inc(@Int -> @Int)
+private fn safe_inc(@Int -> @Int)
   requires(@Int.0 >= 0)
   ensures(@Int.result > @Int.0)
   effects(pure)
@@ -1109,7 +1109,7 @@ fn safe_inc(@Int -> @Int)
     def test_contracts_with_recursion(self) -> None:
         """Runtime contracts on a recursive function."""
         source = """\
-fn factorial(@Nat -> @Nat)
+private fn factorial(@Nat -> @Nat)
   requires(@Nat.0 >= 0)
   ensures(@Nat.result >= 1)
   decreases(@Nat.0)
@@ -1132,13 +1132,13 @@ class TestUnsupportedSkipped:
     def test_adt_function_compiles(self) -> None:
         """Functions with ADT types now compile (not skipped)."""
         source = """\
-data Option<T> { None, Some(T) }
+private data Option<T> { None, Some(T) }
 
-fn make_none(-> @Option<Int>)
+private fn make_none(-> @Option<Int>)
   requires(true) ensures(true) effects(pure)
 { None }
 
-fn simple(-> @Int)
+private fn simple(-> @Int)
   requires(true) ensures(true) effects(pure)
 { 1 }
 """
@@ -1156,13 +1156,13 @@ effect Counter {
   op tick(Unit -> Unit);
 }
 
-fn count(@Unit -> @Unit)
+private fn count(@Unit -> @Unit)
   requires(true) ensures(true) effects(<Counter>)
 {
   Counter.tick(())
 }
 
-fn simple(-> @Int)
+private fn simple(-> @Int)
   requires(true) ensures(true) effects(pure)
 { 42 }
 """
@@ -1349,21 +1349,21 @@ class TestBoolComparison:
 
     def test_bool_eq_true(self) -> None:
         assert _run(
-            "fn f(@Bool, @Bool -> @Bool) requires(true) ensures(true) "
+            "private fn f(@Bool, @Bool -> @Bool) requires(true) ensures(true) "
             "effects(pure) { @Bool.1 == @Bool.0 }",
             fn="f", args=[1, 1],
         ) == 1
 
     def test_bool_eq_false(self) -> None:
         assert _run(
-            "fn f(@Bool, @Bool -> @Bool) requires(true) ensures(true) "
+            "private fn f(@Bool, @Bool -> @Bool) requires(true) ensures(true) "
             "effects(pure) { @Bool.1 == @Bool.0 }",
             fn="f", args=[1, 0],
         ) == 0
 
     def test_bool_neq(self) -> None:
         assert _run(
-            "fn f(@Bool, @Bool -> @Bool) requires(true) ensures(true) "
+            "private fn f(@Bool, @Bool -> @Bool) requires(true) ensures(true) "
             "effects(pure) { @Bool.1 != @Bool.0 }",
             fn="f", args=[1, 0],
         ) == 1
@@ -1371,7 +1371,7 @@ class TestBoolComparison:
     def test_bool_comparison_uses_i32(self) -> None:
         """Verify WAT uses i32.eq for Bool == Bool, not i64.eq."""
         result = _compile_ok(
-            "fn f(@Bool, @Bool -> @Bool) requires(true) ensures(true) "
+            "private fn f(@Bool, @Bool -> @Bool) requires(true) ensures(true) "
             "effects(pure) { @Bool.1 == @Bool.0 }"
         )
         assert "i32.eq" in result.wat
@@ -1390,21 +1390,21 @@ class TestModuleAssembly:
     def test_pure_no_io_import(self) -> None:
         """Pure functions should not import vera.print."""
         result = _compile_ok(
-            "fn f(-> @Int) requires(true) ensures(true) effects(pure) { 42 }"
+            "private fn f(-> @Int) requires(true) ensures(true) effects(pure) { 42 }"
         )
         assert "vera.print" not in result.wat
 
     def test_pure_no_memory(self) -> None:
         """Pure functions without strings should not declare memory."""
         result = _compile_ok(
-            "fn f(-> @Int) requires(true) ensures(true) effects(pure) { 42 }"
+            "private fn f(-> @Int) requires(true) ensures(true) effects(pure) { 42 }"
         )
         assert "(memory" not in result.wat
 
     def test_io_has_import_and_memory(self) -> None:
         """IO functions import vera.print and declare memory."""
         source = _IO_PRELUDE + """\
-fn main(@Unit -> @Unit)
+private fn main(@Unit -> @Unit)
   requires(true) ensures(true) effects(<IO>)
 { IO.print("hello") }
 """
@@ -1416,15 +1416,15 @@ fn main(@Unit -> @Unit)
     def test_multiple_exports(self) -> None:
         """Multiple compilable functions are all exported."""
         source = """\
-fn add(@Int, @Int -> @Int)
+private fn add(@Int, @Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { @Int.1 + @Int.0 }
 
-fn mul(@Int, @Int -> @Int)
+private fn mul(@Int, @Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { @Int.1 * @Int.0 }
 
-fn neg(@Int -> @Int)
+private fn neg(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { -@Int.0 }
 """
@@ -1446,7 +1446,7 @@ class TestExecuteErrors:
     def test_function_not_found(self) -> None:
         """execute() with unknown function name raises RuntimeError."""
         result = _compile_ok(
-            "fn f(-> @Int) requires(true) ensures(true) effects(pure) { 42 }"
+            "private fn f(-> @Int) requires(true) ensures(true) effects(pure) { 42 }"
         )
         with pytest.raises(RuntimeError, match="not found"):
             execute(result, fn_name="nonexistent")
@@ -1472,7 +1472,7 @@ class TestExecuteErrors:
     def test_first_export_used_when_no_main(self) -> None:
         """When no 'main' function, the first exported function is called."""
         source = """\
-fn compute(-> @Int)
+private fn compute(-> @Int)
   requires(true) ensures(true) effects(pure)
 { 99 }
 """
@@ -1502,7 +1502,7 @@ class TestStateEffect:
     def test_state_int_get_default(self) -> None:
         """get(()) returns 0 by default for State<Int>."""
         source = """\
-fn f(-> @Int)
+private fn f(-> @Int)
   requires(true) ensures(true) effects(<State<Int>>)
 { get(()) }
 """
@@ -1512,7 +1512,7 @@ fn f(-> @Int)
     def test_state_int_put_then_get(self) -> None:
         """put(42) then get(()) returns 42."""
         source = """\
-fn f(-> @Int)
+private fn f(-> @Int)
   requires(true) ensures(true) effects(<State<Int>>)
 {
   put(42);
@@ -1525,7 +1525,7 @@ fn f(-> @Int)
     def test_increment_pattern(self) -> None:
         """Classic increment: get, add 1, put — state goes from 0 to 1."""
         source = """\
-fn increment(@Unit -> @Unit)
+private fn increment(@Unit -> @Unit)
   requires(true) ensures(true) effects(<State<Int>>)
 {
   let @Int = get(());
@@ -1553,7 +1553,7 @@ fn increment(@Unit -> @Unit)
     def test_state_bool_get_default(self) -> None:
         """Bool state defaults to 0 (false)."""
         source = """\
-fn f(-> @Bool)
+private fn f(-> @Bool)
   requires(true) ensures(true) effects(<State<Bool>>)
 { get(()) }
 """
@@ -1563,7 +1563,7 @@ fn f(-> @Bool)
     def test_state_bool_put_get(self) -> None:
         """put(true) then get(()) returns 1."""
         source = """\
-fn f(-> @Bool)
+private fn f(-> @Bool)
   requires(true) ensures(true) effects(<State<Bool>>)
 {
   put(true);
@@ -1576,7 +1576,7 @@ fn f(-> @Bool)
     def test_state_float64_get_default(self) -> None:
         """Float64 state defaults to 0.0."""
         source = """\
-fn f(-> @Float64)
+private fn f(-> @Float64)
   requires(true) ensures(true) effects(<State<Float64>>)
 { get(()) }
 """
@@ -1586,7 +1586,7 @@ fn f(-> @Float64)
     def test_state_nat_compiles(self) -> None:
         """State<Nat> compiles (Nat maps to i64)."""
         source = """\
-fn f(-> @Nat)
+private fn f(-> @Nat)
   requires(true) ensures(true) effects(<State<Nat>>)
 { get(()) }
 """
@@ -1596,7 +1596,7 @@ fn f(-> @Nat)
     def test_state_string_rejected(self) -> None:
         """State<String> is unsupported — function skipped with warning."""
         source = """\
-fn f(-> @Int)
+private fn f(-> @Int)
   requires(true) ensures(true) effects(<State<String>>)
 { 42 }
 """
@@ -1608,7 +1608,7 @@ fn f(-> @Int)
     def test_state_with_io(self) -> None:
         """Mixed effects(<State<Int>, IO>) compiles and both work."""
         source = """\
-fn f(@Unit -> @Unit)
+private fn f(@Unit -> @Unit)
   requires(true) ensures(true) effects(<State<Int>, IO>)
 {
   put(42);
@@ -1623,7 +1623,7 @@ fn f(@Unit -> @Unit)
     def test_state_wat_has_imports(self) -> None:
         """WAT output contains State import declarations."""
         source = """\
-fn f(-> @Int)
+private fn f(-> @Int)
   requires(true) ensures(true) effects(<State<Int>>)
 { get(()) }
 """
@@ -1634,7 +1634,7 @@ fn f(-> @Int)
     def test_multiple_state_types(self) -> None:
         """Multiple State types emit all imports."""
         source = """\
-fn f(@Int -> @Unit)
+private fn f(@Int -> @Unit)
   requires(true) ensures(true) effects(<State<Int>, State<Bool>>)
 {
   put(@Int.0);
@@ -1651,7 +1651,7 @@ fn f(@Int -> @Unit)
     def test_put_void_no_drop(self) -> None:
         """put(x) in ExprStmt does not emit a drop instruction."""
         source = """\
-fn f(@Unit -> @Unit)
+private fn f(@Unit -> @Unit)
   requires(true) ensures(true) effects(<State<Int>>)
 {
   put(42);
@@ -1669,7 +1669,7 @@ fn f(@Unit -> @Unit)
     def test_state_initial_value(self) -> None:
         """Initial state override: get(()) returns the initial value."""
         source = """\
-fn f(-> @Int)
+private fn f(-> @Int)
   requires(true) ensures(true) effects(<State<Int>>)
 { get(()) }
 """
@@ -1681,7 +1681,7 @@ fn f(-> @Int)
     def test_pure_no_state_imports(self) -> None:
         """Pure functions don't produce State imports."""
         source = """\
-fn f(-> @Int)
+private fn f(-> @Int)
   requires(true) ensures(true) effects(pure)
 { 42 }
 """
@@ -1757,9 +1757,9 @@ class TestHeapAllocation:
     def test_heap_ptr_global_emitted(self) -> None:
         """When ADTs are declared, $heap_ptr global appears in WAT."""
         source = """\
-data Color { Red, Green, Blue }
+private data Color { Red, Green, Blue }
 
-fn f(-> @Int)
+private fn f(-> @Int)
   requires(true) ensures(true) effects(pure)
 { 42 }
 """
@@ -1770,9 +1770,9 @@ fn f(-> @Int)
     def test_alloc_function_emitted(self) -> None:
         """When ADTs are declared, $alloc function appears in WAT."""
         source = """\
-data Color { Red, Green, Blue }
+private data Color { Red, Green, Blue }
 
-fn f(-> @Int)
+private fn f(-> @Int)
   requires(true) ensures(true) effects(pure)
 { 42 }
 """
@@ -1784,7 +1784,7 @@ fn f(-> @Int)
     def test_no_alloc_without_adt(self) -> None:
         """Pure programs without ADTs should NOT emit allocator."""
         source = """\
-fn f(-> @Int)
+private fn f(-> @Int)
   requires(true) ensures(true) effects(pure)
 { 42 }
 """
@@ -1795,9 +1795,9 @@ fn f(-> @Int)
     def test_heap_ptr_starts_after_strings(self) -> None:
         """Heap pointer initial value should be after string data."""
         source = """\
-data Color { Red, Green, Blue }
+private data Color { Red, Green, Blue }
 
-fn main(@Unit -> @Unit)
+private fn main(@Unit -> @Unit)
   requires(true) ensures(true) effects(<IO>)
 { IO.print("hello") }
 """
@@ -1809,9 +1809,9 @@ fn main(@Unit -> @Unit)
     def test_heap_ptr_zero_without_strings(self) -> None:
         """Without strings, heap starts at offset 0."""
         source = """\
-data Flag { On, Off }
+private data Flag { On, Off }
 
-fn f(-> @Int)
+private fn f(-> @Int)
   requires(true) ensures(true) effects(pure)
 { 42 }
 """
@@ -1821,9 +1821,9 @@ fn f(-> @Int)
     def test_alloc_alignment_logic(self) -> None:
         """Alloc function contains 8-byte alignment rounding."""
         source = """\
-data Bit { Zero, One }
+private data Bit { Zero, One }
 
-fn f(-> @Int)
+private fn f(-> @Int)
   requires(true) ensures(true) effects(pure)
 { 42 }
 """
@@ -1834,9 +1834,9 @@ fn f(-> @Int)
     def test_memory_emitted_with_adt(self) -> None:
         """ADTs cause memory to be declared even without strings."""
         source = """\
-data Flag { On, Off }
+private data Flag { On, Off }
 
-fn f(-> @Int)
+private fn f(-> @Int)
   requires(true) ensures(true) effects(pure)
 { 42 }
 """
@@ -1850,9 +1850,9 @@ class TestAdtMetadata:
     def test_nullary_layout(self) -> None:
         """Nullary constructor: tag only, total_size = 8."""
         source = """\
-data Unit2 { MkUnit }
+private data Unit2 { MkUnit }
 
-fn f(-> @Int)
+private fn f(-> @Int)
   requires(true) ensures(true) effects(pure)
 { 42 }
 """
@@ -1865,9 +1865,9 @@ fn f(-> @Int)
     def test_single_int_field_layout(self) -> None:
         """Constructor with Int field: tag(4) + pad(4) + i64(8) = 16."""
         source = """\
-data Wrapper { Wrap(Int) }
+private data Wrapper { Wrap(Int) }
 
-fn f(-> @Int)
+private fn f(-> @Int)
   requires(true) ensures(true) effects(pure)
 { 42 }
 """
@@ -1880,9 +1880,9 @@ fn f(-> @Int)
     def test_multiple_fields_layout(self) -> None:
         """Constructor with Int + Bool: tag(4) + pad(4) + i64(8) + i32(4) → 24."""
         source = """\
-data Pair { MkPair(Int, Bool) }
+private data Pair { MkPair(Int, Bool) }
 
-fn f(-> @Int)
+private fn f(-> @Int)
   requires(true) ensures(true) effects(pure)
 { 42 }
 """
@@ -1896,9 +1896,9 @@ fn f(-> @Int)
     def test_multiple_constructors_tags(self) -> None:
         """Each constructor gets a sequential tag."""
         source = """\
-data Color { Red, Green, Blue }
+private data Color { Red, Green, Blue }
 
-fn f(-> @Int)
+private fn f(-> @Int)
   requires(true) ensures(true) effects(pure)
 { 42 }
 """
@@ -1911,9 +1911,9 @@ fn f(-> @Int)
     def test_float64_field_layout(self) -> None:
         """Constructor with Float64 field: tag(4) + pad(4) + f64(8) = 16."""
         source = """\
-data Box { MkBox(Float64) }
+private data Box { MkBox(Float64) }
 
-fn f(-> @Int)
+private fn f(-> @Int)
   requires(true) ensures(true) effects(pure)
 { 42 }
 """
@@ -1925,9 +1925,9 @@ fn f(-> @Int)
     def test_bool_field_layout(self) -> None:
         """Constructor with Bool field: tag(4) + i32(4) = 8."""
         source = """\
-data Toggle { MkToggle(Bool) }
+private data Toggle { MkToggle(Bool) }
 
-fn f(-> @Int)
+private fn f(-> @Int)
   requires(true) ensures(true) effects(pure)
 { 42 }
 """
@@ -1939,9 +1939,9 @@ fn f(-> @Int)
     def test_type_param_is_pointer(self) -> None:
         """Type parameters map to i32 (pointer)."""
         source = """\
-data Box<T> { MkBox(T) }
+private data Box<T> { MkBox(T) }
 
-fn f(-> @Int)
+private fn f(-> @Int)
   requires(true) ensures(true) effects(pure)
 { 42 }
 """
@@ -1953,9 +1953,9 @@ fn f(-> @Int)
     def test_mixed_adt_constructors(self) -> None:
         """Option-like ADT: None is nullary, Some has a field."""
         source = """\
-data MyOption<T> { MyNone, MySome(T) }
+private data MyOption<T> { MyNone, MySome(T) }
 
-fn f(-> @Int)
+private fn f(-> @Int)
   requires(true) ensures(true) effects(pure)
 { 42 }
 """
@@ -1980,9 +1980,9 @@ class TestAdtConstructors:
     def test_nullary_constructor_returns_pointer(self) -> None:
         """A nullary constructor (Red) compiles and returns an i32 >= 0."""
         source = """\
-data Color { Red, Green, Blue }
+private data Color { Red, Green, Blue }
 
-fn make_red(-> @Color)
+private fn make_red(-> @Color)
   requires(true) ensures(true) effects(pure)
 { Red }
 """
@@ -1995,17 +1995,17 @@ fn make_red(-> @Color)
     def test_nullary_different_tags(self) -> None:
         """Different nullary constructors compile to distinct functions."""
         source = """\
-data Color { Red, Green, Blue }
+private data Color { Red, Green, Blue }
 
-fn make_red(-> @Color)
+private fn make_red(-> @Color)
   requires(true) ensures(true) effects(pure)
 { Red }
 
-fn make_green(-> @Color)
+private fn make_green(-> @Color)
   requires(true) ensures(true) effects(pure)
 { Green }
 
-fn make_blue(-> @Color)
+private fn make_blue(-> @Color)
   requires(true) ensures(true) effects(pure)
 { Blue }
 """
@@ -2017,9 +2017,9 @@ fn make_blue(-> @Color)
     def test_constructor_with_int_field(self) -> None:
         """Constructor with Int field: Wrap(@Int.0) compiles."""
         source = """\
-data Wrapper { Wrap(Int) }
+private data Wrapper { Wrap(Int) }
 
-fn wrap(@Int -> @Wrapper)
+private fn wrap(@Int -> @Wrapper)
   requires(true) ensures(true) effects(pure)
 { Wrap(@Int.0) }
 """
@@ -2032,9 +2032,9 @@ fn wrap(@Int -> @Wrapper)
     def test_constructor_with_bool_field(self) -> None:
         """Constructor with Bool field: MkToggle(@Bool.0) compiles."""
         source = """\
-data Toggle { MkToggle(Bool) }
+private data Toggle { MkToggle(Bool) }
 
-fn toggle(@Bool -> @Toggle)
+private fn toggle(@Bool -> @Toggle)
   requires(true) ensures(true) effects(pure)
 { MkToggle(@Bool.0) }
 """
@@ -2047,9 +2047,9 @@ fn toggle(@Bool -> @Toggle)
     def test_option_none(self) -> None:
         """None as Option<Int> compiles (nullary constructor)."""
         source = """\
-data Option<T> { None, Some(T) }
+private data Option<T> { None, Some(T) }
 
-fn make_none(-> @Option<Int>)
+private fn make_none(-> @Option<Int>)
   requires(true) ensures(true) effects(pure)
 { None }
 """
@@ -2061,9 +2061,9 @@ fn make_none(-> @Option<Int>)
     def test_option_some(self) -> None:
         """Some(@Int.0) as Option<Int> compiles."""
         source = """\
-data Option<T> { None, Some(T) }
+private data Option<T> { None, Some(T) }
 
-fn make_some(@Int -> @Option<Int>)
+private fn make_some(@Int -> @Option<Int>)
   requires(true) ensures(true) effects(pure)
 { Some(@Int.0) }
 """
@@ -2076,9 +2076,9 @@ fn make_some(@Int -> @Option<Int>)
     def test_wat_contains_alloc_call(self) -> None:
         """WAT output for constructor contains call $alloc."""
         source = """\
-data Color { Red, Green, Blue }
+private data Color { Red, Green, Blue }
 
-fn make_red(-> @Color)
+private fn make_red(-> @Color)
   requires(true) ensures(true) effects(pure)
 { Red }
 """
@@ -2088,9 +2088,9 @@ fn make_red(-> @Color)
     def test_wat_contains_store_with_offset(self) -> None:
         """WAT output for Some(x) contains field store with offset."""
         source = """\
-data Wrapper { Wrap(Int) }
+private data Wrapper { Wrap(Int) }
 
-fn wrap(@Int -> @Wrapper)
+private fn wrap(@Int -> @Wrapper)
   requires(true) ensures(true) effects(pure)
 { Wrap(@Int.0) }
 """
@@ -2100,9 +2100,9 @@ fn wrap(@Int -> @Wrapper)
     def test_nullary_tag_store(self) -> None:
         """WAT for Red (tag=0) stores tag 0; Green (tag=1) stores tag 1."""
         source = """\
-data Color { Red, Green, Blue }
+private data Color { Red, Green, Blue }
 
-fn make_green(-> @Color)
+private fn make_green(-> @Color)
   requires(true) ensures(true) effects(pure)
 { Green }
 """
@@ -2114,9 +2114,9 @@ fn make_green(-> @Color)
     def test_constructor_in_let_binding(self) -> None:
         """Constructor result in a let binding compiles."""
         source = """\
-data Wrapper { Wrap(Int) }
+private data Wrapper { Wrap(Int) }
 
-fn make_wrap(@Int -> @Wrapper)
+private fn make_wrap(@Int -> @Wrapper)
   requires(true) ensures(true) effects(pure)
 {
   let @Wrapper = Wrap(@Int.0);
@@ -2131,9 +2131,9 @@ fn make_wrap(@Int -> @Wrapper)
     def test_constructor_in_if_branches(self) -> None:
         """Constructors in both branches of if-then-else compile."""
         source = """\
-data Option<T> { None, Some(T) }
+private data Option<T> { None, Some(T) }
 
-fn maybe(@Bool -> @Option<Int>)
+private fn maybe(@Bool -> @Option<Int>)
   requires(true) ensures(true) effects(pure)
 {
   if @Bool.0 then { Some(42) }
@@ -2151,9 +2151,9 @@ fn maybe(@Bool -> @Option<Int>)
     def test_adt_param_compiles(self) -> None:
         """Function taking ADT param uses (param $p0 i32) in WAT."""
         source = """\
-data Color { Red, Green, Blue }
+private data Color { Red, Green, Blue }
 
-fn identity(@Color -> @Color)
+private fn identity(@Color -> @Color)
   requires(true) ensures(true) effects(pure)
 { @Color.0 }
 """
@@ -2173,9 +2173,9 @@ class TestMatchExpressions:
     def test_match_option_none_arm(self) -> None:
         """Match on None arm returns 0."""
         source = """\
-data Option<T> { None, Some(T) }
+private data Option<T> { None, Some(T) }
 
-fn test_none(-> @Int)
+private fn test_none(-> @Int)
   requires(true) ensures(true) effects(pure)
 {
   let @Option<Int> = None;
@@ -2190,9 +2190,9 @@ fn test_none(-> @Int)
     def test_match_option_some_arm(self) -> None:
         """Match on Some arm extracts value."""
         source = """\
-data Option<T> { None, Some(T) }
+private data Option<T> { None, Some(T) }
 
-fn test_some(-> @Int)
+private fn test_some(-> @Int)
   requires(true) ensures(true) effects(pure)
 {
   let @Option<Int> = Some(42);
@@ -2207,9 +2207,9 @@ fn test_some(-> @Int)
     def test_match_color_red(self) -> None:
         """Match on Red arm returns 0."""
         source = """\
-data Color { Red, Green, Blue }
+private data Color { Red, Green, Blue }
 
-fn test_red(-> @Int)
+private fn test_red(-> @Int)
   requires(true) ensures(true) effects(pure)
 {
   let @Color = Red;
@@ -2225,9 +2225,9 @@ fn test_red(-> @Int)
     def test_match_color_green(self) -> None:
         """Match on Green arm returns 1."""
         source = """\
-data Color { Red, Green, Blue }
+private data Color { Red, Green, Blue }
 
-fn test_green(-> @Int)
+private fn test_green(-> @Int)
   requires(true) ensures(true) effects(pure)
 {
   let @Color = Green;
@@ -2243,9 +2243,9 @@ fn test_green(-> @Int)
     def test_match_color_blue(self) -> None:
         """Match on Blue arm returns 2."""
         source = """\
-data Color { Red, Green, Blue }
+private data Color { Red, Green, Blue }
 
-fn test_blue(-> @Int)
+private fn test_blue(-> @Int)
   requires(true) ensures(true) effects(pure)
 {
   let @Color = Blue;
@@ -2261,9 +2261,9 @@ fn test_blue(-> @Int)
     def test_match_extracts_int(self) -> None:
         """Match extracts Int field and uses it in body."""
         source = """\
-data Option<T> { None, Some(T) }
+private data Option<T> { None, Some(T) }
 
-fn test(-> @Int)
+private fn test(-> @Int)
   requires(true) ensures(true) effects(pure)
 {
   let @Option<Int> = Some(99);
@@ -2278,9 +2278,9 @@ fn test(-> @Int)
     def test_match_extracts_bool(self) -> None:
         """Match extracts Bool field."""
         source = """\
-data Toggle { MkToggle(Bool) }
+private data Toggle { MkToggle(Bool) }
 
-fn test(-> @Bool)
+private fn test(-> @Bool)
   requires(true) ensures(true) effects(pure)
 {
   let @Toggle = MkToggle(true);
@@ -2294,9 +2294,9 @@ fn test(-> @Bool)
     def test_match_two_fields(self) -> None:
         """Match extracts first of two fields."""
         source = """\
-data Pair { MkPair(Int, Bool) }
+private data Pair { MkPair(Int, Bool) }
 
-fn test(-> @Int)
+private fn test(-> @Int)
   requires(true) ensures(true) effects(pure)
 {
   let @Pair = MkPair(42, true);
@@ -2310,9 +2310,9 @@ fn test(-> @Int)
     def test_match_wildcard_catchall(self) -> None:
         """Wildcard catch-all matches None."""
         source = """\
-data Option<T> { None, Some(T) }
+private data Option<T> { None, Some(T) }
 
-fn test(-> @Int)
+private fn test(-> @Int)
   requires(true) ensures(true) effects(pure)
 {
   let @Option<Int> = None;
@@ -2327,7 +2327,7 @@ fn test(-> @Int)
     def test_match_wildcard_only(self) -> None:
         """Single wildcard arm on Int."""
         source = """\
-fn test(@Int -> @Int)
+private fn test(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   match @Int.0 {
@@ -2340,9 +2340,9 @@ fn test(@Int -> @Int)
     def test_match_wildcard_sub_pattern(self) -> None:
         """Wildcard inside constructor sub-pattern."""
         source = """\
-data Option<T> { None, Some(T) }
+private data Option<T> { None, Some(T) }
 
-fn test(-> @Int)
+private fn test(-> @Int)
   requires(true) ensures(true) effects(pure)
 {
   let @Option<Int> = Some(77);
@@ -2357,7 +2357,7 @@ fn test(-> @Int)
     def test_match_bool_true(self) -> None:
         """Bool match on true arm."""
         source = """\
-fn test(@Bool -> @Int)
+private fn test(@Bool -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   match @Bool.0 {
@@ -2371,7 +2371,7 @@ fn test(@Bool -> @Int)
     def test_match_bool_false(self) -> None:
         """Bool match on false arm."""
         source = """\
-fn test(@Bool -> @Int)
+private fn test(@Bool -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   match @Bool.0 {
@@ -2385,7 +2385,7 @@ fn test(@Bool -> @Int)
     def test_match_int_literal(self) -> None:
         """Int literal match, first arm."""
         source = """\
-fn test(@Int -> @Int)
+private fn test(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   match @Int.0 {
@@ -2400,7 +2400,7 @@ fn test(@Int -> @Int)
     def test_match_int_second_arm(self) -> None:
         """Int literal match, second arm."""
         source = """\
-fn test(@Int -> @Int)
+private fn test(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   match @Int.0 {
@@ -2415,7 +2415,7 @@ fn test(@Int -> @Int)
     def test_match_int_wildcard_fallback(self) -> None:
         """Int literal match, wildcard fallback."""
         source = """\
-fn test(@Int -> @Int)
+private fn test(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   match @Int.0 {
@@ -2430,9 +2430,9 @@ fn test(@Int -> @Int)
     def test_match_binding_catchall(self) -> None:
         """Binding pattern as catch-all."""
         source = """\
-data Option<T> { None, Some(T) }
+private data Option<T> { None, Some(T) }
 
-fn test(-> @Int)
+private fn test(-> @Int)
   requires(true) ensures(true) effects(pure)
 {
   let @Option<Int> = None;
@@ -2447,9 +2447,9 @@ fn test(-> @Int)
     def test_match_in_let_binding(self) -> None:
         """Match result used in a let binding."""
         source = """\
-data Option<T> { None, Some(T) }
+private data Option<T> { None, Some(T) }
 
-fn test(-> @Int)
+private fn test(-> @Int)
   requires(true) ensures(true) effects(pure)
 {
   let @Option<Int> = Some(10);
@@ -2465,9 +2465,9 @@ fn test(-> @Int)
     def test_match_wat_contains_tag_load(self) -> None:
         """WAT output for ADT match contains i32.load (tag load)."""
         source = """\
-data Color { Red, Green, Blue }
+private data Color { Red, Green, Blue }
 
-fn test(-> @Int)
+private fn test(-> @Int)
   requires(true) ensures(true) effects(pure)
 {
   let @Color = Red;
@@ -2484,9 +2484,9 @@ fn test(-> @Int)
     def test_match_function_compiles(self) -> None:
         """Function with match is now exported (not skipped)."""
         source = """\
-data Option<T> { None, Some(T) }
+private data Option<T> { None, Some(T) }
 
-fn unwrap_or(@Option<Int> -> @Int)
+private fn unwrap_or(@Option<Int> -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   match @Option<Int>.0 {
@@ -2510,11 +2510,11 @@ class TestMonomorphization:
     def test_identity_int(self) -> None:
         """forall<T> fn identity instantiated with Int."""
         source = """\
-forall<T> fn identity(@T -> @T)
+private forall<T> fn identity(@T -> @T)
   requires(true) ensures(true) effects(pure)
 { @T.0 }
 
-fn main(-> @Int)
+private fn main(-> @Int)
   requires(true) ensures(true) effects(pure)
 { identity(42) }
 """
@@ -2523,11 +2523,11 @@ fn main(-> @Int)
     def test_identity_bool(self) -> None:
         """forall<T> fn identity instantiated with Bool."""
         source = """\
-forall<T> fn identity(@T -> @T)
+private forall<T> fn identity(@T -> @T)
   requires(true) ensures(true) effects(pure)
 { @T.0 }
 
-fn main(-> @Bool)
+private fn main(-> @Bool)
   requires(true) ensures(true) effects(pure)
 { identity(true) }
 """
@@ -2536,15 +2536,15 @@ fn main(-> @Bool)
     def test_identity_two_instantiations(self) -> None:
         """Same generic function instantiated with both Int and Bool."""
         source = """\
-forall<T> fn identity(@T -> @T)
+private forall<T> fn identity(@T -> @T)
   requires(true) ensures(true) effects(pure)
 { @T.0 }
 
-fn test_int(-> @Int)
+private fn test_int(-> @Int)
   requires(true) ensures(true) effects(pure)
 { identity(42) }
 
-fn test_bool(-> @Bool)
+private fn test_bool(-> @Bool)
   requires(true) ensures(true) effects(pure)
 { identity(false) }
 """
@@ -2560,11 +2560,11 @@ fn test_bool(-> @Bool)
     def test_identity_slot_ref_arg(self) -> None:
         """Generic function called with a slot reference argument."""
         source = """\
-forall<T> fn identity(@T -> @T)
+private forall<T> fn identity(@T -> @T)
   requires(true) ensures(true) effects(pure)
 { @T.0 }
 
-fn main(@Int -> @Int)
+private fn main(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { identity(@Int.0) }
 """
@@ -2573,11 +2573,11 @@ fn main(@Int -> @Int)
     def test_const_function(self) -> None:
         """forall<A, B> fn const with two type parameters."""
         source = """\
-forall<A, B> fn const(@A, @B -> @A)
+private forall<A, B> fn const(@A, @B -> @A)
   requires(true) ensures(true) effects(pure)
 { @A.0 }
 
-fn main(-> @Int)
+private fn main(-> @Int)
   requires(true) ensures(true) effects(pure)
 { const(42, true) }
 """
@@ -2586,9 +2586,9 @@ fn main(-> @Int)
     def test_generic_with_adt_match(self) -> None:
         """forall<T> fn is_some with ADT match (Some case)."""
         source = """\
-data Option<T> { None, Some(T) }
+private data Option<T> { None, Some(T) }
 
-forall<T> fn is_some(@Option<T> -> @Bool)
+private forall<T> fn is_some(@Option<T> -> @Bool)
   requires(true) ensures(true) effects(pure)
 {
   match @Option<T>.0 {
@@ -2597,7 +2597,7 @@ forall<T> fn is_some(@Option<T> -> @Bool)
   }
 }
 
-fn main(-> @Bool)
+private fn main(-> @Bool)
   requires(true) ensures(true) effects(pure)
 { is_some(Some(1)) }
 """
@@ -2606,9 +2606,9 @@ fn main(-> @Bool)
     def test_generic_with_adt_match_none(self) -> None:
         """forall<T> fn is_some with ADT match (None case)."""
         source = """\
-data Option<T> { None, Some(T) }
+private data Option<T> { None, Some(T) }
 
-forall<T> fn is_some(@Option<T> -> @Bool)
+private forall<T> fn is_some(@Option<T> -> @Bool)
   requires(true) ensures(true) effects(pure)
 {
   match @Option<T>.0 {
@@ -2617,7 +2617,7 @@ forall<T> fn is_some(@Option<T> -> @Bool)
   }
 }
 
-fn main(-> @Bool)
+private fn main(-> @Bool)
   requires(true) ensures(true) effects(pure)
 {
   let @Option<Int> = None;
@@ -2629,11 +2629,11 @@ fn main(-> @Bool)
     def test_generic_fn_wat_has_mangled_name(self) -> None:
         """WAT output contains mangled function name."""
         source = """\
-forall<T> fn identity(@T -> @T)
+private forall<T> fn identity(@T -> @T)
   requires(true) ensures(true) effects(pure)
 { @T.0 }
 
-fn main(-> @Int)
+private fn main(-> @Int)
   requires(true) ensures(true) effects(pure)
 { identity(42) }
 """
@@ -2643,11 +2643,11 @@ fn main(-> @Int)
     def test_generic_fn_mangled_in_exports(self) -> None:
         """Mangled name appears in exports, original generic does not."""
         source = """\
-forall<T> fn identity(@T -> @T)
+private forall<T> fn identity(@T -> @T)
   requires(true) ensures(true) effects(pure)
 { @T.0 }
 
-fn main(-> @Int)
+private fn main(-> @Int)
   requires(true) ensures(true) effects(pure)
 { identity(42) }
 """
@@ -2658,15 +2658,15 @@ fn main(-> @Int)
     def test_non_generic_fn_unaffected(self) -> None:
         """Non-generic functions compile normally alongside generic ones."""
         source = """\
-forall<T> fn identity(@T -> @T)
+private forall<T> fn identity(@T -> @T)
   requires(true) ensures(true) effects(pure)
 { @T.0 }
 
-fn double(@Int -> @Int)
+private fn double(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { @Int.0 + @Int.0 }
 
-fn main(-> @Int)
+private fn main(-> @Int)
   requires(true) ensures(true) effects(pure)
 { double(identity(21)) }
 """
@@ -2675,11 +2675,11 @@ fn main(-> @Int)
     def test_generic_identity_in_let_binding(self) -> None:
         """Generic call result used in a let binding."""
         source = """\
-forall<T> fn identity(@T -> @T)
+private forall<T> fn identity(@T -> @T)
   requires(true) ensures(true) effects(pure)
 { @T.0 }
 
-fn main(-> @Int)
+private fn main(-> @Int)
   requires(true) ensures(true) effects(pure)
 {
   let @Int = identity(10);
@@ -2691,11 +2691,11 @@ fn main(-> @Int)
     def test_generic_chained_calls(self) -> None:
         """Generic function called with result of another generic call."""
         source = """\
-forall<T> fn identity(@T -> @T)
+private forall<T> fn identity(@T -> @T)
   requires(true) ensures(true) effects(pure)
 { @T.0 }
 
-fn main(-> @Int)
+private fn main(-> @Int)
   requires(true) ensures(true) effects(pure)
 { identity(identity(99)) }
 """
@@ -2704,11 +2704,11 @@ fn main(-> @Int)
     def test_generic_in_if_branch(self) -> None:
         """Generic call inside an if-then-else branch."""
         source = """\
-forall<T> fn identity(@T -> @T)
+private forall<T> fn identity(@T -> @T)
   requires(true) ensures(true) effects(pure)
 { @T.0 }
 
-fn main(@Bool -> @Int)
+private fn main(@Bool -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   if @Bool.0 then { identity(1) } else { identity(2) }
@@ -2720,11 +2720,11 @@ fn main(@Bool -> @Int)
     def test_generic_with_arithmetic_arg(self) -> None:
         """Generic function called with arithmetic expression as argument."""
         source = """\
-forall<T> fn identity(@T -> @T)
+private forall<T> fn identity(@T -> @T)
   requires(true) ensures(true) effects(pure)
 { @T.0 }
 
-fn main(-> @Int)
+private fn main(-> @Int)
   requires(true) ensures(true) effects(pure)
 { identity(3 + 4) }
 """
@@ -2733,11 +2733,11 @@ fn main(-> @Int)
     def test_generic_no_callers_skipped(self) -> None:
         """Generic function with no callers is gracefully skipped."""
         source = """\
-forall<T> fn identity(@T -> @T)
+private forall<T> fn identity(@T -> @T)
   requires(true) ensures(true) effects(pure)
 { @T.0 }
 
-fn main(-> @Int)
+private fn main(-> @Int)
   requires(true) ensures(true) effects(pure)
 { 42 }
 """
@@ -2776,12 +2776,12 @@ class TestClosures:
         """An anonymous function with no free variables compiles and runs."""
         src = """\
 type IntToInt = fn(Int -> Int) effects(pure);
-fn make_fn(@Unit -> @IntToInt)
+private fn make_fn(@Unit -> @IntToInt)
   requires(true) ensures(true) effects(pure)
 {
   fn(@Int -> @Int) effects(pure) { @Int.0 * 2 }
 }
-fn test(@Unit -> @Int)
+private fn test(@Unit -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   let @IntToInt = make_fn(());
@@ -2794,12 +2794,12 @@ fn test(@Unit -> @Int)
         """An anonymous function that captures an outer binding."""
         src = """\
 type IntToInt = fn(Int -> Int) effects(pure);
-fn make_adder(@Int -> @IntToInt)
+private fn make_adder(@Int -> @IntToInt)
   requires(true) ensures(true) effects(pure)
 {
   fn(@Int -> @Int) effects(pure) { @Int.0 + @Int.1 }
 }
-fn test(@Unit -> @Int)
+private fn test(@Unit -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   let @IntToInt = make_adder(10);
@@ -2812,12 +2812,12 @@ fn test(@Unit -> @Int)
         """apply_fn invokes a closure with the correct argument."""
         src = """\
 type IntToInt = fn(Int -> Int) effects(pure);
-fn make_doubler(@Unit -> @IntToInt)
+private fn make_doubler(@Unit -> @IntToInt)
   requires(true) ensures(true) effects(pure)
 {
   fn(@Int -> @Int) effects(pure) { @Int.0 * 2 }
 }
-fn test(@Unit -> @Int)
+private fn test(@Unit -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   let @IntToInt = make_doubler(());
@@ -2830,12 +2830,12 @@ fn test(@Unit -> @Int)
         """apply_fn on a capturing closure produces the correct result."""
         src = """\
 type IntToInt = fn(Int -> Int) effects(pure);
-fn make_multiplier(@Int -> @IntToInt)
+private fn make_multiplier(@Int -> @IntToInt)
   requires(true) ensures(true) effects(pure)
 {
   fn(@Int -> @Int) effects(pure) { @Int.0 * @Int.1 }
 }
-fn test(@Unit -> @Int)
+private fn test(@Unit -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   let @IntToInt = make_multiplier(3);
@@ -2848,12 +2848,12 @@ fn test(@Unit -> @Int)
         """Store a closure in a let binding, then use it."""
         src = """\
 type IntToInt = fn(Int -> Int) effects(pure);
-fn make_fn(@Int -> @IntToInt)
+private fn make_fn(@Int -> @IntToInt)
   requires(true) ensures(true) effects(pure)
 {
   fn(@Int -> @Int) effects(pure) { @Int.0 + @Int.1 }
 }
-fn test(@Unit -> @Int)
+private fn test(@Unit -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   let @IntToInt = make_fn(100);
@@ -2867,17 +2867,17 @@ fn test(@Unit -> @Int)
         """Pass a closure as a function parameter."""
         src = """\
 type IntToInt = fn(Int -> Int) effects(pure);
-fn apply(@IntToInt, @Int -> @Int)
+private fn apply(@IntToInt, @Int -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   apply_fn(@IntToInt.0, @Int.0)
 }
-fn make_fn(@Int -> @IntToInt)
+private fn make_fn(@Int -> @IntToInt)
   requires(true) ensures(true) effects(pure)
 {
   fn(@Int -> @Int) effects(pure) { @Int.0 + @Int.1 }
 }
-fn test(@Unit -> @Int)
+private fn test(@Unit -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   let @IntToInt = make_fn(50);
@@ -2889,9 +2889,9 @@ fn test(@Unit -> @Int)
     def test_closure_in_match(self) -> None:
         """Use a closure inside a match arm with an ADT constructor."""
         src = """\
-data Option<T> { None, Some(T) }
+private data Option<T> { None, Some(T) }
 type IntMapper = fn(Int -> Int) effects(pure);
-fn map_option(@Option<Int>, @IntMapper -> @Option<Int>)
+private fn map_option(@Option<Int>, @IntMapper -> @Option<Int>)
   requires(true) ensures(true) effects(pure)
 {
   match @Option<Int>.0 {
@@ -2899,12 +2899,12 @@ fn map_option(@Option<Int>, @IntMapper -> @Option<Int>)
     Some(@Int) -> Some(apply_fn(@IntMapper.0, @Int.0))
   }
 }
-fn make_adder(@Int -> @IntMapper)
+private fn make_adder(@Int -> @IntMapper)
   requires(true) ensures(true) effects(pure)
 {
   fn(@Int -> @Int) effects(pure) { @Int.0 + @Int.1 }
 }
-fn test(@Unit -> @Int)
+private fn test(@Unit -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   let @IntMapper = make_adder(100);
@@ -2920,9 +2920,9 @@ fn test(@Unit -> @Int)
     def test_closure_in_match_none(self) -> None:
         """map_option on None returns None."""
         src = """\
-data Option<T> { None, Some(T) }
+private data Option<T> { None, Some(T) }
 type IntMapper = fn(Int -> Int) effects(pure);
-fn map_option(@Option<Int>, @IntMapper -> @Option<Int>)
+private fn map_option(@Option<Int>, @IntMapper -> @Option<Int>)
   requires(true) ensures(true) effects(pure)
 {
   match @Option<Int>.0 {
@@ -2930,12 +2930,12 @@ fn map_option(@Option<Int>, @IntMapper -> @Option<Int>)
     Some(@Int) -> Some(apply_fn(@IntMapper.0, @Int.0))
   }
 }
-fn make_adder(@Int -> @IntMapper)
+private fn make_adder(@Int -> @IntMapper)
   requires(true) ensures(true) effects(pure)
 {
   fn(@Int -> @Int) effects(pure) { @Int.0 + @Int.1 }
 }
-fn test(@Unit -> @Int)
+private fn test(@Unit -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   let @IntMapper = make_adder(100);
@@ -2952,7 +2952,7 @@ fn test(@Unit -> @Int)
         """A function with a function-type parameter is not skipped."""
         src = """\
 type IntToInt = fn(Int -> Int) effects(pure);
-fn apply(@IntToInt, @Int -> @Int)
+private fn apply(@IntToInt, @Int -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   apply_fn(@IntToInt.0, @Int.0)
@@ -2965,7 +2965,7 @@ fn apply(@IntToInt, @Int -> @Int)
         """WAT output includes a funcref table when closures are used."""
         src = """\
 type IntToInt = fn(Int -> Int) effects(pure);
-fn make_fn(@Unit -> @IntToInt)
+private fn make_fn(@Unit -> @IntToInt)
   requires(true) ensures(true) effects(pure)
 {
   fn(@Int -> @Int) effects(pure) { @Int.0 }
@@ -2981,17 +2981,17 @@ fn make_fn(@Unit -> @IntToInt)
         """WAT output contains call_indirect for apply_fn."""
         src = """\
 type IntToInt = fn(Int -> Int) effects(pure);
-fn apply(@IntToInt, @Int -> @Int)
+private fn apply(@IntToInt, @Int -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   apply_fn(@IntToInt.0, @Int.0)
 }
-fn make_fn(@Unit -> @IntToInt)
+private fn make_fn(@Unit -> @IntToInt)
   requires(true) ensures(true) effects(pure)
 {
   fn(@Int -> @Int) effects(pure) { @Int.0 }
 }
-fn test(@Unit -> @Int)
+private fn test(@Unit -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   let @IntToInt = make_fn(());
@@ -3006,7 +3006,7 @@ fn test(@Unit -> @Int)
         """WAT output contains a closure type signature declaration."""
         src = """\
 type IntToInt = fn(Int -> Int) effects(pure);
-fn make_fn(@Unit -> @IntToInt)
+private fn make_fn(@Unit -> @IntToInt)
   requires(true) ensures(true) effects(pure)
 {
   fn(@Int -> @Int) effects(pure) { @Int.0 }
@@ -3047,12 +3047,12 @@ fn make_fn(@Unit -> @IntToInt)
         """Multiple closures get distinct table entries."""
         src = """\
 type IntToInt = fn(Int -> Int) effects(pure);
-fn make_adder(@Int -> @IntToInt)
+private fn make_adder(@Int -> @IntToInt)
   requires(true) ensures(true) effects(pure)
 {
   fn(@Int -> @Int) effects(pure) { @Int.0 + @Int.1 }
 }
-fn test(@Unit -> @Int)
+private fn test(@Unit -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   let @IntToInt = make_adder(10);
@@ -3068,12 +3068,12 @@ fn test(@Unit -> @Int)
         """Each closure captures the value at its creation point."""
         src = """\
 type IntToInt = fn(Int -> Int) effects(pure);
-fn make_adder(@Int -> @IntToInt)
+private fn make_adder(@Int -> @IntToInt)
   requires(true) ensures(true) effects(pure)
 {
   fn(@Int -> @Int) effects(pure) { @Int.0 + @Int.1 }
 }
-fn test(@Unit -> @Int)
+private fn test(@Unit -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   let @IntToInt = make_adder(1);
@@ -3103,7 +3103,7 @@ class TestEffectHandlers:
     def test_handle_state_get_init(self) -> None:
         """handle[State<Int>](@Int = 42) in { get(()) } returns 42."""
         src = """\
-fn test(@Unit -> @Int)
+private fn test(@Unit -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   handle[State<Int>](@Int = 42) {
@@ -3119,7 +3119,7 @@ fn test(@Unit -> @Int)
     def test_handle_state_put_get(self) -> None:
         """put then get returns the put value."""
         src = """\
-fn test(@Unit -> @Int)
+private fn test(@Unit -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   handle[State<Int>](@Int = 0) {
@@ -3136,7 +3136,7 @@ fn test(@Unit -> @Int)
     def test_handle_state_increment(self) -> None:
         """put(get(()) + 1) increments the state."""
         src = """\
-fn test(@Unit -> @Int)
+private fn test(@Unit -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   handle[State<Int>](@Int = 0) {
@@ -3153,7 +3153,7 @@ fn test(@Unit -> @Int)
     def test_handle_state_run_counter(self) -> None:
         """The run_counter pattern: init 0, put 0, then 3x increment."""
         src = """\
-fn test(@Unit -> @Int)
+private fn test(@Unit -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   handle[State<Int>](@Int = 0) {
@@ -3173,7 +3173,7 @@ fn test(@Unit -> @Int)
     def test_handle_state_initial_value(self) -> None:
         """Non-zero initial state is set correctly."""
         src = """\
-fn test(@Unit -> @Int)
+private fn test(@Unit -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   handle[State<Int>](@Int = 100) {
@@ -3190,7 +3190,7 @@ fn test(@Unit -> @Int)
     def test_handle_state_in_let(self) -> None:
         """Handler body can use let bindings."""
         src = """\
-fn test(@Unit -> @Int)
+private fn test(@Unit -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   handle[State<Int>](@Int = 0) {
@@ -3209,7 +3209,7 @@ fn test(@Unit -> @Int)
     def test_handle_state_pure_function(self) -> None:
         """A pure function with handle[State<T>] compiles (not skipped)."""
         src = """\
-fn test(@Unit -> @Int)
+private fn test(@Unit -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   handle[State<Int>](@Int = 7) {
@@ -3226,7 +3226,7 @@ fn test(@Unit -> @Int)
     def test_handle_state_bool(self) -> None:
         """State<Bool> handler works."""
         src = """\
-fn test(@Unit -> @Bool)
+private fn test(@Unit -> @Bool)
   requires(true) ensures(true) effects(pure)
 {
   handle[State<Bool>](@Bool = false) {
@@ -3243,7 +3243,7 @@ fn test(@Unit -> @Bool)
     def test_handle_state_wat_has_imports(self) -> None:
         """WAT output contains state host imports."""
         src = """\
-fn test(@Unit -> @Int)
+private fn test(@Unit -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   handle[State<Int>](@Int = 0) {
@@ -3266,8 +3266,8 @@ fn test(@Unit -> @Int)
 effect Exn<E> {
   op throw(E -> Unit);
 }
-data Option<T> { None, Some(T) }
-fn test(@Int -> @Option<Int>)
+private data Option<T> { None, Some(T) }
+private fn test(@Int -> @Option<Int>)
   requires(true) ensures(true) effects(pure)
 {
   handle[Exn<Int>] {
@@ -3325,7 +3325,7 @@ fn test(@Int -> @Option<Int>)
 class TestByteType:
     def test_byte_identity(self) -> None:
         src = """
-fn f(@Byte -> @Byte) requires(true) ensures(true) effects(pure) {
+private fn f(@Byte -> @Byte) requires(true) ensures(true) effects(pure) {
   @Byte.0
 }
 """
@@ -3333,7 +3333,7 @@ fn f(@Byte -> @Byte) requires(true) ensures(true) effects(pure) {
 
     def test_byte_zero(self) -> None:
         src = """
-fn f(-> @Byte) requires(true) ensures(true) effects(pure) {
+private fn f(-> @Byte) requires(true) ensures(true) effects(pure) {
   0
 }
 """
@@ -3341,7 +3341,7 @@ fn f(-> @Byte) requires(true) ensures(true) effects(pure) {
 
     def test_byte_max(self) -> None:
         src = """
-fn f(-> @Byte) requires(true) ensures(true) effects(pure) {
+private fn f(-> @Byte) requires(true) ensures(true) effects(pure) {
   255
 }
 """
@@ -3349,7 +3349,7 @@ fn f(-> @Byte) requires(true) ensures(true) effects(pure) {
 
     def test_byte_let_binding(self) -> None:
         src = """
-fn f(@Byte -> @Byte) requires(true) ensures(true) effects(pure) {
+private fn f(@Byte -> @Byte) requires(true) ensures(true) effects(pure) {
   let @Byte = @Byte.0;
   @Byte.0
 }
@@ -3358,7 +3358,7 @@ fn f(@Byte -> @Byte) requires(true) ensures(true) effects(pure) {
 
     def test_byte_eq(self) -> None:
         src = """
-fn f(@Byte, @Byte -> @Bool) requires(true) ensures(true) effects(pure) {
+private fn f(@Byte, @Byte -> @Bool) requires(true) ensures(true) effects(pure) {
   @Byte.0 == @Byte.1
 }
 """
@@ -3368,7 +3368,7 @@ fn f(@Byte, @Byte -> @Bool) requires(true) ensures(true) effects(pure) {
     def test_byte_lt_unsigned(self) -> None:
         # @Byte.0 = second param (de Bruijn 0), @Byte.1 = first param
         src = """
-fn f(@Byte, @Byte -> @Bool) requires(true) ensures(true) effects(pure) {
+private fn f(@Byte, @Byte -> @Bool) requires(true) ensures(true) effects(pure) {
   @Byte.0 < @Byte.1
 }
 """
@@ -3379,7 +3379,7 @@ fn f(@Byte, @Byte -> @Bool) requires(true) ensures(true) effects(pure) {
 
     def test_byte_gt_unsigned(self) -> None:
         src = """
-fn f(@Byte, @Byte -> @Bool) requires(true) ensures(true) effects(pure) {
+private fn f(@Byte, @Byte -> @Bool) requires(true) ensures(true) effects(pure) {
   @Byte.0 > @Byte.1
 }
 """
@@ -3390,7 +3390,7 @@ fn f(@Byte, @Byte -> @Bool) requires(true) ensures(true) effects(pure) {
 
     def test_byte_le(self) -> None:
         src = """
-fn f(@Byte, @Byte -> @Bool) requires(true) ensures(true) effects(pure) {
+private fn f(@Byte, @Byte -> @Bool) requires(true) ensures(true) effects(pure) {
   @Byte.0 <= @Byte.1
 }
 """
@@ -3402,7 +3402,7 @@ fn f(@Byte, @Byte -> @Bool) requires(true) ensures(true) effects(pure) {
 
     def test_byte_ge(self) -> None:
         src = """
-fn f(@Byte, @Byte -> @Bool) requires(true) ensures(true) effects(pure) {
+private fn f(@Byte, @Byte -> @Bool) requires(true) ensures(true) effects(pure) {
   @Byte.0 >= @Byte.1
 }
 """
@@ -3415,7 +3415,7 @@ fn f(@Byte, @Byte -> @Bool) requires(true) ensures(true) effects(pure) {
     def test_byte_unsigned_comparison_wat(self) -> None:
         """Byte comparisons should use unsigned i32 ops."""
         src = """
-fn f(@Byte, @Byte -> @Bool) requires(true) ensures(true) effects(pure) {
+private fn f(@Byte, @Byte -> @Bool) requires(true) ensures(true) effects(pure) {
   @Byte.0 < @Byte.1
 }
 """
@@ -3431,7 +3431,7 @@ fn f(@Byte, @Byte -> @Bool) requires(true) ensures(true) effects(pure) {
 class TestArrayLit:
     def test_int_array_index_0(self) -> None:
         src = """
-fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+private fn f(-> @Int) requires(true) ensures(true) effects(pure) {
   let @Array<Int> = [10, 20, 30];
   @Array<Int>.0[0]
 }
@@ -3440,7 +3440,7 @@ fn f(-> @Int) requires(true) ensures(true) effects(pure) {
 
     def test_int_array_index_1(self) -> None:
         src = """
-fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+private fn f(-> @Int) requires(true) ensures(true) effects(pure) {
   let @Array<Int> = [10, 20, 30];
   @Array<Int>.0[1]
 }
@@ -3449,7 +3449,7 @@ fn f(-> @Int) requires(true) ensures(true) effects(pure) {
 
     def test_int_array_index_2(self) -> None:
         src = """
-fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+private fn f(-> @Int) requires(true) ensures(true) effects(pure) {
   let @Array<Int> = [10, 20, 30];
   @Array<Int>.0[2]
 }
@@ -3458,7 +3458,7 @@ fn f(-> @Int) requires(true) ensures(true) effects(pure) {
 
     def test_single_element_array(self) -> None:
         src = """
-fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+private fn f(-> @Int) requires(true) ensures(true) effects(pure) {
   let @Array<Int> = [42];
   @Array<Int>.0[0]
 }
@@ -3467,7 +3467,7 @@ fn f(-> @Int) requires(true) ensures(true) effects(pure) {
 
     def test_bool_array(self) -> None:
         src = """
-fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
+private fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
   let @Array<Bool> = [true, false, true];
   @Array<Bool>.0[1]
 }
@@ -3477,7 +3477,7 @@ fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
     def test_array_wat_has_alloc(self) -> None:
         """Array literal WAT should contain call $alloc."""
         src = """
-fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+private fn f(-> @Int) requires(true) ensures(true) effects(pure) {
   let @Array<Int> = [1, 2, 3];
   @Array<Int>.0[0]
 }
@@ -3488,7 +3488,7 @@ fn f(-> @Int) requires(true) ensures(true) effects(pure) {
     def test_array_wat_has_bounds_check(self) -> None:
         """Array indexing WAT should contain unreachable for OOB."""
         src = """
-fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+private fn f(-> @Int) requires(true) ensures(true) effects(pure) {
   let @Array<Int> = [1, 2, 3];
   @Array<Int>.0[0]
 }
@@ -3505,7 +3505,7 @@ fn f(-> @Int) requires(true) ensures(true) effects(pure) {
 class TestArrayBoundsCheck:
     def test_oob_positive_index(self) -> None:
         src = """
-fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+private fn f(-> @Int) requires(true) ensures(true) effects(pure) {
   let @Array<Int> = [10, 20, 30];
   @Array<Int>.0[3]
 }
@@ -3514,7 +3514,7 @@ fn f(-> @Int) requires(true) ensures(true) effects(pure) {
 
     def test_oob_large_index(self) -> None:
         src = """
-fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+private fn f(-> @Int) requires(true) ensures(true) effects(pure) {
   let @Array<Int> = [10, 20, 30];
   @Array<Int>.0[100]
 }
@@ -3523,7 +3523,7 @@ fn f(-> @Int) requires(true) ensures(true) effects(pure) {
 
     def test_last_valid_index(self) -> None:
         src = """
-fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+private fn f(-> @Int) requires(true) ensures(true) effects(pure) {
   let @Array<Int> = [10, 20, 30];
   @Array<Int>.0[2]
 }
@@ -3532,7 +3532,7 @@ fn f(-> @Int) requires(true) ensures(true) effects(pure) {
 
     def test_first_valid_index(self) -> None:
         src = """
-fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+private fn f(-> @Int) requires(true) ensures(true) effects(pure) {
   let @Array<Int> = [10, 20, 30];
   @Array<Int>.0[0]
 }
@@ -3548,7 +3548,7 @@ fn f(-> @Int) requires(true) ensures(true) effects(pure) {
 class TestArrayLength:
     def test_length_three(self) -> None:
         src = """
-fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+private fn f(-> @Int) requires(true) ensures(true) effects(pure) {
   let @Array<Int> = [10, 20, 30];
   length(@Array<Int>.0)
 }
@@ -3557,7 +3557,7 @@ fn f(-> @Int) requires(true) ensures(true) effects(pure) {
 
     def test_length_one(self) -> None:
         src = """
-fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+private fn f(-> @Int) requires(true) ensures(true) effects(pure) {
   let @Array<Int> = [42];
   length(@Array<Int>.0)
 }
@@ -3566,7 +3566,7 @@ fn f(-> @Int) requires(true) ensures(true) effects(pure) {
 
     def test_length_in_comparison(self) -> None:
         src = """
-fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
+private fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
   let @Array<Int> = [10, 20, 30];
   length(@Array<Int>.0) == 3
 }
@@ -3575,7 +3575,7 @@ fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
 
     def test_length_in_let(self) -> None:
         src = """
-fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+private fn f(-> @Int) requires(true) ensures(true) effects(pure) {
   let @Array<Int> = [1, 2, 3, 4, 5];
   let @Int = length(@Array<Int>.0);
   @Int.0
@@ -3586,10 +3586,10 @@ fn f(-> @Int) requires(true) ensures(true) effects(pure) {
     def test_array_fn_param_compiles(self) -> None:
         """Functions with Array params should compile with pair params."""
         src = """
-fn f(@Array<Int> -> @Int) requires(true) ensures(true) effects(pure) {
+private fn f(@Array<Int> -> @Int) requires(true) ensures(true) effects(pure) {
   @Array<Int>.0[0]
 }
-fn g(-> @Int) requires(true) ensures(true) effects(pure) {
+private fn g(-> @Int) requires(true) ensures(true) effects(pure) {
   42
 }
 """
@@ -3611,7 +3611,7 @@ class TestAssertAssume:
     def test_assert_true(self) -> None:
         """assert(true) should not trap."""
         assert _run("""
-fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+private fn f(-> @Int) requires(true) ensures(true) effects(pure) {
   assert(true);
   42
 }
@@ -3620,7 +3620,7 @@ fn f(-> @Int) requires(true) ensures(true) effects(pure) {
     def test_assert_false(self) -> None:
         """assert(false) should trap."""
         _run_trap("""
-fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+private fn f(-> @Int) requires(true) ensures(true) effects(pure) {
   assert(false);
   42
 }
@@ -3629,7 +3629,7 @@ fn f(-> @Int) requires(true) ensures(true) effects(pure) {
     def test_assert_with_expression(self) -> None:
         """assert with a computed expression."""
         assert _run("""
-fn f(@Int -> @Int) requires(true) ensures(true) effects(pure) {
+private fn f(@Int -> @Int) requires(true) ensures(true) effects(pure) {
   assert(@Int.0 > 0);
   @Int.0 + 1
 }
@@ -3638,7 +3638,7 @@ fn f(@Int -> @Int) requires(true) ensures(true) effects(pure) {
     def test_assert_expression_false_traps(self) -> None:
         """assert with expression that evaluates to false."""
         _run_trap("""
-fn f(@Int -> @Int) requires(true) ensures(true) effects(pure) {
+private fn f(@Int -> @Int) requires(true) ensures(true) effects(pure) {
   assert(@Int.0 > 0);
   @Int.0
 }
@@ -3647,7 +3647,7 @@ fn f(@Int -> @Int) requires(true) ensures(true) effects(pure) {
     def test_assert_in_sequence(self) -> None:
         """assert followed by computation."""
         assert _run("""
-fn f(@Int, @Int -> @Int) requires(true) ensures(true) effects(pure) {
+private fn f(@Int, @Int -> @Int) requires(true) ensures(true) effects(pure) {
   assert(@Int.1 > 0);
   let @Int = @Int.1 + @Int.0;
   assert(@Int.0 > 0);
@@ -3658,7 +3658,7 @@ fn f(@Int, @Int -> @Int) requires(true) ensures(true) effects(pure) {
     def test_assume_is_noop(self) -> None:
         """assume should be a no-op at runtime."""
         assert _run("""
-fn f(@Int -> @Int) requires(true) ensures(true) effects(pure) {
+private fn f(@Int -> @Int) requires(true) ensures(true) effects(pure) {
   assume(@Int.0 > 0);
   @Int.0 * 2
 }
@@ -3667,7 +3667,7 @@ fn f(@Int -> @Int) requires(true) ensures(true) effects(pure) {
     def test_assert_wat_contains_unreachable(self) -> None:
         """WAT should contain unreachable for assert."""
         result = _compile_ok("""
-fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+private fn f(-> @Int) requires(true) ensures(true) effects(pure) {
   assert(true);
   1
 }
@@ -3684,7 +3684,7 @@ class TestForall:
     def test_forall_all_positive(self) -> None:
         """forall over array where all elements satisfy predicate."""
         assert _run("""
-fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
+private fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
   let @Array<Int> = [1, 2, 3];
   forall(@Int, length(@Array<Int>.0), fn(@Int -> @Bool) effects(pure) {
     @Array<Int>.0[@Int.0] > 0
@@ -3695,7 +3695,7 @@ fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
     def test_forall_not_all_positive(self) -> None:
         """forall over array where one element fails predicate."""
         assert _run("""
-fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
+private fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
   let @Array<Int> = [1, -2, 3];
   forall(@Int, length(@Array<Int>.0), fn(@Int -> @Bool) effects(pure) {
     @Array<Int>.0[@Int.0] > 0
@@ -3706,7 +3706,7 @@ fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
     def test_forall_empty_domain(self) -> None:
         """forall with empty domain should be vacuously true."""
         assert _run("""
-fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
+private fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
   forall(@Int, 0, fn(@Int -> @Bool) effects(pure) {
     false
   })
@@ -3716,7 +3716,7 @@ fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
     def test_forall_single_element_true(self) -> None:
         """forall with single element, predicate true."""
         assert _run("""
-fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
+private fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
   let @Array<Int> = [42];
   forall(@Int, length(@Array<Int>.0), fn(@Int -> @Bool) effects(pure) {
     @Array<Int>.0[@Int.0] > 0
@@ -3727,7 +3727,7 @@ fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
     def test_forall_single_element_false(self) -> None:
         """forall with single element, predicate false."""
         assert _run("""
-fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
+private fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
   let @Array<Int> = [-1];
   forall(@Int, length(@Array<Int>.0), fn(@Int -> @Bool) effects(pure) {
     @Array<Int>.0[@Int.0] > 0
@@ -3738,7 +3738,7 @@ fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
     def test_forall_all_equal(self) -> None:
         """forall checking all elements equal a value."""
         assert _run("""
-fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
+private fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
   let @Array<Int> = [7, 7, 7];
   forall(@Int, length(@Array<Int>.0), fn(@Int -> @Bool) effects(pure) {
     @Array<Int>.0[@Int.0] == 7
@@ -3756,7 +3756,7 @@ class TestExists:
     def test_exists_has_zero(self) -> None:
         """exists with one matching element."""
         assert _run("""
-fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
+private fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
   let @Array<Int> = [1, 0, 3];
   exists(@Int, length(@Array<Int>.0), fn(@Int -> @Bool) effects(pure) {
     @Array<Int>.0[@Int.0] == 0
@@ -3767,7 +3767,7 @@ fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
     def test_exists_no_match(self) -> None:
         """exists with no matching element."""
         assert _run("""
-fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
+private fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
   let @Array<Int> = [1, 2, 3];
   exists(@Int, length(@Array<Int>.0), fn(@Int -> @Bool) effects(pure) {
     @Array<Int>.0[@Int.0] == 0
@@ -3778,7 +3778,7 @@ fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
     def test_exists_empty_domain(self) -> None:
         """exists with empty domain should be false."""
         assert _run("""
-fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
+private fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
   exists(@Int, 0, fn(@Int -> @Bool) effects(pure) {
     true
   })
@@ -3788,7 +3788,7 @@ fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
     def test_exists_single_element_true(self) -> None:
         """exists with single matching element."""
         assert _run("""
-fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
+private fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
   let @Array<Int> = [0];
   exists(@Int, length(@Array<Int>.0), fn(@Int -> @Bool) effects(pure) {
     @Array<Int>.0[@Int.0] == 0
@@ -3799,7 +3799,7 @@ fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
     def test_exists_single_element_false(self) -> None:
         """exists with single non-matching element."""
         assert _run("""
-fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
+private fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
   let @Array<Int> = [5];
   exists(@Int, length(@Array<Int>.0), fn(@Int -> @Bool) effects(pure) {
     @Array<Int>.0[@Int.0] == 0
@@ -3817,7 +3817,7 @@ class TestQuantifierWat:
     def test_forall_wat_has_loop(self) -> None:
         """WAT for forall should contain loop and block."""
         result = _compile_ok("""
-fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
+private fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
   let @Array<Int> = [1, 2, 3];
   forall(@Int, length(@Array<Int>.0), fn(@Int -> @Bool) effects(pure) {
     @Array<Int>.0[@Int.0] > 0
@@ -3831,7 +3831,7 @@ fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
     def test_exists_wat_has_loop(self) -> None:
         """WAT for exists should contain loop and block."""
         result = _compile_ok("""
-fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
+private fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
   let @Array<Int> = [1, 2, 3];
   exists(@Int, length(@Array<Int>.0), fn(@Int -> @Bool) effects(pure) {
     @Array<Int>.0[@Int.0] == 0
@@ -3859,7 +3859,7 @@ type Percentage = { @Int | @Int.0 >= 0 && @Int.0 <= 100 };
 
     def test_safe_divide_basic(self) -> None:
         val = _run(self._PREAMBLE + """
-fn safe_divide(@Int, @PosInt -> @Int)
+private fn safe_divide(@Int, @PosInt -> @Int)
   requires(true) ensures(true) effects(pure)
 { @Int.0 / @PosInt.0 }
 """, fn="safe_divide", args=[10, 2])
@@ -3867,7 +3867,7 @@ fn safe_divide(@Int, @PosInt -> @Int)
 
     def test_safe_divide_integer_division(self) -> None:
         val = _run(self._PREAMBLE + """
-fn safe_divide(@Int, @PosInt -> @Int)
+private fn safe_divide(@Int, @PosInt -> @Int)
   requires(true) ensures(true) effects(pure)
 { @Int.0 / @PosInt.0 }
 """, fn="safe_divide", args=[7, 3])
@@ -3875,7 +3875,7 @@ fn safe_divide(@Int, @PosInt -> @Int)
 
     def test_to_percentage_clamp_low(self) -> None:
         val = _run(self._PREAMBLE + """
-fn to_percentage(@Int -> @Percentage)
+private fn to_percentage(@Int -> @Percentage)
   requires(true) ensures(true) effects(pure)
 {
   if @Int.0 < 0 then { 0 }
@@ -3886,7 +3886,7 @@ fn to_percentage(@Int -> @Percentage)
 
     def test_to_percentage_passthrough(self) -> None:
         val = _run(self._PREAMBLE + """
-fn to_percentage(@Int -> @Percentage)
+private fn to_percentage(@Int -> @Percentage)
   requires(true) ensures(true) effects(pure)
 {
   if @Int.0 < 0 then { 0 }
@@ -3897,7 +3897,7 @@ fn to_percentage(@Int -> @Percentage)
 
     def test_to_percentage_clamp_high(self) -> None:
         val = _run(self._PREAMBLE + """
-fn to_percentage(@Int -> @Percentage)
+private fn to_percentage(@Int -> @Percentage)
   requires(true) ensures(true) effects(pure)
 {
   if @Int.0 < 0 then { 0 }
@@ -3909,7 +3909,7 @@ fn to_percentage(@Int -> @Percentage)
     def test_refined_type_let_binding(self) -> None:
         """Let binding to a refined type alias resolves correctly."""
         val = _run(self._PREAMBLE + """
-fn f(@Int -> @Int)
+private fn f(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   let @PosInt = @Int.0;
@@ -3921,14 +3921,14 @@ fn f(@Int -> @Int)
     def test_refined_return_in_expr(self) -> None:
         """Function returning a refined type works in expressions."""
         val = _run(self._PREAMBLE + """
-fn clamp(@Int -> @Percentage)
+private fn clamp(@Int -> @Percentage)
   requires(true) ensures(true) effects(pure)
 {
   if @Int.0 < 0 then { 0 }
   else { if @Int.0 > 100 then { 100 } else { @Int.0 } }
 }
 
-fn main(-> @Int) requires(true) ensures(true) effects(pure) {
+private fn main(-> @Int) requires(true) ensures(true) effects(pure) {
   clamp(200) + clamp(50)
 }
 """)
@@ -3937,11 +3937,11 @@ fn main(-> @Int) requires(true) ensures(true) effects(pure) {
     def test_refined_type_exports_in_wat(self) -> None:
         """WAT should contain function exports for refined-type fns."""
         result = _compile_ok(self._PREAMBLE + """
-fn safe_divide(@Int, @PosInt -> @Int)
+private fn safe_divide(@Int, @PosInt -> @Int)
   requires(true) ensures(true) effects(pure)
 { @Int.0 / @PosInt.0 }
 
-fn to_percentage(@Int -> @Percentage)
+private fn to_percentage(@Int -> @Percentage)
   requires(true) ensures(true) effects(pure)
 {
   if @Int.0 < 0 then { 0 }
@@ -3963,7 +3963,7 @@ class TestStringArraySignatures:
     def test_string_param(self) -> None:
         """Function taking a String param compiles with pair params."""
         src = """
-fn say(@String -> @Unit)
+private fn say(@String -> @Unit)
   requires(true) ensures(true) effects(<IO>)
 { IO.print(@String.0) }
 """
@@ -3975,7 +3975,7 @@ fn say(@String -> @Unit)
     def test_string_return(self) -> None:
         """Function returning a String compiles with (result i32 i32)."""
         src = '''
-fn greeting(-> @String)
+private fn greeting(-> @String)
   requires(true) ensures(true) effects(pure)
 { "hello" }
 '''
@@ -3986,7 +3986,7 @@ fn greeting(-> @String)
     def test_string_param_and_return(self) -> None:
         """String param + String return: identity-like function."""
         src = """
-fn echo(@String -> @String)
+private fn echo(@String -> @String)
   requires(true) ensures(true) effects(pure)
 { @String.0 }
 """
@@ -3998,11 +3998,11 @@ fn echo(@String -> @String)
     def test_string_call_chain(self) -> None:
         """String-returning fn called by another fn via IO.print."""
         src = '''
-fn greeting(-> @String)
+private fn greeting(-> @String)
   requires(true) ensures(true) effects(pure)
 { "hello world" }
 
-fn main(-> @Unit)
+private fn main(-> @Unit)
   requires(true) ensures(true) effects(<IO>)
 { IO.print(greeting()) }
 '''
@@ -4013,7 +4013,7 @@ fn main(-> @Unit)
     def test_array_param(self) -> None:
         """Function taking an Array<Int> param compiles with pair params."""
         src = """
-fn get_len(@Array<Int> -> @Int)
+private fn get_len(@Array<Int> -> @Int)
   requires(true) ensures(true) effects(pure)
 { length(@Array<Int>.0) }
 """
@@ -4025,7 +4025,7 @@ fn get_len(@Array<Int> -> @Int)
     def test_array_return(self) -> None:
         """Function returning an Array literal compiles."""
         src = """
-fn nums(-> @Array<Int>)
+private fn nums(-> @Array<Int>)
   requires(true) ensures(true) effects(pure)
 { [1, 2, 3] }
 """
@@ -4036,7 +4036,7 @@ fn nums(-> @Array<Int>)
     def test_mixed_params(self) -> None:
         """Function with both pair and primitive params."""
         src = """
-fn add_to(@Int, @String -> @Int)
+private fn add_to(@Int, @String -> @Int)
   requires(true) ensures(true) effects(pure)
 { @Int.0 + 1 }
 """
@@ -4053,7 +4053,7 @@ fn add_to(@Int, @String -> @Int)
     def test_string_return_execution(self) -> None:
         """Executing a String-returning function returns a pointer."""
         src = '''
-fn hello(-> @String)
+private fn hello(-> @String)
   requires(true) ensures(true) effects(pure)
 { "hello" }
 '''
@@ -4074,7 +4074,7 @@ class TestOldNewContracts:
     def test_old_new_postcondition_compiles(self) -> None:
         """Function with old()/new() in ensures clause compiles to WASM."""
         src = """
-fn increment(@Unit -> @Unit)
+private fn increment(@Unit -> @Unit)
   requires(true)
   ensures(new(State<Int>) == old(State<Int>) + 1)
   effects(<State<Int>>)
@@ -4090,7 +4090,7 @@ fn increment(@Unit -> @Unit)
     def test_old_new_postcondition_passes(self) -> None:
         """Postcondition holds — no trap when new == old + 1."""
         src = """
-fn increment(@Unit -> @Unit)
+private fn increment(@Unit -> @Unit)
   requires(true)
   ensures(new(State<Int>) == old(State<Int>) + 1)
   effects(<State<Int>>)
@@ -4111,7 +4111,7 @@ fn increment(@Unit -> @Unit)
     def test_old_new_postcondition_traps(self) -> None:
         """Postcondition violated — traps when increment is wrong."""
         src = """
-fn bad_increment(@Unit -> @Unit)
+private fn bad_increment(@Unit -> @Unit)
   requires(true)
   ensures(new(State<Int>) == old(State<Int>) + 1)
   effects(<State<Int>>)
@@ -4131,7 +4131,7 @@ fn bad_increment(@Unit -> @Unit)
     def test_trivial_ensures_no_snapshot(self) -> None:
         """ensures(true) with State effect does NOT emit a snapshot."""
         src = """
-fn inc(@Unit -> @Unit)
+private fn inc(@Unit -> @Unit)
   requires(true) ensures(true)
   effects(<State<Int>>)
 {
@@ -4157,7 +4157,7 @@ fn inc(@Unit -> @Unit)
     def test_old_new_wat_structure(self) -> None:
         """WAT contains state_get snapshot before body and new() in postcondition."""
         src = """
-fn increment(@Unit -> @Unit)
+private fn increment(@Unit -> @Unit)
   requires(true)
   ensures(new(State<Int>) == old(State<Int>) + 1)
   effects(<State<Int>>)
@@ -4180,7 +4180,7 @@ fn increment(@Unit -> @Unit)
         """new(State<T>) reads the current value, not the snapshot."""
         # Increment by 5 but claim increment by 5 in postcondition
         src = """
-fn add_five(@Unit -> @Unit)
+private fn add_five(@Unit -> @Unit)
   requires(true)
   ensures(new(State<Int>) == old(State<Int>) + 5)
   effects(<State<Int>>)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -31,64 +31,64 @@ def test_example_files_parse(filename: str) -> None:
 
 class TestExpressions:
     def test_integer_literal(self) -> None:
-        tree = parse("fn f(@Unit -> @Int) requires(true) ensures(true) effects(pure) { 42 }")
+        tree = parse("private fn f(@Unit -> @Int) requires(true) ensures(true) effects(pure) { 42 }")
         assert tree is not None
 
     def test_arithmetic(self) -> None:
-        parse("fn f(@Int -> @Int) requires(true) ensures(true) effects(pure) { @Int.0 + 1 }")
-        parse("fn f(@Int -> @Int) requires(true) ensures(true) effects(pure) { @Int.0 * 2 - 3 }")
-        parse("fn f(@Int -> @Int) requires(true) ensures(true) effects(pure) { @Int.0 / 2 % 3 }")
+        parse("private fn f(@Int -> @Int) requires(true) ensures(true) effects(pure) { @Int.0 + 1 }")
+        parse("private fn f(@Int -> @Int) requires(true) ensures(true) effects(pure) { @Int.0 * 2 - 3 }")
+        parse("private fn f(@Int -> @Int) requires(true) ensures(true) effects(pure) { @Int.0 / 2 % 3 }")
 
     def test_comparison(self) -> None:
-        parse("fn f(@Int -> @Bool) requires(true) ensures(true) effects(pure) { @Int.0 > 0 }")
-        parse("fn f(@Int -> @Bool) requires(true) ensures(true) effects(pure) { @Int.0 <= 10 }")
+        parse("private fn f(@Int -> @Bool) requires(true) ensures(true) effects(pure) { @Int.0 > 0 }")
+        parse("private fn f(@Int -> @Bool) requires(true) ensures(true) effects(pure) { @Int.0 <= 10 }")
 
     def test_boolean_operators(self) -> None:
-        parse("fn f(@Bool, @Bool -> @Bool) requires(true) ensures(true) effects(pure) { @Bool.0 && @Bool.1 }")
-        parse("fn f(@Bool, @Bool -> @Bool) requires(true) ensures(true) effects(pure) { @Bool.0 || @Bool.1 }")
-        parse("fn f(@Bool -> @Bool) requires(true) ensures(true) effects(pure) { !@Bool.0 }")
+        parse("private fn f(@Bool, @Bool -> @Bool) requires(true) ensures(true) effects(pure) { @Bool.0 && @Bool.1 }")
+        parse("private fn f(@Bool, @Bool -> @Bool) requires(true) ensures(true) effects(pure) { @Bool.0 || @Bool.1 }")
+        parse("private fn f(@Bool -> @Bool) requires(true) ensures(true) effects(pure) { !@Bool.0 }")
 
     def test_implies(self) -> None:
-        parse("fn f(@Bool, @Bool -> @Bool) requires(true) ensures(true) effects(pure) { @Bool.0 ==> @Bool.1 }")
+        parse("private fn f(@Bool, @Bool -> @Bool) requires(true) ensures(true) effects(pure) { @Bool.0 ==> @Bool.1 }")
 
     def test_pipe(self) -> None:
-        parse("fn f(@Int -> @Int) requires(true) ensures(true) effects(pure) { @Int.0 + 1 |> abs() }")
+        parse("private fn f(@Int -> @Int) requires(true) ensures(true) effects(pure) { @Int.0 + 1 |> abs() }")
 
     def test_negation(self) -> None:
-        parse("fn f(@Int -> @Int) requires(true) ensures(true) effects(pure) { -@Int.0 }")
+        parse("private fn f(@Int -> @Int) requires(true) ensures(true) effects(pure) { -@Int.0 }")
 
     def test_parenthesized(self) -> None:
-        parse("fn f(@Int -> @Int) requires(true) ensures(true) effects(pure) { (@Int.0 + 1) * 2 }")
+        parse("private fn f(@Int -> @Int) requires(true) ensures(true) effects(pure) { (@Int.0 + 1) * 2 }")
 
     def test_array_literal(self) -> None:
-        parse("fn f(@Unit -> @Array<Int>) requires(true) ensures(true) effects(pure) { [1, 2, 3] }")
+        parse("private fn f(@Unit -> @Array<Int>) requires(true) ensures(true) effects(pure) { [1, 2, 3] }")
 
     def test_array_index(self) -> None:
-        parse("fn f(@Array<Int> -> @Int) requires(true) ensures(true) effects(pure) { @Array<Int>.0[0] }")
+        parse("private fn f(@Array<Int> -> @Int) requires(true) ensures(true) effects(pure) { @Array<Int>.0[0] }")
 
     def test_string_literal(self) -> None:
-        parse('fn f(@Unit -> @String) requires(true) ensures(true) effects(pure) { "hello" }')
+        parse('private fn f(@Unit -> @String) requires(true) ensures(true) effects(pure) { "hello" }')
 
     def test_unit_literal(self) -> None:
-        parse("fn f(@Unit -> @Unit) requires(true) ensures(true) effects(pure) { () }")
+        parse("private fn f(@Unit -> @Unit) requires(true) ensures(true) effects(pure) { () }")
 
 
 class TestFunctions:
     def test_multiple_params(self) -> None:
-        parse("fn f(@Int, @Bool, @String -> @Int) requires(true) ensures(true) effects(pure) { @Int.0 }")
+        parse("private fn f(@Int, @Bool, @String -> @Int) requires(true) ensures(true) effects(pure) { @Int.0 }")
 
     def test_multiple_requires(self) -> None:
-        parse("fn f(@Int -> @Int) requires(@Int.0 > 0) requires(@Int.0 < 100) ensures(true) effects(pure) { @Int.0 }")
+        parse("private fn f(@Int -> @Int) requires(@Int.0 > 0) requires(@Int.0 < 100) ensures(true) effects(pure) { @Int.0 }")
 
     def test_multiple_ensures(self) -> None:
-        parse("fn f(@Int -> @Nat) requires(true) ensures(@Nat.result >= 0) ensures(@Nat.result <= @Int.0) effects(pure) { @Int.0 }")
+        parse("private fn f(@Int -> @Nat) requires(true) ensures(@Nat.result >= 0) ensures(@Nat.result <= @Int.0) effects(pure) { @Int.0 }")
 
     def test_decreases_clause(self) -> None:
-        parse("fn f(@Nat -> @Nat) requires(true) ensures(true) decreases(@Nat.0) effects(pure) { @Nat.0 }")
+        parse("private fn f(@Nat -> @Nat) requires(true) ensures(true) decreases(@Nat.0) effects(pure) { @Nat.0 }")
 
     def test_recursive_call(self) -> None:
         parse("""
-        fn f(@Nat -> @Nat)
+        private fn f(@Nat -> @Nat)
           requires(true)
           ensures(true)
           decreases(@Nat.0)
@@ -100,7 +100,7 @@ class TestFunctions:
 
     def test_where_block(self) -> None:
         parse("""
-        fn outer(@Int -> @Int)
+        private fn outer(@Int -> @Int)
           requires(true)
           ensures(true)
           effects(pure)
@@ -122,7 +122,7 @@ class TestFunctions:
 class TestConditionals:
     def test_if_then_else(self) -> None:
         parse("""
-        fn f(@Bool -> @Int)
+        private fn f(@Bool -> @Int)
           requires(true)
           ensures(true)
           effects(pure)
@@ -135,9 +135,9 @@ class TestConditionals:
 class TestPatternMatching:
     def test_match_constructors(self) -> None:
         parse("""
-        data Color { Red, Green, Blue }
+        private data Color { Red, Green, Blue }
 
-        fn to_int(@Color -> @Int)
+        private fn to_int(@Color -> @Int)
           requires(true)
           ensures(true)
           effects(pure)
@@ -152,9 +152,9 @@ class TestPatternMatching:
 
     def test_match_with_binding(self) -> None:
         parse("""
-        data Maybe<T> { Nothing, Just(T) }
+        private data Maybe<T> { Nothing, Just(T) }
 
-        fn unwrap_or(@Maybe<Int>, @Int -> @Int)
+        private fn unwrap_or(@Maybe<Int>, @Int -> @Int)
           requires(true)
           ensures(true)
           effects(pure)
@@ -168,7 +168,7 @@ class TestPatternMatching:
 
     def test_wildcard_pattern(self) -> None:
         parse("""
-        fn f(@Int -> @Int)
+        private fn f(@Int -> @Int)
           requires(true)
           ensures(true)
           effects(pure)
@@ -183,16 +183,16 @@ class TestPatternMatching:
 
 class TestEffects:
     def test_pure(self) -> None:
-        parse("fn f(@Int -> @Int) requires(true) ensures(true) effects(pure) { @Int.0 }")
+        parse("private fn f(@Int -> @Int) requires(true) ensures(true) effects(pure) { @Int.0 }")
 
     def test_single_effect(self) -> None:
-        parse("fn f(@Unit -> @Unit) requires(true) ensures(true) effects(<IO>) { () }")
+        parse("private fn f(@Unit -> @Unit) requires(true) ensures(true) effects(<IO>) { () }")
 
     def test_parameterized_effect(self) -> None:
-        parse("fn f(@Unit -> @Unit) requires(true) ensures(true) effects(<State<Int>>) { () }")
+        parse("private fn f(@Unit -> @Unit) requires(true) ensures(true) effects(<State<Int>>) { () }")
 
     def test_multiple_effects(self) -> None:
-        parse("fn f(@Unit -> @Unit) requires(true) ensures(true) effects(<State<Int>, IO>) { () }")
+        parse("private fn f(@Unit -> @Unit) requires(true) ensures(true) effects(<State<Int>, IO>) { () }")
 
     def test_effect_declaration(self) -> None:
         parse("""
@@ -204,7 +204,7 @@ class TestEffects:
 
     def test_handler(self) -> None:
         parse("""
-        fn f(@Unit -> @Int)
+        private fn f(@Unit -> @Int)
           requires(true)
           ensures(true)
           effects(pure)
@@ -223,7 +223,7 @@ class TestEffects:
 class TestBlocks:
     def test_let_binding(self) -> None:
         parse("""
-        fn f(@Int -> @Int)
+        private fn f(@Int -> @Int)
           requires(true)
           ensures(true)
           effects(pure)
@@ -235,7 +235,7 @@ class TestBlocks:
 
     def test_multiple_statements(self) -> None:
         parse("""
-        fn f(@Int -> @Int)
+        private fn f(@Int -> @Int)
           requires(true)
           ensures(true)
           effects(pure)
@@ -248,7 +248,7 @@ class TestBlocks:
 
     def test_expression_statement(self) -> None:
         parse("""
-        fn f(@Unit -> @Unit)
+        private fn f(@Unit -> @Unit)
           requires(true)
           ensures(true)
           effects(<IO>)
@@ -262,7 +262,7 @@ class TestBlocks:
 class TestContracts:
     def test_old_new_in_ensures(self) -> None:
         parse("""
-        fn f(@Unit -> @Unit)
+        private fn f(@Unit -> @Unit)
           requires(true)
           ensures(new(State<Int>) == old(State<Int>) + 1)
           effects(<State<Int>>)
@@ -273,7 +273,7 @@ class TestContracts:
 
     def test_result_reference(self) -> None:
         parse("""
-        fn f(@Int -> @Int)
+        private fn f(@Int -> @Int)
           requires(true)
           ensures(@Int.result >= 0)
           effects(pure)
@@ -285,14 +285,14 @@ class TestContracts:
 
 class TestDataTypes:
     def test_simple_adt(self) -> None:
-        parse("data Bool { True, False }")
+        parse("private data Bool { True, False }")
 
     def test_parameterized_adt(self) -> None:
-        parse("data Option<T> { None, Some(T) }")
+        parse("private data Option<T> { None, Some(T) }")
 
     def test_adt_with_invariant(self) -> None:
         parse("""
-        data Positive invariant(@Int.0 > 0) {
+        private data Positive invariant(@Int.0 > 0) {
           MkPositive(Int)
         }
         """)
@@ -330,7 +330,7 @@ class TestComments:
     def test_line_comment(self) -> None:
         parse("""
         -- this is a comment
-        fn f(@Int -> @Int)
+        private fn f(@Int -> @Int)
           requires(true)
           ensures(true)
           effects(pure)
@@ -342,7 +342,7 @@ class TestComments:
     def test_block_comment(self) -> None:
         parse("""
         {- block comment -}
-        fn f(@Int -> @Int)
+        private fn f(@Int -> @Int)
           requires(true)
           ensures(true)
           effects(pure)
@@ -353,7 +353,7 @@ class TestComments:
 
     def test_annotation_comment(self) -> None:
         parse("""
-        fn add(@Int /* left */, @Int /* right */ -> @Int /* sum */)
+        private fn add(@Int /* left */, @Int /* right */ -> @Int /* sum */)
           requires(true)
           ensures(@Int.result == @Int.0 + @Int.1)
           effects(pure)
@@ -365,7 +365,7 @@ class TestComments:
     def test_annotation_comment_standalone(self) -> None:
         parse("""
         /* Helper function */
-        fn id(@Int -> @Int)
+        private fn id(@Int -> @Int)
           requires(true)
           ensures(true)
           effects(pure)
@@ -379,7 +379,7 @@ class TestComments:
         -- Line comment
         {- Block comment -}
         /* Annotation comment */
-        fn f(@Int -> @Int)
+        private fn f(@Int -> @Int)
           requires(true)
           ensures(true)
           effects(pure)
@@ -397,7 +397,7 @@ class TestComments:
 class TestAnonymousFunctions:
     def test_closure_as_argument(self) -> None:
         parse("""
-        fn f(@Int -> @Int)
+        private fn f(@Int -> @Int)
           requires(true)
           ensures(true)
           effects(pure)
@@ -411,7 +411,7 @@ class TestAnonymousFunctions:
         parse("""
         type IntToInt = fn(Int -> Int) effects(pure);
 
-        fn apply(@IntToInt, @Int -> @Int)
+        private fn apply(@IntToInt, @Int -> @Int)
           requires(true)
           ensures(true)
           effects(pure)
@@ -423,7 +423,7 @@ class TestAnonymousFunctions:
     def test_closure_in_let(self) -> None:
         """Anonymous functions can be bound in let statements."""
         parse("""
-        fn f(@Int -> @Int)
+        private fn f(@Int -> @Int)
           requires(true)
           ensures(true)
           effects(pure)
@@ -437,7 +437,7 @@ class TestAnonymousFunctions:
 class TestGenerics:
     def test_forall_single_type_var(self) -> None:
         parse("""
-        forall<T> fn identity(@T -> @T)
+        private forall<T> fn identity(@T -> @T)
           requires(true)
           ensures(true)
           effects(pure)
@@ -448,7 +448,7 @@ class TestGenerics:
 
     def test_forall_multiple_type_vars(self) -> None:
         parse("""
-        forall<A, B> fn const(@A, @B -> @A)
+        private forall<A, B> fn const(@A, @B -> @A)
           requires(true)
           ensures(true)
           effects(pure)
@@ -459,7 +459,7 @@ class TestGenerics:
 
     def test_generic_data_type_multiple_params(self) -> None:
         parse("""
-        data Either<L, R> {
+        private data Either<L, R> {
           Left(L),
           Right(R)
         }
@@ -467,7 +467,7 @@ class TestGenerics:
 
     def test_generic_function_call(self) -> None:
         parse("""
-        forall<T> fn wrap(@T -> @Option<T>)
+        private forall<T> fn wrap(@T -> @Option<T>)
           requires(true)
           ensures(true)
           effects(pure)
@@ -486,7 +486,7 @@ class TestRefinementTypes:
         parse("""
         type NonNegInt = { @Int | @Int.0 >= 0 };
 
-        fn sqrt(@NonNegInt -> @Int)
+        private fn sqrt(@NonNegInt -> @Int)
           requires(true)
           ensures(@Int.result >= 0)
           effects(pure)
@@ -502,7 +502,7 @@ class TestRefinementTypes:
 class TestTupleDestructuring:
     def test_basic_destruct(self) -> None:
         parse("""
-        fn swap(@Tuple<Int, String> -> @Tuple<String, Int>)
+        private fn swap(@Tuple<Int, String> -> @Tuple<String, Int>)
           requires(true)
           ensures(true)
           effects(pure)
@@ -516,7 +516,7 @@ class TestTupleDestructuring:
 class TestQuantifiers:
     def test_forall_expr(self) -> None:
         parse("""
-        fn all_positive(@Array<Int> -> @Bool)
+        private fn all_positive(@Array<Int> -> @Bool)
           requires(true)
           ensures(true)
           effects(pure)
@@ -529,7 +529,7 @@ class TestQuantifiers:
 
     def test_exists_expr(self) -> None:
         parse("""
-        fn has_zero(@Array<Int> -> @Bool)
+        private fn has_zero(@Array<Int> -> @Bool)
           requires(true)
           ensures(true)
           effects(pure)
@@ -544,7 +544,7 @@ class TestQuantifiers:
 class TestAssertAssume:
     def test_assert(self) -> None:
         parse("""
-        fn f(@Int -> @Int)
+        private fn f(@Int -> @Int)
           requires(true)
           ensures(true)
           effects(pure)
@@ -556,7 +556,7 @@ class TestAssertAssume:
 
     def test_assume(self) -> None:
         parse("""
-        fn f(@Int -> @Int)
+        private fn f(@Int -> @Int)
           requires(true)
           ensures(true)
           effects(pure)
@@ -570,7 +570,7 @@ class TestAssertAssume:
 class TestQualifiedCalls:
     def test_effect_qualified_call(self) -> None:
         parse("""
-        fn f(@Unit -> @Int)
+        private fn f(@Unit -> @Int)
           requires(true)
           ensures(true)
           effects(<State<Int>>)
@@ -584,7 +584,7 @@ class TestQualifiedCalls:
         parse("""
         import vera.math(abs);
 
-        fn f(@Int -> @Int)
+        private fn f(@Int -> @Int)
           requires(true)
           ensures(true)
           effects(pure)
@@ -600,7 +600,7 @@ class TestFunctionTypes:
         parse("""
         type Mapper = fn(Int -> Int) effects(pure);
 
-        fn apply(@Mapper, @Int -> @Int)
+        private fn apply(@Mapper, @Int -> @Int)
           requires(true)
           ensures(true)
           effects(pure)
@@ -614,7 +614,7 @@ class TestFunctionTypes:
         parse("""
         type Action = fn(Unit -> Unit) effects(<IO>);
 
-        fn run(@Action -> @Unit)
+        private fn run(@Action -> @Unit)
           requires(true)
           ensures(true)
           effects(<IO>)
@@ -632,7 +632,7 @@ class TestFunctionTypes:
 class TestFloatLiterals:
     def test_float_in_expression(self) -> None:
         parse("""
-        fn f(@Unit -> @Float64)
+        private fn f(@Unit -> @Float64)
           requires(true)
           ensures(true)
           effects(pure)
@@ -643,7 +643,7 @@ class TestFloatLiterals:
 
     def test_float_arithmetic(self) -> None:
         parse("""
-        fn f(@Float64 -> @Float64)
+        private fn f(@Float64 -> @Float64)
           requires(true)
           ensures(true)
           effects(pure)
@@ -656,10 +656,10 @@ class TestFloatLiterals:
 class TestNestedPatterns:
     def test_nested_constructor_pattern(self) -> None:
         parse("""
-        data Option<T> { None, Some(T) }
-        data List<T> { Nil, Cons(T, List<T>) }
+        private data Option<T> { None, Some(T) }
+        private data List<T> { Nil, Cons(T, List<T>) }
 
-        fn head_or_zero(@List<Option<Int>> -> @Int)
+        private fn head_or_zero(@List<Option<Int>> -> @Int)
           requires(true)
           ensures(true)
           effects(pure)
@@ -673,7 +673,7 @@ class TestNestedPatterns:
 
     def test_literal_and_wildcard_patterns(self) -> None:
         parse("""
-        fn describe(@Int -> @String)
+        private fn describe(@Int -> @String)
           requires(true)
           ensures(true)
           effects(pure)
@@ -690,7 +690,7 @@ class TestNestedPatterns:
 class TestHandlerVariations:
     def test_handler_without_state(self) -> None:
         parse("""
-        fn f(@Unit -> @Option<Int>)
+        private fn f(@Unit -> @Option<Int>)
           requires(true)
           ensures(true)
           effects(pure)
@@ -706,7 +706,7 @@ class TestHandlerVariations:
 
     def test_handler_multiple_clauses(self) -> None:
         parse("""
-        fn f(@Unit -> @Int)
+        private fn f(@Unit -> @Int)
           requires(true)
           ensures(true)
           effects(pure)
@@ -724,7 +724,7 @@ class TestHandlerVariations:
 
     def test_handler_with_qualified_effect(self) -> None:
         parse("""
-        fn f(@Unit -> @String)
+        private fn f(@Unit -> @String)
           requires(true)
           ensures(true)
           effects(pure)
@@ -743,7 +743,7 @@ class TestHandlerVariations:
     def test_handler_with_clause(self) -> None:
         """Handler clause with state update parses."""
         parse("""
-        fn f(@Unit -> @Int)
+        private fn f(@Unit -> @Int)
           requires(true) ensures(true) effects(pure)
         {
           handle[State<Int>](@Int = 0) {
@@ -759,7 +759,7 @@ class TestHandlerVariations:
         """Handler with-clause populates state_update on HandlerClause."""
         from vera.parser import parse_to_ast
         prog = parse_to_ast("""
-fn f(@Unit -> @Int)
+private fn f(@Unit -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   handle[State<Int>](@Int = 0) {
@@ -781,7 +781,7 @@ fn f(@Unit -> @Int)
 class TestImpliesOperator:
     def test_implies_in_contract(self) -> None:
         parse("""
-        fn f(@Int -> @Int)
+        private fn f(@Int -> @Int)
           requires(@Int.0 > 0 ==> @Int.0 < 100)
           ensures(true)
           effects(pure)
@@ -792,7 +792,7 @@ class TestImpliesOperator:
 
     def test_implies_right_associative(self) -> None:
         parse("""
-        fn f(@Bool, @Bool, @Bool -> @Bool)
+        private fn f(@Bool, @Bool, @Bool -> @Bool)
           requires(true)
           ensures(true)
           effects(pure)
@@ -810,20 +810,20 @@ class TestImpliesOperator:
 class TestParseErrors:
     def test_missing_contract_block(self) -> None:
         with pytest.raises(ParseError):
-            parse("fn f(@Int -> @Int) { @Int.0 }")
+            parse("private fn f(@Int -> @Int) { @Int.0 }")
 
     def test_missing_effects(self) -> None:
         with pytest.raises(ParseError):
-            parse("fn f(@Int -> @Int) requires(true) ensures(true) { @Int.0 }")
+            parse("private fn f(@Int -> @Int) requires(true) ensures(true) { @Int.0 }")
 
     def test_missing_body(self) -> None:
         with pytest.raises(ParseError):
-            parse("fn f(@Int -> @Int) requires(true) ensures(true) effects(pure)")
+            parse("private fn f(@Int -> @Int) requires(true) ensures(true) effects(pure)")
 
     def test_unclosed_brace(self) -> None:
         with pytest.raises(ParseError):
-            parse("fn f(@Int -> @Int) requires(true) ensures(true) effects(pure) { @Int.0")
+            parse("private fn f(@Int -> @Int) requires(true) ensures(true) effects(pure) { @Int.0")
 
     def test_invalid_token(self) -> None:
         with pytest.raises(ParseError):
-            parse("fn f(@Int -> @Int) requires(true) ensures(true) effects(pure) { $ }")
+            parse("private fn f(@Int -> @Int) requires(true) ensures(true) effects(pure) { $ }")

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -92,7 +92,7 @@ class TestTrivialContracts:
 
     def test_requires_true_ensures_true(self) -> None:
         _verify_ok("""
-fn f(@Int -> @Int)
+private fn f(@Int -> @Int)
   requires(true)
   ensures(true)
   effects(pure)
@@ -101,7 +101,7 @@ fn f(@Int -> @Int)
 
     def test_trivial_counted_as_tier1(self) -> None:
         result = _verify("""
-fn f(@Int -> @Int)
+private fn f(@Int -> @Int)
   requires(true)
   ensures(true)
   effects(pure)
@@ -120,7 +120,7 @@ class TestEnsuresVerification:
 
     def test_identity_postcondition(self) -> None:
         _verify_ok("""
-fn id(@Int -> @Int)
+private fn id(@Int -> @Int)
   requires(true)
   ensures(@Int.result == @Int.0)
   effects(pure)
@@ -129,7 +129,7 @@ fn id(@Int -> @Int)
 
     def test_addition_postcondition(self) -> None:
         _verify_ok("""
-fn add(@Int, @Int -> @Int)
+private fn add(@Int, @Int -> @Int)
   requires(true)
   ensures(@Int.result == @Int.0 + @Int.1)
   effects(pure)
@@ -138,7 +138,7 @@ fn add(@Int, @Int -> @Int)
 
     def test_subtraction_postcondition(self) -> None:
         _verify_ok("""
-fn sub(@Int, @Int -> @Int)
+private fn sub(@Int, @Int -> @Int)
   requires(true)
   ensures(@Int.result == @Int.0 - @Int.1)
   effects(pure)
@@ -147,7 +147,7 @@ fn sub(@Int, @Int -> @Int)
 
     def test_negation_postcondition(self) -> None:
         _verify_ok("""
-fn neg(@Int -> @Int)
+private fn neg(@Int -> @Int)
   requires(true)
   ensures(@Int.result == 0 - @Int.0)
   effects(pure)
@@ -156,7 +156,7 @@ fn neg(@Int -> @Int)
 
     def test_safe_divide_postcondition(self) -> None:
         _verify_ok("""
-fn safe_divide(@Int, @Int -> @Int)
+private fn safe_divide(@Int, @Int -> @Int)
   requires(@Int.1 != 0)
   ensures(@Int.result == @Int.0 / @Int.1)
   effects(pure)
@@ -165,7 +165,7 @@ fn safe_divide(@Int, @Int -> @Int)
 
     def test_constant_function(self) -> None:
         _verify_ok("""
-fn zero(@Int -> @Int)
+private fn zero(@Int -> @Int)
   requires(true)
   ensures(@Int.result == 0)
   effects(pure)
@@ -174,7 +174,7 @@ fn zero(@Int -> @Int)
 
     def test_boolean_postcondition(self) -> None:
         _verify_ok("""
-fn is_positive(@Int -> @Bool)
+private fn is_positive(@Int -> @Bool)
   requires(@Int.0 > 0)
   ensures(@Bool.result == true)
   effects(pure)
@@ -191,7 +191,7 @@ class TestIfThenElse:
 
     def test_absolute_value(self) -> None:
         _verify_ok("""
-fn absolute_value(@Int -> @Int)
+private fn absolute_value(@Int -> @Int)
   requires(true)
   ensures(@Int.result >= 0)
   effects(pure)
@@ -202,7 +202,7 @@ fn absolute_value(@Int -> @Int)
 
     def test_max(self) -> None:
         _verify_ok("""
-fn max(@Int, @Int -> @Int)
+private fn max(@Int, @Int -> @Int)
   requires(true)
   ensures(@Int.result >= @Int.0)
   ensures(@Int.result >= @Int.1)
@@ -214,7 +214,7 @@ fn max(@Int, @Int -> @Int)
 
     def test_min(self) -> None:
         _verify_ok("""
-fn min(@Int, @Int -> @Int)
+private fn min(@Int, @Int -> @Int)
   requires(true)
   ensures(@Int.result <= @Int.0)
   ensures(@Int.result <= @Int.1)
@@ -226,7 +226,7 @@ fn min(@Int, @Int -> @Int)
 
     def test_clamp(self) -> None:
         _verify_ok("""
-fn clamp(@Int, @Int, @Int -> @Int)
+private fn clamp(@Int, @Int, @Int -> @Int)
   requires(@Int.1 <= @Int.2)
   ensures(@Int.result >= @Int.1)
   ensures(@Int.result <= @Int.2)
@@ -239,7 +239,7 @@ fn clamp(@Int, @Int, @Int -> @Int)
 
     def test_nested_if(self) -> None:
         _verify_ok("""
-fn sign(@Int -> @Int)
+private fn sign(@Int -> @Int)
   requires(true)
   ensures(@Int.result >= -1)
   ensures(@Int.result <= 1)
@@ -260,7 +260,7 @@ class TestLetBindings:
 
     def test_let_identity(self) -> None:
         _verify_ok("""
-fn double(@Int -> @Int)
+private fn double(@Int -> @Int)
   requires(true)
   ensures(@Int.result == @Int.0 + @Int.0)
   effects(pure)
@@ -272,7 +272,7 @@ fn double(@Int -> @Int)
 
     def test_chained_lets(self) -> None:
         _verify_ok("""
-fn triple(@Int -> @Int)
+private fn triple(@Int -> @Int)
   requires(true)
   ensures(@Int.result == @Int.0 + @Int.0 + @Int.0)
   effects(pure)
@@ -293,7 +293,7 @@ class TestMultipleContracts:
 
     def test_multiple_ensures(self) -> None:
         _verify_ok("""
-fn bounded(@Int -> @Int)
+private fn bounded(@Int -> @Int)
   requires(@Int.0 >= 0)
   requires(@Int.0 <= 100)
   ensures(@Int.result >= 0)
@@ -304,7 +304,7 @@ fn bounded(@Int -> @Int)
 
     def test_multiple_requires_strengthen(self) -> None:
         _verify_ok("""
-fn positive_div(@Int, @Int -> @Int)
+private fn positive_div(@Int, @Int -> @Int)
   requires(@Int.0 > 0)
   requires(@Int.1 > 0)
   ensures(@Int.result >= 0)
@@ -323,7 +323,7 @@ class TestCounterexamples:
     def test_false_postcondition(self) -> None:
         """ensures(@Int.result > @Int.0) fails when result == input."""
         _verify_err("""
-fn bad(@Int -> @Int)
+private fn bad(@Int -> @Int)
   requires(true)
   ensures(@Int.result > @Int.0)
   effects(pure)
@@ -333,7 +333,7 @@ fn bad(@Int -> @Int)
     def test_false_always(self) -> None:
         """ensures(false) always fails."""
         _verify_err("""
-fn always_fail(@Int -> @Int)
+private fn always_fail(@Int -> @Int)
   requires(true)
   ensures(false)
   effects(pure)
@@ -343,7 +343,7 @@ fn always_fail(@Int -> @Int)
     def test_counterexample_has_values(self) -> None:
         """Counterexample includes concrete slot values."""
         result = _verify("""
-fn bad(@Int -> @Int)
+private fn bad(@Int -> @Int)
   requires(true)
   ensures(@Int.result > 0)
   effects(pure)
@@ -358,7 +358,7 @@ fn bad(@Int -> @Int)
     def test_violation_has_fix_suggestion(self) -> None:
         """Error diagnostic includes a fix suggestion."""
         result = _verify("""
-fn bad(@Int -> @Int)
+private fn bad(@Int -> @Int)
   requires(true)
   ensures(@Int.result > @Int.0)
   effects(pure)
@@ -372,7 +372,7 @@ fn bad(@Int -> @Int)
     def test_violation_has_spec_ref(self) -> None:
         """Error diagnostic includes a spec reference."""
         result = _verify("""
-fn bad(@Int -> @Int)
+private fn bad(@Int -> @Int)
   requires(true)
   ensures(@Int.result > @Int.0)
   effects(pure)
@@ -386,7 +386,7 @@ fn bad(@Int -> @Int)
         """Adding a precondition can make a failing postcondition valid."""
         # Without precondition: fails
         _verify_err("""
-fn bad(@Int -> @Int)
+private fn bad(@Int -> @Int)
   requires(true)
   ensures(@Int.result > 0)
   effects(pure)
@@ -395,7 +395,7 @@ fn bad(@Int -> @Int)
 
         # With precondition: passes
         _verify_ok("""
-fn good(@Int -> @Int)
+private fn good(@Int -> @Int)
   requires(@Int.0 > 0)
   ensures(@Int.result > 0)
   effects(pure)
@@ -412,7 +412,7 @@ class TestTierClassification:
 
     def test_linear_arithmetic_is_tier1(self) -> None:
         result = _verify("""
-fn f(@Int, @Int -> @Int)
+private fn f(@Int, @Int -> @Int)
   requires(@Int.1 != 0)
   ensures(@Int.result == @Int.0 + @Int.1)
   effects(pure)
@@ -423,7 +423,7 @@ fn f(@Int, @Int -> @Int)
 
     def test_generic_function_is_tier3(self) -> None:
         result = _verify("""
-forall<T>
+private forall<T>
 fn id(@T -> @T)
   requires(true)
   ensures(@T.result == @T.0)
@@ -435,9 +435,9 @@ fn id(@T -> @T)
     def test_match_body_is_tier3(self) -> None:
         """Functions with match in the body fall to Tier 3."""
         result = _verify("""
-data Bool2 { True2, False2 }
+private data Bool2 { True2, False2 }
 
-fn invert(@Bool2 -> @Bool2)
+private fn invert(@Bool2 -> @Bool2)
   requires(true)
   ensures(true)
   effects(pure)
@@ -455,7 +455,7 @@ fn invert(@Bool2 -> @Bool2)
     def test_recursive_call_is_tier3(self) -> None:
         """Recursive functions still have Tier 3 for decreases."""
         result = _verify("""
-fn factorial(@Nat -> @Nat)
+private fn factorial(@Nat -> @Nat)
   requires(true)
   ensures(@Nat.result >= 1)
   decreases(@Nat.0)
@@ -479,7 +479,7 @@ class TestArithmetic:
 
     def test_nat_non_negative(self) -> None:
         _verify_ok("""
-fn nat_id(@Nat -> @Nat)
+private fn nat_id(@Nat -> @Nat)
   requires(true)
   ensures(@Nat.result >= 0)
   effects(pure)
@@ -489,7 +489,7 @@ fn nat_id(@Nat -> @Nat)
     def test_nat_constraint_used(self) -> None:
         """Nat parameters are constrained >= 0 in Z3."""
         _verify_ok("""
-fn nat_plus_one(@Nat -> @Int)
+private fn nat_plus_one(@Nat -> @Int)
   requires(true)
   ensures(@Int.result > 0)
   effects(pure)
@@ -504,7 +504,7 @@ fn nat_plus_one(@Nat -> @Int)
         contradicts the Nat >= 0 constraint, so verification must fail.
         """
         _verify_err("""
-fn bad(@Unit -> @Nat)
+private fn bad(@Unit -> @Nat)
   requires(true)
   ensures(@Nat.result >= 0)
   effects(pure)
@@ -514,7 +514,7 @@ fn bad(@Unit -> @Nat)
     def test_int_to_nat_positive_ok(self) -> None:
         """Int expression returned as Nat: verifier passes when >= 0."""
         _verify_ok("""
-fn good(@Nat -> @Nat)
+private fn good(@Nat -> @Nat)
   requires(true)
   ensures(@Nat.result >= 0)
   effects(pure)
@@ -524,7 +524,7 @@ fn good(@Nat -> @Nat)
     def test_int_to_nat_conditional(self) -> None:
         """Int body with conditional: verifier checks all paths >= 0."""
         _verify_ok("""
-fn abs_nat(@Int -> @Nat)
+private fn abs_nat(@Int -> @Nat)
   requires(true)
   ensures(@Nat.result >= 0)
   effects(pure)
@@ -536,7 +536,7 @@ fn abs_nat(@Int -> @Nat)
 
     def test_modular_arithmetic(self) -> None:
         _verify_ok("""
-fn remainder(@Int, @Int -> @Int)
+private fn remainder(@Int, @Int -> @Int)
   requires(@Int.1 > 0)
   ensures(true)
   effects(pure)
@@ -553,7 +553,7 @@ class TestSummary:
 
     def test_all_trivial(self) -> None:
         result = _verify("""
-fn f(@Int -> @Int)
+private fn f(@Int -> @Int)
   requires(true)
   ensures(true)
   effects(pure)
@@ -565,7 +565,7 @@ fn f(@Int -> @Int)
 
     def test_mixed_tiers(self) -> None:
         result = _verify("""
-fn f(@Nat -> @Nat)
+private fn f(@Nat -> @Nat)
   requires(true)
   ensures(@Nat.result >= 0)
   decreases(@Nat.0)
@@ -585,13 +585,13 @@ fn f(@Nat -> @Nat)
 
     def test_multiple_functions_accumulate(self) -> None:
         result = _verify("""
-fn f(@Int -> @Int)
+private fn f(@Int -> @Int)
   requires(true)
   ensures(@Int.result == @Int.0)
   effects(pure)
 { @Int.0 }
 
-fn g(@Int -> @Int)
+private fn g(@Int -> @Int)
   requires(true)
   ensures(@Int.result == @Int.0 + 1)
   effects(pure)
@@ -613,7 +613,7 @@ class TestEdgeCases:
     def test_empty_body_unit(self) -> None:
         """Unit-returning function with trivial contracts."""
         _verify_ok("""
-fn noop(@Unit -> @Unit)
+private fn noop(@Unit -> @Unit)
   requires(true)
   ensures(true)
   effects(pure)
@@ -622,7 +622,7 @@ fn noop(@Unit -> @Unit)
 
     def test_deeply_nested_if(self) -> None:
         _verify_ok("""
-fn deep(@Int -> @Int)
+private fn deep(@Int -> @Int)
   requires(true)
   ensures(@Int.result >= 0)
   ensures(@Int.result <= 3)
@@ -638,7 +638,7 @@ fn deep(@Int -> @Int)
     def test_implies_in_contract(self) -> None:
         """The ==> operator works in contracts."""
         _verify_ok("""
-fn f(@Int -> @Int)
+private fn f(@Int -> @Int)
   requires(true)
   ensures(@Int.0 > 0 ==> @Int.result > 0)
   effects(pure)
@@ -647,7 +647,7 @@ fn f(@Int -> @Int)
 
     def test_boolean_logic_in_contract(self) -> None:
         _verify_ok("""
-fn f(@Int -> @Int)
+private fn f(@Int -> @Int)
   requires(@Int.0 > 0 && @Int.0 < 100)
   ensures(@Int.result > 0 || @Int.result == 0)
   effects(pure)
@@ -665,13 +665,13 @@ class TestCallSiteVerification:
     def test_call_satisfied_precondition(self) -> None:
         """Calling with a literal that satisfies requires(@Int.0 != 0)."""
         _verify_ok("""
-fn non_zero(@Int -> @Int)
+private fn non_zero(@Int -> @Int)
   requires(@Int.0 != 0)
   ensures(true)
   effects(pure)
 { @Int.0 }
 
-fn caller(@Unit -> @Int)
+private fn caller(@Unit -> @Int)
   requires(true)
   ensures(true)
   effects(pure)
@@ -681,13 +681,13 @@ fn caller(@Unit -> @Int)
     def test_call_violated_precondition(self) -> None:
         """Calling with literal 0 violates requires(@Int.0 != 0)."""
         _verify_err("""
-fn non_zero(@Int -> @Int)
+private fn non_zero(@Int -> @Int)
   requires(@Int.0 != 0)
   ensures(true)
   effects(pure)
 { @Int.0 }
 
-fn bad_caller(@Unit -> @Int)
+private fn bad_caller(@Unit -> @Int)
   requires(true)
   ensures(true)
   effects(pure)
@@ -697,13 +697,13 @@ fn bad_caller(@Unit -> @Int)
     def test_call_precondition_forwarded(self) -> None:
         """Caller's precondition implies callee's — passes."""
         _verify_ok("""
-fn non_zero(@Int -> @Int)
+private fn non_zero(@Int -> @Int)
   requires(@Int.0 != 0)
   ensures(true)
   effects(pure)
 { @Int.0 }
 
-fn safe_caller(@Int -> @Int)
+private fn safe_caller(@Int -> @Int)
   requires(@Int.0 != 0)
   ensures(true)
   effects(pure)
@@ -713,13 +713,13 @@ fn safe_caller(@Int -> @Int)
     def test_call_postcondition_assumed(self) -> None:
         """Caller's ensures relies on callee's postcondition."""
         _verify_ok("""
-fn succ(@Int -> @Int)
+private fn succ(@Int -> @Int)
   requires(true)
   ensures(@Int.result == @Int.0 + 1)
   effects(pure)
 { @Int.0 + 1 }
 
-fn add_two(@Int -> @Int)
+private fn add_two(@Int -> @Int)
   requires(true)
   ensures(@Int.result == @Int.0 + 2)
   effects(pure)
@@ -733,7 +733,7 @@ fn add_two(@Int -> @Int)
         and base case returns 1, so result >= 1 is provable.
         """
         result = _verify("""
-fn factorial(@Nat -> @Nat)
+private fn factorial(@Nat -> @Nat)
   requires(true)
   ensures(@Nat.result >= 1)
   decreases(@Nat.0)
@@ -751,13 +751,13 @@ fn factorial(@Nat -> @Nat)
     def test_call_trivial_precondition(self) -> None:
         """Callee with requires(true) — always satisfied."""
         _verify_ok("""
-fn id(@Int -> @Int)
+private fn id(@Int -> @Int)
   requires(true)
   ensures(@Int.result == @Int.0)
   effects(pure)
 { @Int.0 }
 
-fn caller(@Int -> @Int)
+private fn caller(@Int -> @Int)
   requires(true)
   ensures(@Int.result == @Int.0)
   effects(pure)
@@ -767,13 +767,13 @@ fn caller(@Int -> @Int)
     def test_call_in_let_binding(self) -> None:
         """Call result used via let binding, passed to second call."""
         _verify_ok("""
-fn succ(@Int -> @Int)
+private fn succ(@Int -> @Int)
   requires(true)
   ensures(@Int.result == @Int.0 + 1)
   effects(pure)
 { @Int.0 + 1 }
 
-fn add_two_let(@Int -> @Int)
+private fn add_two_let(@Int -> @Int)
   requires(true)
   ensures(@Int.result == @Int.0 + 2)
   effects(pure)
@@ -786,7 +786,7 @@ fn add_two_let(@Int -> @Int)
     def test_where_block_call(self) -> None:
         """Call to a where-block helper function."""
         _verify_ok("""
-fn outer(@Int -> @Int)
+private fn outer(@Int -> @Int)
   requires(true)
   ensures(@Int.result == @Int.0 + 1)
   effects(pure)
@@ -803,14 +803,14 @@ where {
     def test_generic_call_falls_to_tier3(self) -> None:
         """Calls to generic functions bail to Tier 3."""
         result = _verify("""
-forall<T>
+private forall<T>
 fn id(@T -> @T)
   requires(true)
   ensures(@T.result == @T.0)
   effects(pure)
 { @T.0 }
 
-fn caller(@Int -> @Int)
+private fn caller(@Int -> @Int)
   requires(true)
   ensures(true)
   effects(pure)
@@ -824,14 +824,14 @@ fn caller(@Int -> @Int)
     def test_multiple_preconditions_all_checked(self) -> None:
         """Two requires on callee, second one violated."""
         _verify_err("""
-fn guarded(@Int -> @Int)
+private fn guarded(@Int -> @Int)
   requires(@Int.0 > 0)
   requires(@Int.0 < 100)
   ensures(true)
   effects(pure)
 { @Int.0 }
 
-fn bad_caller(@Int -> @Int)
+private fn bad_caller(@Int -> @Int)
   requires(@Int.0 > 0)
   ensures(true)
   effects(pure)
@@ -841,14 +841,14 @@ fn bad_caller(@Int -> @Int)
     def test_precondition_via_caller_requires(self) -> None:
         """Caller's requires forwards two constraints to satisfy callee."""
         _verify_ok("""
-fn guarded(@Int -> @Int)
+private fn guarded(@Int -> @Int)
   requires(@Int.0 > 0)
   requires(@Int.0 < 100)
   ensures(true)
   effects(pure)
 { @Int.0 }
 
-fn good_caller(@Int -> @Int)
+private fn good_caller(@Int -> @Int)
   requires(@Int.0 > 0)
   requires(@Int.0 < 100)
   ensures(true)
@@ -859,13 +859,13 @@ fn good_caller(@Int -> @Int)
     def test_multiple_calls_in_sequence(self) -> None:
         """Two calls in sequence, each gets a fresh return variable."""
         _verify_ok("""
-fn inc(@Int -> @Int)
+private fn inc(@Int -> @Int)
   requires(true)
   ensures(@Int.result == @Int.0 + 1)
   effects(pure)
 { @Int.0 + 1 }
 
-fn add_two_seq(@Int -> @Int)
+private fn add_two_seq(@Int -> @Int)
   requires(true)
   ensures(@Int.result == @Int.0 + 2)
   effects(pure)
@@ -878,13 +878,13 @@ fn add_two_seq(@Int -> @Int)
     def test_violation_error_mentions_callee_name(self) -> None:
         """Error message includes the callee function name."""
         errors = _verify_err("""
-fn non_zero(@Int -> @Int)
+private fn non_zero(@Int -> @Int)
   requires(@Int.0 != 0)
   ensures(true)
   effects(pure)
 { @Int.0 }
 
-fn bad(@Int -> @Int)
+private fn bad(@Int -> @Int)
   requires(true)
   ensures(true)
   effects(pure)
@@ -904,13 +904,13 @@ class TestPipeVerification:
     def test_pipe_verifies(self) -> None:
         """Pipe expression in verified function."""
         _verify_ok("""
-fn inc(@Int -> @Int)
+private fn inc(@Int -> @Int)
   requires(true)
   ensures(true)
   effects(pure)
 { @Int.0 + 1 }
 
-fn main(@Int -> @Int)
+private fn main(@Int -> @Int)
   requires(true)
   ensures(true)
   effects(pure)

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.33"
+__version__ = "0.0.34"

--- a/vera/checker.py
+++ b/vera/checker.py
@@ -127,22 +127,37 @@ class TypeChecker:
         self._import_names: dict[
             tuple[str, ...], set[str] | None
         ] = {}
+        # C7c: unfiltered module declarations (for "is private" errors).
+        self._module_all_functions: dict[
+            tuple[str, ...], dict[str, FunctionInfo]
+        ] = {}
+        self._module_all_data_types: dict[
+            tuple[str, ...], dict[str, AdtInfo]
+        ] = {}
         # De-dup removed-alias errors (emitted once per alias name).
         self._reported_alias_errors: set[str] = set()
 
+    @staticmethod
+    def _is_public(visibility: str | None) -> bool:
+        """True if the declaration is explicitly ``public``."""
+        return visibility == "public"
+
     # -----------------------------------------------------------------
-    # C7b: cross-module registration
+    # C7b/C7c: cross-module registration
     # -----------------------------------------------------------------
 
     def _register_modules(self, program: ast.Program) -> None:
-        """Register declarations from resolved modules (C7b).
+        """Register declarations from resolved modules (C7b/C7c).
 
         1. Build an import-name filter from the program's ``import``
            declarations (selective vs wildcard).
         2. For each resolved module, run the registration pass in an
            isolated TypeChecker to populate its ``TypeEnv``, then
            harvest the declarations into per-module dicts.
-        3. Inject selectively imported names into ``self.env`` so
+        3. C7c: filter to public declarations only.  Store unfiltered
+           dicts for better "is private" error messages.
+        4. C7c: emit errors when selective imports reference private names.
+        5. Inject selectively imported *public* names into ``self.env`` so
            bare calls (``abs(42)`` after ``import vera.math(abs)``)
            resolve through the normal ``_check_call_with_args`` path.
         """
@@ -163,26 +178,89 @@ class TypeChecker:
             temp = TypeChecker(source=mod.source)
             temp._register_all(mod.program)
 
-            # Keep only module-declared names (builtins have span=None)
-            mod_fns = {
+            # All module-declared names (exclude builtins)
+            all_fns = {
                 k: v for k, v in temp.env.functions.items()
                 if k not in builtin_fn_names or v.span is not None
             }
-            mod_data = {
+            all_data = {
                 k: v for k, v in temp.env.data_types.items()
                 if k not in builtin_data_names
             }
+
+            # C7c: keep unfiltered dicts for "is private" error messages
+            self._module_all_functions[mod.path] = all_fns
+            self._module_all_data_types[mod.path] = all_data
+
+            # 3. C7c: filter to public only
+            mod_fns = {
+                k: v for k, v in all_fns.items()
+                if self._is_public(v.visibility)
+            }
+            mod_data = {
+                k: v for k, v in all_data.items()
+                if self._is_public(v.visibility)
+            }
+            # Constructors: include only from public ADTs
+            public_adt_ctors: set[str] = set()
+            for dt_info in mod_data.values():
+                public_adt_ctors.update(dt_info.constructors)
             mod_ctors = {
                 k: v for k, v in temp.env.constructors.items()
                 if k not in builtin_ctor_names
+                and k in public_adt_ctors
             }
 
             self._module_functions[mod.path] = mod_fns
             self._module_data_types[mod.path] = mod_data
             self._module_constructors[mod.path] = mod_ctors
 
-            # 3. Inject into main env for bare calls
+            # 4. C7c: check selective imports for private names
             name_filter = self._import_names.get(mod.path)
+            mod_label = ".".join(mod.path)
+            if name_filter is not None:
+                imp_node = self._find_import_decl(program, mod.path)
+                for name in sorted(name_filter):
+                    priv_fn = all_fns.get(name)
+                    priv_dt = all_data.get(name)
+                    if (priv_fn is not None
+                            and not self._is_public(priv_fn.visibility)):
+                        self._error(
+                            imp_node,
+                            f"Cannot import '{name}' from module "
+                            f"'{mod_label}': it is private.",
+                            rationale=(
+                                "Only public declarations can be imported."
+                            ),
+                            fix=(
+                                f"Mark '{name}' as public in the module, "
+                                f"or remove it from the import list."
+                            ),
+                            spec_ref=(
+                                'Chapter 5, Section 5.8 '
+                                '"Function Visibility"'
+                            ),
+                        )
+                    elif (priv_dt is not None
+                            and not self._is_public(priv_dt.visibility)):
+                        self._error(
+                            imp_node,
+                            f"Cannot import '{name}' from module "
+                            f"'{mod_label}': it is private.",
+                            rationale=(
+                                "Only public declarations can be imported."
+                            ),
+                            fix=(
+                                f"Mark '{name}' as public in the module, "
+                                f"or remove it from the import list."
+                            ),
+                            spec_ref=(
+                                'Chapter 5, Section 5.8 '
+                                '"Function Visibility"'
+                            ),
+                        )
+
+            # 5. Inject public names into main env for bare calls
             for fn_name, fn_info in mod_fns.items():
                 if name_filter is None or fn_name in name_filter:
                     self.env.functions.setdefault(fn_name, fn_info)
@@ -190,10 +268,19 @@ class TypeChecker:
                 if name_filter is None or dt_name in name_filter:
                     self.env.data_types.setdefault(dt_name, dt_info)
             for ct_name, ct_info in mod_ctors.items():
-                # Constructors: include if parent type is in import list
                 parent = ct_info.parent_type
                 if name_filter is None or parent in name_filter:
                     self.env.constructors.setdefault(ct_name, ct_info)
+
+    @staticmethod
+    def _find_import_decl(
+        program: ast.Program, path: tuple[str, ...],
+    ) -> ast.Node:
+        """Find the ImportDecl node for a given module path."""
+        for imp in program.imports:
+            if imp.path == path:
+                return imp
+        return program  # fallback
 
     # -----------------------------------------------------------------
     # Diagnostics
@@ -360,20 +447,40 @@ class TypeChecker:
     def _register_all(self, program: ast.Program) -> None:
         """Register all top-level declarations (forward reference support)."""
         for tld in program.declarations:
-            self._register_decl(tld.decl)
+            # C7c: require explicit visibility on fn/data declarations
+            if (tld.visibility is None
+                    and isinstance(tld.decl, (ast.FnDecl, ast.DataDecl))):
+                name = tld.decl.name
+                kind = "fn" if isinstance(tld.decl, ast.FnDecl) else "data"
+                self._error(
+                    tld.decl,
+                    f"Missing visibility on '{name}'. "
+                    f"Add 'public' or 'private' before '{kind}'.",
+                    rationale=(
+                        "Every top-level function and data type must have "
+                        "an explicit visibility annotation."
+                    ),
+                    fix=f"private {kind} {name}(...) or public {kind} {name}(...)",
+                    spec_ref='Chapter 5, Section 5.8 "Function Visibility"',
+                )
+            self._register_decl(tld.decl, visibility=tld.visibility)
 
-    def _register_decl(self, decl: ast.Decl) -> None:
+    def _register_decl(
+        self, decl: ast.Decl, visibility: str | None = None,
+    ) -> None:
         """Register a single declaration's signature."""
         if isinstance(decl, ast.DataDecl):
-            self._register_data(decl)
+            self._register_data(decl, visibility=visibility)
         elif isinstance(decl, ast.TypeAliasDecl):
             self._register_alias(decl)
         elif isinstance(decl, ast.EffectDecl):
             self._register_effect(decl)
         elif isinstance(decl, ast.FnDecl):
-            self._register_fn(decl)
+            self._register_fn(decl, visibility=visibility)
 
-    def _register_data(self, decl: ast.DataDecl) -> None:
+    def _register_data(
+        self, decl: ast.DataDecl, visibility: str | None = None,
+    ) -> None:
         """Register an ADT and its constructors."""
         # Set up type params for resolving constructor field types
         saved_params = dict(self.env.type_params)
@@ -400,6 +507,7 @@ class TypeChecker:
             name=decl.name,
             type_params=decl.type_params,
             constructors=ctors,
+            visibility=visibility,
         )
 
         self.env.type_params = saved_params
@@ -446,12 +554,15 @@ class TypeChecker:
 
         self.env.type_params = saved_params
 
-    def _register_fn(self, decl: ast.FnDecl) -> None:
+    def _register_fn(
+        self, decl: ast.FnDecl, visibility: str | None = None,
+    ) -> None:
         """Register a function signature."""
         from vera.registration import register_fn
         register_fn(
             self.env, decl,
             self._resolve_type, self._resolve_effect_row,
+            visibility=visibility,
         )
 
     # -----------------------------------------------------------------
@@ -1207,7 +1318,8 @@ class TypeChecker:
         Lookup order:
         1. Module not resolved → warning (same as C7a).
         2. Name not in selective import list → error.
-        3. Function found → delegate to ``_check_fn_call_with_info``.
+        2.5. C7c: function is private → error.
+        3. Function found (public) → delegate to ``_check_fn_call_with_info``.
         4. Function not found in module → warning with available list.
         """
         mod_path = tuple(expr.path)
@@ -1246,6 +1358,31 @@ class TypeChecker:
                     f"Change the import to include '{fn_name}': "
                     f"import {mod_label}"
                     f"({', '.join(sorted(import_filter | {fn_name}))});"
+                ),
+            )
+            for arg in expr.args:
+                self._synth_expr(arg)
+            return UnknownType()
+
+        # 2.5 C7c: visibility check — is the function private?
+        all_fns = self._module_all_functions.get(mod_path, {})
+        fn_all = all_fns.get(fn_name)
+        if fn_all is not None and not self._is_public(fn_all.visibility):
+            self._error(
+                expr,
+                f"Function '{fn_name}' in module '{mod_label}' is "
+                f"private and cannot be accessed from outside "
+                f"its module.",
+                rationale=(
+                    "Only functions marked 'public' can be called "
+                    "from other modules."
+                ),
+                fix=(
+                    f"Mark the function as public in the module: "
+                    f"public fn {fn_name}(...)"
+                ),
+                spec_ref=(
+                    'Chapter 5, Section 5.8 "Function Visibility"'
                 ),
             )
             for arg in expr.args:

--- a/vera/environment.py
+++ b/vera/environment.py
@@ -43,6 +43,7 @@ class FunctionInfo:
     span: object | None = None  # ast.Span
     contracts: tuple[object, ...] = ()  # ast.Contract nodes (for C4)
     param_type_exprs: tuple[object, ...] = ()  # ast.TypeExpr nodes (for C6b)
+    visibility: str | None = None  # "public" | "private" | None (C7c)
 
 
 @dataclass
@@ -51,6 +52,7 @@ class AdtInfo:
     name: str
     type_params: tuple[str, ...] | None
     constructors: dict[str, ConstructorInfo]
+    visibility: str | None = None  # "public" | "private" | None (C7c)
 
 
 @dataclass

--- a/vera/registration.py
+++ b/vera/registration.py
@@ -22,6 +22,7 @@ def register_fn(
     decl: ast.FnDecl,
     resolve_type: Callable[[ast.TypeExpr], Type],
     resolve_effect_row: Callable[[ast.EffectRow], EffectRowType],
+    visibility: str | None = None,
 ) -> None:
     """Register a function signature in the environment.
 
@@ -47,6 +48,7 @@ def register_fn(
         span=decl.span,
         contracts=decl.contracts,
         param_type_exprs=decl.params,
+        visibility=visibility,
     )
 
     if decl.where_fns:


### PR DESCRIPTION
## Summary

- Every top-level `fn` and `data` declaration now requires explicit `public` or `private` annotation -- no implicit default, enforcing design principle 3 (one canonical form)
- Cross-module access control: only `public` declarations are importable; private names produce targeted diagnostics
- Selective imports of private names caught at import site
- Wildcard imports automatically filter to public-only
- Constructor visibility derived from parent ADT
- Updated all 14 examples, all test inline sources (5 test files), 6 spec chapters, README, SKILLS.md, and docs site -- no bare `fn`/`data` declarations remain anywhere in the repo
- 927 tests (13 new), mypy clean, all validation scripts pass

## Test plan

- [x] `pytest tests/ -v` -- 927 tests pass (13 new in `TestVisibilityEnforcement`)
- [x] `mypy vera/` -- clean
- [x] `python scripts/check_examples.py` -- 14/14 pass
- [x] `python scripts/check_spec_examples.py` -- pass
- [x] `python scripts/check_readme_examples.py` -- pass
- [x] `python scripts/check_version_sync.py` -- 0.0.34 consistent
- [x] Pre-commit hooks pass (mypy + pytest + examples + readme)

Closes partial #14.