### PR TITLE
C8b: stable error code taxonomy (#80)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ vera run file.vera --fn f -- 42   # Call function f with argument 42
 
 ### Error handling
 
-Error messages are natural language instructions explaining what went wrong and how to fix it. They include the offending source line, a rationale, a concrete code fix, and a spec reference. Feed the full error back into your context to correct the code.
+Error messages are natural language instructions explaining what went wrong and how to fix it. They include the offending source line, a rationale, a concrete code fix, a spec reference, and a stable error code. Feed the full error back into your context to correct the code.
 
 For machine-parseable errors, use the `--json` flag:
 
@@ -43,12 +43,30 @@ For machine-parseable errors, use the `--json` flag:
       "source_line": "private fn add(@Int, @Int -> @Int)",
       "rationale": "Vera requires all functions to have explicit contracts...",
       "fix": "Add a contract block after the signature:\n\n  private fn example(@Int -> @Int)\n    requires(true)\n    ensures(@Int.result >= 0)\n    effects(pure)\n  {\n    ...\n  }",
-      "spec_ref": "Chapter 5, Section 5.1 \"Function Structure\""
+      "spec_ref": "Chapter 5, Section 5.1 \"Function Structure\"",
+      "error_code": "E001"
     }
   ],
   "warnings": []
 }
 ```
+
+### Error codes
+
+Every diagnostic has a stable error code. Common codes:
+
+| Code | Meaning |
+|------|---------|
+| E001 | Missing contract block (requires/ensures/effects) |
+| E121 | Function body type doesn't match return type |
+| E130 | Unresolved slot reference (@T.n has no matching binding) |
+| E140 | Arithmetic requires numeric operands |
+| E170 | Let binding type mismatch |
+| E200 | Unresolved function call |
+| E300 | If condition is not Bool |
+| E311 | Non-exhaustive match |
+
+Full code ranges: E0xx (parse), E1xx (type/expressions), E2xx (calls), E3xx (control flow), E5xx (verification), E6xx (codegen). See `vera/errors.py` `ERROR_CODES` for the complete registry.
 
 The `verify --json` output includes a verification summary:
 
@@ -108,7 +126,7 @@ Each stage is a module with a single public API function (`parse_file`, `transfo
 ### Testing
 
 ```bash
-pytest tests/ -v                       # Run all tests (913 tests)
+pytest tests/ -v                       # Run all tests (984 tests)
 mypy vera/                             # Type-check the compiler
 python scripts/check_examples.py       # All 14 examples must pass
 ```
@@ -119,7 +137,7 @@ Test helpers follow a pattern: `_check_ok(source)` / `_check_err(source, match)`
 
 - All 14 examples in `examples/` must pass `vera check` and `vera verify`
 - `mypy vera/` must be clean
-- `pytest tests/ -v` must pass (currently 913 tests)
+- `pytest tests/ -v` must pass (currently 984 tests)
 - Version must be in sync across `vera/__init__.py`, `pyproject.toml`, and `CHANGELOG.md`
 
 ### Contributing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.43] - 2026-02-27
