### PR TITLE
C8b: module-qualified call syntax uses :: delimiter (#95)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.44] - 2026-02-28
+
+### Changed
+- **Module-qualified call syntax uses `::` delimiter** (C8b, [#95](https://github.com/aallan/vera/issues/95)):
+  - Module-qualified calls now use `::` between module path and function name: `vera.math::abs(42)`
+  - Resolves LALR(1) grammar ambiguity where `module_path` greedily consumed the function name
+  - Old dot syntax (`vera.math.abs(42)`) is rejected with a targeted "did you mean `::` ?" error (E008)
+  - Added `format_expr` support for `ModuleCall` AST nodes
+  - Updated spec chapters 8 and 10, examples, and all documentation
+  - 12 new tests (996 total, up from 984)
+
 ## [0.0.43] - 2026-02-27
 
 ### Added
@@ -643,7 +654,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Grammar: handler body simplified to avoid LALR reduce/reduce conflict
 - `pyproject.toml`: corrected build backend, package discovery, PEP 639 compliance
 
-[Unreleased]: https://github.com/aallan/vera/compare/v0.0.43...HEAD
+[Unreleased]: https://github.com/aallan/vera/compare/v0.0.44...HEAD
+[0.0.44]: https://github.com/aallan/vera/compare/v0.0.43...v0.0.44
 [0.0.43]: https://github.com/aallan/vera/compare/v0.0.42...v0.0.43
 [0.0.42]: https://github.com/aallan/vera/compare/v0.0.41...v0.0.42
 [0.0.41]: https://github.com/aallan/vera/compare/v0.0.40...v0.0.41

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ C8 addresses the accumulated technical debt and UX gaps before v0.1.0. Open issu
 
 - <del>[#112](https://github.com/aallan/vera/issues/112) informative runtime contract violation error messages</del> ([v0.0.42](https://github.com/aallan/vera/releases/tag/v0.0.42))
 - <del>[#80](https://github.com/aallan/vera/issues/80) stable error code taxonomy for diagnostics</del> (v0.0.43)
-- [#95](https://github.com/aallan/vera/issues/95) LALR grammar fix for module-qualified call syntax
+- <del>[#95](https://github.com/aallan/vera/issues/95) LALR grammar fix for module-qualified call syntax</del> (v0.0.44)
 - [#75](https://github.com/aallan/vera/issues/75) `vera fmt` canonical formatter
 - [#79](https://github.com/aallan/vera/issues/79) `vera test` contract-driven testing
 

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -549,7 +549,7 @@ Cross-module compilation uses a flattening strategy: imported function bodies ar
 
 Type aliases and effect declarations are module-local and cannot be imported. If another module needs the same alias or effect, it must declare its own copy.
 
-Note: module-qualified call syntax (`vera.math.abs(42)`) is not yet parseable due to an LALR grammar limitation ([#95](https://github.com/aallan/vera/issues/95)). Use bare calls instead.
+Module-qualified calls use `::` between the module path and the function name: `vera.math::abs(42)`. The dot-separated path identifies the module and `::` separates it from the function name. This syntax can be used anywhere a function call is valid, and always resolves against the specific module's public declarations — it is not affected by local shadowing.
 
 See: spec Chapter 8 for the full module system specification.
 

--- a/examples/modules.vera
+++ b/examples/modules.vera
@@ -32,6 +32,15 @@ public fn abs_max(@Int, @Int -> @Int)
   abs(max(@Int.0, @Int.1))
 }
 
+-- Module-qualified call syntax (C8b, #95)
+public fn qualified_abs(@Int -> @Int)
+  requires(true)
+  ensures(@Int.result >= 0)
+  effects(pure)
+{
+  vera.math::abs(@Int.0)
+}
+
 -- Private function — internal to this module
 private fn helper(@Int -> @Int)
   requires(true)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.43"
+version = "0.0.44"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/spec/08-modules.md
+++ b/spec/08-modules.md
@@ -158,13 +158,21 @@ The shadowing rule is implemented via `setdefault`: imported names are injected 
 
 ### 8.5.3 Module-Qualified Calls
 
-Vera's grammar defines a `ModuleCall` syntax for module-qualified function calls:
+Vera supports module-qualified function calls using `::` to separate the module path from the function name:
 
 ```
-vera.math.abs(-5)
+vera.math::abs(-5)
 ```
 
-The path portion (`vera.math`) identifies the module and the final segment (`abs`) identifies the function. This syntax is defined in the grammar and the AST but is currently limited by an LALR parser ambiguity ([#95](https://github.com/aallan/vera/issues/95)). Use bare calls (Section 8.5.1) instead.
+The path portion (`vera.math`) identifies the module using dot separators, and `::` separates the path from the function name (`abs`). Arguments follow in parentheses. This syntax can be used anywhere a function call is valid.
+
+The grammar is:
+
+```ebnf
+module_call: module_path "::" LOWER_IDENT "(" arg_list? ")"
+```
+
+Module-qualified calls always resolve against the specific module's public declarations. They are not affected by local shadowing -- if the importer defines its own `abs`, a module-qualified call `vera.math::abs(x)` still calls the module's version.
 
 ### 8.5.4 Constructor Resolution
 
@@ -432,7 +440,6 @@ The current module system has the following limitations, each tracked as a GitHu
 
 | Limitation | Issue | Notes |
 |-----------|-------|-------|
-| Module-qualified call syntax | [#95](https://github.com/aallan/vera/issues/95) | LALR grammar limitation prevents parsing `path.fn(args)` — use bare calls |
 | Name collision in flat compilation | [#110](https://github.com/aallan/vera/issues/110) | If two imported modules define functions with the same name, the flat namespace may collide |
 | No re-exports | — | A module cannot re-export declarations imported from other modules |
 | No wildcard exclusion | — | Cannot import all names except specific ones |

--- a/spec/10-grammar.md
+++ b/spec/10-grammar.md
@@ -300,10 +300,12 @@ result_ref: AT type_expr DOT RESULT
 fn_call: LOWER_IDENT LPAREN arg_list? RPAREN          // function call
        | UPPER_IDENT LPAREN arg_list? RPAREN           // constructor call
        | UPPER_IDENT                                    // nullary constructor
-       | qualified_call                                 // Effect.op(args) or module.fn(args)
+       | qualified_call                                 // Effect.op(args)
+       | module_call                                    // module::fn(args)
 
 qualified_call: UPPER_IDENT DOT LOWER_IDENT LPAREN arg_list? RPAREN  // Effect.operation(args)
-             | module_path DOT LOWER_IDENT LPAREN arg_list? RPAREN   // module.function(args)
+
+module_call: module_path DOUBLE_COLON LOWER_IDENT LPAREN arg_list? RPAREN  // module::function(args)
 
 arg_list: expr (COMMA expr)*
 ```

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -54,6 +54,7 @@ from vera.ast import (
     LetStmt,
     MatchArm,
     MatchExpr,
+    ModuleCall,
     ModuleDecl,
     NamedType,
     NullaryConstructor,
@@ -79,6 +80,7 @@ from vera.ast import (
     UnitLit,
     WildcardPattern,
 )
+from vera.ast import format_expr
 from vera.errors import TransformError, VeraError
 from vera.parser import parse, parse_to_ast
 from vera.transform import transform
@@ -598,6 +600,43 @@ class TestExpressions:
         anon = call.args[0]
         assert len(anon.params) == 1
         assert isinstance(anon.effect, PureEffect)
+
+    def test_module_call_ast_structure(self):
+        """Module-qualified call parses to ModuleCall AST (#95)."""
+        prog = _ast("""
+        import vera.math;
+        private fn f(@Int -> @Int)
+          requires(true) ensures(true) effects(pure)
+        { vera.math::abs(@Int.0) }
+        """)
+        fn = prog.declarations[0].decl
+        body = fn.body.expr
+        assert isinstance(body, ModuleCall)
+        assert body.path == ("vera", "math")
+        assert body.name == "abs"
+        assert len(body.args) == 1
+
+    def test_module_call_single_segment(self):
+        """Single-segment module call: math::abs(@Int.0)."""
+        prog = _ast("""
+        import math;
+        private fn f(@Int -> @Int)
+          requires(true) ensures(true) effects(pure)
+        { math::abs(@Int.0) }
+        """)
+        fn = prog.declarations[0].decl
+        body = fn.body.expr
+        assert isinstance(body, ModuleCall)
+        assert body.path == ("math",)
+        assert body.name == "abs"
+
+    def test_format_expr_module_call(self):
+        """format_expr produces :: syntax for ModuleCall."""
+        mc = ModuleCall(
+            path=("vera", "math"), name="abs",
+            args=(IntLit(value=42),),
+        )
+        assert format_expr(mc) == "vera.math::abs(42)"
 
 
 # -- Contract expressions --

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -1337,9 +1337,8 @@ private fn classify(@Int -> @String)
 class TestModuleCallDiagnostics:
     """Test improved module-call diagnostic messages (C7a).
 
-    Module call syntax has a known LALR limitation (grammar eats the
-    function name as part of the module_path). These tests construct
-    AST nodes manually to exercise the checker logic.
+    These tests construct AST nodes manually to exercise the checker
+    logic in isolation from the parser.
     """
 
     @staticmethod
@@ -1407,9 +1406,9 @@ class TestCrossModuleTyping:
     """Test cross-module type merging (C7b).
 
     These tests verify that imported function signatures are registered
-    and used for type-checking.  Due to the LALR grammar limitation (#95),
-    ModuleCall tests construct AST nodes manually.  Bare-call tests use
-    ``parse_to_ast`` since ``fn_call`` parses fine.
+    and used for type-checking.  Manual-AST ModuleCall tests are retained
+    for checker isolation; parse-from-source tests in TestModuleCallParsed
+    verify end-to-end parsing with :: syntax.
     """
 
     # Reusable module sources
@@ -1920,6 +1919,80 @@ private fn main(@Int -> @Int)
         assert "private" in msg.lower()
         assert "priv_fn" in msg
         assert "mymod" in msg
+
+
+# =====================================================================
+# Module-qualified call parse tests (#95)
+# =====================================================================
+
+class TestModuleCallParsed:
+    """Module-qualified call tests using parsed :: syntax (#95)."""
+
+    MATH_MODULE = """\
+public fn abs(@Int -> @Int)
+  requires(true)
+  ensures(@Int.result >= 0)
+  effects(pure)
+{ if @Int.0 < 0 then { 0 - @Int.0 } else { @Int.0 } }
+
+public fn max(@Int, @Int -> @Int)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{ if @Int.0 > @Int.1 then { @Int.0 } else { @Int.1 } }
+"""
+
+    @staticmethod
+    def _resolved(
+        path: tuple[str, ...], source: str
+    ) -> "ResolvedModule":
+        from vera.resolver import ResolvedModule
+        prog = parse_to_ast(source)
+        return ResolvedModule(
+            path=path, file_path=Path("/fake"), program=prog, source=source,
+        )
+
+    def test_parsed_module_call_typechecks(self) -> None:
+        """Parsed :: syntax produces ModuleCall that type-checks."""
+        mod = self._resolved(("math",), self.MATH_MODULE)
+        source = """\
+import math(abs);
+private fn f(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ math::abs(@Int.0) }
+"""
+        prog = parse_to_ast(source)
+        diags = typecheck(prog, source=source, resolved_modules=[mod])
+        errors = [d for d in diags if d.severity == "error"]
+        assert errors == [], [e.description for e in errors]
+
+    def test_parsed_multi_segment_path(self) -> None:
+        """Multi-segment path vera.math::abs type-checks."""
+        mod = self._resolved(("vera", "math"), self.MATH_MODULE)
+        source = """\
+import vera.math(abs);
+private fn f(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ vera.math::abs(@Int.0) }
+"""
+        prog = parse_to_ast(source)
+        diags = typecheck(prog, source=source, resolved_modules=[mod])
+        errors = [d for d in diags if d.severity == "error"]
+        assert errors == [], [e.description for e in errors]
+
+    def test_parsed_module_call_arity_error(self) -> None:
+        """Parsed :: call with wrong arity produces error."""
+        mod = self._resolved(("math",), self.MATH_MODULE)
+        source = """\
+import math(abs);
+private fn f(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ math::abs(@Int.0, @Int.0) }
+"""
+        prog = parse_to_ast(source)
+        diags = typecheck(prog, source=source, resolved_modules=[mod])
+        errors = [d for d in diags if d.severity == "error"]
+        assert any("argument" in e.description.lower() for e in errors)
 
 
 # =====================================================================

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -580,7 +580,7 @@ class TestQualifiedCalls:
         """)
 
     def test_import_and_direct_call(self) -> None:
-        """After importing, call functions directly (module_call has LALR limitation with multi-segment paths)."""
+        """After importing, call functions directly via bare calls."""
         parse("""
         import vera.math(abs);
 
@@ -592,6 +592,65 @@ class TestQualifiedCalls:
           abs(@Int.0)
         }
         """)
+
+
+class TestModuleQualifiedCalls:
+    """Module-qualified calls use :: syntax (#95)."""
+
+    def test_single_segment_module_call(self) -> None:
+        """Single-segment path: math::abs(42)."""
+        parse("""
+        import math;
+        private fn f(@Int -> @Int)
+          requires(true) ensures(true) effects(pure)
+        { math::abs(@Int.0) }
+        """)
+
+    def test_multi_segment_module_call(self) -> None:
+        """Multi-segment path: vera.math::abs(42)."""
+        parse("""
+        import vera.math;
+        private fn f(@Int -> @Int)
+          requires(true) ensures(true) effects(pure)
+        { vera.math::abs(@Int.0) }
+        """)
+
+    def test_module_call_no_args(self) -> None:
+        """Module-qualified call with no arguments."""
+        parse("""
+        import util;
+        private fn f(@Unit -> @Int)
+          requires(true) ensures(true) effects(pure)
+        { util::get_value() }
+        """)
+
+    def test_module_call_multiple_args(self) -> None:
+        """Module-qualified call with multiple arguments."""
+        parse("""
+        import math;
+        private fn f(@Int, @Int -> @Int)
+          requires(true) ensures(true) effects(pure)
+        { math::max(@Int.0, @Int.1) }
+        """)
+
+    def test_module_call_in_expression(self) -> None:
+        """Module-qualified call nested in an expression."""
+        parse("""
+        import math;
+        private fn f(@Int -> @Int)
+          requires(true) ensures(true) effects(pure)
+        { math::abs(@Int.0) + 1 }
+        """)
+
+    def test_old_dot_syntax_rejected(self) -> None:
+        """Old dot syntax produces a 'did you mean ::' error (E008)."""
+        with pytest.raises(ParseError, match="::"):
+            parse("""
+            import math;
+            private fn f(@Int -> @Int)
+              requires(true) ensures(true) effects(pure)
+            { math.abs(@Int.0) }
+            """)
 
 
 class TestFunctionTypes:

--- a/vera/README.md
+++ b/vera/README.md
@@ -580,7 +580,7 @@ Honest inventory of what the compiler cannot do, and where each limitation is ad
 
 | Limitation | Why | Planned |
 |-----------|-----|---------|
-| **Module system limitations** | Module system complete (C7a-C7f); remaining issues: LALR grammar limitation for qualified calls, flat-compilation name collisions | [#95](https://github.com/aallan/vera/issues/95), [#110](https://github.com/aallan/vera/issues/110) |
+| **Module system limitations** | Module system complete (C7a-C7f); remaining issue: flat-compilation name collisions | [#110](https://github.com/aallan/vera/issues/110) |
 | **Limited effect checking** | Pure vs effectful only; no subeffecting or row unification | [#21](https://github.com/aallan/vera/issues/21) |
 | **No termination verification** | `decreases` clauses parsed but always Tier 3 | [#45](https://github.com/aallan/vera/issues/45) |
 | **No quantifier verification** | `forall`/`exists` in contracts always Tier 3 | [#13](https://github.com/aallan/vera/issues/13) |

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.43"
+__version__ = "0.0.44"

--- a/vera/ast.py
+++ b/vera/ast.py
@@ -391,7 +391,7 @@ class QualifiedCall(Expr):
 
 @dataclass(frozen=True)
 class ModuleCall(Expr):
-    """Module-path call: path.to.module.function(args)."""
+    """Module-path call: path.to.module::function(args)."""
     path: tuple[str, ...]
     name: str
     args: tuple[Expr, ...]
@@ -744,6 +744,10 @@ def format_expr(expr: Expr) -> str:
     if isinstance(expr, FnCall):
         args = ", ".join(format_expr(a) for a in expr.args)
         return f"{expr.name}({args})"
+    if isinstance(expr, ModuleCall):
+        path = ".".join(expr.path)
+        args = ", ".join(format_expr(a) for a in expr.args)
+        return f"{path}::{expr.name}({args})"
     if isinstance(expr, OldExpr):
         ref = expr.effect_ref
         if isinstance(ref, EffectRef):

--- a/vera/codegen.py
+++ b/vera/codegen.py
@@ -537,7 +537,7 @@ class CodeGenerator:
             # C7e: if the function is known (imported), skip it — wasm.py
             # will desugar the ModuleCall to a flat FnCall.
             if node.name not in known:
-                qual = ".".join(node.path) + "." + node.name
+                qual = ".".join(node.path) + "::" + node.name
                 if qual not in seen:
                     seen.add(qual)
                     self._emit_cross_module_error(node, node.name, qual)

--- a/vera/errors.py
+++ b/vera/errors.py
@@ -282,6 +282,38 @@ def unclosed_block(
     )
 
 
+def module_call_dot_syntax(
+    file: Optional[str],
+    source: str,
+    line: int,
+    column: int,
+) -> Diagnostic:
+    """Diagnostic for old dot syntax in module-qualified calls."""
+    return Diagnostic(
+        description=(
+            "Module-qualified calls use '::' between the module path "
+            "and the function name, not '.'. "
+            "Did you mean to use '::' syntax?"
+        ),
+        location=SourceLocation(file=file, line=line, column=column),
+        source_line=_get_source_line(source, line),
+        rationale=(
+            "Vera uses '::' to separate the module path from the function "
+            "name in module-qualified calls. The dot-separated module path "
+            "is ambiguous with the function name in an LALR(1) grammar, so "
+            "'::' provides an unambiguous delimiter."
+        ),
+        fix=(
+            "Use '::' between the module path and the function name:\n"
+            "\n"
+            "  vera.math::abs(-5)\n"
+            "  collections::sort([3, 1, 2])"
+        ),
+        spec_ref='Chapter 8, Section 8.5.3 "Module-Qualified Calls"',
+        error_code="E008",
+    )
+
+
 def unexpected_token(
     file: Optional[str],
     source: str,
@@ -339,6 +371,12 @@ def diagnose_lark_error(
         if expected & {"EFFECTS", "effects"}:
             return missing_effect_clause(file, source, line, column)
 
+        # Pattern: old dot syntax for module-qualified calls
+        # module_path consumed all idents including the fn name, parser
+        # expects "::" (__ANON_9) but got "("
+        if token == "(" and "__ANON_9" in expected:
+            return module_call_dot_syntax(file, source, line, column)
+
         # Fallback
         return unexpected_token(file, source, line, column, token, expected)
 
@@ -378,6 +416,7 @@ ERROR_CODES: dict[str, str] = {
     "E005": "Unexpected token",
     "E006": "Unexpected character",
     "E007": "Internal parser error",
+    "E008": "Module-qualified call uses dot instead of ::",
     "E010": "Unhandled grammar rule",
     # E1xx — Type Checker: Core & Expressions
     "E120": "Data invariant not Bool",

--- a/vera/grammar.lark
+++ b/vera/grammar.lark
@@ -217,7 +217,7 @@ fn_call: LOWER_IDENT "(" arg_list? ")"                         -> func_call
        | UPPER_IDENT "(" arg_list? ")"                         -> constructor_call
        | UPPER_IDENT                                            -> nullary_constructor_expr
        | UPPER_IDENT "." LOWER_IDENT "(" arg_list? ")"         -> qualified_call
-       | module_path "." LOWER_IDENT "(" arg_list? ")"         -> module_call
+       | module_path "::" LOWER_IDENT "(" arg_list? ")"        -> module_call
 
 arg_list: expr ("," expr)*
 


### PR DESCRIPTION
## Summary
- Module-qualified calls now use `:\:` between module path and function name: `vera.math::abs(42)`
- Resolves LALR(1) grammar ambiguity where `module_path` greedily consumed the function name
- Old dot syntax rejected with targeted E008 "did you mean `:\:` ?" error
- Added `format_expr` support for `ModuleCall` AST nodes
- Updated spec chapters 8 and 10, examples, SKILLS.md, and all documentation
- 12 new tests (996 total, up from 984)

## Changes (16 files, +266 -22)
- `vera/grammar.lark`: `"."` to `"::"` in `module_call` rule
- `vera/ast.py`: `format_expr` case for `ModuleCall`, updated docstring
- `vera/errors.py`: E008 error factory, detection pattern in `diagnose_lark_error`, registry entry
- `vera/codegen.py`: display label uses `:\:`
- `examples/modules.vera`: new `qualified_abs` function demonstrating `:\:` syntax
- `tests/test_parser.py`: 6 new tests in `TestModuleQualifiedCalls`
- `tests/test_ast.py`: 3 new tests (structure, single segment, format_expr)
- `tests/test_checker.py`: 3 new tests in `TestModuleCallParsed` (parse-from-source)
- `spec/08-modules.md`: rewrote 8.5.3, removed #95 from limitations table
- `spec/10-grammar.md`: separated `module_call` rule with `DOUBLE_COLON`
- `SKILLS.md`: replaced limitation note with `:\:` documentation
- `vera/README.md`: updated limitations table
- `README.md`: strikethrough #95 in roadmap
- `CHANGELOG.md`: v0.0.44 entry
- `vera/__init__.py`, `pyproject.toml`: version bump to 0.0.44

## Test plan
- [x] 996 tests pass (`pytest tests/ -q`)
- [x] mypy clean (`mypy vera/`)
- [x] All 14 examples pass (`scripts/check_examples.py`)
- [x] Spec code blocks parse (`scripts/check_spec_examples.py`)
- [x] README code blocks parse (`scripts/check_readme_examples.py`)
- [x] Version consistent (`scripts/check_version_sync.py`)
- [x] Pre-commit hooks pass

Closes #95

Generated with [Claude Code](https://claude.ai/code)