### PR TITLE
Fix bare fn in error messages, docs, and test_resolver

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,9 +40,9 @@ For machine-parseable errors, use the `--json` flag:
       "severity": "error",
       "description": "Function is missing its contract block...",
       "location": {"file": "example.vera", "line": 12, "column": 1},
-      "source_line": "fn add(@Int, @Int -> @Int)",
+      "source_line": "private fn add(@Int, @Int -> @Int)",
       "rationale": "Vera requires all functions to have explicit contracts...",
-      "fix": "Add a contract block after the signature:\n\n  fn example(@Int -> @Int)\n    requires(true)\n    ensures(@Int.result >= 0)\n    effects(pure)\n  {\n    ...\n  }",
+      "fix": "Add a contract block after the signature:\n\n  private fn example(@Int -> @Int)\n    requires(true)\n    ensures(@Int.result >= 0)\n    effects(pure)\n  {\n    ...\n  }",
       "spec_ref": "Chapter 5, Section 5.1 \"Function Structure\""
     }
   ],

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Every error includes what went wrong, why, how to fix it with a concrete code ex
 ```
 Error in main.vera at line 12, column 1:
 
-    fn add(@Int, @Int -> @Int)
+    private fn add(@Int, @Int -> @Int)
     ^
 
   Function "add" is missing its contract block. Every function in Vera
@@ -120,7 +120,7 @@ Error in main.vera at line 12, column 1:
 
   Add a contract block after the signature:
 
-    fn add(@Int, @Int -> @Int)
+    private fn add(@Int, @Int -> @Int)
       requires(true)
       ensures(@Int.result == @Int.0 + @Int.1)
       effects(pure)

--- a/spec/00-introduction.md
+++ b/spec/00-introduction.md
@@ -71,7 +71,7 @@ Every diagnostic MUST include:
 ```
 Error in examples/bad.vera at line 5, column 1:
 
-    fn add(@Int, @Int -> @Int)
+    private fn add(@Int, @Int -> @Int)
     ^
 
   Function "add" is missing its contract block. Every function in Vera
@@ -80,7 +80,7 @@ Error in examples/bad.vera at line 5, column 1:
 
   Add a contract block after the signature:
 
-    fn add(@Int, @Int -> @Int)
+    private fn add(@Int, @Int -> @Int)
       requires(true)
       ensures(@Int.result == @Int.0 + @Int.1)
       effects(pure)

