### PR TITLE
Add vision scenario to roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,29 @@ New effects, types, abilities, and standard library extensions (spec §0.8).
 - [#130](https://github.com/aallan/vera/issues/130) package system and registry
 - [#143](https://github.com/aallan/vera/issues/143) comprehensive example programs
 
+### Where this is going
+
+The features on the C9 roadmap -- `<Http>` ([#57](https://github.com/aallan/vera/issues/57)), `<Inference>` ([#61](https://github.com/aallan/vera/issues/61)), and the `Markdown` type ([#147](https://github.com/aallan/vera/issues/147)) -- converge into a single design goal: an LLM should be able to write a short Vera function that searches the web, feeds the results into another model, and returns typed, contract-checked output. No scaffolding, no untyped string wrangling, no unchecked side effects.
+
+A research function that searches YouTube, summarises the results via LLM inference, and returns structured Markdown might look like this:
+
+```vera
+public fn research_topic(@String -> @MdBlock)
+  requires(length(@String.0) > 0)
+  ensures(md_has_heading(@MdBlock.result, 1))
+  effects(<Http, Inference>)
+{
+  let @Array<MdBlock> = youtube_search(@String.0, 5);
+  let @String = md_render_all(@Array<MdBlock>.0);
+  let @String = complete("Summarise this research:\n" ++ @String.0);
+  md_parse(@String.0)
+}
+```
+
+Five lines of logic. The signature carries all the ceremony -- parameter types, contracts, effect declarations -- so the body reads like a pipeline. The `<Http, Inference>` effect annotation means a caller that only permits `<Http>` cannot invoke this function, and an effect handler can mock both effects for deterministic testing. The postcondition `md_has_heading(@MdBlock.result, 1)` constrains the shape of the LLM response at the type level: if the model produces output that lacks a top-level heading, the contract fails.
+
+This is what "designed for LLMs to write" means in practice: the language makes the intent machine-checkable, the side effects explicit, and the output structurally typed -- in fewer lines than most languages need for a HTTP request.
+
 ## Getting Started
 
 ### Prerequisites

--- a/TESTING.md
+++ b/TESTING.md
@@ -10,7 +10,7 @@ This is the single source of truth for Vera's testing infrastructure, coverage d
 | **Compiler code coverage** | 87% of 6,446 statements (CI minimum: 80%) |
 | **Example programs** | 14, all validated through `vera check` + `vera verify` |
 | **Spec code blocks** | 96 parseable blocks from 13 spec chapters, all validated |
-| **README code blocks** | 5 Vera blocks, all validated |
+| **README code blocks** | 6 Vera blocks (5 validated, 1 allowlisted future syntax) |
 | **CI matrix** | 6 combinations (Python 3.11/3.12/3.13 x Ubuntu/macOS) |
 
 ## Running Tests

--- a/scripts/check_readme_examples.py
+++ b/scripts/check_readme_examples.py
@@ -28,6 +28,15 @@ ALLOWLIST: dict[int, tuple[str, str]] = {
 
     # Section "Algebraic effects" — uses get(()) and put(...) unqualified
     # 93: ("MISMATCH", "State effect example uses unqualified get/put"),
+
+    # =================================================================
+    # FUTURE — uses syntax/types from unimplemented features.
+    # When the feature lands, this entry will go stale and CI will flag
+    # it for removal (meaning the block should then parse successfully).
+    # =================================================================
+
+    # Section "Where this is going" — depends on #57 (Http), #61 (Inference), #147 (Markdown)
+    319: ("FUTURE", "Vision example uses MdBlock, Http, Inference (issues #57, #61, #147)"),
 }
 
 

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -14,6 +14,14 @@ from vera.parser import parse
 
 README = Path(__file__).parent.parent / "README.md"
 
+# -- Allowlist: README blocks that are intentionally unparseable. ----------
+# Must stay in sync with scripts/check_readme_examples.py.
+# Each key is the 1-based line number of the opening ```vera fence.
+ALLOWLIST: dict[int, str] = {
+    # "Where this is going" — depends on #57 (Http), #61 (Inference), #147 (Markdown)
+    319: "Vision example uses MdBlock, Http, Inference (issues #57, #61, #147)",
+}
+
 
 def _extract_vera_blocks(path: Path) -> list[tuple[int, str]]:
     """Extract all ```vera blocks from a Markdown file.
@@ -47,6 +55,8 @@ class TestReadmeCodeSamples:
 
         failures: list[tuple[int, str]] = []
         for line_no, content in blocks:
+            if line_no in ALLOWLIST:
+                continue
             try:
                 parse(content, file="<readme>")
             except Exception as exc:
@@ -62,7 +72,7 @@ class TestReadmeCodeSamples:
         """README should have the expected number of Vera code blocks."""
         blocks = _extract_vera_blocks(README)
         # Currently: hello_world, absolute_value, safe_divide,
-        # increment (State), double
-        assert len(blocks) == 5, (
-            f"Expected 5 Vera blocks in README.md, found {len(blocks)}"
+        # increment (State), double, research_topic (vision, allowlisted)
+        assert len(blocks) == 6, (
+            f"Expected 6 Vera blocks in README.md, found {len(blocks)}"
         )


### PR DESCRIPTION
## Summary
- Adds a **Where this is going** section after C10 in the roadmap, showing how `<Http>` (#57), `<Inference>` (#61), and the `Markdown` type (#147) converge into a five-line research function
- The code example uses future syntax (`MdBlock`, `Http`, `Inference` effects) and is allowlisted in both `scripts/check_readme_examples.py` and `tests/test_readme.py` -- when the features land, CI will flag the stale allowlist entries for removal
- Updates TESTING.md overview to reflect the new block count (6 Vera blocks, 5 validated + 1 allowlisted)
- Comments on #143 with the scenario for future example tracking

## Test plan
- [x] All 1,076 tests pass
- [x] mypy clean
- [x] `check_readme_examples.py` passes (5 parsed OK, 1 allowlisted)
- [x] `check_spec_examples.py` passes
- [x] `check_version_sync.py` passes
- [x] All pre-commit hooks pass

Generated with [Claude Code](https://claude.com/claude-code)