+
+### Added
+- **Stable error code taxonomy for diagnostics** (C8b, [#80](https://github.com/aallan/vera/issues/80)):
+  - Every diagnostic now carries a stable error code (`E001`–`E607`)
+  - Codes are grouped by compiler phase: parse (E0xx), type check (E1xx–E3xx), verification (E5xx), codegen (E6xx)
+  - 80 error codes across 8 files, covering all 77+ diagnostic emission sites
+  - `Diagnostic` dataclass gains `error_code: str` field
+  - `format()` output shows `[Exxx]` prefix when code is present
+  - `to_dict()` includes `error_code` in JSON output
+  - Central `ERROR_CODES` registry in `vera/errors.py` maps codes to short descriptions
+  - 13 new tests (984 total, up from 971)
+
 ## [0.0.42] - 2026-02-27
 
 ### Changed
@@ -630,7 +643,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Grammar: handler body simplified to avoid LALR reduce/reduce conflict
 - `pyproject.toml`: corrected build backend, package discovery, PEP 639 compliance
 
-[Unreleased]: https://github.com/aallan/vera/compare/v0.0.42...HEAD
+[Unreleased]: https://github.com/aallan/vera/compare/v0.0.43...HEAD
+[0.0.43]: https://github.com/aallan/vera/compare/v0.0.42...v0.0.43
 [0.0.42]: https://github.com/aallan/vera/compare/v0.0.41...v0.0.42
 [0.0.41]: https://github.com/aallan/vera/compare/v0.0.40...v0.0.41
 [0.0.40]: https://github.com/aallan/vera/compare/v0.0.39...v0.0.40

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,23 @@ Each stage is a module with a public API function and is independently testable.
 {"ok": true, "file": "...", "diagnostics": [], "warnings": []}
 ```
 
-Each diagnostic includes: `severity`, `description`, `location` (`file`, `line`, `column`), `source_line`, `rationale`, `fix`, and `spec_ref`. The `verify --json` output also includes a `verification` summary with `tier1_verified`, `tier3_runtime`, and `total` counts.
+Each diagnostic includes: `severity`, `description`, `location` (`file`, `line`, `column`), `source_line`, `rationale`, `fix`, `spec_ref`, and `error_code`. The `verify --json` output also includes a `verification` summary with `tier1_verified`, `tier3_runtime`, and `total` counts.
+
+### Error codes
+
+Every diagnostic has a stable error code (`E001`–`E607`). Codes are grouped by compiler phase:
+
+| Range | Phase |
+|-------|-------|
+| E001–E007 | Parse errors |
+| E010 | Transform errors |
+| E1xx | Type check: core + expressions |
+| E2xx | Type check: calls |
+| E3xx | Type check: control flow |
+| E5xx | Verification |
+| E6xx | Codegen |
+
+See `vera/errors.py` `ERROR_CODES` dict for the full registry.
 
 ## Git commits
 

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ C8 addresses the accumulated technical debt and UX gaps before v0.1.0. Open issu
 **C8b — Diagnostics and tooling** — improve the developer (human and LLM) experience
 
 - <del>[#112](https://github.com/aallan/vera/issues/112) informative runtime contract violation error messages</del> ([v0.0.42](https://github.com/aallan/vera/releases/tag/v0.0.42))
-- [#80](https://github.com/aallan/vera/issues/80) stable error code taxonomy for diagnostics
+- <del>[#80](https://github.com/aallan/vera/issues/80) stable error code taxonomy for diagnostics</del> (v0.0.43)
 - [#95](https://github.com/aallan/vera/issues/95) LALR grammar fix for module-qualified call syntax
 - [#75](https://github.com/aallan/vera/issues/75) `vera fmt` canonical formatter
 - [#79](https://github.com/aallan/vera/issues/79) `vera test` contract-driven testing

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -37,7 +37,26 @@ Use `--json` on `check` or `verify` for machine-readable output:
 {"ok": true, "file": "...", "diagnostics": [], "warnings": []}
 ```
 
-On error, each diagnostic includes `severity`, `description`, `location` (`file`, `line`, `column`), `source_line`, `rationale`, `fix`, and `spec_ref`. The `verify --json` output also includes a `verification` summary with `tier1_verified`, `tier3_runtime`, and `total` counts.
+On error, each diagnostic includes `severity`, `description`, `location` (`file`, `line`, `column`), `source_line`, `rationale`, `fix`, `spec_ref`, and `error_code`. The `verify --json` output also includes a `verification` summary with `tier1_verified`, `tier3_runtime`, and `total` counts.
+
+### Error codes
+
+Every diagnostic has a stable error code (`E001`–`E607`) grouped by compiler phase:
+
+- **E001–E007** — Parse errors (missing contracts, unexpected tokens)
+- **E010** — Transform errors (internal)
+- **E120–E176** — Type check: core + expressions (type mismatches, slot resolution, operators)
+- **E200–E233** — Type check: calls (unresolved functions, argument mismatches, module calls)
+- **E300–E335** — Type check: control flow (if/match, patterns, effect handlers)
+- **E500–E525** — Verification (contract violations, undecidable fallbacks)
+- **E600–E607** — Codegen (unsupported features)
+
+Common codes you'll encounter:
+- **E130** — Unresolved slot reference (`@T.n` has no matching binding)
+- **E121** — Function body type doesn't match return type
+- **E200** — Unresolved function call
+- **E300** — If condition is not Bool
+- **E001** — Missing contract block (requires/ensures/effects)
 
 ## Function Structure
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.42"
+version = "0.0.43"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -1920,3 +1920,151 @@ private fn main(@Int -> @Int)
         assert "private" in msg.lower()
         assert "priv_fn" in msg
         assert "mymod" in msg
+
+
+# =====================================================================
+# Error code tests
+# =====================================================================
+
+class TestErrorCodes:
+    """Verify that diagnostics carry stable error codes."""
+
+    def test_error_code_in_format_output(self) -> None:
+        """Error codes appear in formatted diagnostic output."""
+        from vera.errors import Diagnostic, SourceLocation
+        d = Diagnostic(
+            description="test error",
+            location=SourceLocation(line=1, column=1),
+            error_code="E130",
+        )
+        formatted = d.format()
+        assert "[E130]" in formatted
+
+    def test_error_code_in_json_output(self) -> None:
+        """Error codes appear in to_dict() JSON output."""
+        from vera.errors import Diagnostic, SourceLocation
+        d = Diagnostic(
+            description="test error",
+            location=SourceLocation(line=1, column=1),
+            error_code="E130",
+        )
+        data = d.to_dict()
+        assert data["error_code"] == "E130"
+
+    def test_no_error_code_omitted_from_format(self) -> None:
+        """Diagnostics without codes don't show empty brackets."""
+        from vera.errors import Diagnostic, SourceLocation
+        d = Diagnostic(
+            description="test error",
+            location=SourceLocation(line=1, column=1),
+        )
+        formatted = d.format()
+        assert "[" not in formatted.split("\n")[0]
+
+    def test_no_error_code_omitted_from_json(self) -> None:
+        """Diagnostics without codes don't include error_code in JSON."""
+        from vera.errors import Diagnostic, SourceLocation
+        d = Diagnostic(
+            description="test error",
+            location=SourceLocation(line=1, column=1),
+        )
+        data = d.to_dict()
+        assert "error_code" not in data
+
+    def test_error_codes_registry_valid(self) -> None:
+        """All codes in ERROR_CODES are valid Exxx patterns and unique."""
+        import re
+        from vera.errors import ERROR_CODES
+        pattern = re.compile(r"^E\d{3}$")
+        seen: set[str] = set()
+        for code in ERROR_CODES:
+            assert pattern.match(code), f"Invalid code format: {code}"
+            assert code not in seen, f"Duplicate code: {code}"
+            seen.add(code)
+        assert len(ERROR_CODES) >= 70  # sanity: we defined ~80 codes
+
+    def test_slot_ref_error_has_code_E130(self) -> None:
+        """Unresolved slot reference produces E130."""
+        src = """\
+private fn f(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Bool.0 }
+"""
+        diags = _errors(src)
+        assert any(d.error_code == "E130" for d in diags)
+
+    def test_body_type_mismatch_has_code_E121(self) -> None:
+        """Function body type mismatch produces E121."""
+        src = """\
+private fn f(@Int -> @Bool)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 }
+"""
+        diags = _errors(src)
+        assert any(d.error_code == "E121" for d in diags)
+
+    def test_if_condition_not_bool_has_code_E300(self) -> None:
+        """If condition not Bool produces E300."""
+        src = """\
+private fn f(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ if @Int.0 then { 1 } else { 0 } }
+"""
+        diags = _errors(src)
+        assert any(d.error_code == "E300" for d in diags)
+
+    def test_unresolved_function_has_code_E200(self) -> None:
+        """Unresolved function produces E200 (warning)."""
+        src = """\
+private fn f(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ unknown_fn(@Int.0) }
+"""
+        diags = _check(src)
+        assert any(d.error_code == "E200" for d in diags)
+
+    def test_requires_not_bool_has_code_E123(self) -> None:
+        """requires() with non-Bool predicate produces E123."""
+        src = """\
+private fn f(@Int -> @Int)
+  requires(@Int.0) ensures(true) effects(pure)
+{ @Int.0 }
+"""
+        diags = _errors(src)
+        assert any(d.error_code == "E123" for d in diags)
+
+    def test_let_binding_mismatch_has_code_E170(self) -> None:
+        """Let binding type mismatch produces E170."""
+        src = """\
+private fn f(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  let @Bool = @Int.0;
+  @Int.0
+}
+"""
+        diags = _errors(src)
+        assert any(d.error_code == "E170" for d in diags)
+
+    def test_assert_not_bool_has_code_E172(self) -> None:
+        """assert() with non-Bool produces E172."""
+        src = """\
+private fn f(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  assert(@Int.0);
+  @Int.0
+}
+"""
+        diags = _errors(src)
+        assert any(d.error_code == "E172" for d in diags)
+
+    def test_arithmetic_non_numeric_has_code_E140(self) -> None:
+        """Arithmetic on non-numeric produces E140."""
+        src = """\
+private fn f(@Bool -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Bool.0 + 1 }
+"""
+        diags = _errors(src)
+        assert any(d.error_code == "E140" for d in diags)

--- a/vera/README.md
+++ b/vera/README.md
@@ -80,17 +80,17 @@ execute(compile_result, ...)    # → run WASM via wasmtime
 | `ast.py` | 785 | Transform | Frozen dataclass AST nodes, source formatting | `Program`, `Node`, `Expr`, `format_expr` |
 | `types.py` | 307 | Type check | Semantic type representation | `Type`, `is_subtype()` |
 | `environment.py` | 302 | Type check | Type environment, scope stacks | `TypeEnv` |
-| `checker/` | 2,194 | Type check | Two-pass type checker (mixin package) | `typecheck()` |
-| `  core.py` | 349 | | TypeChecker class, orchestration, contracts | |
+| `checker/` | 2,248 | Type check | Two-pass type checker (mixin package) | `typecheck()` |
+| `  core.py` | 356 | | TypeChecker class, orchestration, contracts | |
 | `  resolution.py` | 190 | | AST TypeExpr → semantic Type, inference | |
 | `  modules.py` | 153 | | Cross-module registration (C7b/C7c) | |
 | `  registration.py` | 138 | | Pass 1 forward declarations | |
-| `  expressions.py` | 530 | | Expression synthesis, operators, statements | |
-| `  calls.py` | 390 | | Function/constructor/module calls | |
-| `  control.py` | 439 | | If/match, patterns, effect handlers | |
+| `  expressions.py` | 548 | | Expression synthesis, operators, statements | |
+| `  calls.py` | 405 | | Function/constructor/module calls | |
+| `  control.py` | 453 | | If/match, patterns, effect handlers | |
 | `resolver.py` | 213 | Resolve | Module path resolution, parse cache | `ModuleResolver` |
 | `smt.py` | 547 | Verify | Z3 translation layer | `SmtContext`, `SlotEnv` |
-| `verifier.py` | 691 | Verify | Contract verification | `verify()` |
+| `verifier.py` | 703 | Verify | Contract verification | `verify()` |
 | `wasm/` | 2,474 | Compile | WASM translation layer (package) | `WasmContext`, `WasmSlotEnv`, `StringPool` |
 | ` ├ context.py` | 369 | | Composed WasmContext, expression dispatcher, block translation | |
 | ` ├ helpers.py` | 211 | | WasmSlotEnv, StringPool, type mapping, array element helpers | |
@@ -99,12 +99,12 @@ execute(compile_result, ...)    # → run WASM via wasmtime
 | ` ├ calls.py` | 223 | | Function calls, generic resolution, effect handlers | |
 | ` ├ closures.py` | 248 | | Closures, anonymous functions, free variable analysis | |
 | ` └ data.py` | 460 | | Constructors, match expressions, arrays, indexing | |
-| `codegen.py` | 2,035 | Compile | Codegen orchestrator | `compile()`, `execute()` |
-| `errors.py` | 354 | All | Diagnostic class, error hierarchy | `Diagnostic`, `VeraError` |
+| `codegen.py` | 2,140 | Compile | Codegen orchestrator | `compile()`, `execute()` |
+| `errors.py` | 459 | All | Diagnostic class, error hierarchy, error code registry | `Diagnostic`, `VeraError`, `ERROR_CODES` |
 | `cli.py` | 682 | All | CLI commands | `main()` |
 | `registration.py` | 58 | Type check | Shared function registration | `register_fn()` |
 
-Total: ~11,792 lines of Python + 330 lines of grammar.
+Total: ~12,069 lines of Python + 330 lines of grammar.
 
 ## Parsing
 
@@ -190,7 +190,7 @@ Node
 
 ## Type Checking
 
-**Files:** `checker/` (2,194 lines across 8 modules), `types.py` (307 lines), `environment.py` (302 lines)
+**Files:** `checker/` (2,248 lines across 8 modules), `types.py` (307 lines), `environment.py` (302 lines)
 
 This is the most architecturally complex stage.
 
@@ -285,7 +285,7 @@ Additionally, `resume` is bound as a temporary function inside handler clause bo
 
 ## Contract Verification
 
-**Files:** `verifier.py` (691 lines), `smt.py` (547 lines)
+**Files:** `verifier.py` (703 lines), `smt.py` (547 lines)
 
 ### Tiered model
 
@@ -369,7 +369,7 @@ Error at line 3, column 3:
 
 ## Code Generation
 
-**Files:** `codegen.py` (2,035 lines), `wasm/` (2,474 lines across 7 modules)
+**Files:** `codegen.py` (2,140 lines), `wasm/` (2,474 lines across 7 modules)
 
 ### Compilation pipeline
 
@@ -411,7 +411,7 @@ Preconditions are checked at function entry. Postconditions store the return val
 
 ## Error System
 
-**File:** `errors.py` (354 lines)
+**File:** `errors.py` (459 lines)
 
 ```
 VeraError (exception hierarchy)
@@ -421,7 +421,7 @@ VeraError (exception hierarchy)
 └── VerifyError      ← accumulated as Diagnostic, never raised
 ```
 
-Every diagnostic includes six fields designed for LLM consumption:
+Every diagnostic includes eight fields designed for LLM consumption:
 
 ```
 ┌──────────────────────────────────────────────────────┐
@@ -434,6 +434,7 @@ Every diagnostic includes six fields designed for LLM consumption:
 │  fix           concrete corrected code               │
 │  spec_ref      "Chapter X, Section Y.Z"              │
 │  severity      "error" or "warning"                  │
+│  error_code    stable identifier ("E130", "E200")    │
 └──────────────────────────────────────────────────────┘
 ```
 
@@ -473,11 +474,27 @@ The type system includes open effect rows (`row_var` field in `ConcreteEffectRow
 
 ### 7. LLM-oriented diagnostics
 
-Every diagnostic includes a description (what went wrong), rationale (which language rule), fix (corrected code), and spec reference. The compiler's output is designed to be fed directly back to the model as corrective context. See spec Chapter 0, Section 0.5 "Diagnostics as Instructions" for the philosophy.
+Every diagnostic includes a description (what went wrong), rationale (which language rule), fix (corrected code), spec reference, and a stable error code (`E001`–`E607`). The compiler's output is designed to be fed directly back to the model as corrective context. See spec Chapter 0, Section 0.5 "Diagnostics as Instructions" for the philosophy.
+
+### 8. Stable error code taxonomy
+
+Every diagnostic has a unique code grouped by compiler phase:
+
+| Range | Phase | Source |
+|-------|-------|--------|
+| E001–E007 | Parse | `errors.py` factory functions |
+| E010 | Transform | `transform.py` |
+| E1xx | Type check: core + expressions | `checker/core.py`, `checker/expressions.py` |
+| E2xx | Type check: calls | `checker/calls.py` |
+| E3xx | Type check: control flow | `checker/control.py` |
+| E5xx | Verification | `verifier.py` |
+| E6xx | Codegen | `codegen.py` |
+
+The `ERROR_CODES` dict in `errors.py` maps every code to a short description (80 entries). Codes are stable across versions — they can be used for programmatic filtering, suppression, and documentation lookups. Formatted output shows the code in brackets: `[E130] Error at line 5, column 3:`.
 
 ## Test Suite
 
-**971 tests** across 11 files, plus 4 validation scripts and CI infrastructure.
+**984 tests** across 11 files, plus 4 validation scripts and CI infrastructure.
 
 ### Test files
 
@@ -485,7 +502,7 @@ Every diagnostic includes a description (what went wrong), rationale (which lang
 |------|------:|------:|----------------|
 | `test_parser.py` | 97 | 829 | Grammar rules, operator precedence, parse errors |
 | `test_ast.py` | 84 | 896 | AST transformation, node structure, serialisation |
-| `test_checker.py` | 143 | 1,922 | Type synthesis, slot resolution, effects, contracts, exhaustiveness, cross-module typing, visibility |
+| `test_checker.py` | 156 | 2,070 | Type synthesis, slot resolution, effects, contracts, exhaustiveness, cross-module typing, visibility, error codes |
 | `test_verifier.py` | 77 | 1,118 | Z3 verification, counterexamples, tier classification, Int→Nat enforcement, call-site preconditions, pipe operator, cross-module contracts |
 | `test_codegen.py` | 357 | 4,680 | WASM compilation, arithmetic, Float64 (incl. modulo), Byte, arrays, ADTs, match, generics, closures, State\<T\>, control flow, strings, IO, contracts, contract fail messages, bounds checking, length, quantifiers, assert/assume, refinement type aliases, pipe operator, String/Array signatures, old/new state postconditions, cross-module codegen, example round-trips |
 | `test_cli.py` | 85 | 1,138 | CLI commands (check, verify, compile, run), subprocess integration, JSON error paths, runtime traps, arg validation, multi-file resolution |
@@ -495,7 +512,7 @@ Every diagnostic includes a description (what went wrong), rationale (which lang
 | `test_readme.py` | 2 | 68 | README code sample parsing |
 | `test_errors.py` | 34 | 287 | Diagnostic formatting, serialisation, error patterns, SourceLocation, diagnose_lark_error |
 
-Total: 11,660 lines of test code.
+Total: 12,032 lines of test code.
 
 ### Round-trip testing
 

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.42"
+__version__ = "0.0.43"

--- a/vera/checker/calls.py
+++ b/vera/checker/calls.py
@@ -58,6 +58,7 @@ class CallsMixin:
             rationale="The function is not defined in this file and may come "
                       "from an unresolved import.",
             severity="warning",
+            error_code="E200",
         )
         # Still synth arg types to find errors within them
         for arg in args:
@@ -80,6 +81,7 @@ class CallsMixin:
                 f"Function '{fn_info.name}' expects {len(fn_info.param_types)}"
                 f" argument(s), got {len(args)}.",
                 spec_ref='Chapter 5, Section 5.1 "Function Declarations"',
+                error_code="E201",
             )
             return fn_info.return_type
 
@@ -107,6 +109,7 @@ class CallsMixin:
                     f"{pretty_type(arg_ty)}, expected "
                     f"{pretty_type(param_ty)}.",
                     spec_ref='Chapter 5, Section 5.1 "Function Declarations"',
+                    error_code="E202",
                 )
 
         # Track effects
@@ -135,6 +138,7 @@ class CallsMixin:
                 node,
                 f"Effect operation '{op_info.name}' expects "
                 f"{len(param_types)} argument(s), got {len(args)}.",
+                error_code="E203",
             )
             return return_type
 
@@ -149,6 +153,7 @@ class CallsMixin:
                     f"Argument {i} of '{op_info.name}' has type "
                     f"{pretty_type(arg_ty)}, expected "
                     f"{pretty_type(param_ty)}.",
+                    error_code="E204",
                 )
 
         return return_type
@@ -177,6 +182,7 @@ class CallsMixin:
                 expr,
                 f"Unknown constructor '{expr.name}'.",
                 severity="warning",
+                error_code="E210",
             )
             for arg in expr.args:
                 self._synth_expr(arg)
@@ -193,6 +199,7 @@ class CallsMixin:
                     expr,
                     f"Constructor '{expr.name}' is nullary but was given "
                     f"{len(expr.args)} argument(s).",
+                    error_code="E211",
                 )
             return self._ctor_result_type(ci, arg_types)
 
@@ -201,6 +208,7 @@ class CallsMixin:
                 expr,
                 f"Constructor '{expr.name}' expects "
                 f"{len(ci.field_types)} field(s), got {len(expr.args)}.",
+                error_code="E212",
             )
             return self._ctor_result_type(ci, arg_types)
 
@@ -221,6 +229,7 @@ class CallsMixin:
                     f"Constructor '{expr.name}' field {i} has type "
                     f"{pretty_type(arg_ty)}, expected "
                     f"{pretty_type(field_ty)}.",
+                    error_code="E213",
                 )
 
         return self._ctor_result_type(ci, arg_types)
@@ -230,7 +239,7 @@ class CallsMixin:
         ci = self.env.lookup_constructor(expr.name)
         if ci is None:
             self._error(expr, f"Unknown constructor '{expr.name}'.",
-                        severity="warning")
+                        severity="warning", error_code="E214")
             return UnknownType()
 
         if ci.field_types is not None:
@@ -238,6 +247,7 @@ class CallsMixin:
                 expr,
                 f"Constructor '{expr.name}' requires "
                 f"{len(ci.field_types)} field(s) but was used as nullary.",
+                error_code="E215",
             )
 
         return self._ctor_result_type(ci, [])
@@ -288,6 +298,7 @@ class CallsMixin:
             expr,
             f"Unresolved qualified call '{expr.qualifier}.{expr.name}'.",
             severity="warning",
+            error_code="E220",
         )
         for arg in expr.args:
             self._synth_expr(arg)
@@ -318,6 +329,7 @@ class CallsMixin:
                     "No module matching this import path was resolved. "
                     "Check that the file exists and is imported."
                 ),
+                error_code="E230",
             )
             for arg in expr.args:
                 self._synth_expr(arg)
@@ -340,6 +352,7 @@ class CallsMixin:
                     f"import {mod_label}"
                     f"({', '.join(sorted(import_filter | {fn_name}))});"
                 ),
+                error_code="E231",
             )
             for arg in expr.args:
                 self._synth_expr(arg)
@@ -365,6 +378,7 @@ class CallsMixin:
                 spec_ref=(
                     'Chapter 5, Section 5.8 "Function Visibility"'
                 ),
+                error_code="E232",
             )
             for arg in expr.args:
                 self._synth_expr(arg)
@@ -384,6 +398,7 @@ class CallsMixin:
             f"'{mod_label}'."
             + (f" Available functions: {available}." if available else ""),
             severity="warning",
+            error_code="E233",
         )
         for arg in expr.args:
             self._synth_expr(arg)

--- a/vera/checker/control.py
+++ b/vera/checker/control.py
@@ -38,6 +38,7 @@ class ControlFlowMixin:
                     f"If condition must be Bool, found "
                     f"{pretty_type(cond_ty)}.",
                     spec_ref='Chapter 4, Section 4.8 "Conditional Expressions"',
+                    error_code="E300",
                 )
 
         then_ty = self._synth_expr(expr.then_branch)
@@ -70,6 +71,7 @@ class ControlFlowMixin:
             rationale="Both branches of an if-expression must have "
                       "the same type.",
             spec_ref='Chapter 4, Section 4.8 "Conditional Expressions"',
+            error_code="E301",
         )
         return then_ty  # use then-branch type as best guess
 
@@ -110,6 +112,7 @@ class ControlFlowMixin:
                         f"{pretty_type(result_type)}.",
                         rationale="All match arms must have the same type.",
                         spec_ref='Chapter 4, Section 4.9 "Pattern Matching"',
+                        error_code="E302",
                     )
 
         self._check_exhaustiveness(expr, scrutinee_ty)
@@ -145,6 +148,7 @@ class ControlFlowMixin:
                     "matches all remaining values.",
                     fix="Remove this arm or move it before the catch-all.",
                     spec_ref='Chapter 4, Section 4.9.3 "Unreachable Arms"',
+                    error_code="E310",
                 )
             return  # catch-all guarantees exhaustiveness
 
@@ -172,6 +176,7 @@ class ControlFlowMixin:
                     fix="Add a wildcard '_' arm or cover all cases.",
                     spec_ref='Chapter 4, Section 4.9.2 '
                     '"Exhaustiveness Checking"',
+                    error_code="E311",
                 )
             return
 
@@ -196,6 +201,7 @@ class ControlFlowMixin:
                     fix="Add a wildcard '_' arm or cover all cases.",
                     spec_ref='Chapter 4, Section 4.9.2 '
                     '"Exhaustiveness Checking"',
+                    error_code="E312",
                 )
             return
 
@@ -210,6 +216,7 @@ class ControlFlowMixin:
             fix="Add a wildcard '_' arm or a binding pattern.",
             spec_ref='Chapter 4, Section 4.9.2 '
             '"Exhaustiveness Checking"',
+            error_code="E313",
         )
 
     # -----------------------------------------------------------------
@@ -241,7 +248,7 @@ class ControlFlowMixin:
         ci = self.env.lookup_constructor(pat.name)
         if ci is None:
             self._error(pat, f"Unknown constructor '{pat.name}' in pattern.",
-                        severity="warning")
+                        severity="warning", error_code="E320")
             return []
 
         # Infer type args from expected type
@@ -260,6 +267,7 @@ class ControlFlowMixin:
                 pat,
                 f"Constructor '{pat.name}' has {len(field_types)} field(s), "
                 f"pattern has {len(pat.sub_patterns)} sub-pattern(s).",
+                error_code="E321",
             )
             return []
 
@@ -274,7 +282,7 @@ class ControlFlowMixin:
         ci = self.env.lookup_constructor(pat.name)
         if ci is None:
             self._error(pat, f"Unknown constructor '{pat.name}' in pattern.",
-                        severity="warning")
+                        severity="warning", error_code="E322")
         return []
 
     def _check_binding_pattern(self, pat: ast.BindingPattern,
@@ -300,6 +308,7 @@ class ControlFlowMixin:
             self._error(
                 expr.effect,
                 f"Unknown effect '{effect_inst.name}' in handler.",
+                error_code="E330",
             )
             return UnknownType()
 
@@ -320,6 +329,7 @@ class ControlFlowMixin:
                         f"Handler state initial value has type "
                         f"{pretty_type(init_type)}, expected "
                         f"{pretty_type(state_type)}.",
+                        error_code="E331",
                     )
 
         # Compute handler state canonical type name (for with-clause checks)
@@ -336,6 +346,7 @@ class ControlFlowMixin:
                     clause if hasattr(clause, 'span') else expr,
                     f"Effect '{eff_info.name}' has no operation "
                     f"'{clause.op_name}'.",
+                    error_code="E332",
                 )
                 continue
 
@@ -375,6 +386,7 @@ class ControlFlowMixin:
                         clause,
                         "Handler clause has 'with' state update but "
                         "handler has no state declaration.",
+                        error_code="E333",
                     )
                 else:
                     upd_slot = self._type_expr_to_slot_name(upd_te)
@@ -384,6 +396,7 @@ class ControlFlowMixin:
                             f"State update type '{upd_slot}' does not "
                             f"match handler state type "
                             f"'{state_tname_outer}'.",
+                            error_code="E334",
                         )
                     upd_type = self._synth_expr(upd_expr)
                     if (upd_type and state_type
@@ -394,6 +407,7 @@ class ControlFlowMixin:
                             f"State update expression has type "
                             f"{pretty_type(upd_type)}, expected "
                             f"{pretty_type(state_type)}.",
+                            error_code="E335",
                         )
 
             # Restore previous resume binding (if any)

--- a/vera/checker/core.py
+++ b/vera/checker/core.py
@@ -149,7 +149,8 @@ class TypeChecker(
 
     def _error(self, node: ast.Node, description: str, *,
                rationale: str = "", fix: str = "",
-               spec_ref: str = "", severity: str = "error") -> None:
+               spec_ref: str = "", severity: str = "error",
+               error_code: str = "") -> None:
         """Record a type error diagnostic."""
         loc = SourceLocation(file=self.file)
         if node.span:
@@ -163,6 +164,7 @@ class TypeChecker(
             fix=fix,
             spec_ref=spec_ref,
             severity=severity,
+            error_code=error_code,
         ))
 
     def _source_line(self, node: ast.Node) -> str:
@@ -212,6 +214,7 @@ class TypeChecker(
                     rationale="Data type invariants are predicates that must "
                               "evaluate to Bool.",
                     spec_ref='Chapter 2, Section 2.5 "Algebraic Data Types"',
+                    error_code="E120",
                 )
 
             self.env.type_params = saved_params
@@ -263,6 +266,7 @@ class TypeChecker(
                     fix=f"Change the return type or adjust the body "
                         f"expression.",
                     spec_ref='Chapter 5, Section 5.1 "Function Declarations"',
+                    error_code="E121",
                 )
 
         # 7. Check effect compliance (basic)
@@ -277,6 +281,7 @@ class TypeChecker(
                 fix=f"Declare the appropriate effects, e.g. "
                     f"effects(<{next(iter(self._effect_ops_used), '...')}>).",
                 spec_ref='Chapter 7, Section 7.4 "Performing Effects"',
+                error_code="E122",
             )
 
         # 8. Check where-block functions
@@ -324,6 +329,7 @@ class TypeChecker(
                     f"{pretty_type(ty)}.",
                     rationale="Contract predicates must evaluate to Bool.",
                     spec_ref='Chapter 6, Section 6.2 "Preconditions"',
+                    error_code="E123",
                 )
 
         elif isinstance(contract, ast.Ensures):
@@ -339,6 +345,7 @@ class TypeChecker(
                     f"{pretty_type(ty)}.",
                     rationale="Contract predicates must evaluate to Bool.",
                     spec_ref='Chapter 6, Section 6.3 "Postconditions"',
+                    error_code="E124",
                 )
 
         elif isinstance(contract, ast.Decreases):

--- a/vera/checker/expressions.py
+++ b/vera/checker/expressions.py
@@ -96,7 +96,7 @@ class ExpressionsMixin:
             return self._check_old_expr(expr)
         if isinstance(expr, ast.NewExpr):
             return self._check_new_expr(expr)
-        self._error(expr, f"Unknown expression type: {type(expr).__name__}")
+        self._error(expr, f"Unknown expression type: {type(expr).__name__}", error_code="E176")
         return None
 
     # -----------------------------------------------------------------
@@ -122,6 +122,7 @@ class ExpressionsMixin:
                 fix=f"Ensure enough {tname} bindings are in scope, or use a "
                     f"lower index.",
                 spec_ref='Chapter 3, Section 3.4 "Reference Resolution"',
+                error_code="E130",
             )
             return UnknownType()
         return resolved
@@ -138,6 +139,7 @@ class ExpressionsMixin:
                           "postcondition context.",
                 fix="Move the @T.result reference inside an ensures() clause.",
                 spec_ref='Chapter 3, Section 3.6 "The @result Reference"',
+                error_code="E131",
             )
             return UnknownType()
 
@@ -178,6 +180,7 @@ class ExpressionsMixin:
                     rationale="Arithmetic operators work on Int, Nat, or "
                               "Float64.",
                     spec_ref='Chapter 4, Section 4.3 "Operators"',
+                    error_code="E140",
                 )
                 return UnknownType()
             # Allow Nat+Int => Int, etc. Result is the more general type.
@@ -192,6 +195,7 @@ class ExpressionsMixin:
                 rationale="Both operands must be the same numeric type "
                           "(or Nat where Int is expected).",
                 spec_ref='Chapter 4, Section 4.3 "Operators"',
+                error_code="E141",
             )
             return UnknownType()
 
@@ -207,6 +211,7 @@ class ExpressionsMixin:
                     f"{pretty_type(right_ty)}.",
                     rationale="Equality comparison requires compatible types.",
                     spec_ref='Chapter 4, Section 4.3 "Operators"',
+                    error_code="E142",
                 )
             return BOOL
 
@@ -221,6 +226,7 @@ class ExpressionsMixin:
                     f"found {pretty_type(left_ty)} and "
                     f"{pretty_type(right_ty)}.",
                     spec_ref='Chapter 4, Section 4.3 "Operators"',
+                    error_code="E143",
                 )
             return BOOL
 
@@ -234,6 +240,7 @@ class ExpressionsMixin:
                     f"Left operand of '{op.value}' must be Bool, found "
                     f"{pretty_type(left_ty)}.",
                     spec_ref='Chapter 4, Section 4.3 "Operators"',
+                    error_code="E144",
                 )
             if not is_subtype(right_base, BOOL):
                 self._error(
@@ -241,6 +248,7 @@ class ExpressionsMixin:
                     f"Right operand of '{op.value}' must be Bool, found "
                     f"{pretty_type(right_ty)}.",
                     spec_ref='Chapter 4, Section 4.3 "Operators"',
+                    error_code="E145",
                 )
             return BOOL
 
@@ -282,6 +290,7 @@ class ExpressionsMixin:
                     f"Operator '!' requires Bool operand, found "
                     f"{pretty_type(operand_ty)}.",
                     spec_ref='Chapter 4, Section 4.3 "Operators"',
+                    error_code="E146",
                 )
             return BOOL
 
@@ -292,6 +301,7 @@ class ExpressionsMixin:
                     f"Operator '-' requires numeric operand, found "
                     f"{pretty_type(operand_ty)}.",
                     spec_ref='Chapter 4, Section 4.3 "Operators"',
+                    error_code="E147",
                 )
                 return UnknownType()
             # Negating Nat produces Int (may go negative)
@@ -332,6 +342,7 @@ class ExpressionsMixin:
                         f"Array index must be Int or Nat, found "
                         f"{pretty_type(idx_ty)}.",
                         spec_ref='Chapter 4, Section 4.4 "Array Access"',
+                        error_code="E160",
                     )
             return elem_type
 
@@ -340,6 +351,7 @@ class ExpressionsMixin:
             f"Cannot index {pretty_type(coll_ty)}: indexing requires "
             f"Array<T>.",
             spec_ref='Chapter 4, Section 4.4 "Array Access"',
+            error_code="E161",
         )
         return UnknownType()
 
@@ -378,6 +390,7 @@ class ExpressionsMixin:
                         f"Let binding expects {pretty_type(declared_type)}, "
                         f"value has type {pretty_type(val_type)}.",
                         spec_ref='Chapter 4, Section 4.5 "Let Bindings"',
+                        error_code="E170",
                     )
 
         tname = self._type_expr_to_slot_name(stmt.type_expr)
@@ -418,6 +431,7 @@ class ExpressionsMixin:
                     f"{pretty_type(body_type)}, expected "
                     f"{pretty_type(ret_type)}.",
                     spec_ref='Chapter 5, Section 5.7 "Anonymous Functions"',
+                    error_code="E171",
                 )
 
         return FunctionType(param_types, ret_type, eff)
@@ -459,6 +473,7 @@ class ExpressionsMixin:
                     expr.expr,
                     f"assert() requires Bool, found {pretty_type(ty)}.",
                     spec_ref='Chapter 6, Section 6.6 "Assertions"',
+                    error_code="E172",
                 )
         return UNIT
 
@@ -471,6 +486,7 @@ class ExpressionsMixin:
                     expr.expr,
                     f"assume() requires Bool, found {pretty_type(ty)}.",
                     spec_ref='Chapter 6, Section 6.7 "Assumptions"',
+                    error_code="E173",
                 )
         return UNIT
 
@@ -503,6 +519,7 @@ class ExpressionsMixin:
                 expr,
                 "old() is only valid inside ensures() clauses.",
                 spec_ref='Chapter 7, Section 7.9 "Effect-Contract Interaction"',
+                error_code="E174",
             )
         ei = self._resolve_effect_ref(expr.effect_ref)
         if ei:
@@ -516,6 +533,7 @@ class ExpressionsMixin:
                 expr,
                 "new() is only valid inside ensures() clauses.",
                 spec_ref='Chapter 7, Section 7.9 "Effect-Contract Interaction"',
+                error_code="E175",
             )
         ei = self._resolve_effect_ref(expr.effect_ref)
         if ei:

--- a/vera/codegen.py
+++ b/vera/codegen.py
@@ -371,6 +371,7 @@ class CodeGenerator:
         description: str,
         *,
         rationale: str = "",
+        error_code: str = "",
     ) -> None:
         """Record a compilation warning (function skipped)."""
         loc = SourceLocation(file=self.file)
@@ -383,6 +384,7 @@ class CodeGenerator:
             source_line=self._get_source_line(loc.line),
             rationale=rationale,
             severity="warning",
+            error_code=error_code,
         ))
 
     def _get_source_line(self, line: int) -> str:
@@ -1274,6 +1276,7 @@ class CodeGenerator:
                     f"Function '{decl.name}' has unsupported parameter type.",
                     rationale="Only Int, Nat, Float64, Bool, and Unit types "
                     "are compilable in the current WASM backend.",
+                    error_code="E600",
                 )
                 return None
             if wt == "i32_pair":
@@ -1301,6 +1304,7 @@ class CodeGenerator:
                 f"Function '{decl.name}' has unsupported return type.",
                 rationale="Only Int, Nat, Bool, and Unit types are "
                 "compilable in the current WASM backend.",
+                error_code="E601",
             )
             return None
         if ret_wt == "i32_pair":
@@ -1329,6 +1333,7 @@ class CodeGenerator:
                 rationale="The WASM backend does not yet support all "
                 "Vera expression types. This function will not appear "
                 "in the compiled output.",
+                error_code="E602",
             )
             return None
 
@@ -1948,6 +1953,7 @@ class CodeGenerator:
                             f"effect '{eff.name}' — skipped.",
                             rationale="Only pure, IO, and State<T> effects "
                             "are compilable.",
+                            error_code="E603",
                         )
                         return False
                 else:
@@ -1963,6 +1969,7 @@ class CodeGenerator:
                     decl,
                     f"Function '{decl.name}' has unsupported parameter type "
                     f"— skipped.",
+                    error_code="E604",
                 )
                 return False
 
@@ -1973,6 +1980,7 @@ class CodeGenerator:
                 decl,
                 f"Function '{decl.name}' has unsupported return type "
                 f"— skipped.",
+                error_code="E605",
             )
             return False
 
@@ -1991,6 +1999,7 @@ class CodeGenerator:
                 f"Function '{decl.name}' uses State without "
                 f"a type argument — skipped.",
                 rationale="State<T> requires exactly one type argument.",
+                error_code="E606",
             )
             return False
         type_arg = eff.type_args[0]
@@ -2002,6 +2011,7 @@ class CodeGenerator:
                 f"unsupported type — skipped.",
                 rationale="State<T> requires a compilable primitive type "
                 "(Int, Nat, Bool, Float64).",
+                error_code="E607",
             )
             return False
         type_name = self._type_expr_to_slot_name(type_arg)

--- a/vera/errors.py
+++ b/vera/errors.py
@@ -58,6 +58,7 @@ class Diagnostic:
     fix: str = ""
     spec_ref: str = ""
     severity: str = "error"
+    error_code: str = ""
 
     def format(self) -> str:
         """Format as a natural language diagnostic for LLM consumption."""
@@ -65,7 +66,8 @@ class Diagnostic:
 
         # Header with location
         loc = str(self.location)
-        parts.append(f"{self.severity.title()} at {loc}:")
+        prefix = f"[{self.error_code}] " if self.error_code else ""
+        parts.append(f"{prefix}{self.severity.title()} at {loc}:")
 
         # Source context with pointer
         if self.source_line:
@@ -117,6 +119,8 @@ class Diagnostic:
             d["fix"] = self.fix
         if self.spec_ref:
             d["spec_ref"] = self.spec_ref
+        if self.error_code:
+            d["error_code"] = self.error_code
         return d
 
 
@@ -196,6 +200,7 @@ def missing_contract_block(
             "  }"
         ),
         spec_ref='Chapter 5, Section 5.1 "Function Structure"',
+        error_code="E001",
     )
 
 
@@ -222,6 +227,7 @@ def missing_effect_clause(
             '  effects(<State<Int>, IO>)  -- for multiple effects'
         ),
         spec_ref='Chapter 7, Section 7.1 "Effect Declarations"',
+        error_code="E002",
     )
 
 
@@ -250,6 +256,7 @@ def malformed_slot_reference(
             "  @T.result  -- return value (in postconditions only)"
         ),
         spec_ref='Chapter 3, Section 3.1 "Slot Reference Syntax"',
+        error_code="E003",
     )
 
 
@@ -271,6 +278,7 @@ def unclosed_block(
             'Add the missing "}" to close the block.'
         ),
         spec_ref='Chapter 1, Section 1.6 "Canonical Formatting"',
+        error_code="E004",
     )
 
 
@@ -294,6 +302,7 @@ def unexpected_token(
         ),
         location=SourceLocation(file=file, line=line, column=column),
         source_line=_get_source_line(source, line),
+        error_code="E005",
     )
 
 
@@ -345,10 +354,106 @@ def diagnose_lark_error(
             ),
             location=SourceLocation(file=file, line=line, column=column),
             source_line=_get_source_line(source, line),
+            error_code="E006",
         )
 
     # Unknown exception type — wrap it
     return Diagnostic(
         description=f"Internal parser error: {exc}",
         location=SourceLocation(file=file),
+        error_code="E007",
     )
+
+
+# =====================================================================
+# Error code registry
+# =====================================================================
+
+ERROR_CODES: dict[str, str] = {
+    # E0xx — Parse & Transform
+    "E001": "Missing contract block",
+    "E002": "Missing effect clause",
+    "E003": "Malformed slot reference",
+    "E004": "Missing closing brace",
+    "E005": "Unexpected token",
+    "E006": "Unexpected character",
+    "E007": "Internal parser error",
+    "E010": "Unhandled grammar rule",
+    # E1xx — Type Checker: Core & Expressions
+    "E120": "Data invariant not Bool",
+    "E121": "Function body type mismatch",
+    "E122": "Pure function performs effects",
+    "E123": "Precondition predicate not Bool",
+    "E124": "Postcondition predicate not Bool",
+    "E130": "Unresolved slot reference",
+    "E131": "Result ref outside ensures",
+    "E140": "Arithmetic requires numeric operands",
+    "E141": "Arithmetic requires matching numeric types",
+    "E142": "Cannot compare incompatible types",
+    "E143": "Ordering requires orderable operands",
+    "E144": "Logical operand not Bool (left)",
+    "E145": "Logical operand not Bool (right)",
+    "E146": "Unary not requires Bool",
+    "E147": "Unary negate requires numeric",
+    "E160": "Array index must be Int or Nat",
+    "E161": "Cannot index non-array type",
+    "E170": "Let binding type mismatch",
+    "E171": "Anonymous function body type mismatch",
+    "E172": "Assert requires Bool",
+    "E173": "Assume requires Bool",
+    "E174": "old() outside ensures",
+    "E175": "new() outside ensures",
+    "E176": "Unknown expression type",
+    # E2xx — Type Checker: Calls
+    "E200": "Unresolved function",
+    "E201": "Wrong argument count",
+    "E202": "Argument type mismatch",
+    "E203": "Effect operation wrong argument count",
+    "E204": "Effect operation argument type mismatch",
+    "E210": "Unknown constructor",
+    "E211": "Constructor is nullary",
+    "E212": "Constructor wrong field count",
+    "E213": "Constructor field type mismatch",
+    "E214": "Unknown nullary constructor",
+    "E215": "Constructor requires arguments",
+    "E220": "Unresolved qualified call",
+    "E230": "Module not found",
+    "E231": "Function not imported from module",
+    "E232": "Function is private in module",
+    "E233": "Function not found in module",
+    # E3xx — Type Checker: Control Flow
+    "E300": "If condition not Bool",
+    "E301": "If branches incompatible types",
+    "E302": "Match arm type mismatch",
+    "E310": "Unreachable match arm",
+    "E311": "Non-exhaustive match (ADT)",
+    "E312": "Non-exhaustive match (Bool)",
+    "E313": "Non-exhaustive match (infinite type)",
+    "E320": "Unknown constructor in pattern",
+    "E321": "Pattern constructor wrong arity",
+    "E322": "Unknown nullary constructor in pattern",
+    "E330": "Unknown effect in handler",
+    "E331": "Handler state type mismatch",
+    "E332": "Effect has no such operation",
+    "E333": "Handler with-state but no state declaration",
+    "E334": "State update type name mismatch",
+    "E335": "State update expression type mismatch",
+    # E5xx — Verification
+    "E500": "Postcondition verified false",
+    "E501": "Call-site precondition violation",
+    "E520": "Cannot verify contract (generic function)",
+    "E521": "Cannot verify precondition (undecidable)",
+    "E522": "Cannot verify postcondition (body undecidable)",
+    "E523": "Cannot verify postcondition (expression undecidable)",
+    "E524": "Cannot verify postcondition (timeout)",
+    "E525": "Cannot verify termination metric",
+    # E6xx — Codegen
+    "E600": "Unsupported parameter type",
+    "E601": "Unsupported return type",
+    "E602": "Unsupported body expression type",
+    "E603": "Unsupported closure",
+    "E604": "Unsupported state effect type",
+    "E605": "Unsupported state type parameter",
+    "E606": "State without proper effect declaration",
+    "E607": "State with unsupported operations",
+}

--- a/vera/transform.py
+++ b/vera/transform.py
@@ -110,7 +110,8 @@ def _transform_error(msg: str, meta: Any = None) -> TransformError:
     loc = SourceLocation()
     if meta and hasattr(meta, "line") and meta.line is not None:
         loc = SourceLocation(line=meta.line, column=meta.column)
-    return TransformError(Diagnostic(description=msg, location=loc))
+    return TransformError(Diagnostic(description=msg, location=loc,
+                                      error_code="E010"))
 
 
 class VeraTransformer(Transformer):

--- a/vera/verifier.py
+++ b/vera/verifier.py
@@ -131,6 +131,7 @@ class ContractVerifier:
         rationale: str = "",
         fix: str = "",
         spec_ref: str = "",
+        error_code: str = "",
     ) -> None:
         """Record a verification error."""
         loc = SourceLocation(file=self.file)
@@ -145,6 +146,7 @@ class ContractVerifier:
             fix=fix,
             spec_ref=spec_ref,
             severity="error",
+            error_code=error_code,
         ))
 
     def _warning(
@@ -154,6 +156,7 @@ class ContractVerifier:
         *,
         rationale: str = "",
         spec_ref: str = "",
+        error_code: str = "",
     ) -> None:
         """Record a verification warning (Tier 3 fallback)."""
         loc = SourceLocation(file=self.file)
@@ -167,6 +170,7 @@ class ContractVerifier:
             rationale=rationale,
             spec_ref=spec_ref,
             severity="warning",
+            error_code=error_code,
         ))
 
     def _get_source_line(self, line: int) -> str:
@@ -379,6 +383,7 @@ class ContractVerifier:
                         rationale="Generic functions have type variables that "
                                   "cannot be represented in the SMT solver.",
                         spec_ref='Chapter 6, Section 6.5 "Verification Tiers"',
+                        error_code="E520",
                     )
                 else:
                     self.summary.tier1_verified += 1
@@ -439,6 +444,7 @@ class ContractVerifier:
                                   "pattern matching, effect operations, "
                                   "quantifiers).",
                         spec_ref='Chapter 6, Section 6.5 "Verification Tiers"',
+                        error_code="E521",
                     )
                     continue
                 assumptions.append(z3_pre)
@@ -480,6 +486,7 @@ class ContractVerifier:
                                   "pattern matching, effect operations, "
                                   "generic calls).",
                         spec_ref='Chapter 6, Section 6.5 "Verification Tiers"',
+                        error_code="E522",
                     )
                     continue
 
@@ -497,6 +504,7 @@ class ContractVerifier:
                         rationale="The postcondition expression contains "
                                   "constructs that cannot be translated to SMT.",
                         spec_ref='Chapter 6, Section 6.5 "Verification Tiers"',
+                        error_code="E523",
                     )
                     continue
 
@@ -521,6 +529,7 @@ class ContractVerifier:
                                   "may indicate the formula is too complex or "
                                   "the timeout was reached.",
                         spec_ref='Chapter 6, Section 6.5 "Verification Tiers"',
+                        error_code="E524",
                     )
 
         # 6. Handle decreases clauses (Tier 3 for now)
@@ -537,6 +546,7 @@ class ContractVerifier:
                               "functions requires reasoning about recursive "
                               "call sites, which is not yet implemented.",
                     spec_ref='Chapter 6, Section 6.6 "Termination"',
+                    error_code="E525",
                 )
 
     # -----------------------------------------------------------------
@@ -586,6 +596,7 @@ class ContractVerifier:
                 "postcondition to match the actual function behaviour."
             ),
             spec_ref='Chapter 6, Section 6.4 "Verification Conditions"',
+            error_code="E500",
         )
 
     def _report_call_violation(
@@ -633,6 +644,7 @@ class ContractVerifier:
                 f"precondition is satisfied."
             ),
             spec_ref='Chapter 6, Section 6.4.2 "Call-Site Verification"',
+            error_code="E501",
         )
 
     def _contract_source_text(self, contract: ast.Contract) -> str:


### PR DESCRIPTION
## Summary

- Add `error_code` field to `Diagnostic` dataclass with `[Exxx]` prefix in formatted output and `error_code` in JSON
- Assign 80 unique codes across 6 phase-based ranges: E0xx (parse), E010 (transform), E1xx (core/expressions), E2xx (calls), E3xx (control flow), E5xx (verification), E6xx (codegen)
- Add `ERROR_CODES` registry dict (80 entries) to `errors.py` for future tooling
- Add 13 new tests covering format output, JSON output, registry validity, and representative codes
- Update all documentation: CLAUDE.md, SKILLS.md, AGENTS.md, vera/README.md, CHANGELOG.md

## Test plan

- [x] All 984 tests pass (`pytest tests/ -q`)
- [x] mypy clean (`mypy vera/`)
- [x] All 14 examples pass (`python scripts/check_examples.py`)
- [x] Version sync verified (`python scripts/check_version_sync.py`)
- [x] Pre-commit hooks pass (mypy + pytest + examples + trailing whitespace)

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)