### PR TITLE
Fix stale doc counts and incorrect spec_ref citations

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ The language specification is in draft across 13 chapters:
 
 ### Testing
 
-The compiler has 1,267 tests with 88% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations. Every commit validates all 15 example programs and 96 specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference -- coverage tables, test helpers, CI pipeline, and infrastructure details.
+The compiler has 1,287 tests with 88% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations. Every commit validates all 15 example programs and 96 specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference -- coverage tables, test helpers, CI pipeline, and infrastructure details.
 
 ## Roadmap
 
@@ -219,7 +219,7 @@ Before starting the module system, C6.5 addressed residual gaps in single-file c
 <details>
 <summary>C6 — Codegen Completeness (<a href="https://github.com/aallan/vera/releases/tag/v0.0.10">v0.0.10</a>–<a href="https://github.com/aallan/vera/releases/tag/v0.0.24">v0.0.24</a>) ✓</summary>
 
-C6 extended WASM compilation to all language constructs, working through the dependency graph from simplest to most complex. All 14 examples now compile.
+C6 extended WASM compilation to all language constructs, working through the dependency graph from simplest to most complex. All 15 examples now compile.
 
 | Sub-phase | Scope | Version |
 |-----------|-------|---------|
@@ -637,7 +637,7 @@ vera/
 │   ├── formatter.py               # Canonical code formatter
 │   ├── errors.py                  # LLM-oriented diagnostics
 │   └── cli.py                     # Command-line interface
-├── examples/                      # 14 example Vera programs
+├── examples/                      # 15 example Vera programs
 ├── tests/                         # Test suite (see TESTING.md)
 └── scripts/                       # CI and validation scripts
     ├── check_examples.py          # Verify all .vera examples

--- a/TESTING.md
+++ b/TESTING.md
@@ -199,7 +199,7 @@ Allowlisted entries have stale-detection: when a feature lands or a spec edit sh
 
 ## Pre-commit Hooks
 
-After running `pre-commit install`, every commit is checked by 10 hooks:
+After running `pre-commit install`, every commit is checked by 11 hooks:
 
 | Hook | What it does |
 |------|-------------|
@@ -211,7 +211,7 @@ After running `pre-commit install`, every commit is checked by 10 hooks:
 | `debug-statements` | Detect `pdb`/`ipdb` imports |
 | `mypy vera/` | Type-check compiler in strict mode |
 | `pytest tests/ -q` | Run full test suite |
-| `check_examples.py` | All 14 examples pass `vera check` + `vera verify` |
+| `check_examples.py` | All 15 examples pass `vera check` + `vera verify` |
 | `check_readme_examples.py` | README code blocks parse correctly |
 
 The example and README hooks are smart about triggers -- they only run when `.vera` files, `vera/**/*.py`, or `grammar.lark` change.

--- a/vera/checker/core.py
+++ b/vera/checker/core.py
@@ -328,7 +328,7 @@ class TypeChecker(
                     f"requires() predicate must be Bool, found "
                     f"{pretty_type(ty)}.",
                     rationale="Contract predicates must evaluate to Bool.",
-                    spec_ref='Chapter 6, Section 6.2 "Preconditions"',
+                    spec_ref='Chapter 6, Section 6.2.1 "Preconditions"',
                     error_code="E123",
                 )
 
@@ -344,7 +344,7 @@ class TypeChecker(
                     f"ensures() predicate must be Bool, found "
                     f"{pretty_type(ty)}.",
                     rationale="Contract predicates must evaluate to Bool.",
-                    spec_ref='Chapter 6, Section 6.3 "Postconditions"',
+                    spec_ref='Chapter 6, Section 6.2.2 "Postconditions"',
                     error_code="E124",
                 )
 

--- a/vera/checker/expressions.py
+++ b/vera/checker/expressions.py
@@ -472,7 +472,7 @@ class ExpressionsMixin:
                 self._error(
                     expr.expr,
                     f"assert() requires Bool, found {pretty_type(ty)}.",
-                    spec_ref='Chapter 6, Section 6.6 "Assertions"',
+                    spec_ref='Chapter 6, Section 6.2.5 "Assertions"',
                     error_code="E172",
                 )
         return UNIT
@@ -485,7 +485,7 @@ class ExpressionsMixin:
                 self._error(
                     expr.expr,
                     f"assume() requires Bool, found {pretty_type(ty)}.",
-                    spec_ref='Chapter 6, Section 6.7 "Assumptions"',
+                    spec_ref='Chapter 6, Section 6.2.6 "Assumptions"',
                     error_code="E173",
                 )
         return UNIT

