### PR TITLE
v0.0.50: post-merge docs for string built-ins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.50] - 2026-03-02
+
+### Added
+- **Eight string/conversion built-in operations** (C8e, [#134](https://github.com/aallan/vera/issues/134), [#52](https://github.com/aallan/vera/issues/52)):
+  First external contribution by [@rlseaman](https://github.com/rlseaman) in PR [#173](https://github.com/aallan/vera/pull/173).
+  - `string_length(@String -> @Nat)` — byte length of a string
+  - `string_concat(@String, @String -> @String)` — concatenation
+  - `string_slice(@String, @Nat, @Nat -> @String)` — substring extraction
+  - `char_code(@String, @Int -> @Nat)` — ASCII code at index
+  - `parse_nat(@String -> @Nat)` — decimal string to natural number
+  - `parse_float64(@String -> @Float64)` — decimal string to float
+  - `to_string(@Int -> @String)` — integer to decimal string
+  - `strip(@String -> @String)` — trim leading/trailing whitespace (zero-copy)
+  - New example: `examples/string_ops.vera` (15 examples total)
+  - 52 new tests: 10 type checker + 42 codegen/runtime
+  - Uses bump allocator (`$alloc`); GC deferred to [#51](https://github.com/aallan/vera/issues/51)
+  - `parse_nat` returns bare `Nat` pending [#174](https://github.com/aallan/vera/issues/174) (spec requires `Result<Nat, String>`)
+  - 1,267 tests total
+
 ## [0.0.49] - 2026-03-01
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ vera fmt --check file.vera        # Check if already canonical
 pytest tests/ -v                  # Run the test suite (see TESTING.md)
 mypy vera/                        # Type-check the compiler itself
 
-python scripts/check_examples.py      # Verify all 14 examples parse + check + verify
+python scripts/check_examples.py      # Verify all 15 examples parse + check + verify
 python scripts/check_spec_examples.py # Verify spec code blocks parse
 python scripts/check_readme_examples.py # Verify README code blocks parse
 python scripts/check_version_sync.py  # Verify version consistency
@@ -50,7 +50,7 @@ python scripts/check_version_sync.py  # Verify version consistency
 
 - `spec/` — Language specification (Chapters 0-7, 9-12)
 - `vera/` — Reference compiler: grammar, parser, AST, transformer, type checker, verifier, codegen, CLI
-- `examples/` — 14 example Vera programs (all must pass `vera check` and `vera verify`)
+- `examples/` — 15 example Vera programs (all must pass `vera check` and `vera verify`)
 - `tests/` — Test suite
 - `scripts/` — CI and validation scripts
 
@@ -69,7 +69,7 @@ Each stage is a module with a public API function and is independently testable.
 ## What not to break
 
 - Pre-commit hooks run mypy + pytest + example validation on every commit
-- All 14 examples in `examples/` must pass `vera check` and `vera verify`
+- All 15 examples in `examples/` must pass `vera check` and `vera verify`
 - Version must stay in sync across `vera/__init__.py`, `pyproject.toml`, and `CHANGELOG.md`
 - All tests must pass: `pytest tests/ -v`
 - Type checking must be clean: `mypy vera/`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,15 @@ For contributions to the reference compiler:
 6. Commit your changes with a clear commit message.
 7. Push to your fork and open a pull request.
 
+### Built-in functions and types
+
+When adding or modifying built-in functions (registered in `vera/environment.py`):
+
+- **Match the spec.** Type signatures should use the types specified in the language specification (e.g. `NAT` where the spec says `Nat`, not `INT`). Reference the relevant spec chapter and section in your PR description.
+- **Add type checker tests** in `tests/test_checker.py` — at minimum, one test with correct types and one with a wrong argument type.
+- **Add codegen/runtime tests** in `tests/test_codegen.py` — cover normal cases, edge cases (empty inputs, zero values), and composition with other built-ins.
+- **Update the example** if an existing example demonstrates the feature, or add a new one in `examples/`.
+
 ## Development Setup
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ The language specification is in draft across 13 chapters:
 
 ### Testing
 
-The compiler has 1,209 tests with 88% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations. Every commit validates all 14 example programs and 96 specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference -- coverage tables, test helpers, CI pipeline, and infrastructure details.
+The compiler has 1,267 tests with 88% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations. Every commit validates all 15 example programs and 96 specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference -- coverage tables, test helpers, CI pipeline, and infrastructure details.
 
 ## Roadmap
 
@@ -280,7 +280,8 @@ C8 addresses the accumulated technical debt and UX gaps before v0.1.0. Open issu
 - [#51](https://github.com/aallan/vera/issues/51) garbage collection for WASM linear memory
 - [#132](https://github.com/aallan/vera/issues/132) arrays of compound types in codegen
 - [#52](https://github.com/aallan/vera/issues/52) dynamic string construction
-- [#134](https://github.com/aallan/vera/issues/134) string built-in operations (length, concat, slice)
+- ~~[#134](https://github.com/aallan/vera/issues/134) string built-in operations (length, concat, slice)~~ — [v0.0.50](https://github.com/aallan/vera/releases/tag/v0.0.50)
+- [#174](https://github.com/aallan/vera/issues/174) `parse_nat` should return `Result<Nat, String>` per spec
 - [#106](https://github.com/aallan/vera/issues/106) universal to-string conversion (Show/Display)
 - [#56](https://github.com/aallan/vera/issues/56) incremental compilation
 

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -361,6 +361,41 @@ Blocks contain statements followed by a final expression:
 
 Statements end with `;`. The final expression (no `;`) is the block's value.
 
+## Built-in Functions
+
+### Array operations
+
+```vera
+length(@Array<Int>.0)  -- returns Int (always >= 0)
+```
+
+### String operations
+
+```vera
+string_length(@String.0)                -- returns Nat
+string_concat(@String.0, @String.1)     -- returns String
+string_slice(@String.0, @Nat.0, @Nat.1) -- returns String (start, end)
+char_code(@String.0, @Int.0)            -- returns Nat (ASCII code at index)
+parse_nat(@String.0)                    -- returns Nat (decimal string to number)
+parse_float64(@String.0)                -- returns Float64
+to_string(@Int.0)                       -- returns String (integer to decimal)
+strip(@String.0)                        -- returns String (trim whitespace)
+```
+
+String functions use the bump allocator (`$alloc`). `strip` is zero-copy (returns a view into the original string). `parse_nat` skips leading spaces.
+
+Example:
+
+```vera
+private fn greet(@String -> @String)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  string_concat("Hello, ", @String.0)
+}
+```
+
 ## Contracts
 
 ### requires (preconditions)

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,9 +6,9 @@ This is the single source of truth for Vera's testing infrastructure, coverage d
 
 | Metric | Value |
 |--------|-------|
-| **Tests** | 1,209 across 19 files (~14,200 lines of test code) |
+| **Tests** | 1,267 across 19 files (~16,200 lines of test code) |
 | **Compiler code coverage** | 88% of 6,861 statements (CI minimum: 80%) |
-| **Example programs** | 14, all validated through `vera check` + `vera verify` |
+| **Example programs** | 15, all validated through `vera check` + `vera verify` |
 | **Spec code blocks** | 96 parseable blocks from 13 spec chapters: 72 parse, 57 type-check, 56 verify |
 | **README code blocks** | 6 Vera blocks (5 validated, 1 allowlisted future syntax) |
 | **CI matrix** | 6 combinations (Python 3.11/3.12/3.13 x Ubuntu/macOS) |
@@ -28,7 +28,7 @@ pytest tests/ --cov=vera --cov-report=term-missing   # with coverage
 mypy vera/                                           # strict mode
 
 # Validation scripts
-python scripts/check_examples.py                     # 14 example programs
+python scripts/check_examples.py                     # 15 example programs
 python scripts/check_spec_examples.py                # spec code blocks
 python scripts/check_readme_examples.py              # README code blocks
 python scripts/check_version_sync.py                 # version consistency
@@ -40,9 +40,9 @@ python scripts/check_version_sync.py                 # version consistency
 |------|------:|------:|----------------|
 | `test_parser.py` | 103 | 888 | Grammar rules, operator precedence, parse errors |
 | `test_ast.py` | 87 | 935 | AST transformation, node structure, serialisation |
-| `test_checker.py` | 159 | 2,143 | Type synthesis, slot resolution, effects, contracts, exhaustiveness, cross-module typing, visibility, error codes |
+| `test_checker.py` | 173 | 2,263 | Type synthesis, slot resolution, effects, contracts, exhaustiveness, cross-module typing, visibility, error codes, string built-ins |
 | `test_verifier.py` | 77 | 1,118 | Z3 verification, counterexamples, tier classification, call-site preconditions, pipe operator, cross-module contracts |
-| `test_codegen.py` | 280 | 3,352 | WASM compilation, arithmetic, Float64, Byte, arrays, ADTs, match, generics, State\<T\>, control flow, strings, IO, bounds checking, quantifiers, assert/assume, refinement type aliases, pipe operator, example round-trips |
+| `test_codegen.py` | 317 | 3,725 | WASM compilation, arithmetic, Float64, Byte, arrays, ADTs, match, generics, State\<T\>, control flow, strings, IO, bounds checking, quantifiers, assert/assume, refinement type aliases, pipe operator, string built-ins, example round-trips |
 | `test_codegen_contracts.py` | 32 | 576 | Runtime pre/postconditions, contract fail messages, old/new state postconditions |
 | `test_codegen_monomorphize.py` | 17 | 360 | Generic instantiation, type inference, monomorphization edge cases |
 | `test_codegen_closures.py` | 17 | 416 | Closure lifting, captured variables, higher-order functions |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.49"
+version = "0.0.50"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/scripts/check_readme_examples.py
+++ b/scripts/check_readme_examples.py
@@ -36,7 +36,7 @@ ALLOWLIST: dict[int, tuple[str, str]] = {
     # =================================================================
 
     # Section "Where this is going" — depends on #57 (Http), #61 (Inference), #147 (Markdown)
-    321: ("FUTURE", "Vision example uses MdBlock, Http, Inference (issues #57, #61, #147)"),
+    322: ("FUTURE", "Vision example uses MdBlock, Http, Inference (issues #57, #61, #147)"),
 }
 
 

--- a/spec/04-expressions.md
+++ b/spec/04-expressions.md
@@ -300,17 +300,24 @@ Future array operations (`map`, `fold`, `slice`) will be added alongside the mod
 
 ## 4.13 String Operations
 
-> **Status: Not yet implemented.** Depends on dynamic string construction ([#52](https://github.com/aallan/vera/issues/52)).
-
-String operations will be provided by the standard library:
+String operations are provided as built-in functions:
 
 ```
-string_length(@String.0)             -- returns Nat
-string_concat(@String.0, @String.1)  -- returns String
-string_slice(@String.0, @Nat.0, @Nat.1)  -- returns String
+string_length(@String.0)                -- returns Nat
+string_concat(@String.0, @String.1)     -- returns String
+string_slice(@String.0, @Nat.0, @Nat.1) -- returns String
+char_code(@String.0, @Int.0)            -- returns Nat (ASCII code at index)
+parse_nat(@String.0)                    -- returns Nat (see note below)
+parse_float64(@String.0)                -- returns Float64
+to_string(@Int.0)                       -- returns String
+strip(@String.0)                        -- returns String (trim whitespace)
 ```
 
-String concatenation will use a function, not an operator. There is no `+` on strings. Currently, only string constants (literals) are supported — see Chapter 9, Section 9.4.1 for the current state of collections and Chapter 11, Section 11.5 for the string pool implementation.
+String concatenation uses a function, not an operator. There is no `+` on strings.
+
+> **Note:** `parse_nat` currently returns bare `Nat`. Per Section 9, it should return `Result<Nat, String>` to handle invalid input. This is tracked in [#174](https://github.com/aallan/vera/issues/174).
+
+String memory is allocated via the bump allocator and is not freed. Garbage collection for WASM linear memory is tracked in [#51](https://github.com/aallan/vera/issues/51). See Chapter 11, Section 11.5 for the string pool implementation.
 
 ## 4.14 Expression Precedence (Complete)
 

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -19,7 +19,7 @@ README = Path(__file__).parent.parent / "README.md"
 # Each key is the 1-based line number of the opening ```vera fence.
 ALLOWLIST: dict[int, str] = {
     # "Where this is going" — depends on #57 (Http), #61 (Inference), #147 (Markdown)
-    321: "Vision example uses MdBlock, Http, Inference (issues #57, #61, #147)",
+    322: "Vision example uses MdBlock, Http, Inference (issues #57, #61, #147)",
 }
 
 

--- a/vera/README.md
+++ b/vera/README.md
@@ -293,6 +293,14 @@ Context flags (`in_ensures`, `in_contract`, `current_return_type`, `current_effe
 | `IO` | Effect | No operations exposed at type level |
 | `Diverge` | Effect | No operations — marker for non-termination |
 | `length` | Function | `forall<T> Array<T> → Int`, pure |
+| `string_length` | Function | `String → Nat`, pure |
+| `string_concat` | Function | `String, String → String`, pure |
+| `string_slice` | Function | `String, Nat, Nat → String`, pure |
+| `char_code` | Function | `String, Int → Nat`, pure |
+| `parse_nat` | Function | `String → Nat`, pure (see [#174](https://github.com/aallan/vera/issues/174)) |
+| `parse_float64` | Function | `String → Float64`, pure |
+| `to_string` | Function | `Int → String`, pure |
+| `strip` | Function | `String → String`, pure (zero-copy) |
 
 Additionally, `resume` is bound as a temporary function inside handler clause bodies (in `_check_handle()`). Its type is derived from the operation: for `op(params) → ReturnType`, `resume` has type `fn(ReturnType) → Unit effects(pure)`. The binding is added to `env.functions` before checking the clause body and removed afterward.
 

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.49"
+__version__ = "0.0.50"


### PR DESCRIPTION
## Summary

- Version bump 0.0.49 → 0.0.50 following merge of PR #173 (eight string/conversion built-in operations by @rlseaman)
- Spec §4.13 updated: removed "Not yet implemented" banner, listed all 8 operations with signatures, added `parse_nat` Result limitation note linking to #174
- SKILLS.md: new "Built-in Functions" section documenting array and string operations
- vera/README.md: 8 string functions added to built-ins table
- README.md: test/example counts updated (1,267 tests, 15 examples), #134 struck out with version link, #174 added to C8e roadmap
- TESTING.md: test counts updated
- CLAUDE.md: example count 14 → 15
- CONTRIBUTING.md: added spec alignment guidance for built-in function contributions
- Allowlist line numbers fixed for shifted README code block

## Context

Post-merge housekeeping for PR #173. Also opened #174 to track `parse_nat → Result<Nat, String>` and added comments to #52 and #134.

## Test plan

- [x] 1,267 tests pass
- [x] mypy clean
- [x] All 15 examples pass
- [x] Version sync passes
- [x] README code blocks pass
- [x] Spec code blocks pass
- [x] All pre-commit hooks pass