### PR TITLE
Drop Alloc effect from spec, close #137

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,6 @@ C8 addresses the accumulated technical debt and UX gaps before v0.1.0. Open issu
 **C8c — Verification depth** — expand what the SMT solver can prove
 
 - [#136](https://github.com/aallan/vera/issues/136) register `Diverge` as built-in effect
-- [#137](https://github.com/aallan/vera/issues/137) register `Alloc` as built-in effect
 - [#13](https://github.com/aallan/vera/issues/13) expand SMT decidable fragment (Tier 2 verification)
 - [#45](https://github.com/aallan/vera/issues/45) `decreases` clause termination verification
 

--- a/scripts/check_spec_examples.py
+++ b/scripts/check_spec_examples.py
@@ -95,8 +95,7 @@ ALLOWLIST: dict[tuple[str, int], str] = {
     ("07-effects.md", 268): "FRAGMENT",     # fn(Unit -> A) in param position
 
     # Chapter 7 — empty effect bodies (parser requires op_decl+)
-    ("07-effects.md", 309): "FRAGMENT",     # effect Diverge {} — no operations
-    ("07-effects.md", 317): "FRAGMENT",     # effect Alloc {} — no operations
+    ("07-effects.md", 311): "FRAGMENT",     # effect Diverge {} — no operations
 }
 
 

--- a/spec/07-effects.md
+++ b/spec/07-effects.md
@@ -282,6 +282,8 @@ This function always performs `IO` (for the logging), plus whatever effects `E` 
 
 ## 7.7 Built-in Effects
 
+**Design note.** An alternative implementation targeting memory-constrained environments may wish to introduce an `Alloc` marker effect to distinguish allocating from non-allocating functions. The reference implementation omits this because WASM's managed linear memory makes allocation-tracking uninformative at the type level — nearly every non-trivial function allocates, so the effect would carry little signal.
+
 ### 7.7.1 `IO`
 
 ```
@@ -311,14 +313,6 @@ effect Diverge {}
 ```
 
 The `Diverge` effect has no operations. Declaring `effects(<Diverge>)` means the function may not terminate. Functions without `Diverge` in their effect row MUST be proven to terminate (via `decreases` clauses on recursion).
-
-### 7.7.4 `Alloc`
-
-```
-effect Alloc {}
-```
-
-The `Alloc` effect has no operations. It marks functions that allocate heap memory. In the reference implementation, all functions that create arrays, strings, closures, or ADT values implicitly have `Alloc`. This effect is automatically inferred and does not need to be declared manually — it is the one exception to the "all effects declared" rule.
 
 ## 7.8 Effect Subtyping
 


### PR DESCRIPTION
## Summary
- Removed `Alloc` effect from spec Chapter 7 Section 7.7.4
- Added design note for future alternative compilers targeting memory-constrained environments
- Removed #137 from C8c roadmap in README
- Removed allowlist entry from check_spec_examples.py

## Rationale
The `Alloc` effect was the sole exception to Vera's "all effects declared" rule. This exception is unjustified: nearly every non-trivial function allocates (ADTs, arrays, closures, strings), so the effect carries no useful signal. If an effect is so pervasive that declaring it is impractical, it does not belong in the effect system.

The `$alloc` WASM bump allocator function is unrelated and unaffected.

## Test plan
- [x] Spec code blocks parse (scripts/check_spec_examples.py)
- [x] README code blocks parse (scripts/check_readme_examples.py)
- [x] 996 tests pass (pytest tests/ -q)
- [x] Pre-commit hooks pass

Closes #137

Generated with [Claude Code](https://claude.ai/code)