### PR TITLE
Code review fixes: safe_divide, README, tracking issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ C8 addresses the accumulated technical debt and UX gaps before v0.1.0. Open issu
 
 - <del>[#99](https://github.com/aallan/vera/issues/99) decompose `checker.py` (~1,900 lines) into `checker/` submodules</del> ([v0.0.40](https://github.com/aallan/vera/releases/tag/v0.0.40))
 - <del>[#100](https://github.com/aallan/vera/issues/100) decompose `wasm.py` (~2,300 lines) into `wasm/` submodules</del> ([v0.0.41](https://github.com/aallan/vera/releases/tag/v0.0.41))
+- [#155](https://github.com/aallan/vera/issues/155) decompose `codegen.py` (~2,140 lines) into `codegen/` submodules
 
 **C8b — Diagnostics and tooling** — improve the developer (human and LLM) experience
 
@@ -252,6 +253,7 @@ C8 addresses the accumulated technical debt and UX gaps before v0.1.0. Open issu
 - <del>[#95](https://github.com/aallan/vera/issues/95) LALR grammar fix for module-qualified call syntax</del> ([v0.0.44](https://github.com/aallan/vera/releases/tag/v0.0.44))
 - <del>[#75](https://github.com/aallan/vera/issues/75) `vera fmt` canonical formatter</del> ([v0.0.45](https://github.com/aallan/vera/releases/tag/v0.0.45))
 - [#79](https://github.com/aallan/vera/issues/79) `vera test` contract-driven testing
+- [#156](https://github.com/aallan/vera/issues/156) improve test coverage for WASM translation modules
 
 **C8c — Verification depth** — expand what the SMT solver can prove
 
@@ -267,6 +269,7 @@ C8 addresses the accumulated technical debt and UX gaps before v0.1.0. Open issu
 
 **C8e — Codegen gaps** — extend WASM compilation
 
+- [#154](https://github.com/aallan/vera/issues/154) `list_ops.vera` runtime failure — recursive generic ADT codegen
 - [#110](https://github.com/aallan/vera/issues/110) name collision detection for flat module compilation
 - [#131](https://github.com/aallan/vera/issues/131) nested constructor pattern codegen
 - [#53](https://github.com/aallan/vera/issues/53) `Exn<E>` and custom effect handler compilation
@@ -579,10 +582,11 @@ vera/
 │   │   └── data.py               #   Constructors, match, arrays
 │   ├── codegen.py                 # Code generation orchestrator
 │   ├── resolver.py                # Module resolver
+│   ├── formatter.py               # Canonical code formatter
 │   ├── errors.py                  # LLM-oriented diagnostics
 │   └── cli.py                     # Command-line interface
 ├── examples/                      # 14 example Vera programs
-├── tests/                         # Test suite (951 tests)
+├── tests/                         # Test suite (1,071 tests)
 ├── scripts/                       # CI and validation scripts
 │   ├── check_examples.py          # Verify all .vera examples
 │   ├── check_spec_examples.py     # Verify spec code blocks parse

--- a/examples/safe_divide.vera
+++ b/examples/safe_divide.vera
@@ -7,11 +7,15 @@ public fn safe_divide(@Int, @Int -> @Int)
   @Int.0 / @Int.1
 }
 
--- Entry point: exercise safe_divide(10, 2) = 5
+-- Entry point: exercise safe_divide(2, 10) = 5
+--
+-- De Bruijn binding order: the rightmost parameter is @Int.0 (dividend = 10),
+-- the leftmost is @Int.1 (divisor = 2). The body computes @Int.0 / @Int.1 = 10 / 2 = 5.
+-- The requires clause guards @Int.1 != 0 (the divisor, i.e. the first argument).
 public fn test_divide(@Unit -> @Int)
   requires(true)
-  ensures(true)
+  ensures(@Int.result == 5)
   effects(pure)
 {
-  safe_divide(10, 2)
+  safe_divide(2, 10)
 }


### PR DESCRIPTION
## Summary

Addresses findings from a code review of the v0.0.45 release.

### Fixes in this PR

- **safe_divide.vera**: The comment claimed `safe_divide(10, 2) = 5` but the actual result was `0` due to De Bruijn parameter binding order (`@Int.0` = rightmost param). Swapped arguments to `safe_divide(2, 10) = 5` and added a comment explaining the binding order. Strengthened `ensures` to `@Int.result == 5` (verifier proves it Tier 1).
- **README.md**: Updated stale test count (951 -> 1,071), added missing `formatter.py` to project tree, added three new issues to the roadmap.

### New tracking issues opened

| Issue | Section | Description |
|-------|---------|-------------|
| [#154](https://github.com/aallan/vera/issues/154) | C8e | `list_ops.vera` runtime failure: WASM compilation error in recursive generic ADT |
| [#155](https://github.com/aallan/vera/issues/155) | C8a | Decompose `codegen.py` (~2,140 lines) into `codegen/` submodules |
| [#156](https://github.com/aallan/vera/issues/156) | C8b | Improve test coverage for WASM translation modules |

## Test plan

- [x] `python scripts/check_examples.py` passes (all 14 examples)
- [x] `python scripts/check_readme_examples.py` passes
- [x] `vera verify examples/safe_divide.vera` passes (4 Tier 1)
- [x] `vera run examples/safe_divide.vera --fn test_divide` returns 5

Generated with [Claude Code](https://claude.com/claude-code)