### PR TITLE
Bump version to v0.0.45

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.45] - 2026-02-28
+
+### Added
+- **`vera fmt` canonical code formatter** ([#75](https://github.com/aallan/vera/issues/75)):
+  - New `vera fmt` command formats Vera source to the canonical form defined in Spec §1.8
+  - `--write` flag for in-place formatting, `--check` flag for CI (exit 1 if non-canonical)
+  - AST-based formatter with pre-pass comment extraction and reattachment
+  - Precedence-aware parenthesization for binary expressions
+  - All 10 formatting rules enforced: indentation, braces, commas, operators, semicolons, parentheses, contracts, one-per-line, no trailing whitespace, final newline
+  - New `vera/formatter.py` module (1,018 lines)
+  - 75 new tests (1,071 total, up from 996)
+  - All 14 examples reformatted to canonical form
+  - SKILLS.md and spec examples updated to canonical form ([#150](https://github.com/aallan/vera/issues/150))
+
 ## [0.0.44] - 2026-02-28
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ C8 addresses the accumulated technical debt and UX gaps before v0.1.0. Open issu
 - <del>[#112](https://github.com/aallan/vera/issues/112) informative runtime contract violation error messages</del> ([v0.0.42](https://github.com/aallan/vera/releases/tag/v0.0.42))
 - <del>[#80](https://github.com/aallan/vera/issues/80) stable error code taxonomy for diagnostics</del> ([v0.0.43](https://github.com/aallan/vera/releases/tag/v0.0.43))
 - <del>[#95](https://github.com/aallan/vera/issues/95) LALR grammar fix for module-qualified call syntax</del> ([v0.0.44](https://github.com/aallan/vera/releases/tag/v0.0.44))
-- <del>[#75](https://github.com/aallan/vera/issues/75) `vera fmt` canonical formatter</del>
+- <del>[#75](https://github.com/aallan/vera/issues/75) `vera fmt` canonical formatter</del> ([v0.0.45](https://github.com/aallan/vera/releases/tag/v0.0.45))
 - [#79](https://github.com/aallan/vera/issues/79) `vera test` contract-driven testing
 
 **C8c — Verification depth** — expand what the SMT solver can prove

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.44"
+version = "0.0.45"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.44"
+__version__ = "0.0.45"


### PR DESCRIPTION
## Summary

- Bumps version to 0.0.45 in `vera/__init__.py` and `pyproject.toml`
- Adds changelog entry for v0.0.45 (`vera fmt` canonical formatter, #75, #150)
- Adds version link to README roadmap for #75

## Test plan

- [x] Pre-commit hooks pass (mypy, pytest, examples)
- [x] Version sync check will pass after merge

Generated with [Claude Code](https://claude.com/claude-code)