### PR TITLE
Mutual recursion termination verification (#45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.52] - 2026-03-02
+
+### Added
+- **Mutual recursion termination verification** (C8c, [#45](https://github.com/aallan/vera/issues/45)):
+  Verifies `decreases` clauses across mutually recursive `where`-block function groups,
+  promoting the last E525 contract in `mutual_recursion.vera` from Tier 3 to Tier 1.
+  - Where-block functions now have their contracts verified (requires, ensures, decreases)
+  - Cross-function measure checking: callee measure evaluated in callee parameter env
+  - Verification rate: 96 T1, 3 T3, 99 total (97.0% static)
+  - 4 new verifier tests, 1,287 tests total
+
 ## [0.0.51] - 2026-03-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ C8 addresses the accumulated technical debt and UX gaps before v0.1.0. Open issu
 
 - <del>[#136](https://github.com/aallan/vera/issues/136) register `Diverge` as built-in effect</del> ([v0.0.49](https://github.com/aallan/vera/releases/tag/v0.0.49))
 - <del>[#13](https://github.com/aallan/vera/issues/13) expand SMT decidable fragment (Tier 2 verification)</del> ([v0.0.51](https://github.com/aallan/vera/releases/tag/v0.0.51))
-- [#45](https://github.com/aallan/vera/issues/45) `decreases` clause termination verification (self-recursive Nat/ADT done in v0.0.51; mutual recursion pending)
+- <del>[#45](https://github.com/aallan/vera/issues/45) `decreases` clause termination verification</del> ([v0.0.52](https://github.com/aallan/vera/releases/tag/v0.0.52))
 
 **C8d — Type system** — close type-checking gaps
 
@@ -372,7 +372,7 @@ OK: examples/safe_divide.vera
 Verification: 2 verified (Tier 1)
 ```
 
-`vera verify` runs the type checker and then verifies contracts using Z3. Tier 1 contracts (decidable arithmetic, comparisons, Boolean logic, match expressions, ADT constructors, and decreases clauses) are proved automatically. Contracts that Z3 cannot decide are reported as Tier 3 (runtime checks) with a warning. Across all 15 examples, 92 of 96 contracts (95.8%) are verified statically.
+`vera verify` runs the type checker and then verifies contracts using Z3. Tier 1 contracts (decidable arithmetic, comparisons, Boolean logic, match expressions, ADT constructors, and decreases clauses) are proved automatically. Contracts that Z3 cannot decide are reported as Tier 3 (runtime checks) with a warning. Across all 15 examples, 96 of 99 contracts (97.0%) are verified statically.
 
 ### Format a program
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,12 +6,12 @@ This is the single source of truth for Vera's testing infrastructure, coverage d
 
 | Metric | Value |
 |--------|-------|
-| **Tests** | 1,283 across 19 files (~16,600 lines of test code) |
+| **Tests** | 1,287 across 19 files (~16,700 lines of test code) |
 | **Compiler code coverage** | 88% of 6,861 statements (CI minimum: 80%) |
 | **Example programs** | 15, all validated through `vera check` + `vera verify` |
 | **Spec code blocks** | 96 parseable blocks from 13 spec chapters: 72 parse, 57 type-check, 56 verify |
 | **README code blocks** | 6 Vera blocks (5 validated, 1 allowlisted future syntax) |
-| **Contract verification** | 92 of 96 contracts (95.8%) verified statically (Tier 1) |
+| **Contract verification** | 96 of 99 contracts (97.0%) verified statically (Tier 1) |
 | **CI matrix** | 6 combinations (Python 3.11/3.12/3.13 x Ubuntu/macOS) |
 
 ## Running Tests
@@ -42,7 +42,7 @@ python scripts/check_version_sync.py                 # version consistency
 | `test_parser.py` | 103 | 888 | Grammar rules, operator precedence, parse errors |
 | `test_ast.py` | 87 | 935 | AST transformation, node structure, serialisation |
 | `test_checker.py` | 173 | 2,263 | Type synthesis, slot resolution, effects, contracts, exhaustiveness, cross-module typing, visibility, error codes, string built-ins |
-| `test_verifier.py` | 93 | 1,480 | Z3 verification, counterexamples, tier classification, call-site preconditions, pipe operator, cross-module contracts, match/ADT verification, decreases verification |
+| `test_verifier.py` | 97 | 1,580 | Z3 verification, counterexamples, tier classification, call-site preconditions, pipe operator, cross-module contracts, match/ADT verification, decreases verification, mutual recursion |
 | `test_codegen.py` | 317 | 3,725 | WASM compilation, arithmetic, Float64, Byte, arrays, ADTs, match, generics, State\<T\>, control flow, strings, IO, bounds checking, quantifiers, assert/assume, refinement type aliases, pipe operator, string built-ins, example round-trips |
 | `test_codegen_contracts.py` | 32 | 576 | Runtime pre/postconditions, contract fail messages, old/new state postconditions |
 | `test_codegen_monomorphize.py` | 17 | 360 | Generic instantiation, type inference, monomorphization edge cases |
@@ -93,20 +93,19 @@ Across all 15 example programs:
 
 | Metric | Value |
 |--------|-------|
-| **Tier 1 (static)** | 92 contracts — proved automatically by Z3 |
-| **Tier 3 (runtime)** | 4 contracts — verified at runtime via assertion checks |
-| **Total** | 96 contracts (95.8% static) |
+| **Tier 1 (static)** | 96 contracts — proved automatically by Z3 |
+| **Tier 3 (runtime)** | 3 contracts — verified at runtime via assertion checks |
+| **Total** | 99 contracts (97.0% static) |
 
-The 4 remaining Tier 3 contracts and why they cannot be promoted:
+The 3 remaining Tier 3 contracts and why they cannot be promoted:
 
 | Example | Contract | Reason |
 |---------|----------|--------|
 | generics.vera | `ensures(@T.result == @T.0)` | Generic type parameters have no Z3 sort |
 | generics.vera | `ensures(@A.result == @A.0)` | Generic type parameters have no Z3 sort |
 | increment.vera | `ensures(new(State<Int>) == old(State<Int>) + 1)` | `old`/`new` state modeling not yet implemented |
-| mutual_recursion.vera | `decreases(@Nat.0)` | Mutual recursion termination requires cross-function measure reasoning |
 
-The Tier 1 fragment covers: integer/boolean arithmetic, comparisons, if/else, let bindings, match expressions, ADT constructors, function calls (modular postcondition), `length`, and `decreases` clauses (self-recursive with Nat or structural ADT measures).
+The Tier 1 fragment covers: integer/boolean arithmetic, comparisons, if/else, let bindings, match expressions, ADT constructors, function calls (modular postcondition), `length`, and `decreases` clauses (self-recursive, mutual recursion via where-blocks, Nat and structural ADT measures).
 
 ## Language Feature Coverage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.51"
+version = "0.0.52"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -210,8 +210,8 @@ class TestCmdVerify:
     def test_tier3_example(
         self, capsys: pytest.CaptureFixture[str]
     ) -> None:
-        """mutual_recursion.vera has contracts that fall to Tier 3."""
-        rc = cmd_verify(MUTUAL_RECURSION)
+        """increment.vera has contracts that fall to Tier 3."""
+        rc = cmd_verify(INCREMENT)
         assert rc == 0
         captured = capsys.readouterr()
         assert "OK:" in captured.out
@@ -261,7 +261,7 @@ class TestCmdVerify:
 
     def test_json_tier3(self, capsys: pytest.CaptureFixture[str]) -> None:
         """Tier 3 file produces JSON with runtime check counts."""
-        rc = cmd_verify(MUTUAL_RECURSION, as_json=True)
+        rc = cmd_verify(INCREMENT, as_json=True)
         assert rc == 0
         data = json.loads(capsys.readouterr().out)
         assert data["ok"] is True

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -84,32 +84,23 @@ class TestTier3:
     """Functions with runtime-checked contracts should be tested."""
 
     def test_tier3_passing(self) -> None:
-        """A function with a decreases clause should be tested (Tier 3).
+        """A function with an unverifiable decreases(0) should be tested.
 
-        Simple Nat decreases are now verified (Tier 1), so we use
-        mutual recursion which cannot be verified yet.
+        Mutual recursion is now verified (Tier 1), so we use a
+        non-recursive function with decreases(0) which stays Tier 3.
         """
         source = """\
-public fn is_even(@Nat -> @Bool)
+public fn identity(@Nat -> @Nat)
   requires(true)
   ensures(true)
-  decreases(@Nat.0)
+  decreases(0)
   effects(pure)
 {
-  if @Nat.0 == 0 then { true } else { is_odd(@Nat.0 - 1) }
+  @Nat.0
 }
-  where {
-    fn is_odd(@Nat -> @Bool)
-      requires(true)
-      ensures(true)
-      effects(pure)
-    {
-      if @Nat.0 == 0 then { false } else { is_even(@Nat.0 - 1) }
-    }
-  }
 """
         result = _test(source, trials=10)
-        f = _fn_result(result, "is_even")
+        f = _fn_result(result, "identity")
         assert f.category == "tested"
         assert f.trials_passed > 0
         assert f.trials_failed == 0
@@ -331,23 +322,14 @@ public fn proved(@Int -> @Int)
   @Int.0 + 1
 }
 
-public fn tested_fn(@Nat -> @Bool)
+public fn tested_fn(@Nat -> @Nat)
   requires(true)
   ensures(true)
-  decreases(@Nat.0)
+  decreases(0)
   effects(pure)
 {
-  if @Nat.0 == 0 then { true } else { is_odd(@Nat.0 - 1) }
+  @Nat.0
 }
-  where {
-    fn is_odd(@Nat -> @Bool)
-      requires(true)
-      ensures(true)
-      effects(pure)
-    {
-      if @Nat.0 == 0 then { false } else { tested_fn(@Nat.0 - 1) }
-    }
-  }
 
 public forall<T> fn generic_fn(@T -> @T)
   requires(true) ensures(true) effects(pure)
@@ -357,7 +339,7 @@ public forall<T> fn generic_fn(@T -> @T)
         s = result.summary
         # proved → verified (Tier 1)
         assert s.verified >= 1
-        # tested_fn → tested (Tier 3 due to mutual recursion decreases)
+        # tested_fn → tested (Tier 3 due to unverifiable decreases(0))
         assert s.tested >= 1
         # generic_fn → skipped
         assert s.skipped >= 1

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -1363,8 +1363,8 @@ private fn sum_to(@Nat -> @Nat)
         e525 = [d for d in result.diagnostics if d.error_code == "E525"]
         assert e525 == [], "Nat decreases should be verified (no E525)"
 
-    def test_mutual_recursion_stays_tier3(self) -> None:
-        """Mutual recursion decreases cannot be verified yet."""
+    def test_mutual_recursion_verified(self) -> None:
+        """Mutual recursion decreases are now verified via where-block groups."""
         source = EXAMPLES_DIR / "mutual_recursion.vera"
         if not source.exists():
             pytest.skip("mutual_recursion.vera not found")
@@ -1373,7 +1373,8 @@ private fn sum_to(@Nat -> @Nat)
         typecheck(ast, text)
         result = verify(ast, text, file=str(source))
         e525 = [d for d in result.diagnostics if d.error_code == "E525"]
-        assert len(e525) >= 1, "Mutual recursion should remain Tier 3"
+        assert e525 == [], "Mutual recursion decreases should be verified"
+        assert result.summary.tier3_runtime == 0
 
     def test_factorial_example_all_t1(self) -> None:
         """factorial.vera should have zero Tier 3 contracts."""
@@ -1460,11 +1461,13 @@ private fn sum(@List<Int> -> @Int)
         assert result.summary.tier1_verified == 8
 
     def test_overall_tier_counts(self) -> None:
-        """All examples together: 90 T1 / 6 T3 without module resolution.
+        """All examples together: 94 T1 / 5 T3 without module resolution.
 
-        With module resolution (via CLI), it's 92 T1 / 4 T3.
+        With module resolution (via CLI), it's 96 T1 / 3 T3.
         The 2-contract difference comes from modules.vera which needs
         cross-module imports to verify call-site preconditions.
+        The 99 total (vs 96 in v0.0.51) reflects where-block functions
+        (is_odd) now having their contracts verified.
         """
         t1 = t3 = total = 0
         for f in sorted(EXAMPLES_DIR.glob("*.vera")):
@@ -1475,6 +1478,103 @@ private fn sum(@List<Int> -> @Int)
             t1 += result.summary.tier1_verified
             t3 += result.summary.tier3_runtime
             total += result.summary.total
-        assert t1 == 90, f"Expected 90 T1, got {t1}"
-        assert t3 == 6, f"Expected 6 T3, got {t3}"
-        assert total == 96, f"Expected 96 total, got {total}"
+        assert t1 == 94, f"Expected 94 T1, got {t1}"
+        assert t3 == 5, f"Expected 5 T3, got {t3}"
+        assert total == 99, f"Expected 99 total, got {total}"
+
+
+# =====================================================================
+# Mutual recursion decreases verification tests
+# =====================================================================
+
+class TestMutualRecursionDecreases:
+    """Verify decreases clauses for mutually recursive where-block functions."""
+
+    def test_mutual_recursion_decreases_verified(self) -> None:
+        """is_even/is_odd with matching decreases(@Nat.0) both verify."""
+        source = """\
+public fn is_even(@Nat -> @Bool)
+  requires(true)
+  ensures(true)
+  decreases(@Nat.0)
+  effects(pure)
+{
+  if @Nat.0 == 0 then { true } else { is_odd(@Nat.0 - 1) }
+}
+  where {
+    fn is_odd(@Nat -> @Bool)
+      requires(true)
+      ensures(true)
+      decreases(@Nat.0)
+      effects(pure)
+    {
+      if @Nat.0 == 0 then { false } else { is_even(@Nat.0 - 1) }
+    }
+  }
+"""
+        result = _verify(source)
+        e525 = [d for d in result.diagnostics if d.error_code == "E525"]
+        assert e525 == [], f"Expected no E525, got {e525}"
+        assert result.summary.tier3_runtime == 0
+
+    def test_sibling_without_decreases_stays_tier3(self) -> None:
+        """If a sibling has no decreases clause, caller stays Tier 3."""
+        source = """\
+public fn f(@Nat -> @Nat)
+  requires(true)
+  ensures(true)
+  decreases(@Nat.0)
+  effects(pure)
+{
+  if @Nat.0 == 0 then { 0 } else { g(@Nat.0 - 1) }
+}
+  where {
+    fn g(@Nat -> @Nat)
+      requires(true)
+      ensures(true)
+      effects(pure)
+    {
+      if @Nat.0 == 0 then { 0 } else { f(@Nat.0 - 1) }
+    }
+  }
+"""
+        result = _verify(source)
+        e525 = [d for d in result.diagnostics if d.error_code == "E525"]
+        assert len(e525) == 1, "f's decreases should be Tier 3 (sibling has none)"
+
+    def test_where_block_contracts_verified(self) -> None:
+        """Where-block functions have their own contracts verified."""
+        source = """\
+public fn outer(@Nat -> @Nat)
+  requires(true)
+  ensures(@Nat.result >= 0)
+  effects(pure)
+{
+  helper(@Nat.0)
+}
+  where {
+    fn helper(@Nat -> @Nat)
+      requires(true)
+      ensures(@Nat.result >= 0)
+      effects(pure)
+    {
+      @Nat.0
+    }
+  }
+"""
+        result = _verify(source)
+        # Both outer and helper have requires + ensures = 4 contracts
+        assert result.summary.tier1_verified == 4
+        assert result.summary.tier3_runtime == 0
+
+    def test_mutual_recursion_example_all_t1(self) -> None:
+        """mutual_recursion.vera should have zero Tier 3 contracts."""
+        source = EXAMPLES_DIR / "mutual_recursion.vera"
+        if not source.exists():
+            pytest.skip("mutual_recursion.vera not found")
+        text = source.read_text()
+        prog = parse_to_ast(text)
+        typecheck(prog, text)
+        result = verify(prog, text, file=str(source))
+        assert result.summary.tier3_runtime == 0
+        assert result.summary.tier1_verified == 8

--- a/vera/README.md
+++ b/vera/README.md
@@ -528,7 +528,7 @@ Honest inventory of what the compiler cannot do, and where each limitation is ad
 |-----------|-----|---------|
 | **Module system limitations** | Module system complete (C7a-C7f); remaining issue: flat-compilation name collisions | [#110](https://github.com/aallan/vera/issues/110) |
 | **Limited effect checking** | Pure vs effectful only; no subeffecting or row unification | [#21](https://github.com/aallan/vera/issues/21) |
-| **Partial termination verification** | `decreases` verified for self-recursive functions (Nat and structural ADT); mutual recursion still Tier 3 | [#45](https://github.com/aallan/vera/issues/45) |
+| **No quantifier termination** | `decreases` verified for self-recursive and mutual recursion (where-blocks); no support for lexicographic ordering or non-structural measures | [#45](https://github.com/aallan/vera/issues/45) |
 | **No quantifier verification** | `forall`/`exists` in contracts always Tier 3 | [#13](https://github.com/aallan/vera/issues/13) |
 | **Minimal type inference** | Call-site generic instantiation only, no Hindley-Milner | [#55](https://github.com/aallan/vera/issues/55) |
 | **No incremental compilation** | Full file processed from scratch each time | [#56](https://github.com/aallan/vera/issues/56) |

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.51"
+__version__ = "0.0.52"

--- a/vera/verifier.py
+++ b/vera/verifier.py
@@ -385,7 +385,11 @@ class ContractVerifier:
             if isinstance(tld.decl, ast.FnDecl):
                 self._verify_fn(tld.decl)
 
-    def _verify_fn(self, decl: ast.FnDecl) -> None:
+    def _verify_fn(
+        self,
+        decl: ast.FnDecl,
+        parent_where_group: ast.FnDecl | None = None,
+    ) -> None:
         """Verify all contracts on a single function."""
         # Skip generic functions (type variables can't be translated to Z3)
         if decl.forall_vars:
@@ -559,10 +563,23 @@ class ContractVerifier:
                     )
 
         # 8. Handle decreases clauses — attempt verification
+        # Build mutual recursion group for decreases checking
+        group_decls: dict[str, ast.FnDecl] = {decl.name: decl}
+        if decl.where_fns:
+            for wfn in decl.where_fns:
+                group_decls[wfn.name] = wfn
+        elif parent_where_group is not None:
+            group_decls[parent_where_group.name] = parent_where_group
+            if parent_where_group.where_fns:
+                for wfn in parent_where_group.where_fns:
+                    group_decls[wfn.name] = wfn
+
         for contract in decl.contracts:
             if isinstance(contract, ast.Decreases):
                 self.summary.total += 1
-                if self._verify_decreases(decl, contract, smt, slot_env):
+                if self._verify_decreases(
+                    decl, contract, smt, slot_env, group_decls,
+                ):
                     self.summary.tier1_verified += 1
                 else:
                     self.summary.tier3_runtime += 1
@@ -574,11 +591,16 @@ class ContractVerifier:
                         rationale="Self-recursive functions with Nat or "
                                   "structural ADT measures are verified "
                                   "automatically. This function may use "
-                                  "mutual recursion or a measure that "
-                                  "cannot be translated to Z3.",
+                                  "a measure that cannot be translated "
+                                  "to Z3.",
                         spec_ref='Chapter 6, Section 6.6 "Termination"',
                         error_code="E525",
                     )
+
+        # 9. Verify where-block functions
+        if decl.where_fns:
+            for wfn in decl.where_fns:
+                self._verify_fn(wfn, parent_where_group=decl)
 
     # -----------------------------------------------------------------
     # Decreases verification (termination)
@@ -590,12 +612,14 @@ class ContractVerifier:
         contract: ast.Decreases,
         smt: SmtContext,
         slot_env: SlotEnv,
+        group_decls: dict[str, ast.FnDecl],
     ) -> bool:
         """Attempt to verify a decreases clause.
 
         Returns True if the measure strictly decreases at every recursive
-        call site while remaining non-negative.  Returns False if
-        verification fails or the measure cannot be translated.
+        call site (including mutual recursion via where-block siblings)
+        while remaining non-negative.  Returns False if verification fails
+        or the measure cannot be translated.
         """
         if not contract.exprs:
             return False
@@ -606,23 +630,24 @@ class ContractVerifier:
         if z3_initial is None:
             return False
 
-        # Collect all recursive call sites with their path conditions
+        # Collect all recursive call sites (self + mutual) with path conds
+        group_names = set(group_decls.keys())
         calls = self._collect_recursive_calls(
-            decl.name, decl.body, smt, slot_env,
+            decl.name, decl.body, smt, slot_env, group_names,
         )
         if not calls:
-            # No self-recursive calls found → can't verify
-            # (might be mutual recursion or base case only)
+            # No recursive calls found → can't verify
             return False
 
         import z3 as z3mod
 
         # For each call site, verify the measure decreases
-        for call_args, z3_path_conds, call_site_env in calls:
-            # Build callee's slot env from actual arguments,
-            # translating in the call site's env (includes match bindings)
+        for callee_name, call_args, z3_path_conds, call_site_env in calls:
+            callee_decl = group_decls.get(callee_name, decl)
+
+            # Build callee's slot env from actual arguments
             callee_env = SlotEnv()
-            param_type_exprs = list(decl.params)
+            param_type_exprs = list(callee_decl.params)
             if len(call_args) != len(param_type_exprs):
                 return False
             for param_te, arg_expr in zip(param_type_exprs, call_args):
@@ -632,14 +657,25 @@ class ContractVerifier:
                 type_name = self._type_expr_to_slot_name(param_te)
                 callee_env = callee_env.push(type_name, z3_arg)
 
-            # Translate the decreases expression in callee's env
-            z3_callee_measure = smt.translate_expr(measure_expr, callee_env)
+            # For cross-calls, use the callee's decreases expression
+            callee_measure_expr: ast.Expr
+            if callee_name == decl.name:
+                callee_measure_expr = measure_expr
+            else:
+                found = self._find_decreases_expr(callee_decl)
+                if found is None:
+                    return False  # sibling has no decreases clause
+                callee_measure_expr = found
+
+            # Translate the callee's measure in callee's env
+            z3_callee_measure = smt.translate_expr(
+                callee_measure_expr, callee_env,
+            )
             if z3_callee_measure is None:
                 return False
 
             # Verify: path_conds ⟹ measure strictly decreases
             if isinstance(z3_initial.sort(), z3mod.DatatypeSortRef):
-                # ADT measures: use structural rank function
                 rank_fn = smt.get_rank_fn(z3_initial.sort())
                 if rank_fn is None:
                     return False
@@ -666,8 +702,13 @@ class ContractVerifier:
 
         return True
 
-    # Z3 path condition type alias (not imported at module level)
-    _Z3PathCond = object  # Actually z3.ExprRef
+    @staticmethod
+    def _find_decreases_expr(decl: ast.FnDecl) -> ast.Expr | None:
+        """Extract the first decreases expression from a function's contracts."""
+        for c in decl.contracts:
+            if isinstance(c, ast.Decreases) and c.exprs:
+                return c.exprs[0]
+        return None
 
     def _collect_recursive_calls(
         self,
@@ -675,34 +716,38 @@ class ContractVerifier:
         expr: ast.Expr,
         smt: SmtContext,
         slot_env: SlotEnv,
-    ) -> list[tuple[tuple[ast.Expr, ...], list[object], SlotEnv]]:
-        """Walk the AST to find self-recursive call sites.
+        group_names: set[str] | None = None,
+    ) -> list[tuple[str, tuple[ast.Expr, ...], list[object], SlotEnv]]:
+        """Walk the AST to find recursive call sites.
 
-        Returns a list of (call_args, z3_path_conditions, call_site_env)
-        tuples.  Path conditions are Z3 BoolRef expressions that must hold
-        for the call to be reached.  The slot_env is tracked through the
-        walk so that let bindings and match pattern bindings are available.
+        Finds calls to *fn_name* and, when *group_names* is supplied, any
+        call to a function in the mutual recursion group.  Returns a list
+        of ``(callee_name, call_args, z3_path_conditions, slot_env)``
+        tuples.
         """
-        results: list[tuple[tuple[ast.Expr, ...], list[object], SlotEnv]] = []
-        self._walk_for_calls(fn_name, expr, [], results, smt, slot_env)
+        effective = group_names or {fn_name}
+        results: list[tuple[str, tuple[ast.Expr, ...], list[object], SlotEnv]] = []
+        self._walk_for_calls(effective, expr, [], results, smt, slot_env)
         return results
 
     def _walk_for_calls(
         self,
-        fn_name: str,
+        group_names: set[str],
         expr: ast.Expr,
         z3_path_conds: list[object],
-        results: list[tuple[tuple[ast.Expr, ...], list[object], SlotEnv]],
+        results: list[tuple[str, tuple[ast.Expr, ...], list[object], SlotEnv]],
         smt: SmtContext,
         slot_env: SlotEnv,
     ) -> None:
         """Recursively walk AST, tracking Z3 path conditions and slot env."""
         if isinstance(expr, ast.FnCall):
-            if expr.name == fn_name:
-                results.append((expr.args, list(z3_path_conds), slot_env))
+            if expr.name in group_names:
+                results.append(
+                    (expr.name, expr.args, list(z3_path_conds), slot_env),
+                )
             # Also walk into arguments (they might contain recursive calls)
             for arg in expr.args:
-                self._walk_for_calls(fn_name, arg, z3_path_conds, results,
+                self._walk_for_calls(group_names, arg, z3_path_conds, results,
                                      smt, slot_env)
             return
 
@@ -710,59 +755,54 @@ class ContractVerifier:
             z3_cond = smt.translate_expr(expr.condition, slot_env)
             if z3_cond is not None:
                 import z3 as z3mod
-                # Then branch: path_conds + [condition]
                 then_conds = z3_path_conds + [z3_cond]
-                self._walk_for_calls(fn_name, expr.then_branch, then_conds,
-                                     results, smt, slot_env)
-                # Else branch: path_conds + [NOT condition]
+                self._walk_for_calls(group_names, expr.then_branch,
+                                     then_conds, results, smt, slot_env)
                 else_conds = z3_path_conds + [z3mod.Not(z3_cond)]
-                self._walk_for_calls(fn_name, expr.else_branch, else_conds,
-                                     results, smt, slot_env)
+                self._walk_for_calls(group_names, expr.else_branch,
+                                     else_conds, results, smt, slot_env)
             else:
-                # Can't translate condition — walk both branches without extra conds
-                self._walk_for_calls(fn_name, expr.then_branch, z3_path_conds,
-                                     results, smt, slot_env)
-                self._walk_for_calls(fn_name, expr.else_branch, z3_path_conds,
-                                     results, smt, slot_env)
+                self._walk_for_calls(group_names, expr.then_branch,
+                                     z3_path_conds, results, smt, slot_env)
+                self._walk_for_calls(group_names, expr.else_branch,
+                                     z3_path_conds, results, smt, slot_env)
             return
 
         if isinstance(expr, ast.Block):
             cur_env = slot_env
             for stmt in expr.statements:
                 if isinstance(stmt, ast.LetStmt):
-                    self._walk_for_calls(fn_name, stmt.value, z3_path_conds,
-                                         results, smt, cur_env)
-                    # Extend env with let binding
+                    self._walk_for_calls(group_names, stmt.value,
+                                         z3_path_conds, results, smt, cur_env)
                     val = smt.translate_expr(stmt.value, cur_env)
                     if val is not None:
                         type_name = smt._type_expr_to_slot_name(stmt.type_expr)
                         if type_name is not None:
                             cur_env = cur_env.push(type_name, val)
                 elif isinstance(stmt, ast.ExprStmt):
-                    self._walk_for_calls(fn_name, stmt.expr, z3_path_conds,
-                                         results, smt, cur_env)
-            self._walk_for_calls(fn_name, expr.expr, z3_path_conds,
+                    self._walk_for_calls(group_names, stmt.expr,
+                                         z3_path_conds, results, smt, cur_env)
+            self._walk_for_calls(group_names, expr.expr, z3_path_conds,
                                  results, smt, cur_env)
             return
 
         if isinstance(expr, ast.BinaryExpr):
-            self._walk_for_calls(fn_name, expr.left, z3_path_conds, results,
-                                 smt, slot_env)
-            self._walk_for_calls(fn_name, expr.right, z3_path_conds, results,
-                                 smt, slot_env)
+            self._walk_for_calls(group_names, expr.left, z3_path_conds,
+                                 results, smt, slot_env)
+            self._walk_for_calls(group_names, expr.right, z3_path_conds,
+                                 results, smt, slot_env)
             return
 
         if isinstance(expr, ast.UnaryExpr):
-            self._walk_for_calls(fn_name, expr.operand, z3_path_conds,
+            self._walk_for_calls(group_names, expr.operand, z3_path_conds,
                                  results, smt, slot_env)
             return
 
         if isinstance(expr, ast.MatchExpr):
-            self._walk_for_calls(fn_name, expr.scrutinee, z3_path_conds,
+            self._walk_for_calls(group_names, expr.scrutinee, z3_path_conds,
                                  results, smt, slot_env)
             scrutinee_z3 = smt.translate_expr(expr.scrutinee, slot_env)
             for arm in expr.arms:
-                # Extend env with pattern bindings and add recognizer condition
                 arm_env = slot_env
                 arm_conds = z3_path_conds
                 if scrutinee_z3 is not None:
@@ -770,12 +810,11 @@ class ContractVerifier:
                                               slot_env)
                     if bound is not None:
                         arm_env = bound
-                    # Add pattern recognizer condition
                     pat_cond = smt._pattern_condition(scrutinee_z3,
                                                       arm.pattern)
                     if pat_cond is not None:
                         arm_conds = z3_path_conds + [pat_cond]
-                self._walk_for_calls(fn_name, arm.body, arm_conds,
+                self._walk_for_calls(group_names, arm.body, arm_conds,
                                      results, smt, arm_env)
             return
 


### PR DESCRIPTION
## Summary

- Where-block functions now have their contracts verified (requires, ensures, decreases) — adds 3 new verified contracts from is_odd
- The decreases verifier tracks mutual recursion groups instead of a single function name, enabling cross-call measure checking
- Cross-calls use the callee's decreases expression and parameter types to verify the measure strictly decreases
- Verification coverage: 96 T1, 3 T3, 99 total (97.0% static) — up from 92 T1, 4 T3, 96 total (95.8%)

Closes #45 — completes C8c (verification depth).

## Test plan

- [x] All 1,287 tests pass (4 new mutual recursion tests added)
- [x] mypy clean
- [x] All 15 examples pass check + verify
- [x] mutual_recursion.vera: all 8 contracts verified T1, 0 T3
- [x] Tagged v0.0.52 on branch

Generated with [Claude Code](https://claude.com/claude-code)