--- a/spec/06-contracts.md
+++ b/spec/06-contracts.md
@@ -234,7 +234,7 @@ When Z3 finds a counterexample (a VC is invalid), the compiler reports the speci
 ```
 ERROR: Contract violation in function foo (line 5)
 
-    fn foo(@Int -> @Int)
+    private fn foo(@Int -> @Int)
       requires(true)
       ensures(@Int.result > @Int.0)
       ...

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -90,10 +90,10 @@ class TestPathResolution:
         main = """
 import math;
 
-fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+private fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
 """
         lib = """
-fn add(@Int, @Int -> @Int)
+private fn add(@Int, @Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { @Int.0 + @Int.1 }
 """
@@ -106,10 +106,10 @@ fn add(@Int, @Int -> @Int)
         main = """
 import vera.math;
 
-fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+private fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
 """
         lib = """
-fn add(@Int, @Int -> @Int)
+private fn add(@Int, @Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { @Int.0 + @Int.1 }
 """
@@ -124,7 +124,7 @@ fn add(@Int, @Int -> @Int)
         main = """
 import nonexistent;
 
-fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+private fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
 """
         _resolve_err(tmp_path, main, "Cannot resolve import")
 
@@ -133,7 +133,7 @@ fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
         main = """
 import deeply.nested.missing;
 
-fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+private fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
 """
         errors = _resolve_err(tmp_path, main, "Cannot resolve import")
         assert any("deeply.nested.missing" in msg for msg in errors)
@@ -146,10 +146,10 @@ fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
         main = """
 import sibling;
 
-fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+private fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
 """
         lib = """
-fn helper(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+private fn helper(-> @Unit) requires(true) ensures(true) effects(pure) { () }
 """
         # main.vera in subdir/, sibling.vera also in subdir/
         main_file = _write_file(tmp_path, "subdir/main.vera", main)
@@ -181,10 +181,10 @@ class TestParseCaching:
         main = """
 import utils;
 
-fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+private fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
 """
         utils_src = """
-fn helper(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+private fn helper(-> @Unit) requires(true) ensures(true) effects(pure) { () }
 """
         main_file = _write_file(tmp_path, "main.vera", main)
         _write_file(tmp_path, "utils.vera", utils_src)
@@ -210,20 +210,20 @@ fn helper(-> @Unit) requires(true) ensures(true) effects(pure) { () }
 import b;
 import c;
 
-fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+private fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
 """
         b_src = """
 import d;
 
-fn fb(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+private fn fb(-> @Unit) requires(true) ensures(true) effects(pure) { () }
 """
         c_src = """
 import d;
 
-fn fc(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+private fn fc(-> @Unit) requires(true) ensures(true) effects(pure) { () }
 """
         d_src = """
-fn fd(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+private fn fd(-> @Unit) requires(true) ensures(true) effects(pure) { () }
 """
         main_file = _write_file(tmp_path, "main.vera", main_src)
         _write_file(tmp_path, "b.vera", b_src)
@@ -257,12 +257,12 @@ class TestCircularImports:
         a_src = """
 import b;
 
-fn fa(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+private fn fa(-> @Unit) requires(true) ensures(true) effects(pure) { () }
 """
         b_src = """
 import a;
 
-fn fb(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+private fn fb(-> @Unit) requires(true) ensures(true) effects(pure) { () }
 """
         # a.vera imports b.vera, b.vera imports a.vera
         a_file = _write_file(tmp_path, "a.vera", a_src)
@@ -283,7 +283,7 @@ fn fb(-> @Unit) requires(true) ensures(true) effects(pure) { () }
         a_src = """
 import a;
 
-fn fa(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+private fn fa(-> @Unit) requires(true) ensures(true) effects(pure) { () }
 """
         a_file = _write_file(tmp_path, "a.vera", a_src)
 
@@ -304,17 +304,17 @@ fn fa(-> @Unit) requires(true) ensures(true) effects(pure) { () }
         a_src = """
 import b;
 
-fn fa(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+private fn fa(-> @Unit) requires(true) ensures(true) effects(pure) { () }
 """
         b_src = """
 import c;
 
-fn fb(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+private fn fb(-> @Unit) requires(true) ensures(true) effects(pure) { () }
 """
         c_src = """
 import a;
 
-fn fc(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+private fn fc(-> @Unit) requires(true) ensures(true) effects(pure) { () }
 """
         a_file = _write_file(tmp_path, "a.vera", a_src)
         _write_file(tmp_path, "b.vera", b_src)
@@ -344,14 +344,14 @@ class TestImportValidation:
         main = """
 import lib;
 
-fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+private fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
 """
         lib = """
-fn add(@Int, @Int -> @Int)
+private fn add(@Int, @Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { @Int.0 + @Int.1 }
 
-fn sub(@Int, @Int -> @Int)
+private fn sub(@Int, @Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { @Int.0 - @Int.1 }
 """
@@ -365,7 +365,7 @@ fn sub(@Int, @Int -> @Int)
         main = """
 import broken;
 
-fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+private fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
 """
         broken = "this is not valid vera syntax {{{"
         _resolve_err(
@@ -378,14 +378,14 @@ fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
         main = """
 import lib(add, sub);
 
-fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+private fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
 """
         lib = """
-fn add(@Int, @Int -> @Int)
+private fn add(@Int, @Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { @Int.0 + @Int.1 }
 
-fn sub(@Int, @Int -> @Int)
+private fn sub(@Int, @Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { @Int.0 - @Int.1 }
 """
@@ -396,7 +396,7 @@ fn sub(@Int, @Int -> @Int)
     def test_no_imports(self, tmp_path: Path) -> None:
         """File with no imports → empty resolved list."""
         main = """
-fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+private fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
 """
         resolved = _resolve_ok(tmp_path, main)
         assert resolved == []
@@ -406,7 +406,7 @@ fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
         main = """
 module my.app;
 
-fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
+private fn main(-> @Unit) requires(true) ensures(true) effects(pure) { () }
 """
         resolved = _resolve_ok(tmp_path, main)
         assert resolved == []

--- a/vera/README.md
+++ b/vera/README.md
@@ -216,7 +216,7 @@ The compiler maintains two distinct type representations:
 Vera uses typed De Bruijn indices instead of variable names. `@Int.0` means "the most recent `Int` binding", `@Int.1` means "the one before that".
 
 ```
-fn add(@Int, @Int -> @Int) {        Parameters bind left-to-right.
+private fn add(@Int, @Int -> @Int) {        Parameters bind left-to-right.
   let @Int = @Int.0 + @Int.1;       @Int.0 = param₂ (rightmost), @Int.1 = param₁
   @Int.0                             @Int.0 = let binding (shadows param₂)
 }

--- a/vera/errors.py
+++ b/vera/errors.py
@@ -187,7 +187,7 @@ def missing_contract_block(
         fix=(
             "Add a contract block after the signature:\n"
             "\n"
-            "  fn example(@Int -> @Int)\n"
+            "  private fn example(@Int -> @Int)\n"
             "    requires(true)\n"
             "    ensures(@Int.result >= 0)\n"
             "    effects(pure)\n"


### PR DESCRIPTION
## Summary

- Adds `private` to bare `fn` declarations in compiler error message fix suggestions (`vera/errors.py`)
- Updates error message examples in spec chapters, README, AGENTS.md, and `vera/README.md`
- Adds `private` to all 29 inline Vera sources in `tests/test_resolver.py`

Followup to #102 (C7c visibility enforcement) -- these were missed in the initial sweep.

## Test plan

- [x] `pytest tests/ -v` -- 927 tests pass
- [x] Pre-commit hooks pass