### PR TITLE
Spec Chapter 8: Modules (C7f)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.39] - 2026-02-27
+
+### Added
+- **Spec Chapter 8: Modules** (C7f):
+  - New specification chapter covering module declarations, imports, visibility, name resolution, module resolution algorithm, cross-module type checking, verification, and compilation
+  - Formal semantics for the flattening compilation strategy, transitive resolution, circular import detection, and shadowing rules
+  - Clarification that type aliases and effect declarations are module-local (not importable)
+  - Complete worked example with `vera/math.vera`, `vera/collections.vera`, and `modules.vera`
+  - Limitations section tracking #95 (LALR grammar), #110 (name collisions), and future extensions
+
+### Changed
+- **Roadmap restructured**: C7 collapsed as complete (v0.0.31-v0.0.39), C8 defined as the polish phase with sub-phases C8a-C8e grouping all open issues by area
+- Cross-references added from spec Chapters 5, 10, 11, and 12 pointing to Chapter 8
+- `SKILLS.md` module section updated with type-alias/effect locality note and spec reference
+- `vera/README.md` limitations table updated: module system marked complete
+- `docs/index.html` feature grid updated with "Module system" entry
+- README project status: Chapter 8 status changed from "Not started" to "Draft"
+
 ## [0.0.38] - 2026-02-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Vera is in **active development**. The language specification, parser, AST, type
 | — Ch 5: Functions | Draft |
 | — Ch 6: Contracts | Draft |
 | — Ch 7: Effects | Draft |
-| — Ch 8: Modules | Not started |
+| — Ch 8: Modules | Draft |
 | — Ch 9: Standard Library | Draft |
 | — Ch 10: Formal Grammar | Draft |
 | — Ch 11: Compilation Model | Draft |
