### PR TITLE
C8b: informative runtime contract violation messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.42] - 2026-02-27
+
+### Changed
+- **Informative runtime contract violation messages** (C8b, [#112](https://github.com/aallan/vera/issues/112)):
+  - Contract violations now report which function, contract kind, and expression failed
+  - Before: `Runtime contract violation: error while executing at wasm backtrace: ... wasm trap: wasm unreachable instruction executed`
+  - After: `Precondition violation in clamp(@Int, @Int, @Int -> @Int)\n  requires(@Int.1 <= @Int.2) failed`
+  - New `vera.contract_fail` host import passes pre-interned message strings from WASM to the runtime before trapping
+  - Added `format_expr()`, `format_type_expr()`, `format_fn_signature()` to `vera/ast.py` for AST-to-source reconstruction
+  - 20 new tests (971 total, up from 951)
+
 ## [0.0.41] - 2026-02-27
 
 ### Changed
@@ -619,7 +630,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Grammar: handler body simplified to avoid LALR reduce/reduce conflict
 - `pyproject.toml`: corrected build backend, package discovery, PEP 639 compliance
 
-[Unreleased]: https://github.com/aallan/vera/compare/v0.0.41...HEAD
+[Unreleased]: https://github.com/aallan/vera/compare/v0.0.42...HEAD
+[0.0.42]: https://github.com/aallan/vera/compare/v0.0.41...v0.0.42
 [0.0.41]: https://github.com/aallan/vera/compare/v0.0.40...v0.0.41
 [0.0.40]: https://github.com/aallan/vera/compare/v0.0.39...v0.0.40
 [0.0.39]: https://github.com/aallan/vera/compare/v0.0.38...v0.0.39

--- a/README.md
+++ b/README.md
@@ -244,11 +244,11 @@ C8 addresses the accumulated technical debt and UX gaps before v0.1.0. Open issu
 
 **C8b — Diagnostics and tooling** — improve the developer (human and LLM) experience
 
-- [#112](https://github.com/aallan/vera/issues/112) informative runtime contract violation error messages
+- <del>[#112](https://github.com/aallan/vera/issues/112) informative runtime contract violation error messages</del> ([v0.0.42](https://github.com/aallan/vera/releases/tag/v0.0.42))
 - [#80](https://github.com/aallan/vera/issues/80) stable error code taxonomy for diagnostics
+- [#95](https://github.com/aallan/vera/issues/95) LALR grammar fix for module-qualified call syntax
 - [#75](https://github.com/aallan/vera/issues/75) `vera fmt` canonical formatter
 - [#79](https://github.com/aallan/vera/issues/79) `vera test` contract-driven testing
-- [#95](https://github.com/aallan/vera/issues/95) LALR grammar fix for module-qualified call syntax
 
 **C8c — Verification depth** — expand what the SMT solver can prove
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.41"
+version = "0.0.42"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -93,7 +93,7 @@ def _run_trap(
 ) -> None:
     """Compile, execute, and assert a WASM trap."""
     result = _compile_ok(source)
-    with pytest.raises((wasmtime.WasmtimeError, wasmtime.Trap)):
+    with pytest.raises((wasmtime.WasmtimeError, wasmtime.Trap, RuntimeError)):
         execute(result, fn_name=fn, args=args)
 
 
@@ -1284,7 +1284,7 @@ class TestExampleRoundTrips:
         program = transform(tree)
         result = compile(program, source=source, file=str(path))
         # First param (divisor) is 0 → precondition @Int.1 != 0 violated
-        with pytest.raises((wasmtime.WasmtimeError, wasmtime.Trap)):
+        with pytest.raises((wasmtime.WasmtimeError, wasmtime.Trap, RuntimeError)):
             execute(result, fn_name="safe_divide", args=[0, 10])
 
     def test_mutual_recursion_is_even(self) -> None:
@@ -4168,7 +4168,7 @@ public fn bad_increment(@Unit -> @Unit)
 }
 """
         result = _compile_ok(src)
-        with pytest.raises((wasmtime.WasmtimeError, wasmtime.Trap)):
+        with pytest.raises((wasmtime.WasmtimeError, wasmtime.Trap, RuntimeError)):
             execute(
                 result, fn_name="bad_increment",
                 initial_state={"State_Int": 5},
@@ -4454,3 +4454,227 @@ public fn main(-> @Int)
 { pick() }
 """, [mod], fn="main")
         assert val == 42
+
+
+# =====================================================================
+# Contract failure messages (#112)
+# =====================================================================
+
+class TestContractFailMessages:
+    """Verify that contract violations produce informative error messages."""
+
+    def test_precondition_wat_has_contract_fail(self) -> None:
+        """WAT should call contract_fail before unreachable for requires."""
+        source = """\
+public fn positive(@Int -> @Int)
+  requires(@Int.0 > 0)
+  ensures(true)
+  effects(pure)
+{ @Int.0 }
+"""
+        result = _compile_ok(source)
+        assert "call $vera.contract_fail" in result.wat
+        assert "unreachable" in result.wat
+
+    def test_postcondition_wat_has_contract_fail(self) -> None:
+        """WAT should call contract_fail before unreachable for ensures."""
+        source = """\
+public fn negate(@Int -> @Int)
+  requires(true)
+  ensures(@Int.result > 0)
+  effects(pure)
+{ -@Int.0 }
+"""
+        result = _compile_ok(source)
+        assert "call $vera.contract_fail" in result.wat
+
+    def test_trivial_contract_no_contract_fail(self) -> None:
+        """Trivial contracts should not generate contract_fail calls."""
+        source = """\
+public fn f(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 }
+"""
+        result = _compile_ok(source)
+        assert "contract_fail" not in result.wat
+
+    def test_precondition_violation_message(self) -> None:
+        """Precondition violation should produce an informative error."""
+        source = """\
+public fn positive(@Int -> @Int)
+  requires(@Int.0 > 0)
+  ensures(true)
+  effects(pure)
+{ @Int.0 }
+"""
+        result = _compile_ok(source)
+        with pytest.raises(RuntimeError, match="Precondition violation"):
+            execute(result, fn_name="positive", args=[0])
+
+    def test_postcondition_violation_message(self) -> None:
+        """Postcondition violation should produce an informative error."""
+        source = """\
+public fn negate(@Int -> @Int)
+  requires(true)
+  ensures(@Int.result > 0)
+  effects(pure)
+{ -@Int.0 }
+"""
+        result = _compile_ok(source)
+        with pytest.raises(RuntimeError, match="Postcondition violation"):
+            execute(result, fn_name="negate", args=[5])
+
+    def test_violation_includes_function_name(self) -> None:
+        """Error message should include the function name."""
+        source = """\
+public fn safe_div(@Int, @Int -> @Int)
+  requires(@Int.0 != 0)
+  ensures(true)
+  effects(pure)
+{ @Int.1 / @Int.0 }
+"""
+        result = _compile_ok(source)
+        with pytest.raises(RuntimeError, match="safe_div"):
+            execute(result, fn_name="safe_div", args=[10, 0])
+
+    def test_violation_includes_contract_text(self) -> None:
+        """Error message should include the contract expression."""
+        source = """\
+public fn bounded(@Int -> @Int)
+  requires(@Int.0 >= 0)
+  requires(@Int.0 <= 100)
+  ensures(true)
+  effects(pure)
+{ @Int.0 }
+"""
+        result = _compile_ok(source)
+        with pytest.raises(RuntimeError, match=r"requires\(@Int.0 >= 0\)"):
+            execute(result, fn_name="bounded", args=[-1])
+
+    def test_postcondition_includes_ensures_text(self) -> None:
+        """Postcondition message should include the ensures expression."""
+        source = """\
+public fn double(@Int -> @Int)
+  requires(true)
+  ensures(@Int.result >= 0)
+  effects(pure)
+{ @Int.0 * 2 }
+"""
+        result = _compile_ok(source)
+        with pytest.raises(RuntimeError, match=r"ensures\(@Int.result >= 0\)"):
+            execute(result, fn_name="double", args=[-1])
+
+    def test_precondition_full_message_format(self) -> None:
+        """Full message should have kind, signature, and clause."""
+        source = """\
+public fn clamp(@Int, @Int, @Int -> @Int)
+  requires(@Int.0 <= @Int.1)
+  ensures(true)
+  effects(pure)
+{ @Int.2 }
+"""
+        result = _compile_ok(source)
+        try:
+            execute(result, fn_name="clamp", args=[5, 3, 4])
+            assert False, "Expected RuntimeError"
+        except RuntimeError as exc:
+            msg = str(exc)
+            assert "Precondition violation" in msg
+            assert "clamp" in msg
+            assert "requires(" in msg
+            assert "@Int.0 <= @Int.1" in msg
+            assert "failed" in msg
+
+    def test_unit_postcondition_violation(self) -> None:
+        """Postcondition on Unit-returning function should report correctly."""
+        source = """\
+public fn bad_put(@Int -> @Unit)
+  requires(true)
+  ensures(new(State<Int>) == old(State<Int>) + 1)
+  effects(<State<Int>>)
+{
+  let @Int = get(());
+  put(@Int.0 + 2);
+  ()
+}
+"""
+        result = _compile_ok(source)
+        with pytest.raises(RuntimeError, match="Postcondition violation"):
+            execute(result, fn_name="bad_put", args=[0],
+                    initial_state={"State_Int": 5})
+
+
+class TestFormatExpr:
+    """Unit tests for ast.format_expr and related helpers."""
+
+    def test_int_lit(self) -> None:
+        from vera.ast import IntLit, format_expr
+        assert format_expr(IntLit(value=42)) == "42"
+
+    def test_bool_lit(self) -> None:
+        from vera.ast import BoolLit, format_expr
+        assert format_expr(BoolLit(value=True)) == "true"
+        assert format_expr(BoolLit(value=False)) == "false"
+
+    def test_slot_ref(self) -> None:
+        from vera.ast import SlotRef, format_expr
+        expr = SlotRef(type_name="Int", type_args=None, index=1)
+        assert format_expr(expr) == "@Int.1"
+
+    def test_slot_ref_with_type_args(self) -> None:
+        from vera.ast import NamedType, SlotRef, format_expr
+        expr = SlotRef(
+            type_name="Option",
+            type_args=(NamedType(name="Int", type_args=None),),
+            index=0,
+        )
+        assert format_expr(expr) == "@Option<@Int>.0"
+
+    def test_result_ref(self) -> None:
+        from vera.ast import ResultRef, format_expr
+        expr = ResultRef(type_name="Int", type_args=None)
+        assert format_expr(expr) == "@Int.result"
+
+    def test_binary_le(self) -> None:
+        from vera.ast import BinOp, BinaryExpr, SlotRef, format_expr
+        expr = BinaryExpr(
+            op=BinOp.LE,
+            left=SlotRef(type_name="Int", type_args=None, index=1),
+            right=SlotRef(type_name="Int", type_args=None, index=2),
+        )
+        assert format_expr(expr) == "@Int.1 <= @Int.2"
+
+    def test_unary_not(self) -> None:
+        from vera.ast import BoolLit, UnaryExpr, UnaryOp, format_expr
+        expr = UnaryExpr(op=UnaryOp.NOT, operand=BoolLit(value=True))
+        assert format_expr(expr) == "!true"
+
+    def test_unary_neg(self) -> None:
+        from vera.ast import IntLit, UnaryExpr, UnaryOp, format_expr
+        expr = UnaryExpr(op=UnaryOp.NEG, operand=IntLit(value=5))
+        assert format_expr(expr) == "-5"
+
+    def test_fn_call(self) -> None:
+        from vera.ast import FnCall, IntLit, format_expr
+        expr = FnCall(name="abs", args=(IntLit(value=3),))
+        assert format_expr(expr) == "abs(3)"
+
+    def test_format_fn_signature(self) -> None:
+        from vera.ast import (
+            BoolLit, FnDecl, NamedType, format_fn_signature,
+        )
+        decl = FnDecl(
+            name="clamp",
+            forall_vars=None,
+            params=(
+                NamedType(name="Int", type_args=None),
+                NamedType(name="Int", type_args=None),
+                NamedType(name="Int", type_args=None),
+            ),
+            return_type=NamedType(name="Int", type_args=None),
+            contracts=(),
+            effect=(),
+            body=(BoolLit(value=True),),
+            where_fns=None,
+        )
+        assert format_fn_signature(decl) == "clamp(@Int, @Int, @Int -> @Int)"

--- a/vera/README.md
+++ b/vera/README.md
@@ -77,7 +77,7 @@ execute(compile_result, ...)    # → run WASM via wasmtime
 | `grammar.lark` | 330 | Parse | LALR(1) grammar definition | *(consumed by Lark)* |
 | `parser.py` | 147 | Parse | Lark frontend, error diagnosis | `parse()`, `parse_file()` |
 | `transform.py` | 1,000 | Transform | Lark tree → AST transformer | `transform()` |
-| `ast.py` | 690 | Transform | Frozen dataclass AST nodes | `Program`, `Node`, `Expr` |
+| `ast.py` | 785 | Transform | Frozen dataclass AST nodes, source formatting | `Program`, `Node`, `Expr`, `format_expr` |
 | `types.py` | 307 | Type check | Semantic type representation | `Type`, `is_subtype()` |
 | `environment.py` | 302 | Type check | Type environment, scope stacks | `TypeEnv` |
 | `checker/` | 2,194 | Type check | Two-pass type checker (mixin package) | `typecheck()` |
@@ -104,7 +104,7 @@ execute(compile_result, ...)    # → run WASM via wasmtime
 | `cli.py` | 682 | All | CLI commands | `main()` |
 | `registration.py` | 58 | Type check | Shared function registration | `register_fn()` |
 
-Total: ~11,697 lines of Python + 330 lines of grammar.
+Total: ~11,792 lines of Python + 330 lines of grammar.
 
 ## Parsing
 
@@ -407,6 +407,8 @@ The code generator classifies contracts using the verifier's tier results:
 
 Preconditions are checked at function entry. Postconditions store the return value in a temporary local, check the condition, and trap or return.
 
+**Informative violation messages:** Before each `unreachable`, the codegen emits a call to the `vera.contract_fail` host import with a pre-interned message string describing which contract failed (function name, contract kind, expression text). The host callback stores the message; when the trap is caught, `execute()` raises a `RuntimeError` with the stored message instead of a raw WASM trap. `format_expr()` and `format_fn_signature()` in `ast.py` reconstruct source text from AST nodes for the message.
+
 ## Error System
 
 **File:** `errors.py` (354 lines)
@@ -475,7 +477,7 @@ Every diagnostic includes a description (what went wrong), rationale (which lang
 
 ## Test Suite
 
-**951 tests** across 11 files, plus 4 validation scripts and CI infrastructure.
+**971 tests** across 11 files, plus 4 validation scripts and CI infrastructure.
 
 ### Test files
 
@@ -485,7 +487,7 @@ Every diagnostic includes a description (what went wrong), rationale (which lang
 | `test_ast.py` | 84 | 896 | AST transformation, node structure, serialisation |
 | `test_checker.py` | 143 | 1,922 | Type synthesis, slot resolution, effects, contracts, exhaustiveness, cross-module typing, visibility |
 | `test_verifier.py` | 77 | 1,118 | Z3 verification, counterexamples, tier classification, Int→Nat enforcement, call-site preconditions, pipe operator, cross-module contracts |
-| `test_codegen.py` | 337 | 4,456 | WASM compilation, arithmetic, Float64 (incl. modulo), Byte, arrays, ADTs, match, generics, closures, State\<T\>, control flow, strings, IO, contracts, bounds checking, length, quantifiers, assert/assume, refinement type aliases, pipe operator, String/Array signatures, old/new state postconditions, cross-module codegen, example round-trips |
+| `test_codegen.py` | 357 | 4,680 | WASM compilation, arithmetic, Float64 (incl. modulo), Byte, arrays, ADTs, match, generics, closures, State\<T\>, control flow, strings, IO, contracts, contract fail messages, bounds checking, length, quantifiers, assert/assume, refinement type aliases, pipe operator, String/Array signatures, old/new state postconditions, cross-module codegen, example round-trips |
 | `test_cli.py` | 85 | 1,138 | CLI commands (check, verify, compile, run), subprocess integration, JSON error paths, runtime traps, arg validation, multi-file resolution |
 | `test_resolver.py` | 15 | 412 | Module resolution, path lookup, parse caching, circular import detection |
 | `test_types.py` | 55 | 279 | Type operations: subtyping, equality, substitution, pretty-printing, canonical names |

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.41"
+__version__ = "0.0.42"

--- a/vera/ast.py
+++ b/vera/ast.py
@@ -688,3 +688,98 @@ class _TupleDestruct:
     """Sentinel: tuple destructuring pattern."""
     constructor: str
     type_bindings: tuple[TypeExpr, ...]
+
+
+# =====================================================================
+# Source Text Formatting (for error messages)
+# =====================================================================
+
+def format_type_expr(te: TypeExpr) -> str:
+    """Reconstruct Vera source text from a type expression AST node."""
+    if isinstance(te, NamedType):
+        if te.type_args:
+            args = ", ".join(format_type_expr(a) for a in te.type_args)
+            return f"@{te.name}<{args}>"
+        return f"@{te.name}"
+    if isinstance(te, RefinementType):
+        return format_type_expr(te.base_type)
+    return "@?"
+
+
+def format_expr(expr: Expr) -> str:
+    """Reconstruct Vera source text from an expression AST node.
+
+    Produces human-readable representations for contract expressions
+    in runtime error messages.
+    """
+    if isinstance(expr, IntLit):
+        return str(expr.value)
+    if isinstance(expr, FloatLit):
+        return str(expr.value)
+    if isinstance(expr, BoolLit):
+        return "true" if expr.value else "false"
+    if isinstance(expr, StringLit):
+        return f'"{expr.value}"'
+    if isinstance(expr, SlotRef):
+        base = expr.type_name
+        if expr.type_args:
+            args = ", ".join(format_type_expr(a) for a in expr.type_args)
+            base = f"{base}<{args}>"
+        return f"@{base}.{expr.index}"
+    if isinstance(expr, ResultRef):
+        base = expr.type_name
+        if expr.type_args:
+            args = ", ".join(format_type_expr(a) for a in expr.type_args)
+            base = f"{base}<{args}>"
+        return f"@{base}.result"
+    if isinstance(expr, BinaryExpr):
+        left = format_expr(expr.left)
+        right = format_expr(expr.right)
+        return f"{left} {expr.op.value} {right}"
+    if isinstance(expr, UnaryExpr):
+        operand = format_expr(expr.operand)
+        if expr.op == UnaryOp.NEG:
+            return f"-{operand}"
+        return f"!{operand}"
+    if isinstance(expr, FnCall):
+        args = ", ".join(format_expr(a) for a in expr.args)
+        return f"{expr.name}({args})"
+    if isinstance(expr, OldExpr):
+        ref = expr.effect_ref
+        if isinstance(ref, EffectRef):
+            if ref.type_args:
+                args = ", ".join(format_type_expr(a) for a in ref.type_args)
+                return f"old({ref.name}<{args}>)"
+            return f"old({ref.name})"
+        return "old(...)"
+    if isinstance(expr, NewExpr):
+        ref = expr.effect_ref
+        if isinstance(ref, EffectRef):
+            if ref.type_args:
+                args = ", ".join(format_type_expr(a) for a in ref.type_args)
+                return f"new({ref.name}<{args}>)"
+            return f"new({ref.name})"
+        return "new(...)"
+    if isinstance(expr, ForallExpr):
+        binding = format_type_expr(expr.binding_type)
+        domain = format_expr(expr.domain)
+        return f"forall({binding}, {domain}, ...)"
+    if isinstance(expr, ExistsExpr):
+        binding = format_type_expr(expr.binding_type)
+        domain = format_expr(expr.domain)
+        return f"exists({binding}, {domain}, ...)"
+    if isinstance(expr, IndexExpr):
+        coll = format_expr(expr.collection)
+        idx = format_expr(expr.index)
+        return f"{coll}[{idx}]"
+    return "<expr>"
+
+
+def format_fn_signature(decl: FnDecl) -> str:
+    """Format a function signature for error messages.
+
+    Produces output like: clamp(@Int, @Int, @Int -> @Int)
+    """
+    params = ", ".join(format_type_expr(p) for p in decl.params)
+    ret = format_type_expr(decl.return_type)
+    return f"{decl.name}({params} -> {ret})"

--- a/vera/codegen.py
+++ b/vera/codegen.py
@@ -162,6 +162,29 @@ def execute(
         "vera", "print", print_type, host_print, access_caller=True
     )
 
+    # Host function: vera.contract_fail(ptr: i32, len: i32) -> ()
+    # Stores the violation message so it can be reported on trap.
+    last_violation: list[str] = []
+
+    def host_contract_fail(
+        caller: wasmtime.Caller, ptr: int, length: int,
+    ) -> None:
+        memory = caller["memory"]
+        assert isinstance(memory, wasmtime.Memory)
+        buf = memory.data_ptr(store)
+        data = bytes(buf[ptr:ptr + length])
+        last_violation.clear()
+        last_violation.append(data.decode("utf-8"))
+
+    contract_fail_type = wasmtime.FuncType(
+        [wasmtime.ValType.i32(), wasmtime.ValType.i32()],
+        [],
+    )
+    linker.define_func(
+        "vera", "contract_fail", contract_fail_type,
+        host_contract_fail, access_caller=True,
+    )
+
     # State<T> host functions
     _WASM_VAL_TYPE = {
         "i64": wasmtime.ValType.i64(),
@@ -254,7 +277,15 @@ def execute(
         )
         raise RuntimeError(msg)
 
-    raw_result = func(store, *call_args)
+    try:
+        raw_result = func(store, *call_args)
+    except Exception as exc:
+        # Convert contract violation traps to RuntimeError with
+        # the informative message stored by host_contract_fail.
+        exc_name = type(exc).__name__
+        if exc_name in ("Trap", "WasmtimeError") and last_violation:
+            raise RuntimeError(last_violation[0]) from exc
+        raise
 
     # Extract return value
     value: int | float | None
@@ -304,6 +335,7 @@ class CodeGenerator:
         self._fn_sigs: dict[str, tuple[list[str | None], str | None]] = {}
         # Track which effect operations are needed
         self._needs_io_print: bool = False
+        self._needs_contract_fail: bool = False
         self._needs_memory: bool = False
         self._state_types: list[tuple[str, str]] = []  # (type_name, wasm_type)
 
@@ -1523,6 +1555,31 @@ class CodeGenerator:
     # Runtime contract insertion
     # -----------------------------------------------------------------
 
+    def _format_contract_message(
+        self,
+        decl: ast.FnDecl,
+        contract: ast.Requires | ast.Ensures,
+    ) -> str:
+        """Build a human-readable contract failure message string.
+
+        For a Requires:
+          Precondition violation in clamp(@Int, @Int, @Int -> @Int)
+            requires(@Int.1 <= @Int.2) failed
+
+        For an Ensures:
+          Postcondition violation in double(@Int -> @Int)
+            ensures(@Int.result >= 0) failed
+        """
+        if isinstance(contract, ast.Requires):
+            kind = "Precondition"
+            clause = "requires"
+        else:
+            kind = "Postcondition"
+            clause = "ensures"
+        sig = ast.format_fn_signature(decl)
+        expr_text = ast.format_expr(contract.expr)
+        return f"{kind} violation in {sig}\n  {clause}({expr_text}) failed"
+
     def _compile_preconditions(
         self,
         ctx: WasmContext,
@@ -1535,6 +1592,9 @@ class CodeGenerator:
             [condition]
             i32.eqz
             if
+              i32.const <msg_ptr>
+              i32.const <msg_len>
+              call $vera.contract_fail
               unreachable  ;; trap on precondition violation
             end
         """
@@ -1555,6 +1615,16 @@ class CodeGenerator:
             instrs.extend(cond_instrs)
             instrs.append("i32.eqz")
             instrs.append("if")
+
+            # Report which contract failed before trapping
+            msg = self._format_contract_message(decl, contract)
+            ptr, length = self.string_pool.intern(msg)
+            self._needs_contract_fail = True
+            self._needs_memory = True
+            instrs.append(f"  i32.const {ptr}")
+            instrs.append(f"  i32.const {length}")
+            instrs.append("  call $vera.contract_fail")
+
             instrs.append("  unreachable")
             instrs.append("end")
         return instrs
@@ -1610,6 +1680,15 @@ class CodeGenerator:
                 instrs.extend(cond_instrs)
                 instrs.append("i32.eqz")
                 instrs.append("if")
+
+                msg = self._format_contract_message(decl, ensures)
+                ptr, length = self.string_pool.intern(msg)
+                self._needs_contract_fail = True
+                self._needs_memory = True
+                instrs.append(f"  i32.const {ptr}")
+                instrs.append(f"  i32.const {length}")
+                instrs.append("  call $vera.contract_fail")
+
                 instrs.append("  unreachable")
                 instrs.append("end")
 
@@ -1624,6 +1703,15 @@ class CodeGenerator:
                 instrs.extend(cond_instrs)
                 instrs.append("i32.eqz")
                 instrs.append("if")
+
+                msg = self._format_contract_message(decl, ensures)
+                ptr, length = self.string_pool.intern(msg)
+                self._needs_contract_fail = True
+                self._needs_memory = True
+                instrs.append(f"  i32.const {ptr}")
+                instrs.append(f"  i32.const {length}")
+                instrs.append("  call $vera.contract_fail")
+
                 instrs.append("  unreachable")
                 instrs.append("end")
 
@@ -1748,6 +1836,13 @@ class CodeGenerator:
             parts.append(
                 '  (import "vera" "print" '
                 "(func $vera.print (param i32 i32)))"
+            )
+
+        # Import contract_fail for informative violation messages
+        if self._needs_contract_fail:
+            parts.append(
+                '  (import "vera" "contract_fail" '
+                "(func $vera.contract_fail (param i32 i32)))"
             )
 
         # Import State<T> host functions if needed


### PR DESCRIPTION
## Summary

- Contract violations now report function name, contract kind, and expression text instead of raw WASM traps
- New `vera.contract_fail` host import passes pre-interned message strings from WASM to the runtime before trapping
- Added `format_expr()`, `format_type_expr()`, `format_fn_signature()` to `vera/ast.py` for AST-to-source reconstruction
- 20 new tests (971 total, up from 951)

Closes #112

## Test plan

- [x] All 971 tests pass (`pytest tests/ -q`)
- [x] mypy clean (`mypy vera/`)
- [x] All 14 examples pass (`python scripts/check_examples.py`)
- [x] Spec code blocks parse (`python scripts/check_spec_examples.py`)
- [x] README code blocks parse (`python scripts/check_readme_examples.py`)
- [x] Version sync verified (`python scripts/check_version_sync.py`)
- [x] Pre-commit hooks pass
- [x] Manual verification: `vera run examples/modules.vera -- 3 4 5` produces informative error

🤖 Generated with [Claude Code](https://claude.com/claude-code)