### PR TITLE
Design principles audit: close 3 issues, document decisions in spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,11 +282,8 @@ C8 addresses the accumulated technical debt and UX gaps before v0.1.0. Open issu
 Module refinements, lexical extensions, and IO runtime — completing the existing language before adding new features.
 
 - [#127](https://github.com/aallan/vera/issues/127) module re-exports
-- [#129](https://github.com/aallan/vera/issues/129) import aliasing
-- [#128](https://github.com/aallan/vera/issues/128) wildcard exclusion in imports
 - [#135](https://github.com/aallan/vera/issues/135) IO operations (read_line, read_file, write_file)
 - [#139](https://github.com/aallan/vera/issues/139) scientific notation for float literals
-- [#140](https://github.com/aallan/vera/issues/140) raw strings and multi-line string literals
 
 ### C9 — Language design
 

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -551,6 +551,10 @@ Type aliases and effect declarations are module-local and cannot be imported. If
 
 Module-qualified calls use `::` between the module path and the function name: `vera.math::abs(42)`. The dot-separated path identifies the module and `::` separates it from the function name. This syntax can be used anywhere a function call is valid, and always resolves against the specific module's public declarations — it is not affected by local shadowing.
 
+There is no import aliasing (`import m(abs as math_abs)`) and no wildcard exclusion (`import m hiding(x)`). These are intentional design decisions, not limitations. When names clash, use selective imports to pick the names you need, and use `::` syntax to disambiguate: `vera.math::abs(x)`. This preserves the one-canonical-form principle — every function has exactly one name.
+
+There are no raw strings (`r"..."`) or multi-line string literals. Use escape sequences (`\\`, `\n`, `\t`, `\"`) for special characters. This is by design — alternative string syntaxes would create two representations for the same value.
+
 See: spec Chapter 8 for the full module system specification.
 
 ## Comments
@@ -757,6 +761,46 @@ if @Bool.0 then 1 else 0
 CORRECT:
 ```vera
 if @Bool.0 then { 1 } else { 0 }
+```
+
+### Trying to use import aliasing
+
+WRONG — Vera does not support renaming imports:
+```vera
+import vera.math(abs as math_abs);
+```
+
+CORRECT — use selective import and `::` syntax to disambiguate:
+```vera
+import vera.math(abs);
+vera.math::abs(-5)
+```
+
+### Trying to use wildcard exclusion
+
+WRONG — Vera does not support `hiding` syntax:
+```vera
+import vera.math hiding(max);
+```
+
+CORRECT — use selective import to list the names you need:
+```vera
+import vera.math(abs, min);
+```
+
+### Trying to use raw or multi-line strings
+
+WRONG — Vera does not support raw strings or multi-line literals:
+```
+r"path\to\file"
+"""multi-line
+string"""
+```
+
+CORRECT — use escape sequences:
+```vera
+"path\\to\\file"
+"line one\nline two"
 ```
 
 ## Complete Program Examples

--- a/spec/01-lexical-structure.md
+++ b/spec/01-lexical-structure.md
@@ -172,7 +172,9 @@ Escape sequences:
 | `\0`     | Null |
 | `\u{XXXX}` | Unicode code point (1-6 hex digits) |
 
-No other escape sequences are valid. Raw strings and multi-line string literals are not supported.
+No other escape sequences are valid.
+
+**Design note.** Vera does not support raw string syntax or multi-line string literals. A raw string (`r"..."`) would be an alternative representation for any string containing backslash characters, and a multi-line literal would be an alternative representation for any string containing newline characters. Both would violate the one-canonical-form principle (§0.2.3): the same string value would be expressible in two syntactically distinct ways. Since Vera targets LLM emission rather than human authoring (§0.3.1), the readability benefit of alternative string syntaxes does not justify the representational ambiguity. The escape sequence table above is the canonical and only mechanism for embedding special characters in strings.
 
 ### Boolean Literals
 

--- a/spec/08-modules.md
+++ b/spec/08-modules.md
@@ -64,6 +64,8 @@ A selective import makes only the named declarations available. Each name in the
 Error: Cannot import 'helper' from module 'vera.math': it is private.
 ```
 
+**Design note.** Vera does not support wildcard exclusion syntax (e.g., `import m hiding(x)`). When a module exports names that conflict with local definitions or other imports, the canonical mechanism is selective import: list exactly the names needed. Wildcard exclusion would be a semantic equivalent of selective import — the same import set expressible two ways — violating the one-canonical-form principle (§0.2.3). When wildcard import causes a name clash, the local definition shadows the import (§8.5.2), and the imported version remains accessible via module-qualified call syntax (§8.5.3).
+
 ### 8.3.3 Grammar
 
 ```ebnf
@@ -173,6 +175,8 @@ module_call: module_path "::" LOWER_IDENT "(" arg_list? ")"
 ```
 
 Module-qualified calls always resolve against the specific module's public declarations. They are not affected by local shadowing -- if the importer defines its own `abs`, a module-qualified call `vera.math::abs(x)` still calls the module's version.
+
+**Design note.** Vera does not support import aliasing (renaming a declaration at the import site). When two imported modules export identically-named functions, the module-qualified call syntax (`vera.math::abs(x)`) provides unambiguous disambiguation without introducing a second name for the same declaration. Aliasing would violate the one-canonical-form principle (§0.2.3): the same function could be referenced by different names in different files, making semantically identical call sites textually distinct.
 
 ### 8.5.4 Constructor Resolution
 
@@ -442,6 +446,4 @@ The current module system has the following limitations, each tracked as a GitHu
 |-----------|-------|-------|
 | Name collision in flat compilation | [#110](https://github.com/aallan/vera/issues/110) | If two imported modules define functions with the same name, the flat namespace may collide |
 | No re-exports | — | A module cannot re-export declarations imported from other modules |
-| No wildcard exclusion | — | Cannot import all names except specific ones |
-| No import aliasing | — | Cannot rename imported declarations (e.g., `import m(abs as absolute)`) |
 | No package system | — | Module resolution is file-system-only; no package manager or registry |


### PR DESCRIPTION
## Summary

- Review all 34 open issues against Vera's 6 design goals and 5 non-goals
- **Close 3 issues** as intentional design decisions (all violate Goal 3 — one canonical form):
  - #129 (import aliasing) — module-qualified calls (`::`) already solve disambiguation
  - #128 (wildcard exclusion) — selective imports are the canonical mechanism
  - #140 (raw/multi-line strings) — escape sequences are the canonical string syntax
- **Document rationale in the spec** as design notes (not limitations):
  - Chapter 1 (String Literals): raw/multi-line exclusion rationale
  - Chapter 8 (§8.3): wildcard exclusion rationale
  - Chapter 8 (§8.5.3): import aliasing rationale
  - Chapter 8 (§8.11): remove aliasing/exclusion from limitations table
- **Update SKILLS.md** with explicit notes for LLM coders and 3 new Common Mistakes entries
- **Add design alignment comments** to all 31 remaining open issues with implementation guidance
- **Update dependency comments** on #130, #127, #75 to reflect closures

## Test plan

- [x] `python scripts/check_spec_examples.py` passes (217 blocks, 0 failures)
- [x] `python scripts/check_readme_examples.py` passes (24 blocks, 0 failures)
- [x] `pytest tests/ -q` passes (996 tests)
- [x] Open issue count: 34 → 31

Generated with [Claude Code](https://claude.com/claude-code)