### PR TITLE
Fix strikethrough syntax in roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ C8 addresses the accumulated technical debt and UX gaps before v0.1.0. Open issu
 
 **C8a — Refactoring** — reduce file sizes to improve maintainability
 
-- ~[#99](https://github.com/aallan/vera/issues/99) decompose `checker.py` (~1,900 lines) into `checker/` submodules~ ([v0.0.40](https://github.com/aallan/vera/releases/tag/v0.0.40))
+- ~~[#99](https://github.com/aallan/vera/issues/99) decompose `checker.py` (~1,900 lines) into `checker/` submodules~~ ([v0.0.40](https://github.com/aallan/vera/releases/tag/v0.0.40))
 - [#100](https://github.com/aallan/vera/issues/100) decompose `wasm.py` (~2,300 lines) into `wasm/` submodules
 
 **C8b — Diagnostics and tooling** — improve the developer (human and LLM) experience


### PR DESCRIPTION
Single-char `~` doesn't render as strikethrough on GitHub — needs `~~`.