### PR TITLE
Multi-module codegen via flattening (C7e)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.38] - 2026-02-27
+
+### Added
+- **Multi-module codegen** (C7e — [#50](https://github.com/aallan/vera/issues/50)):
+  - Imported function bodies are now compiled into the WASM module via flattening
+  - `vera compile` and `vera run` work with multi-module programs (previously blocked by C7e guard rail)
+  - Private helper functions called by imported public functions are compiled automatically
+  - `ModuleCall` nodes are desugared to flat `FnCall` in WASM translation (including pipe operator)
+  - Guard rail updated: only truly undefined functions produce errors; imported functions pass through
+  - `modules.vera` example now compiles and runs end-to-end
+  - Spec Chapter 11 updated with cross-module compilation section (11.16)
+- 8 new cross-module codegen tests (951 total, up from 943)
+
+### Changed
+- Error messages for undefined functions no longer reference C7e; instead they report "not found in any imported module"
+
 ## [0.0.37] - 2026-02-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Tracked in [#14](https://github.com/aallan/vera/issues/14) (type-checking) and [
 | C7b | Cross-module type environment — merge public declarations across files | [v0.0.32](https://github.com/aallan/vera/releases/tag/v0.0.32) |
 | C7c | Visibility enforcement — `public`/`private` access control in the checker | [v0.0.34](https://github.com/aallan/vera/releases/tag/v0.0.34)–[v0.0.35](https://github.com/aallan/vera/releases/tag/v0.0.35) |
 | C7d | Cross-module verification — verify contracts that reference imported symbols | [v0.0.37](https://github.com/aallan/vera/releases/tag/v0.0.37) |
-| C7e | Multi-module codegen — WASM import/export tables linking multiple modules | Planned |
+| C7e | Multi-module codegen — flatten imported functions into the WASM module | [v0.0.38](https://github.com/aallan/vera/releases/tag/v0.0.38) |
 | C7f | Spec Chapter 8 — formal module semantics, resolution algorithm, examples | Planned |
 
 ### Next after C7: refactoring
@@ -239,7 +239,7 @@ Tracked in [#14](https://github.com/aallan/vera/issues/14) (type-checking) and [
 
 Open issues grouped by area. These are tracked for future phases beyond C7.
 
-**Codegen gaps** — [#51](https://github.com/aallan/vera/issues/51) garbage collection for WASM linear memory, [#52](https://github.com/aallan/vera/issues/52) dynamic string construction, [#53](https://github.com/aallan/vera/issues/53) `Exn<E>` and custom effect handler compilation, [#106](https://github.com/aallan/vera/issues/106) universal to-string conversion (Show/Display) for all types
+**Codegen gaps** — [#51](https://github.com/aallan/vera/issues/51) garbage collection for WASM linear memory, [#52](https://github.com/aallan/vera/issues/52) dynamic string construction, [#53](https://github.com/aallan/vera/issues/53) `Exn<E>` and custom effect handler compilation, [#106](https://github.com/aallan/vera/issues/106) universal to-string conversion (Show/Display) for all types, [#110](https://github.com/aallan/vera/issues/110) name collision detection for flat module compilation
 
 **Verification** — [#13](https://github.com/aallan/vera/issues/13) expand SMT decidable fragment (Tier 2), [#45](https://github.com/aallan/vera/issues/45) decreases clause termination verification
 

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -526,6 +526,8 @@ Imported functions can be called by name (bare calls): `import vera.math(abs); a
 
 Imported function contracts are verified at call sites by the SMT solver (C7d). Preconditions of imported functions are checked at each call site; postconditions are assumed. This means `abs(x)` with `ensures(@Int.result >= 0)` lets the caller rely on the result being non-negative.
 
+Cross-module compilation uses a flattening strategy (C7e): imported function bodies are compiled into the same WASM module as the importing program. The result is a single self-contained `.wasm` binary. Imported functions are internal (not exported); only the importing program's `public` functions are WASM exports.
+
 Note: module-qualified call syntax (`vera.math.abs(42)`) is not yet parseable due to an LALR grammar limitation. Use bare calls instead.
 
 ## Comments

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.37"
+version = "0.0.38"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/spec/11-compilation.md
+++ b/spec/11-compilation.md
@@ -553,13 +553,27 @@ When the compiler encounters a type alias in a function signature or slot refere
 
 This resolution applies uniformly to parameter types, return types, let bindings, and slot references within function bodies.
 
-## 11.16 Limitations
+## 11.16 Cross-Module Compilation
+
+When a program imports functions from other modules, the compiler uses a **flattening** strategy: imported function bodies are compiled into the same WASM module as the importing program. This produces a single self-contained `.wasm` binary with no external dependencies beyond host imports (IO, State).
+
+The compilation process:
+
+1. **Registration**: For each resolved module, register all function signatures, ADT layouts, and type aliases. Imported names are injected via `setdefault` so local definitions shadow imports.
+2. **Compilation**: After compiling local functions, compile all imported function bodies (including private helpers) as internal (non-exported) WASM functions.
+3. **Call desugaring**: `ModuleCall` nodes (e.g. `math.abs(x)`) are desugared to flat `FnCall` nodes (e.g. `abs(x)`) since the imported function exists in the same WASM module.
+
+Imported functions are **not** exported from the WASM module — only the importing program's `public` functions are exports.
+
+**Known limitation**: If two imported modules define functions with the same name, the flat namespace may produce collisions ([#110](https://github.com/aallan/vera/issues/110)).
+
+## 11.17 Limitations
 
 The current compilation model has the following limitations, each tracked as a GitHub issue:
 
 | Limitation | Issue | Notes |
 |-----------|-------|-------|
-| No module-level code generation | [#50](https://github.com/aallan/vera/issues/50) | Each file compiles independently |
+| Flat module compilation | [#110](https://github.com/aallan/vera/issues/110) | Imported functions are compiled into the importing module; name collisions between modules are not yet detected |
 | No garbage collection | [#51](https://github.com/aallan/vera/issues/51) | Bump allocator only; linear memory is not reclaimed |
 | String constants only | [#52](https://github.com/aallan/vera/issues/52) | No dynamic string construction |
 | Only State\<T\> handlers | [#53](https://github.com/aallan/vera/issues/53) | Exn\<E\> and custom effect handlers not yet compilable |

--- a/spec/12-runtime.md
+++ b/spec/12-runtime.md
@@ -256,5 +256,5 @@ The current runtime has the following limitations, each tracked as a GitHub issu
 |-----------|-------|-------|
 | No garbage collection | [#51](https://github.com/aallan/vera/issues/51) | Bump allocator only; linear memory is not reclaimed |
 | String constants only | [#52](https://github.com/aallan/vera/issues/52) | No dynamic string construction or concatenation at runtime |
-| Single-module execution | [#50](https://github.com/aallan/vera/issues/50) | Each file compiles and executes independently; no cross-module linking |
+| Flat module compilation | [#110](https://github.com/aallan/vera/issues/110) | Imported functions are flattened into the importing module; name collisions between modules not detected |
 | State\<T\> only | [#53](https://github.com/aallan/vera/issues/53) | Only `State<T>` effect handlers are compiled; `Exn<E>` and custom effects use in-WASM handlers |

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -396,6 +396,7 @@ public fn f(-> @Int)
         assert len(errors) == 1
         assert "unknown_fn" in errors[0].description
         assert "not defined in this module" in errors[0].description
+        assert "not found in any imported module" in errors[0].description
         assert result.ok is False
 
     def test_undefined_fn_no_raw_wasmtime_error(self) -> None:
@@ -4241,3 +4242,215 @@ public fn add_five(@Unit -> @Unit)
             initial_state={"State_Int": 100},
         )
         assert exec_result.value is None  # Unit, no trap
+
+
+# =====================================================================
+# Cross-module codegen (C7e)
+# =====================================================================
+
+
+class TestCrossModuleCodegen:
+    """Imported functions are compiled into the WASM module via flattening."""
+
+    # Reusable module sources
+    MATH_MODULE = """\
+public fn abs(@Int -> @Int)
+  requires(true)
+  ensures(@Int.result >= 0)
+  effects(pure)
+{ if @Int.0 < 0 then { 0 - @Int.0 } else { @Int.0 } }
+
+public fn max(@Int, @Int -> @Int)
+  requires(true)
+  ensures(@Int.result >= @Int.0)
+  ensures(@Int.result >= @Int.1)
+  effects(pure)
+{ if @Int.0 >= @Int.1 then { @Int.0 } else { @Int.1 } }
+"""
+
+    HELPER_MODULE = """\
+public fn double(@Int -> @Int)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{ internal(@Int.0) + internal(@Int.0) }
+
+private fn internal(@Int -> @Int)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{ @Int.0 }
+"""
+
+    @staticmethod
+    def _resolved(
+        path: tuple[str, ...], source: str,
+    ) -> "ResolvedModule":
+        """Build a ResolvedModule from source text."""
+        import tempfile
+        from pathlib import Path
+
+        from vera.resolver import ResolvedModule as RM
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".vera", delete=False
+        ) as f:
+            f.write(source)
+            f.flush()
+            fpath = f.name
+
+        tree = parse_file(fpath)
+        prog = transform(tree)
+        return RM(
+            path=path,
+            file_path=Path(fpath),
+            program=prog,
+            source=source,
+        )
+
+    @classmethod
+    def _compile_mod(
+        cls, source: str, modules: list,
+    ) -> CompileResult:
+        """Compile with resolved modules."""
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".vera", delete=False
+        ) as f:
+            f.write(source)
+            f.flush()
+            path = f.name
+
+        tree = parse_file(path)
+        ast = transform(tree)
+        return compile(
+            ast, source=source, file=path, resolved_modules=modules,
+        )
+
+    @classmethod
+    def _run_mod(
+        cls, source: str, modules: list,
+        fn: str | None = None, args: list[int] | None = None,
+    ) -> int:
+        """Compile with modules, execute, and return the integer result."""
+        result = cls._compile_mod(source, modules)
+        errors = [d for d in result.diagnostics if d.severity == "error"]
+        assert not errors, f"Unexpected errors: {[e.description for e in errors]}"
+        exec_result = execute(result, fn_name=fn, args=args)
+        assert exec_result.value is not None, "Expected a return value"
+        return exec_result.value
+
+    # -- Basic compilation --------------------------------------------------
+
+    def test_imported_function_compiles(self) -> None:
+        """Imported function produces valid WASM."""
+        mod = self._resolved(("math",), self.MATH_MODULE)
+        result = self._compile_mod("""\
+import math(abs);
+public fn wrap(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ abs(@Int.0) }
+""", [mod])
+        assert result.ok, [d.description for d in result.diagnostics]
+        assert "$abs" in result.wat
+
+    def test_imported_function_executes(self) -> None:
+        """abs(-5) returns 5 via cross-module call."""
+        mod = self._resolved(("math",), self.MATH_MODULE)
+        val = self._run_mod("""\
+import math(abs);
+public fn wrap(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ abs(@Int.0) }
+""", [mod], fn="wrap", args=[-5])
+        assert val == 5
+
+    def test_multiple_imports_execute(self) -> None:
+        """abs(max(x, y)) compiles and runs correctly."""
+        mod = self._resolved(("math",), self.MATH_MODULE)
+        val = self._run_mod("""\
+import math(abs, max);
+public fn abs_max(@Int, @Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ abs(max(@Int.0, @Int.1)) }
+""", [mod], fn="abs_max", args=[-3, -5])
+        assert val == 3  # abs(max(-3, -5)) = abs(-3) = 3
+
+    # -- Export / visibility -------------------------------------------------
+
+    def test_imported_functions_not_exported(self) -> None:
+        """Imported functions are internal, not WASM exports."""
+        mod = self._resolved(("math",), self.MATH_MODULE)
+        result = self._compile_mod("""\
+import math(abs);
+public fn wrap(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ abs(@Int.0) }
+""", [mod])
+        assert result.ok
+        # Only local public functions are exported
+        assert "wrap" in result.exports
+        assert "abs" not in result.exports
+
+    def test_local_shadows_import(self) -> None:
+        """Local definition of abs shadows the imported one."""
+        mod = self._resolved(("math",), self.MATH_MODULE)
+        val = self._run_mod("""\
+import math(abs);
+public fn abs(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ 999 }
+public fn main(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{ abs(42) }
+""", [mod], fn="main")
+        assert val == 999  # local abs, not imported
+
+    # -- Guard rail ----------------------------------------------------------
+
+    def test_guard_rail_still_catches_unknowns(self) -> None:
+        """Unknown function still produces an error even with modules."""
+        mod = self._resolved(("math",), self.MATH_MODULE)
+        result = self._compile_mod("""\
+import math(abs);
+public fn f(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{ totally_undefined(1) }
+""", [mod])
+        errors = [d for d in result.diagnostics if d.severity == "error"]
+        assert len(errors) == 1
+        assert "totally_undefined" in errors[0].description
+        assert result.ok is False
+
+    # -- Private helper compilation ------------------------------------------
+
+    def test_private_helper_compiled(self) -> None:
+        """Public fn calling private helper works across modules."""
+        mod = self._resolved(("util",), self.HELPER_MODULE)
+        val = self._run_mod("""\
+import util(double);
+public fn main(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ double(@Int.0) }
+""", [mod], fn="main", args=[7])
+        assert val == 14  # double(7) = internal(7) + internal(7) = 14
+
+    # -- Data imports --------------------------------------------------------
+
+    def test_data_imports_dont_break_codegen(self) -> None:
+        """Importing data types alongside functions compiles fine."""
+        data_mod_source = """\
+public data Color { Red, Green, Blue }
+public fn pick(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{ 42 }
+"""
+        mod = self._resolved(("colors",), data_mod_source)
+        val = self._run_mod("""\
+import colors(pick);
+public fn main(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{ pick() }
+""", [mod], fn="main")
+        assert val == 42

--- a/vera/README.md
+++ b/vera/README.md
@@ -547,7 +547,7 @@ Honest inventory of what the compiler cannot do, and where each limitation is ad
 
 | Limitation | Why | Planned |
 |-----------|-----|---------|
-| **Partial module system** | Resolution (C7a), type merging (C7b), visibility (C7c), and verification (C7d) complete; codegen (C7e) pending | [#14](https://github.com/aallan/vera/issues/14), [#50](https://github.com/aallan/vera/issues/50), [#95](https://github.com/aallan/vera/issues/95) |
+| **Partial module system** | Resolution (C7a), type merging (C7b), visibility (C7c), verification (C7d), and codegen (C7e) complete; spec chapter (C7f) pending | [#14](https://github.com/aallan/vera/issues/14), [#95](https://github.com/aallan/vera/issues/95), [#110](https://github.com/aallan/vera/issues/110) |
 | **Limited effect checking** | Pure vs effectful only; no subeffecting or row unification | [#21](https://github.com/aallan/vera/issues/21) |
 | **No termination verification** | `decreases` clauses parsed but always Tier 3 | [#45](https://github.com/aallan/vera/issues/45) |
 | **No quantifier verification** | `forall`/`exists` in contracts always Tier 3 | [#13](https://github.com/aallan/vera/issues/13) |

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.37"
+__version__ = "0.0.38"

--- a/vera/cli.py
+++ b/vera/cli.py
@@ -258,8 +258,10 @@ def cmd_compile(
                 print(e.format(), file=sys.stderr)
             return 1
 
-        # Compile
-        result = codegen_compile(ast, source=source, file=str(p))
+        # Compile (C7e: pass resolved modules for cross-module codegen)
+        result = codegen_compile(
+            ast, source=source, file=str(p), resolved_modules=resolved,
+        )
 
         errors = [d for d in result.diagnostics if d.severity == "error"]
         warnings = [d for d in result.diagnostics if d.severity == "warning"]
@@ -369,8 +371,10 @@ def cmd_run(
                 print(e.format(), file=sys.stderr)
             return 1
 
-        # Compile
-        result = codegen_compile(ast, source=source, file=str(p))
+        # Compile (C7e: pass resolved modules for cross-module codegen)
+        result = codegen_compile(
+            ast, source=source, file=str(p), resolved_modules=resolved,
+        )
 
         if not result.ok:
             errors = [d for d in result.diagnostics if d.severity == "error"]

--- a/vera/codegen.py
+++ b/vera/codegen.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import sys
 from dataclasses import dataclass, field, fields, replace
 from io import StringIO
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import wasmtime
 
@@ -33,6 +33,9 @@ from vera.types import (
     base_type,
 )
 from vera.wasm import StringPool, WasmContext, WasmSlotEnv, wasm_type
+
+if TYPE_CHECKING:
+    from vera.resolver import ResolvedModule
 
 
 # =====================================================================
@@ -105,6 +108,7 @@ def compile(
     program: ast.Program,
     source: str = "",
     file: str | None = None,
+    resolved_modules: list[ResolvedModule] | None = None,
 ) -> CompileResult:
     """Compile a type-checked Vera Program AST to WebAssembly.
 
@@ -112,7 +116,9 @@ def compile(
     and any diagnostics.  The program should already have passed
     type checking and (optionally) verification.
     """
-    gen = CodeGenerator(source=source, file=file)
+    gen = CodeGenerator(
+        source=source, file=file, resolved_modules=resolved_modules,
+    )
     return gen.compile_program(program)
 
 
@@ -287,6 +293,7 @@ class CodeGenerator:
         self,
         source: str = "",
         file: str | None = None,
+        resolved_modules: list[ResolvedModule] | None = None,
     ) -> None:
         self.source = source
         self.file = file
@@ -314,6 +321,13 @@ class CodeGenerator:
         self._closure_fns_wat: list[str] = []  # WAT for lifted closures
         self._needs_table: bool = False
         self._next_closure_id: int = 0
+
+        # Cross-module state (C7e)
+        self._resolved_modules: list[ResolvedModule] = (
+            resolved_modules or []
+        )
+        # Imported FnDecls to compile in Pass 2.5
+        self._imported_fn_decls: list[ast.FnDecl] = []
 
     # -----------------------------------------------------------------
     # Diagnostics
@@ -352,7 +366,10 @@ class CodeGenerator:
 
     def compile_program(self, program: ast.Program) -> CompileResult:
         """Compile a complete Vera program to WebAssembly."""
-        # Pass 1: register all function signatures
+        # Pass 0: register imported module declarations (C7e)
+        self._register_modules(program)
+
+        # Pass 1: register local function signatures (shadows imports)
         self._register_all(program)
 
         # Pass 1.5: monomorphize generic functions
@@ -406,6 +423,19 @@ class CodeGenerator:
                 functions_wat.append(fn_wat)
                 if is_public:
                     exports.append(mdecl.name)
+
+        # Pass 2.5: compile imported function bodies (C7e)
+        imported_seen: set[str] = set()
+        for idecl in self._imported_fn_decls:
+            if idecl.name in imported_seen:
+                continue
+            # Skip if a local function already defined this name
+            if idecl.name in fn_visibility:
+                continue
+            imported_seen.add(idecl.name)
+            fn_wat = self._compile_fn(idecl, export=False)
+            if fn_wat is not None:
+                functions_wat.append(fn_wat)
 
         # Assemble the module
         wat = self._assemble_module(functions_wat)
@@ -470,11 +500,17 @@ class CodeGenerator:
     ) -> None:
         """Recursively walk an AST node looking for unresolved calls."""
         if isinstance(node, ast.ModuleCall):
-            qual = ".".join(node.path) + "." + node.name
-            if qual not in seen:
-                seen.add(qual)
-                self._emit_cross_module_error(node, node.name, qual)
-            return  # don't recurse into args — the call itself is the problem
+            # C7e: if the function is known (imported), skip it — wasm.py
+            # will desugar the ModuleCall to a flat FnCall.
+            if node.name not in known:
+                qual = ".".join(node.path) + "." + node.name
+                if qual not in seen:
+                    seen.add(qual)
+                    self._emit_cross_module_error(node, node.name, qual)
+            # Recurse into args even for known calls
+            for arg in node.args:
+                self._scan_body_for_unknown_calls(arg, known, seen)
+            return
 
         if isinstance(node, ast.FnCall) and node.name not in known:
             if node.name not in seen:
@@ -501,7 +537,7 @@ class CodeGenerator:
         name: str,
         qualified: str | None = None,
     ) -> None:
-        """Emit a diagnostic for an imported function call."""
+        """Emit a diagnostic for an undefined function call."""
         display = qualified or name
         loc = SourceLocation(file=self.file)
         if node.span:
@@ -509,25 +545,100 @@ class CodeGenerator:
             loc.column = node.span.column
         self.diagnostics.append(Diagnostic(
             description=(
-                f"Function '{display}' is not defined in this module. "
-                f"Cross-module compilation is not yet implemented (C7e)."
+                f"Function '{display}' is not defined in this module "
+                f"and was not found in any imported module."
             ),
             location=loc,
             source_line=self._get_source_line(loc.line),
             rationale=(
-                "The type checker allows imported functions to be called "
-                "across module boundaries, but the WASM code generator "
-                "cannot yet link multiple modules together. Each compiled "
-                "module must be self-contained."
+                "The WASM code generator compiles imported functions into "
+                "the output module, but this function was not found in any "
+                "import or local definition."
             ),
             fix=(
-                "Use 'vera check' or 'vera verify' to type-check and "
-                "verify multi-module programs. Single-module programs "
-                "compile and run normally."
+                "Check the function name for typos, or add an import "
+                "for the module that defines it."
             ),
             spec_ref='Chapter 11, "Compilation Model"',
             severity="error",
         ))
+
+    # -----------------------------------------------------------------
+    # Cross-module registration (C7e)
+    # -----------------------------------------------------------------
+
+    def _register_modules(self, program: ast.Program) -> None:
+        """Register imported function signatures for cross-module codegen.
+
+        Mirrors the verifier's ``_register_modules`` pattern (C7d):
+        1. Build import-name filter from ImportDecl nodes.
+        2. For each resolved module, register in isolation and harvest
+           function signatures, ADT layouts, and type aliases.
+        3. Inject into ``self._fn_sigs`` via ``setdefault`` so local
+           definitions shadow imported names.
+        4. Collect all imported FnDecls for compilation in Pass 2.5.
+        """
+        if not self._resolved_modules:
+            return
+
+        # 1. Build import filter: path -> set of names (or None for wildcard)
+        import_names: dict[tuple[str, ...], set[str] | None] = {}
+        for imp in program.imports:
+            import_names[imp.path] = (
+                set(imp.names) if imp.names is not None else None
+            )
+
+        # 2. Register each module in isolation
+        for mod in self._resolved_modules:
+            temp = CodeGenerator(source=mod.source)
+            temp._register_all(mod.program)
+
+            # Build visibility map for this module
+            vis_map: dict[str, str] = {}
+            for tld in mod.program.declarations:
+                if isinstance(tld.decl, ast.FnDecl):
+                    vis_map[tld.decl.name] = tld.visibility or "private"
+                elif isinstance(tld.decl, ast.DataDecl):
+                    vis_map[tld.decl.name] = tld.visibility or "private"
+
+            # Harvest function sigs — include all (public + private) so
+            # private helpers called by imported public fns are available.
+            name_filter = import_names.get(mod.path)
+            for fn_name, sig in temp._fn_sigs.items():
+                # For bare-call injection: only public + in import filter
+                is_public = vis_map.get(fn_name) == "public"
+                in_filter = (
+                    name_filter is None or fn_name in name_filter
+                )
+                if is_public and in_filter:
+                    self._fn_sigs.setdefault(fn_name, sig)
+                # All module functions (including private helpers) get
+                # registered so the guard rail sees them as known
+                self._fn_sigs.setdefault(fn_name, sig)
+
+            # Harvest ADT layouts
+            for adt_name, layouts in temp._adt_layouts.items():
+                is_public = vis_map.get(adt_name) == "public"
+                in_filter = (
+                    name_filter is None or adt_name in name_filter
+                )
+                if is_public and in_filter:
+                    self._adt_layouts.setdefault(adt_name, layouts)
+                    self._needs_alloc = True
+                    self._needs_memory = True
+
+            # Harvest type aliases
+            for alias_name, alias_expr in temp._type_aliases.items():
+                self._type_aliases.setdefault(alias_name, alias_expr)
+
+            # Collect ALL FnDecls from this module for compilation
+            for tld in mod.program.declarations:
+                if isinstance(tld.decl, ast.FnDecl):
+                    self._imported_fn_decls.append(tld.decl)
+                    # Also include where-block functions
+                    if tld.decl.where_fns:
+                        for wfn in tld.decl.where_fns:
+                            self._imported_fn_decls.append(wfn)
 
     # -----------------------------------------------------------------
     # Registration pass
@@ -694,6 +805,12 @@ class CodeGenerator:
             for arm in expr.arms:
                 self._collect_calls_in_expr(
                     arm.body, generic_decls, ctor_to_adt, instances,
+                )
+        elif isinstance(expr, ast.ModuleCall):
+            # C7e: recurse into ModuleCall args for generic call collection
+            for arg in expr.args:
+                self._collect_calls_in_expr(
+                    arg, generic_decls, ctor_to_adt, instances,
                 )
 
     def _infer_type_args_from_call(

--- a/vera/wasm.py
+++ b/vera/wasm.py
@@ -376,7 +376,14 @@ class WasmContext:
             return self._translate_qualified_call(expr, env)
 
         if isinstance(expr, ast.ModuleCall):
-            return None  # cross-module codegen not yet implemented (C7e)
+            # C7e: desugar to flat FnCall — imported function is compiled
+            # into the same WASM module via flattening.
+            desugared = ast.FnCall(
+                name=expr.name,
+                args=expr.args,
+                span=expr.span,
+            )
+            return self._translate_call(desugared, env)
 
         if isinstance(expr, ast.StringLit):
             return self._translate_string_lit(expr)
@@ -500,6 +507,14 @@ class WasmContext:
         # Pipe: a |> f(x, y) → f(a, x, y)
         if expr.op == ast.BinOp.PIPE:
             if isinstance(expr.right, ast.FnCall):
+                desugared = ast.FnCall(
+                    name=expr.right.name,
+                    args=(expr.left,) + expr.right.args,
+                    span=expr.span,
+                )
+                return self._translate_call(desugared, env)
+            # C7e: a |> Module.f(x) → f(a, x)
+            if isinstance(expr.right, ast.ModuleCall):
                 desugared = ast.FnCall(
                     name=expr.right.name,
                     args=(expr.left,) + expr.right.args,


### PR DESCRIPTION
## Summary

- Imported function bodies are compiled into the same WASM module via flattening (no WASM linking needed)
- `ModuleCall` nodes desugared to flat `FnCall` in `wasm.py` since imported functions exist locally
- Private helpers called by imported public functions are compiled automatically
- Guard rail updated: only truly undefined functions error; imported functions pass through
- `vera compile` and `vera run` now work with multi-module programs
- `modules.vera` example compiles and runs end-to-end

## Test plan

- [x] 951 tests pass (943 + 8 new cross-module codegen tests)
- [x] mypy clean
- [x] All 14 examples pass `vera check` and `vera verify`
- [x] All validation scripts pass (README, spec, version sync)
- [x] `vera compile examples/modules.vera` produces valid WASM
- [x] `vera run examples/modules.vera --fn abs_max -- -3 -5` returns 3
- [x] `vera run examples/modules.vera --fn clamp -- 10 1 5` returns 5

Closes #50
Closes part of #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)