### PR TITLE
Update spec examples to canonical form

### DIFF
--- a/scripts/check_spec_examples.py
+++ b/scripts/check_spec_examples.py
@@ -78,11 +78,11 @@ ALLOWLIST: dict[tuple[str, int], str] = {
     ("03-slot-references.md", 343): "FRAGMENT",  # fn(@PosInt, @Int -> @Int) — no name
 
     # Chapter 5 — inline function types in return/param position
-    ("05-functions.md", 203): "FRAGMENT",   # fn make_adder returns fn(...) inline
-    ("05-functions.md", 316): "FRAGMENT",   # fn(A -> B) in param position
+    ("05-functions.md", 211): "FRAGMENT",   # fn make_adder returns fn(...) inline
+    ("05-functions.md", 324): "FRAGMENT",   # fn(A -> B) in param position
 
     # Chapter 6 — inline function type in type alias
-    ("06-contracts.md", 308): "FRAGMENT",   # type SafeDiv = fn(...) + fn apply_div
+    ("06-contracts.md", 312): "FRAGMENT",   # type SafeDiv = fn(...) + fn apply_div
 
     # Chapter 7 — anonymous function at top level
     ("07-effects.md", 116): "FRAGMENT",     # effect Logger + anonymous fn body

--- a/spec/04-expressions.md
+++ b/spec/04-expressions.md
@@ -154,7 +154,11 @@ The braces around branch bodies are mandatory, even for single expressions. This
 
 ```
 -- VALID:
-if @Bool.0 then { 1 } else { 0 }
+if @Bool.0 then {
+  1
+} else {
+  0
+}
 
 -- INVALID (no braces):
 if @Bool.0 then 1 else 0

--- a/spec/05-functions.md
+++ b/spec/05-functions.md
@@ -166,7 +166,11 @@ public fn is_even(@Nat -> @Bool)
   decreases(@Nat.0)
   effects(pure)
 {
-  if @Nat.0 == 0 then { true } else { is_odd(@Nat.0 - 1) }
+  if @Nat.0 == 0 then {
+    true
+  } else {
+    is_odd(@Nat.0 - 1)
+  }
 }
 where {
   fn is_odd(@Nat -> @Bool)
@@ -175,7 +179,11 @@ where {
     decreases(@Nat.0)
     effects(pure)
   {
-    if @Nat.0 == 0 then { false } else { is_even(@Nat.0 - 1) }
+    if @Nat.0 == 0 then {
+      false
+    } else {
+      is_even(@Nat.0 - 1)
+    }
   }
 }
 ```

--- a/spec/06-contracts.md
+++ b/spec/06-contracts.md
@@ -35,7 +35,11 @@ public fn absolute_value(@Int -> @Nat)
   ensures(@Nat.result == @Int.0 || @Nat.result == -@Int.0)
   effects(pure)
 {
-  if @Int.0 >= 0 then { @Int.0 } else { -@Int.0 }
+  if @Int.0 >= 0 then {
+    @Int.0
+  } else {
+    -@Int.0
+  }
 }
 ```
 

--- a/spec/08-modules.md
+++ b/spec/08-modules.md
@@ -86,7 +86,11 @@ public fn abs(@Int -> @Int)
   ensures(@Int.result >= 0)
   effects(pure)
 {
-  if @Int.0 < 0 then { 0 - @Int.0 } else { @Int.0 }
+  if @Int.0 < 0 then {
+    0 - @Int.0
+  } else {
+    @Int.0
+  }
 }
 
 private fn helper(@Int -> @Int)
@@ -110,8 +114,16 @@ private fn helper(@Int -> @Int)
 The same rules apply to `data` declarations:
 
 ```
-public data Color { Red, Green, Blue }
-private data InternalState { Active(Int), Idle }
+public data Color {
+  Red,
+  Green,
+  Blue
+}
+
+private data InternalState {
+  Active(Int),
+  Idle
+}
 ```
 
 When a `public` data type is imported, all of its constructors are also available. A `private` data type's constructors cannot be accessed from outside the module.
@@ -297,7 +309,11 @@ public fn abs(@Int -> @Int)
   ensures(@Int.result >= 0)
   effects(pure)
 {
-  if @Int.0 < 0 then { 0 - @Int.0 } else { @Int.0 }
+  if @Int.0 < 0 then {
+    0 - @Int.0
+  } else {
+    @Int.0
+  }
 }
 ```
 
@@ -357,7 +373,11 @@ public fn abs(@Int -> @Int)
   ensures(@Int.result >= 0)
   effects(pure)
 {
-  if @Int.0 < 0 then { 0 - @Int.0 } else { @Int.0 }
+  if @Int.0 < 0 then {
+    0 - @Int.0
+  } else {
+    @Int.0
+  }
 }
 
 public fn max(@Int, @Int -> @Int)
@@ -366,7 +386,11 @@ public fn max(@Int, @Int -> @Int)
   ensures(@Int.result >= @Int.1)
   effects(pure)
 {
-  if @Int.0 >= @Int.1 then { @Int.0 } else { @Int.1 }
+  if @Int.0 >= @Int.1 then {
+    @Int.0
+  } else {
+    @Int.1
+  }
 }
 ```
 
@@ -375,9 +399,15 @@ public fn max(@Int, @Int -> @Int)
 ```
 module vera.collections;
 
-public data List<T> { Nil, Cons(T, List<T>) }
+public data List<T> {
+  Nil,
+  Cons(T, List<T>)
+}
 
-public data Option<T> { None, Some(T) }
+public data Option<T> {
+  None,
+  Some(T)
+}
 ```
 
 **`modules.vera`** — the importing program:


### PR DESCRIPTION
## Summary

- Standalone code blocks in Chapters 4, 5, 6, and 8 now use canonical multi-line form for if/else and data declarations, per Section 1.8 Rule 2 (closing brace on its own line)
- Inline references in tables and contract clauses are left compact (middle-ground approach per #150 discussion)
- Updated allowlist line numbers in `check_spec_examples.py` to match shifted line positions

## Changes by chapter

| Chapter | Changes |
|---------|---------|
| 4 (Expressions) | 1 single-line if/else expanded |
| 5 (Functions) | 2 function bodies (is_even/is_odd) expanded |
| 6 (Contracts) | 1 function body (absolute_value) expanded |
| 8 (Modules) | 3 function bodies + 4 data declarations expanded |

## What stays compact (by design)

- `ensures(...)` inline expressions (e.g., Chapter 5 line 34)
- WP table entries (Chapter 6 line 211)
- Grammar rationale prose (Chapter 10 line 457)

## Test plan

- [x] `python scripts/check_spec_examples.py` passes (all 96 parseable blocks OK)
- [x] `python scripts/check_examples.py` passes (all 14 examples)
- [x] `python scripts/check_readme_examples.py` passes
- [x] `pytest tests/ -v` passes (1071 tests)
- [x] `mypy vera/` clean

Closes #150