### PR TITLE
Register Diverge as built-in effect (#136)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.49] - 2026-03-01
+
+### Added
+- **Register `Diverge` as built-in effect** (C8c, [#136](https://github.com/aallan/vera/issues/136)):
+  `effects(<Diverge>)` now resolves to the spec-defined marker effect
+  (Chapter 7, Section 7.7.3). Diverge has no operations — it signals that a
+  function may not terminate. Precursor to #45 (termination verification).
+
 ## [0.0.48] - 2026-03-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ C8 addresses the accumulated technical debt and UX gaps before v0.1.0. Open issu
 
 **C8c — Verification depth** — expand what the SMT solver can prove
 
-- [#136](https://github.com/aallan/vera/issues/136) register `Diverge` as built-in effect
+- <del>[#136](https://github.com/aallan/vera/issues/136) register `Diverge` as built-in effect</del> ([v0.0.49](https://github.com/aallan/vera/releases/tag/v0.0.49))
 - [#13](https://github.com/aallan/vera/issues/13) expand SMT decidable fragment (Tier 2 verification)
 - [#45](https://github.com/aallan/vera/issues/45) `decreases` clause termination verification
 

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -426,7 +426,13 @@ effects(pure)                    -- no effects
 effects(<IO>)                    -- performs IO
 effects(<State<Int>>)            -- uses integer state
 effects(<State<Int>, IO>)        -- multiple effects
+effects(<Diverge>)               -- may not terminate
+effects(<Diverge, IO>)           -- divergent with IO
 ```
+
+`Diverge` is a built-in marker effect with no operations. Its presence in the
+effect row signals that the function may not terminate. Functions without
+`Diverge` must be proven total (via `decreases` clauses on recursion).
 
 ### Effect declarations
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.48"
+version = "0.0.49"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -810,6 +810,49 @@ private fn use_counter(@Unit -> @Unit)
 }
 """)
 
+    # ----- Diverge (built-in marker effect, Chapter 7 §7.7.3) --------
+
+    def test_diverge_type_checks(self) -> None:
+        """effects(<Diverge>) is a recognised built-in effect."""
+        _check_ok("""
+private fn loop(@Unit -> @Int)
+  requires(true) ensures(true) effects(<Diverge>)
+{ 0 }
+""")
+
+    def test_diverge_combined_with_io(self) -> None:
+        """Diverge composes with other effects in the same row."""
+        _check_ok("""
+private fn serve(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<Diverge, IO>)
+{
+  IO.print("running");
+  ()
+}
+""")
+
+    def test_diverge_no_operations(self) -> None:
+        """Diverge has no operations — qualified calls produce a warning."""
+        warns = _warnings("""
+private fn bad(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<Diverge>)
+{
+  Diverge.stop(())
+}
+""")
+        assert any("Unresolved qualified call" in w.description for w in warns), \
+            f"Expected unresolved call warning, got: {[w.description for w in warns]}"
+
+    def test_diverge_registered_in_env(self) -> None:
+        """Diverge is present in the environment's effect registry."""
+        from vera.environment import TypeEnv
+        env = TypeEnv()
+        info = env.lookup_effect("Diverge")
+        assert info is not None
+        assert info.name == "Diverge"
+        assert info.type_params is None
+        assert info.operations == {}
+
 
 # =====================================================================
 # Contracts

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -604,6 +604,33 @@ private fn g(@Int -> @Int)
 
 
 # =====================================================================
+# Diverge built-in effect (Chapter 7, §7.7.3)
+# =====================================================================
+
+class TestDivergeEffect:
+    """Diverge is a recognised marker effect with no operations."""
+
+    def test_diverge_verifies(self) -> None:
+        """A function with effects(<Diverge>) should verify cleanly."""
+        _verify_ok("""
+private fn loop(@Unit -> @Int)
+  requires(true) ensures(true) effects(<Diverge>)
+{ 0 }
+""")
+
+    def test_diverge_with_io_verifies(self) -> None:
+        """Diverge composes with other effects for verification."""
+        _verify_ok("""
+private fn serve(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<Diverge, IO>)
+{
+  IO.print("running");
+  ()
+}
+""")
+
+
+# =====================================================================
 # Edge cases
 # =====================================================================
 

--- a/vera/README.md
+++ b/vera/README.md
@@ -291,6 +291,7 @@ Context flags (`in_ensures`, `in_contract`, `current_return_type`, `current_effe
 | `Result<T, E>` | ADT | `Ok(T)`, `Err(E)` constructors |
 | `State<T>` | Effect | `get(Unit) → T`, `put(T) → Unit` operations |
 | `IO` | Effect | No operations exposed at type level |
+| `Diverge` | Effect | No operations — marker for non-termination |
 | `length` | Function | `forall<T> Array<T> → Int`, pure |
 
 Additionally, `resume` is bound as a temporary function inside handler clause bodies (in `_check_handle()`). Its type is derived from the operation: for `op(params) → ReturnType`, `resume` has type `fn(ReturnType) → Unit effects(pure)`. The binding is added to `env.functions` before checking the clause body and removed afterward.

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.48"
+__version__ = "0.0.49"

--- a/vera/environment.py
+++ b/vera/environment.py
@@ -187,6 +187,15 @@ class TypeEnv:
             operations={},
         )
 
+        # Diverge effect — marker for potentially non-terminating functions.
+        # No operations; its presence in the effect row opts out of
+        # termination checking (Chapter 7, Section 7.7.3).
+        self.effects["Diverge"] = EffectInfo(
+            name="Diverge",
+            type_params=None,
+            operations={},
+        )
+
         # Built-in function: length
         self.functions["length"] = FunctionInfo(
             name="length",


### PR DESCRIPTION
## Summary

- Register `Diverge` in `_register_builtins()` as a marker effect with no operations (Chapter 7, Section 7.7.3)
- `effects(<Diverge>)` now resolves to the spec-defined built-in, not an unresolved user-defined name
- Precursor to #45 (termination verification via `decreases` clauses)

## Changes

- **`vera/environment.py`** — add Diverge to built-in effects registry
- **`vera/README.md`** — add Diverge row to built-ins table
- **`SKILLS.md`** — document Diverge in the effects section
- **`tests/test_checker.py`** — 4 tests: type-checks, combined effects, no-ops warning, env registration
- **`tests/test_verifier.py`** — 2 tests: verifies cleanly alone and combined with IO
- Version bump to v0.0.49, CHANGELOG entry, roadmap update

Closes #136

## Test plan

- [x] 6 new Diverge tests pass
- [x] Full suite: 1,215 tests pass
- [x] mypy clean
- [x] All 14 examples pass
- [x] README blocks parse
- [x] Version sync passes
- [x] Pre-commit hooks green