@@ -173,8 +173,24 @@ Development follows an **interleaved spiral** — each phase adds a complete com
 | C5 | [v0.0.9](https://github.com/aallan/vera/releases/tag/v0.0.9) | **WASM codegen** — compile to WebAssembly, `vera compile` / `vera run` | Done |
 | C6 | [v0.0.10](https://github.com/aallan/vera/releases/tag/v0.0.10)–[v0.0.24](https://github.com/aallan/vera/releases/tag/v0.0.24) | **Codegen completeness** — ADTs, match, closures, effects, generics in WASM | Done |
 | C6.5 | [v0.0.25](https://github.com/aallan/vera/releases/tag/v0.0.25)–[v0.0.30](https://github.com/aallan/vera/releases/tag/v0.0.30) | **Codegen cleanup** — handler fixes, missing operators, String/Array support | Done |
-| C7 | — | **Module system** — cross-file imports, public/private visibility | In progress |
-| C8 | v0.1.0 | **End-to-end** — all examples compile and run, spec complete, polish | Planned |
+| C7 | [v0.0.31](https://github.com/aallan/vera/releases/tag/v0.0.31)–[v0.0.39](https://github.com/aallan/vera/releases/tag/v0.0.39) | **Module system** — cross-file imports, visibility, multi-module compilation | Done |
+| C8 | v0.1.0 | **Polish** — refactoring, tooling, diagnostics, verification depth | Next |
+
+<details>
+<summary>C7 — Module System (<a href="https://github.com/aallan/vera/releases/tag/v0.0.31">v0.0.31</a>–<a href="https://github.com/aallan/vera/releases/tag/v0.0.39">v0.0.39</a>) ✓</summary>
+
+C7 implemented the full module system: file-based resolution, cross-module type checking with visibility enforcement, cross-module contract verification, and multi-module WASM compilation using a flattening strategy. Spec Chapter 8 (Modules) documents the formal semantics.
+
+| Sub-phase | Scope | Version |
+|-----------|-------|---------|
+| C7a | Module resolution — map `import` paths to source files and parse them | [v0.0.31](https://github.com/aallan/vera/releases/tag/v0.0.31) |
+| C7b | Cross-module type environment — merge public declarations across files | [v0.0.32](https://github.com/aallan/vera/releases/tag/v0.0.32) |
+| C7c | Visibility enforcement — `public`/`private` access control in the checker | [v0.0.34](https://github.com/aallan/vera/releases/tag/v0.0.34)–[v0.0.35](https://github.com/aallan/vera/releases/tag/v0.0.35) |
+| C7d | Cross-module verification — verify contracts that reference imported symbols | [v0.0.37](https://github.com/aallan/vera/releases/tag/v0.0.37) |
+| C7e | Multi-module codegen — flatten imported functions into the WASM module | [v0.0.38](https://github.com/aallan/vera/releases/tag/v0.0.38) |
+| C7f | Spec Chapter 8 — formal module semantics, resolution algorithm, examples | [v0.0.39](https://github.com/aallan/vera/releases/tag/v0.0.39) |
+
+</details>
 
 <details>
 <summary>C6.5 — Codegen & Checker Cleanup (<a href="https://github.com/aallan/vera/releases/tag/v0.0.25">v0.0.25</a>–<a href="https://github.com/aallan/vera/releases/tag/v0.0.30">v0.0.30</a>) ✓</summary>
@@ -216,36 +232,44 @@ C6 extended WASM compilation to all language constructs, working through the dep
 
 </details>
 
-### What's next: C7 — Module System
+### What's next: C8 — Polish
 
-C7 implements cross-file imports, public/private visibility, and multi-module compilation. The grammar already parses `module`, `import`, `public`, `private`, and module-qualified calls — the checker currently returns `UnknownType()` for cross-module references. C7 builds out the infrastructure to resolve those references end-to-end.
+C8 addresses the accumulated technical debt and UX gaps before v0.1.0. Open issues are grouped into sub-phases ordered by impact and dependency.
 
-Tracked in [#14](https://github.com/aallan/vera/issues/14) (type-checking) and [#50](https://github.com/aallan/vera/issues/50) (code generation). Spec Chapter 8 (Modules) will be written alongside the implementation.
+**C8a — Refactoring** — reduce file sizes to improve maintainability
 
-| Sub-phase | Scope | Status |
-|-----------|-------|--------|
-| C7a | Module resolution — map `import` paths to source files and parse them | [v0.0.31](https://github.com/aallan/vera/releases/tag/v0.0.31) |
-| C7b | Cross-module type environment — merge public declarations across files | [v0.0.32](https://github.com/aallan/vera/releases/tag/v0.0.32) |
-| C7c | Visibility enforcement — `public`/`private` access control in the checker | [v0.0.34](https://github.com/aallan/vera/releases/tag/v0.0.34)–[v0.0.35](https://github.com/aallan/vera/releases/tag/v0.0.35) |
-| C7d | Cross-module verification — verify contracts that reference imported symbols | [v0.0.37](https://github.com/aallan/vera/releases/tag/v0.0.37) |
-| C7e | Multi-module codegen — flatten imported functions into the WASM module | [v0.0.38](https://github.com/aallan/vera/releases/tag/v0.0.38) |
-| C7f | Spec Chapter 8 — formal module semantics, resolution algorithm, examples | Planned |
+- [#99](https://github.com/aallan/vera/issues/99) decompose `checker.py` (~1,900 lines) into `checker/` submodules
+- [#100](https://github.com/aallan/vera/issues/100) decompose `wasm.py` (~2,300 lines) into `wasm/` submodules
 
-### Next after C7: refactoring
+**C8b — Diagnostics and tooling** — improve the developer (human and LLM) experience
 
-[#99](https://github.com/aallan/vera/issues/99) decompose `checker.py` into `checker/` submodules, [#100](https://github.com/aallan/vera/issues/100) decompose `wasm.py` into `wasm/` submodules
+- [#112](https://github.com/aallan/vera/issues/112) informative runtime contract violation error messages
+- [#80](https://github.com/aallan/vera/issues/80) stable error code taxonomy for diagnostics
+- [#75](https://github.com/aallan/vera/issues/75) `vera fmt` canonical formatter
+- [#79](https://github.com/aallan/vera/issues/79) `vera test` contract-driven testing
+- [#95](https://github.com/aallan/vera/issues/95) LALR grammar fix for module-qualified call syntax
 
-### Longer term
+**C8c — Verification depth** — expand what the SMT solver can prove
 
-Open issues grouped by area. These are tracked for future phases beyond C7.
+- [#13](https://github.com/aallan/vera/issues/13) expand SMT decidable fragment (Tier 2 verification)
+- [#45](https://github.com/aallan/vera/issues/45) `decreases` clause termination verification
 
-**Codegen gaps** — [#51](https://github.com/aallan/vera/issues/51) garbage collection for WASM linear memory, [#52](https://github.com/aallan/vera/issues/52) dynamic string construction, [#53](https://github.com/aallan/vera/issues/53) `Exn<E>` and custom effect handler compilation, [#106](https://github.com/aallan/vera/issues/106) universal to-string conversion (Show/Display) for all types, [#110](https://github.com/aallan/vera/issues/110) name collision detection for flat module compilation, [#112](https://github.com/aallan/vera/issues/112) informative runtime contract violation messages
+**C8d — Type system** — close type-checking gaps
 
-**Verification** — [#13](https://github.com/aallan/vera/issues/13) expand SMT decidable fragment (Tier 2), [#45](https://github.com/aallan/vera/issues/45) decreases clause termination verification
+- [#20](https://github.com/aallan/vera/issues/20) TypeVar subtyping
+- [#21](https://github.com/aallan/vera/issues/21) effect row unification and subeffecting
+- [#55](https://github.com/aallan/vera/issues/55) minimal type inference
 
-**Type system** — [#20](https://github.com/aallan/vera/issues/20) TypeVar subtyping, [#21](https://github.com/aallan/vera/issues/21) effect row unification, [#55](https://github.com/aallan/vera/issues/55) minimal type inference
+**C8e — Codegen gaps** — extend WASM compilation
 
-**Tooling** — [#56](https://github.com/aallan/vera/issues/56) incremental compilation, [#75](https://github.com/aallan/vera/issues/75) `vera fmt` canonical formatter, [#79](https://github.com/aallan/vera/issues/79) `vera test` contract-driven testing, [#80](https://github.com/aallan/vera/issues/80) stable error code taxonomy, [#95](https://github.com/aallan/vera/issues/95) LALR grammar fix for module-qualified call syntax
+- [#110](https://github.com/aallan/vera/issues/110) name collision detection for flat module compilation
+- [#106](https://github.com/aallan/vera/issues/106) universal to-string conversion (Show/Display)
+- [#53](https://github.com/aallan/vera/issues/53) `Exn<E>` and custom effect handler compilation
+- [#52](https://github.com/aallan/vera/issues/52) dynamic string construction
+- [#51](https://github.com/aallan/vera/issues/51) garbage collection for WASM linear memory
+- [#56](https://github.com/aallan/vera/issues/56) incremental compilation
+
+### Beyond C8
 
 **Language design (spec §0.8)** — [#57](https://github.com/aallan/vera/issues/57) `<Http>` network access effect, [#58](https://github.com/aallan/vera/issues/58) JSON standard library type, [#59](https://github.com/aallan/vera/issues/59) `<Async>` futures and promises, [#60](https://github.com/aallan/vera/issues/60) abilities and type constraints, [#61](https://github.com/aallan/vera/issues/61) `<Inference>` LLM inference effect, [#62](https://github.com/aallan/vera/issues/62) standard library collections (Set, Map, Decimal)
 

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -524,11 +524,15 @@ Import paths resolve to files on disk: `import vera.math;` looks for `vera/math.
 
 Imported functions can be called by name (bare calls): `import vera.math(abs); abs(-5)` resolves `abs` from the imported module. Selective imports restrict available names; wildcard imports (`import m;`) make all declarations available. Local definitions shadow imported names. Imported ADT constructors are also available: `import col(List); Cons(1, Nil)`.
 
-Imported function contracts are verified at call sites by the SMT solver (C7d). Preconditions of imported functions are checked at each call site; postconditions are assumed. This means `abs(x)` with `ensures(@Int.result >= 0)` lets the caller rely on the result being non-negative.
+Imported function contracts are verified at call sites by the SMT solver. Preconditions of imported functions are checked at each call site; postconditions are assumed. This means `abs(x)` with `ensures(@Int.result >= 0)` lets the caller rely on the result being non-negative.
 
-Cross-module compilation uses a flattening strategy (C7e): imported function bodies are compiled into the same WASM module as the importing program. The result is a single self-contained `.wasm` binary. Imported functions are internal (not exported); only the importing program's `public` functions are WASM exports.
+Cross-module compilation uses a flattening strategy: imported function bodies are compiled into the same WASM module as the importing program. The result is a single self-contained `.wasm` binary. Imported functions are internal (not exported); only the importing program's `public` functions are WASM exports.
 
-Note: module-qualified call syntax (`vera.math.abs(42)`) is not yet parseable due to an LALR grammar limitation. Use bare calls instead.
+Type aliases and effect declarations are module-local and cannot be imported. If another module needs the same alias or effect, it must declare its own copy.
+
+Note: module-qualified call syntax (`vera.math.abs(42)`) is not yet parseable due to an LALR grammar limitation ([#95](https://github.com/aallan/vera/issues/95)). Use bare calls instead.
+
+See: spec Chapter 8 for the full module system specification.
 
 ## Comments
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -565,6 +565,13 @@
             <div class="feature-desc">Portable, sandboxed execution via wasmtime</div>
           </div>
         </div>
+        <div class="feature">
+          <div class="feature-marker"></div>
+          <div>
+            <div class="feature-title">Module system</div>
+            <div class="feature-desc">Cross-file imports with public/private visibility, verified contracts across module boundaries</div>
+          </div>
+        </div>
       </div>
     </div>
   </section>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.38"
+version = "0.0.39"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/scripts/check_spec_examples.py
+++ b/scripts/check_spec_examples.py
@@ -79,7 +79,7 @@ ALLOWLIST: dict[tuple[str, int], str] = {
 
     # Chapter 5 — inline function types in return/param position
     ("05-functions.md", 203): "FRAGMENT",   # fn make_adder returns fn(...) inline
-    ("05-functions.md", 314): "FRAGMENT",   # fn(A -> B) in param position
+    ("05-functions.md", 316): "FRAGMENT",   # fn(A -> B) in param position
 
     # Chapter 6 — inline function type in type alias
     ("06-contracts.md", 308): "FRAGMENT",   # type SafeDiv = fn(...) + fn apply_div

--- a/spec/05-functions.md
+++ b/spec/05-functions.md
@@ -281,6 +281,8 @@ private forall<T> fn identity(@T -> @T)
 
 Type aliases (`type Foo = ...`), effect declarations (`effect E { ... }`), module declarations, and import statements do not take visibility modifiers. Functions declared inside `where` blocks do not take visibility modifiers (they are always local to the parent function).
 
+For the full module system — imports, resolution, cross-module type checking, verification, and compilation — see Chapter 8.
+
 ## 5.9 Generic Functions
 
 Functions may be parameterised by type variables using `forall`:

--- a/spec/08-modules.md
+++ b/spec/08-modules.md
@@ -1,0 +1,440 @@
+# Chapter 8: Modules
+
+## 8.1 Overview
+
+Vera supports a file-based module system. Each `.vera` file is a module. Modules declare their identity, import declarations from other modules, and control which of their own declarations are visible to importers.
+
+The module system provides:
+
+1. **Module identity**: a dotted path that names the module.
+2. **Imports**: selective or wildcard import of declarations from other modules.
+3. **Visibility**: `public` and `private` access control on functions and data types.
+4. **Resolution**: a file-system-based algorithm that maps import paths to source files.
+5. **Cross-module type checking**: imported declarations are registered in the type environment for bare-call lookup.
+6. **Cross-module verification**: imported function contracts are available to the SMT solver at call sites.
+7. **Cross-module compilation**: imported function bodies are flattened into the importing module's WASM binary.
+
+## 8.2 Module Declaration
+
+Every module may optionally declare its identity with a `module` statement at the top of the file:
+
+```
+module vera.math;
+```
+
+The module path is a dot-separated sequence of lowercase identifiers. The path conventionally mirrors the file's location on disk relative to the project root (e.g., `vera.math` corresponds to `vera/math.vera`), but this is not enforced.
+
+The grammar for module declarations is:
+
+```ebnf
+module_decl: MODULE module_path SEMICOLON
+module_path: LOWER_IDENT (DOT LOWER_IDENT)*
+```
+
+The module declaration must appear before any import declarations or top-level definitions. A file without a module declaration is still a valid module — it is treated as an anonymous module.
+
+## 8.3 Import Declarations
+
+A module imports declarations from other modules using `import` statements:
+
+```
+import vera.math;
+import vera.collections(List, Option);
+```
+
+Import declarations appear after the module declaration (if any) and before any top-level definitions. There are two forms:
+
+### 8.3.1 Wildcard Import
+
+```
+import vera.math;
+```
+
+A wildcard import makes all `public` declarations from the imported module available in the importing module. No parenthesised name list is given.
+
+### 8.3.2 Selective Import
+
+```
+import vera.math(abs, max);
+```
+
+A selective import makes only the named declarations available. Each name in the parenthesised list must refer to a `public` declaration in the imported module. Attempting to import a `private` declaration is an error:
+
+```
+Error: Cannot import 'helper' from module 'vera.math': it is private.
+```
+
+### 8.3.3 Grammar
+
+```ebnf
+import_decl: IMPORT module_path import_list? SEMICOLON
+import_list: LPAREN import_name (COMMA import_name)* RPAREN
+import_name: LOWER_IDENT | UPPER_IDENT
+```
+
+Import names can be lowercase (functions) or uppercase (data type names). Importing a data type also makes its constructors available.
+
+## 8.4 Visibility
+
+Every top-level `fn` and `data` declaration must have an explicit visibility modifier: `public` or `private`. Omitting the modifier is a compile error.
+
+```
+public fn abs(@Int -> @Int)
+  requires(true)
+  ensures(@Int.result >= 0)
+  effects(pure)
+{
+  if @Int.0 < 0 then { 0 - @Int.0 } else { @Int.0 }
+}
+
+private fn helper(@Int -> @Int)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  @Int.0 + 1
+}
+```
+
+### 8.4.1 Visibility Rules
+
+- `public` declarations are visible to any module that imports them.
+- `private` declarations are visible only within the module that defines them.
+- Type aliases (`type Foo = ...`), effect declarations (`effect E { ... }`), module declarations, and import statements do not take visibility modifiers. These declarations are **module-local** — they are not importable by other modules. If another module needs the same type alias or effect, it must declare its own copy.
+- Functions declared inside `where` blocks are always local to the parent function and do not take visibility modifiers.
+
+### 8.4.2 Data Type Visibility
+
+The same rules apply to `data` declarations:
+
+```
+public data Color { Red, Green, Blue }
+private data InternalState { Active(Int), Idle }
+```
+
+When a `public` data type is imported, all of its constructors are also available. A `private` data type's constructors cannot be accessed from outside the module.
+
+### 8.4.3 Generic Declarations
+
+For generic functions, the visibility modifier precedes `forall`:
+
+```
+public forall<T> fn identity(@T -> @T)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  @T.0
+}
+```
+
+## 8.5 Name Resolution
+
+### 8.5.1 Bare Calls
+
+Imported declarations are available as **bare calls** — the importer does not need to qualify the name with the module path:
+
+```
+module vera.examples.modules;
+
+import vera.math(abs, max);
+
+public fn abs_max(@Int, @Int -> @Int)
+  requires(true)
+  ensures(@Int.result >= 0)
+  effects(pure)
+{
+  abs(max(@Int.0, @Int.1))
+}
+```
+
+Here, `abs` and `max` resolve to the imported functions from `vera.math`.
+
+### 8.5.2 Shadowing
+
+Local definitions shadow imported declarations. If a module imports `abs` from `vera.math` but also defines its own `abs`, the local definition takes precedence for bare-call resolution. The import is not an error — it is simply unused for that name.
+
+The shadowing rule is implemented via `setdefault`: imported names are injected into the type environment only if no local definition with the same name already exists.
+
+### 8.5.3 Module-Qualified Calls
+
+Vera's grammar defines a `ModuleCall` syntax for module-qualified function calls:
+
+```
+vera.math.abs(-5)
+```
+
+The path portion (`vera.math`) identifies the module and the final segment (`abs`) identifies the function. This syntax is defined in the grammar and the AST but is currently limited by an LALR parser ambiguity ([#95](https://github.com/aallan/vera/issues/95)). Use bare calls (Section 8.5.1) instead.
+
+### 8.5.4 Constructor Resolution
+
+When a `public` data type is imported, its constructors are available as bare names:
+
+```
+import vera.collections(List);
+
+-- Nil and Cons are now available
+```
+
+Constructor names follow the same shadowing rules as function names.
+
+## 8.6 Module Resolution Algorithm
+
+The resolver maps an import path to a source file on disk using a simple file-system-based algorithm.
+
+### 8.6.1 Path Mapping
+
+Given an import path like `vera.math`:
+
+1. Convert the dotted path to directory separators and append `.vera`:
+   `vera.math` becomes `vera/math.vera`
+
+2. Try to find the file relative to the importing file's parent directory.
+
+3. If the importing file's parent differs from the project root, also try relative to the project root.
+
+For example, if `examples/modules.vera` imports `vera.math`, the resolver looks for:
+- `examples/vera/math.vera` (relative to importing file)
+- `vera/math.vera` (relative to project root)
+
+### 8.6.2 Caching
+
+Each resolved module is parsed and transformed exactly once. Subsequent imports of the same module path return the cached result. The cache key is the module path tuple (e.g., `("vera", "math")`).
+
+### 8.6.3 Circular Import Detection
+
+The resolver tracks modules that are currently being resolved (in-progress set). If a module is encountered while it is already in progress, a circular import error is reported:
+
+```
+Error: Circular import detected: 'vera.math' is already being resolved.
+```
+
+Circular imports are not allowed. The dependency graph must be acyclic.
+
+### 8.6.4 Transitive Resolution
+
+When a module is resolved, its own imports are also resolved recursively. This means importing module A, which imports module B, will resolve both A and B. However, declarations from B are not transitively visible to the original importer — only A's public declarations are available.
+
+### 8.6.5 Resolution Errors
+
+If the resolver cannot find a file for an import path, a diagnostic is emitted:
+
+```
+Error: Cannot resolve import 'vera.missing': no file found.
+  Looked for 'vera/missing.vera' relative to the importing file and project root.
+  Fix: Create the file 'vera/missing.vera' or check the import path.
+```
+
+If parsing the resolved file fails, the parse error is reported as a resolution diagnostic with the import location.
+
+## 8.7 Cross-Module Type Checking
+
+When a program has imports, the type checker performs an additional registration pass before checking the main program.
+
+### 8.7.1 Module Registration
+
+For each resolved module:
+
+1. Create a temporary type checker instance with the module's source.
+2. Run the registration pass (Pass 1) to populate the temporary type environment with all of the module's declarations.
+3. Harvest the registered declarations, excluding built-in names.
+4. Filter to `public` declarations only.
+5. Check that selective imports do not reference `private` names.
+6. Inject the filtered declarations into the main program's type environment using `setdefault` (so local definitions shadow imports).
+
+This is Pass 0 of the three-pass type-checking architecture (see Chapter 5).
+
+### 8.7.2 Type Environment Injection
+
+After module registration, the main type environment contains:
+
+- All built-in types and functions.
+- All imported `public` functions (with their full signatures and contracts).
+- All imported `public` data types (with their constructors).
+- All locally declared types and functions (from Pass 1).
+
+Local declarations always take priority over imported declarations due to the `setdefault` injection order: imports are injected first, then local registration overwrites any collisions.
+
+### 8.7.3 Per-Module Dictionaries
+
+The checker maintains per-module dictionaries of all declarations (both public and private) for two purposes:
+
+- **Module-qualified call lookup**: `ModuleCall` nodes look up the function in the specific module's public dictionary.
+- **Better error messages**: when a selective import names a private declaration, the checker can report "it is private" rather than "not found".
+
+## 8.8 Cross-Module Verification
+
+The contract verifier extends the same module registration pattern to make imported function contracts available during SMT verification.
+
+### 8.8.1 Contract Availability
+
+When the verifier encounters a call to an imported function:
+
+- The function's **preconditions** are checked at the call site: the verifier must prove that the arguments satisfy the imported function's `requires()` clauses.
+- The function's **postconditions** are assumed: the verifier uses the imported function's `ensures()` clauses as axioms when reasoning about the call result.
+
+This is the standard modular verification approach: each module verifies its own function bodies, and callers rely on the declared contracts.
+
+### 8.8.2 Example
+
+Given an imported function:
+
+```
+public fn abs(@Int -> @Int)
+  requires(true)
+  ensures(@Int.result >= 0)
+  effects(pure)
+{
+  if @Int.0 < 0 then { 0 - @Int.0 } else { @Int.0 }
+}
+```
+
+A caller in another module can rely on `abs(x) >= 0`:
+
+```
+import vera.math(abs);
+
+public fn non_negative(@Int -> @Int)
+  requires(true)
+  ensures(@Int.result >= 0)
+  effects(pure)
+{
+  abs(@Int.0)
+}
+```
+
+The verifier proves `non_negative`'s postcondition by assuming `abs`'s postcondition (`@Int.result >= 0`).
+
+## 8.9 Cross-Module Compilation
+
+The code generator uses a **flattening** strategy: imported function bodies are compiled into the same WASM module as the importing program. This produces a single self-contained `.wasm` binary.
+
+### 8.9.1 Compilation Process
+
+1. **Pass 0 — Module registration**: For each resolved module, register all function signatures, ADT layouts, and type aliases into the code generator's state. Imported names are injected via `setdefault` so local definitions shadow imports.
+
+2. **Pass 2.5 — Imported function compilation**: After compiling local functions (Pass 2), compile all imported function bodies — both public and private — as internal WASM functions. Private helpers must be compiled because imported public functions may call them.
+
+3. **Call desugaring**: `ModuleCall` AST nodes (e.g., `vera.math.abs(x)`) are desugared to flat `FnCall` nodes (e.g., `abs(x)`) since the imported function exists in the same WASM module.
+
+### 8.9.2 Export Rules
+
+Imported functions are **not** exported from the WASM module. Only the importing program's `public` functions are WASM exports. An imported public function is internal to the compiled binary — it exists as a callable helper but is not externally visible.
+
+### 8.9.3 Guard Rail
+
+The code generator maintains a guard rail that detects calls to undefined functions. After module registration populates the known-function set, the guard rail only flags truly unknown calls — imported functions are recognised as known.
+
+If a function call cannot be resolved against either local definitions or imported modules, the guard rail reports:
+
+```
+Error: Function 'foo' is not defined in this module and was not found in any imported module.
+```
+
+## 8.10 Complete Example
+
+A complete multi-module example demonstrating all features:
+
+**`vera/math.vera`** — a utility module:
+
+```
+module vera.math;
+
+public fn abs(@Int -> @Int)
+  requires(true)
+  ensures(@Int.result >= 0)
+  effects(pure)
+{
+  if @Int.0 < 0 then { 0 - @Int.0 } else { @Int.0 }
+}
+
+public fn max(@Int, @Int -> @Int)
+  requires(true)
+  ensures(@Int.result >= @Int.0)
+  ensures(@Int.result >= @Int.1)
+  effects(pure)
+{
+  if @Int.0 >= @Int.1 then { @Int.0 } else { @Int.1 }
+}
+```
+
+**`vera/collections.vera`** — generic data types:
+
+```
+module vera.collections;
+
+public data List<T> { Nil, Cons(T, List<T>) }
+
+public data Option<T> { None, Some(T) }
+```
+
+**`modules.vera`** — the importing program:
+
+```
+module vera.examples.modules;
+
+import vera.math(abs, max);
+import vera.collections(List, Option);
+
+public fn clamp(@Int, @Int, @Int -> @Int)
+  requires(@Int.1 <= @Int.2)
+  ensures(@Int.result >= @Int.1)
+  ensures(@Int.result <= @Int.2)
+  effects(pure)
+{
+  if @Int.0 < @Int.1 then {
+    @Int.1
+  } else {
+    if @Int.0 > @Int.2 then {
+      @Int.2
+    } else {
+      @Int.0
+    }
+  }
+}
+
+public fn abs_max(@Int, @Int -> @Int)
+  requires(true)
+  ensures(@Int.result >= 0)
+  effects(pure)
+{
+  abs(max(@Int.0, @Int.1))
+}
+
+private fn helper(@Int -> @Int)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  @Int.0 + 1
+}
+```
+
+Running this program:
+
+```
+$ vera check examples/modules.vera
+OK: examples/modules.vera
+
+$ vera verify examples/modules.vera
+OK: examples/modules.vera
+
+$ vera run examples/modules.vera --fn abs_max -- -3 -5
+3
+
+$ vera run examples/modules.vera --fn clamp -- 10 1 5
+5
+```
+
+## 8.11 Limitations
+
+The current module system has the following limitations, each tracked as a GitHub issue:
+
+| Limitation | Issue | Notes |
+|-----------|-------|-------|
+| Module-qualified call syntax | [#95](https://github.com/aallan/vera/issues/95) | LALR grammar limitation prevents parsing `path.fn(args)` — use bare calls |
+| Name collision in flat compilation | [#110](https://github.com/aallan/vera/issues/110) | If two imported modules define functions with the same name, the flat namespace may collide |
+| No re-exports | — | A module cannot re-export declarations imported from other modules |
+| No wildcard exclusion | — | Cannot import all names except specific ones |
+| No import aliasing | — | Cannot rename imported declarations (e.g., `import m(abs as absolute)`) |
+| No package system | — | Module resolution is file-system-only; no package manager or registry |

--- a/spec/10-grammar.md
+++ b/spec/10-grammar.md
@@ -136,6 +136,8 @@ visibility: PUBLIC | PRIVATE
 
 > **Note:** The grammar marks `visibility` as optional (`?`) for parser flexibility, but the type checker enforces it as mandatory for `fn` and `data` declarations (see Section 5.8). Omitting the modifier is a compile error.
 
+For the semantics of module declarations, imports, visibility modifiers, and name resolution, see Chapter 8.
+
 ### 10.3.2 Function Declarations
 
 ```ebnf

--- a/spec/11-compilation.md
+++ b/spec/11-compilation.md
@@ -555,7 +555,7 @@ This resolution applies uniformly to parameter types, return types, let bindings
 
 ## 11.16 Cross-Module Compilation
 
-When a program imports functions from other modules, the compiler uses a **flattening** strategy: imported function bodies are compiled into the same WASM module as the importing program. This produces a single self-contained `.wasm` binary with no external dependencies beyond host imports (IO, State).
+When a program imports functions from other modules (see Chapter 8 for the module system), the compiler uses a **flattening** strategy: imported function bodies are compiled into the same WASM module as the importing program. This produces a single self-contained `.wasm` binary with no external dependencies beyond host imports (IO, State).
 
 The compilation process:
 

--- a/spec/12-runtime.md
+++ b/spec/12-runtime.md
@@ -256,5 +256,5 @@ The current runtime has the following limitations, each tracked as a GitHub issu
 |-----------|-------|-------|
 | No garbage collection | [#51](https://github.com/aallan/vera/issues/51) | Bump allocator only; linear memory is not reclaimed |
 | String constants only | [#52](https://github.com/aallan/vera/issues/52) | No dynamic string construction or concatenation at runtime |
-| Flat module compilation | [#110](https://github.com/aallan/vera/issues/110) | Imported functions are flattened into the importing module; name collisions between modules not detected |
+| Flat module compilation | [#110](https://github.com/aallan/vera/issues/110) | Imported functions are flattened into the importing module (see Chapter 8, Section 8.9); name collisions between modules not detected |
 | State\<T\> only | [#53](https://github.com/aallan/vera/issues/53) | Only `State<T>` effect handlers are compiled; `Exn<E>` and custom effects use in-WASM handlers |

--- a/vera/README.md
+++ b/vera/README.md
@@ -5,7 +5,7 @@ Architecture documentation for the Vera compiler (`vera/` package). This is for 
 For other documentation:
 - [Root README](../README.md) — project overview, getting started, language examples
 - [SKILLS.md](../SKILLS.md) — language reference for LLM agents writing Vera code
-- [spec/](../spec/) — formal language specification (12 chapters)
+- [spec/](../spec/) — formal language specification (13 chapters, 0-12)
 - [CONTRIBUTING.md](../CONTRIBUTING.md) — contributor workflow and conventions
 
 ## Pipeline Overview
@@ -547,7 +547,7 @@ Honest inventory of what the compiler cannot do, and where each limitation is ad
 
 | Limitation | Why | Planned |
 |-----------|-----|---------|
-| **Partial module system** | Resolution (C7a), type merging (C7b), visibility (C7c), verification (C7d), and codegen (C7e) complete; spec chapter (C7f) pending | [#14](https://github.com/aallan/vera/issues/14), [#95](https://github.com/aallan/vera/issues/95), [#110](https://github.com/aallan/vera/issues/110) |
+| **Module system limitations** | Module system complete (C7a-C7f); remaining issues: LALR grammar limitation for qualified calls, flat-compilation name collisions | [#95](https://github.com/aallan/vera/issues/95), [#110](https://github.com/aallan/vera/issues/110) |
 | **Limited effect checking** | Pure vs effectful only; no subeffecting or row unification | [#21](https://github.com/aallan/vera/issues/21) |
 | **No termination verification** | `decreases` clauses parsed but always Tier 3 | [#45](https://github.com/aallan/vera/issues/45) |
 | **No quantifier verification** | `forall`/`exists` in contracts always Tier 3 | [#13](https://github.com/aallan/vera/issues/13) |

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.38"
+__version__ = "0.0.39"


### PR DESCRIPTION
## Summary

- Write spec/08-modules.md (Chapter 8: Modules) covering module declarations, imports, visibility, name resolution algorithm, cross-module type checking, verification, and compilation
- Cross-reference Chapter 8 from spec Chapters 5, 10, 11, and 12
- Clarify that type aliases and effect declarations are module-local (not importable)
- Collapse C7 roadmap section as complete (v0.0.31-v0.0.39), define C8 sub-phases (C8a-C8e) grouping all open issues by area
- Update SKILLS.md, vera/README.md, docs/index.html with module system documentation
- Version bump to v0.0.39

## Test plan

- [x] All 951 tests pass
- [x] mypy clean (15 source files)
- [x] All 14 examples pass check + verify
- [x] Spec code blocks parse (217 total, 0 failures)
- [x] README code blocks parse
- [x] Version sync check passes

Closes #14

Generated with [Claude Code](https://claude.com/claude-code)