### PR TITLE
Use HTML del for roadmap strikethrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ C8 addresses the accumulated technical debt and UX gaps before v0.1.0. Open issu
 
 **C8a — Refactoring** — reduce file sizes to improve maintainability
 
-- ~~[#99](https://github.com/aallan/vera/issues/99) decompose `checker.py` (~1,900 lines) into `checker/` submodules~~ ([v0.0.40](https://github.com/aallan/vera/releases/tag/v0.0.40))
+- <del>[#99](https://github.com/aallan/vera/issues/99) decompose `checker.py` (~1,900 lines) into `checker/` submodules</del> ([v0.0.40](https://github.com/aallan/vera/releases/tag/v0.0.40))
 - [#100](https://github.com/aallan/vera/issues/100) decompose `wasm.py` (~2,300 lines) into `wasm/` submodules
 
 **C8b — Diagnostics and tooling** — improve the developer (human and LLM) experience


### PR DESCRIPTION
GitHub Markdown `~~` can't wrap inline code backticks — the parser gets confused by the backticks and tildes in `(~1,900 lines)`. Using `<del>` instead.