--- a/vera/tester.py
+++ b/vera/tester.py
@@ -5,7 +5,7 @@ WASM, and validates ensures() contracts at runtime.  Functions already
 proved by the verifier (Tier 1) are reported as "verified"; functions
 with Tier 3 contracts are exercised with generated inputs.
 
-See spec/06-contracts.md, Section 6.5 "Verification Tiers".
+See spec/06-contracts.md, Section 6.8 "Summary of Verification Tiers".
 """
 
 from __future__ import annotations

--- a/vera/verifier.py
+++ b/vera/verifier.py
@@ -403,7 +403,7 @@ class ContractVerifier:
                         f"'{decl.name}'. Contract will be checked at runtime.",
                         rationale="Generic functions have type variables that "
                                   "cannot be represented in the SMT solver.",
-                        spec_ref='Chapter 6, Section 6.5 "Verification Tiers"',
+                        spec_ref='Chapter 6, Section 6.8 "Summary of Verification Tiers"',
                         error_code="E520",
                     )
                 else:
@@ -473,7 +473,7 @@ class ContractVerifier:
                                   "that cannot be translated to SMT (e.g., "
                                   "pattern matching, effect operations, "
                                   "quantifiers).",
-                        spec_ref='Chapter 6, Section 6.5 "Verification Tiers"',
+                        spec_ref='Chapter 6, Section 6.8 "Summary of Verification Tiers"',
                         error_code="E521",
                     )
                     continue
@@ -515,7 +515,7 @@ class ContractVerifier:
                                   "cannot be translated to SMT (e.g., "
                                   "effect operations, lambdas, "
                                   "generic calls).",
-                        spec_ref='Chapter 6, Section 6.5 "Verification Tiers"',
+                        spec_ref='Chapter 6, Section 6.8 "Summary of Verification Tiers"',
                         error_code="E522",
                     )
                     continue
@@ -533,7 +533,7 @@ class ContractVerifier:
                         f"Contract will be checked at runtime.",
                         rationale="The postcondition expression contains "
                                   "constructs that cannot be translated to SMT.",
-                        spec_ref='Chapter 6, Section 6.5 "Verification Tiers"',
+                        spec_ref='Chapter 6, Section 6.8 "Summary of Verification Tiers"',
                         error_code="E523",
                     )
                     continue
@@ -558,7 +558,7 @@ class ContractVerifier:
                         rationale="The SMT solver returned 'unknown', which "
                                   "may indicate the formula is too complex or "
                                   "the timeout was reached.",
-                        spec_ref='Chapter 6, Section 6.5 "Verification Tiers"',
+                        spec_ref='Chapter 6, Section 6.8 "Summary of Verification Tiers"',
                         error_code="E524",
                     )
 
@@ -593,7 +593,7 @@ class ContractVerifier:
                                   "automatically. This function may use "
                                   "a measure that cannot be translated "
                                   "to Z3.",
-                        spec_ref='Chapter 6, Section 6.6 "Termination"',
+                        spec_ref='Chapter 5, Section 5.6.1 "Decreases Clauses"',
                         error_code="E525",
                     )
 
@@ -867,7 +867,7 @@ class ContractVerifier:
                 "that excludes the counterexample inputs) or weaken the "
                 "postcondition to match the actual function behaviour."
             ),
-            spec_ref='Chapter 6, Section 6.4 "Verification Conditions"',
+            spec_ref='Chapter 6, Section 6.4.1 "Verification Conditions"',
             error_code="E500",
         )
 


### PR DESCRIPTION
## Summary

- **README.md**: test count 1,267 to 1,287, example count 14 to 15 (directory tree + C6 section)
- **TESTING.md**: example count 14 to 15 (hooks table), hook count 10 to 11
- **verifier.py**: 7 spec_ref fixes -- E520-E524 from 6.5 to 6.8 (Summary of Verification Tiers), E525 from 6.6 to 5.6.1 (Decreases Clauses), E500 from 6.4 to 6.4.1 (Verification Conditions)
- **checker/core.py**: E123 from 6.2 to 6.2.1 (Preconditions), E124 from 6.3 to 6.2.2 (Postconditions)
- **checker/expressions.py**: E172 from 6.6 to 6.2.5 (Assertions), E173 from 6.7 to 6.2.6 (Assumptions)
- **tester.py**: docstring reference from 6.5 to 6.8

## Test plan

- [x] All 1,287 tests pass
- [x] mypy clean
- [x] All 15 examples pass check + verify
- [x] Pre-commit hooks pass

Generated with [Claude Code](https://claude.com/claude-code)