### PR TITLE
Add vera fmt to README and AGENTS docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,9 @@ vera compile file.vera            # Compile to .wasm binary
 vera compile --wat file.vera      # Print WAT text (human-readable WASM)
 vera run file.vera                # Compile and execute (calls main)
 vera run file.vera --fn f -- 42   # Call function f with argument 42
+vera fmt file.vera                # Format to canonical form (stdout)
+vera fmt --write file.vera        # Format in place
+vera fmt --check file.vera        # Check if already canonical
 ```
 
 ### Error handling

--- a/README.md
+++ b/README.md
@@ -341,6 +341,19 @@ Verification: 2 verified (Tier 1)
 
 `vera verify` runs the type checker and then verifies contracts using Z3. Tier 1 contracts (decidable arithmetic, comparisons, Boolean logic) are proved automatically. Contracts that Z3 cannot decide are reported as Tier 3 (runtime checks) with a warning.
 
+### Format a program
+
+```bash
+vera fmt examples/absolute_value.vera
+```
+
+`vera fmt` prints the canonical form of a Vera source file to stdout. Add `--write` to reformat in place, or `--check` to verify a file is already canonical (exits 1 if not):
+
+```bash
+vera fmt --write examples/absolute_value.vera   # reformat in place
+vera fmt --check examples/absolute_value.vera   # check only (for CI)
+```
+
 ### Compile a program
 
 ```
@@ -501,6 +514,7 @@ vera verify your_file.vera             # type-check + verify contracts
 vera compile your_file.vera            # compile to .wasm binary
 vera run your_file.vera                # compile + execute
 vera run your_file.vera --fn f -- 42   # call function f with argument 42
+vera fmt your_file.vera                # format to canonical form (stdout)
 vera verify --json your_file.vera      # verify with JSON diagnostics
 ```
 


### PR DESCRIPTION
## Summary

- Adds "Format a program" subsection to README Getting Started (after Verify contracts)
- Adds `vera fmt` to the For Agents quick-reference command list in README
- Adds `vera fmt`, `vera fmt --write`, and `vera fmt --check` to AGENTS.md command listing
- SKILLS.md and CLAUDE.md already had these (added in PR #149)

## Test plan

- [x] `python scripts/check_readme_examples.py` passes

Generated with [Claude Code](https://claude.com/claude-code)