### PR TITLE
Add design rationale for mandatory visibility in spec

### DIFF
--- a/spec/05-functions.md
+++ b/spec/05-functions.md
@@ -230,7 +230,7 @@ private fn filter_positive(@Array<Int> -> @Array<Int>)
 
 ## 5.8 Function Visibility
 
-Every top-level `fn` and `data` declaration MUST have an explicit visibility modifier: either `public` or `private`. There is no default visibility. Omitting the modifier is a compile error.
+Every top-level `fn` and `data` declaration MUST have an explicit visibility modifier: either `public` or `private`. There is no default visibility. Omitting the modifier is a compile error. This enforces design principle 3 ("one canonical form"): every declaration has exactly one valid shape, eliminating ambiguity about whether an unadorned `fn` is public or private.
 
 ```
 public fn add(@Int, @Int -> @Int)

--- a/spec/10-grammar.md
+++ b/spec/10-grammar.md
@@ -134,6 +134,8 @@ top_level_decl: visibility? fn_decl
 visibility: PUBLIC | PRIVATE
 ```
 
+> **Note:** The grammar marks `visibility` as optional (`?`) for parser flexibility, but the type checker enforces it as mandatory for `fn` and `data` declarations (see Section 5.8). Omitting the modifier is a compile error.
+
 ### 10.3.2 Function Declarations
 
 ```ebnf


### PR DESCRIPTION
## Summary

- Section 5.8: cite design principle 3 (one canonical form) as the reason there is no default visibility
- Section 10.3.1: note that the grammar `?` is parser-level flexibility; the checker enforces mandatory visibility per Section 5.8

Spec-only change, no code modified.

Generated with [Claude Code](https://claude.com/claude-code)