### PR TITLE
Implement effect row subtyping and call-site checking (#21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.54] - 2026-03-02
+
+### Added
+- **Effect row subtyping and call-site effect checking** (C8d, [#21](https://github.com/aallan/vera/issues/21)):
+  Implements the subeffecting rules from Spec Section 7.8: a function with fewer
+  effects can be used where more effects are expected.
+  - `is_effect_subtype()` function in `types.py` encodes subset semantics
+    for effect rows (`effects(pure) <: effects(<IO>) <: effects(<IO, State<Int>>)`)
+  - `FunctionType` subtyping now includes effect covariance: a pure function
+    can be passed where `fn(A -> B) effects(<IO>)` is expected
+  - Call-site check in `checker/calls.py`: calling a function whose effects
+    exceed the caller's context is now an error (E125)
+  - Handler bodies unaffected: handlers temporarily add their effect to the
+    context before checking the body, then discharge it
+  - Effect row variables (`forall<E>`) are permissive pending #55
+  - `effects_equal()` function added for structural effect row comparison
+  - `types_equal()` updated to compare effects in `FunctionType`
+  - 20 new tests (13 unit tests, 7 integration tests)
+  - 1,320 tests total
+
 ## [0.0.53] - 2026-03-02
 
 ### Changed
@@ -791,7 +811,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Grammar: handler body simplified to avoid LALR reduce/reduce conflict
 - `pyproject.toml`: corrected build backend, package discovery, PEP 639 compliance
 
-[Unreleased]: https://github.com/aallan/vera/compare/v0.0.53...HEAD
+[Unreleased]: https://github.com/aallan/vera/compare/v0.0.54...HEAD
+[0.0.54]: https://github.com/aallan/vera/compare/v0.0.53...v0.0.54
 [0.0.53]: https://github.com/aallan/vera/compare/v0.0.52...v0.0.53
 [0.0.52]: https://github.com/aallan/vera/compare/v0.0.51...v0.0.52
 [0.0.51]: https://github.com/aallan/vera/compare/v0.0.50...v0.0.51

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ The language specification is in draft across 13 chapters:
 
 ### Testing
 
-The compiler has 1,300 tests with 88% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations. Every commit validates all 15 example programs and 96 specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference -- coverage tables, test helpers, CI pipeline, and infrastructure details.
+The compiler has 1,320 tests with 88% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations. Every commit validates all 15 example programs and 96 specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference -- coverage tables, test helpers, CI pipeline, and infrastructure details.
 
 ## Roadmap
 
@@ -268,7 +268,7 @@ C8 addresses the accumulated technical debt and UX gaps before v0.1.0. Open issu
 **C8d — Type system** — close type-checking gaps
 
 - <del>[#20](https://github.com/aallan/vera/issues/20) TypeVar subtyping</del> ([v0.0.53](https://github.com/aallan/vera/releases/tag/v0.0.53))
-- [#21](https://github.com/aallan/vera/issues/21) effect row unification and subeffecting
+- <del>[#21](https://github.com/aallan/vera/issues/21) effect row unification and subeffecting</del> ([v0.0.54](https://github.com/aallan/vera/releases/tag/v0.0.54))
 - [#55](https://github.com/aallan/vera/issues/55) minimal type inference
 
 **C8e — Codegen gaps** — extend WASM compilation

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,7 +6,7 @@ This is the single source of truth for Vera's testing infrastructure, coverage d
 
 | Metric | Value |
 |--------|-------|
-| **Tests** | 1,300 across 19 files (~16,900 lines of test code) |
+| **Tests** | 1,320 across 19 files (~17,000 lines of test code) |
 | **Compiler code coverage** | 88% of 6,861 statements (CI minimum: 80%) |
 | **Example programs** | 15, all validated through `vera check` + `vera verify` |
 | **Spec code blocks** | 96 parseable blocks from 13 spec chapters: 72 parse, 57 type-check, 56 verify |
@@ -41,7 +41,7 @@ python scripts/check_version_sync.py                 # version consistency
 |------|------:|------:|----------------|
 | `test_parser.py` | 103 | 888 | Grammar rules, operator precedence, parse errors |
 | `test_ast.py` | 87 | 935 | AST transformation, node structure, serialisation |
-| `test_checker.py` | 181 | 2,340 | Type synthesis, slot resolution, effects, contracts, exhaustiveness, cross-module typing, visibility, error codes, string built-ins, generic rejection |
+| `test_checker.py` | 188 | 2,482 | Type synthesis, slot resolution, effects, effect subtyping, contracts, exhaustiveness, cross-module typing, visibility, error codes, string built-ins, generic rejection |
 | `test_verifier.py` | 97 | 1,580 | Z3 verification, counterexamples, tier classification, call-site preconditions, pipe operator, cross-module contracts, match/ADT verification, decreases verification, mutual recursion |
 | `test_codegen.py` | 317 | 3,725 | WASM compilation, arithmetic, Float64, Byte, arrays, ADTs, match, generics, State\<T\>, control flow, strings, IO, bounds checking, quantifiers, assert/assume, refinement type aliases, pipe operator, string built-ins, example round-trips |
 | `test_codegen_contracts.py` | 32 | 576 | Runtime pre/postconditions, contract fail messages, old/new state postconditions |
@@ -53,7 +53,7 @@ python scripts/check_version_sync.py                 # version consistency
 | `test_formatter.py` | 62 | 554 | Comment extraction, expression/declaration formatting, idempotency, parenthesization, spec rules |
 | `test_cli.py` | 109 | 1,550 | CLI commands (check, verify, compile, run, test, fmt), subprocess integration, JSON error paths, runtime traps, arg validation, multi-file resolution |
 | `test_resolver.py` | 15 | 412 | Module resolution, path lookup, parse caching, circular import detection |
-| `test_types.py` | 60 | 301 | Type operations: subtyping, equality, substitution, pretty-printing, canonical names |
+| `test_types.py` | 73 | 390 | Type operations: subtyping, effect subtyping, equality, substitution, pretty-printing, canonical names |
 | `test_wasm.py` | 22 | 255 | WASM internals: StringPool, WasmSlotEnv, translation edge cases via full pipeline |
 | `test_wasm_coverage.py` | 109 | 1,720 | WASM coverage gaps: helpers unit tests, inference branches, closure free-var walking, operator/data/context edge cases |
 | `test_tester.py` | 13 | 320 | Contract-driven testing: tier classification, input generation, test execution |
@@ -129,6 +129,7 @@ How Vera language features (by spec chapter) map to test files and example progr
 | Ch 6: Contracts | Quantifiers (forall, exists) | test_codegen, test_verifier | quantifiers |
 | Ch 7: Effects | Pure, IO, State\<T\> | test_codegen, test_checker | hello_world, increment |
 | Ch 7: Effects | Effect handlers (handle/resume) | test_codegen, test_checker | effect_handler |
+| Ch 7: Effects | Effect subtyping (§7.8), call-site checking | test_types, test_checker | — |
 | Ch 8: Modules | Imports, cross-module typing and codegen | test_codegen_modules, test_resolver | modules |
 | Ch 11: Compilation | Contract-driven testing (Z3 input gen + WASM execution) | test_tester, test_cli | safe_divide, factorial |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.53"
+version = "0.0.54"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -932,6 +932,148 @@ private fn bad(@Unit -> @Unit)
 
 
 # =====================================================================
+# Effect Subtyping (Spec §7.8)
+# =====================================================================
+
+class TestEffectSubtyping:
+    """Call-site effect checking — functions can only call functions
+    whose effects are a subset of the caller's effect row."""
+
+    def test_pure_calling_effectful_fn_error(self) -> None:
+        """Pure function calling an effectful *function* (not an op) → E125."""
+        _check_err("""
+effect Logger {
+  op log(String -> Unit);
+}
+
+private fn effectful(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<Logger>)
+{
+  Logger.log("hi")
+}
+
+private fn bad(@Unit -> @Unit)
+  requires(true) ensures(true) effects(pure)
+{
+  effectful(())
+}
+""", "requires effects(<Logger>) but call site only allows effects(pure)")
+
+    def test_effectful_calling_same_effect_ok(self) -> None:
+        """Calling a function with the same effect row is fine."""
+        _check_ok("""
+effect Logger {
+  op log(String -> Unit);
+}
+
+private fn effectful(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<Logger>)
+{
+  Logger.log("hi")
+}
+
+private fn caller(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<Logger>)
+{
+  effectful(())
+}
+""")
+
+    def test_effectful_calling_subset_ok(self) -> None:
+        """Calling a function whose effects are a subset of the caller's."""
+        _check_ok("""
+effect Logger {
+  op log(String -> Unit);
+}
+
+effect Tracer {
+  op trace(String -> Unit);
+}
+
+private fn log_only(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<Logger>)
+{
+  Logger.log("hi")
+}
+
+private fn caller(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<Logger, Tracer>)
+{
+  log_only(())
+}
+""")
+
+    def test_effectful_calling_superset_error(self) -> None:
+        """Calling a function that needs more effects than the caller has."""
+        _check_err("""
+effect Logger {
+  op log(String -> Unit);
+}
+
+effect Tracer {
+  op trace(String -> Unit);
+}
+
+private fn needs_both(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<Logger, Tracer>)
+{
+  Logger.log("hi");
+  Tracer.trace("t")
+}
+
+private fn caller(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<Logger>)
+{
+  needs_both(())
+}
+""", "requires effects(<Logger, Tracer>) but call site only allows effects(<Logger>)")
+
+    def test_handler_discharges_effect_ok(self) -> None:
+        """Handler body can use effects — handler discharges them."""
+        _check_ok("""
+private fn run(@Unit -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  handle[State<Int>](@Int = 0) {
+    get(@Unit) -> { resume(@Int.0) },
+    put(@Int) -> { resume(()) }
+  } in {
+    put(42);
+    get(())
+  }
+}
+""")
+
+    def test_pure_calling_pure_fn_ok(self) -> None:
+        """Pure calling pure is always fine."""
+        _check_ok("""
+private fn helper(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 + 1 }
+
+private fn caller(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  helper(@Int.0)
+}
+""")
+
+    def test_io_calling_pure_fn_ok(self) -> None:
+        """An IO context can call a pure function (pure <: IO)."""
+        _check_ok("""
+private fn helper(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 + 1 }
+
+private fn caller(@Int -> @Int)
+  requires(true) ensures(true) effects(<IO>)
+{
+  helper(@Int.0)
+}
+""")
+
+
+# =====================================================================
 # Contracts
 # =====================================================================
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -8,7 +8,7 @@ from vera.types import (
     INT, NAT, BOOL, FLOAT64, STRING, UNIT, NEVER, BYTE,
     PrimitiveType, AdtType, FunctionType, RefinedType, TypeVar, UnknownType,
     PureEffectRow, ConcreteEffectRow, EffectInstance,
-    is_subtype, types_equal, substitute, substitute_effect,
+    is_subtype, is_effect_subtype, types_equal, substitute, substitute_effect,
     pretty_type, pretty_effect, canonical_type_name, base_type,
 )
 from vera import ast
@@ -221,6 +221,95 @@ class TestSubstituteEffect:
         )
         result = substitute_effect(eff, {})
         assert result.row_var == "E"
+
+
+# =====================================================================
+# is_effect_subtype
+# =====================================================================
+
+class TestIsEffectSubtype:
+    """Tests for effect row subtyping (Spec §7.8)."""
+
+    def test_pure_reflexive(self) -> None:
+        assert is_effect_subtype(PureEffectRow(), PureEffectRow())
+
+    def test_pure_subtype_of_concrete(self) -> None:
+        io = ConcreteEffectRow(frozenset({EffectInstance("IO", ())}))
+        assert is_effect_subtype(PureEffectRow(), io)
+
+    def test_concrete_not_subtype_of_pure(self) -> None:
+        io = ConcreteEffectRow(frozenset({EffectInstance("IO", ())}))
+        assert not is_effect_subtype(io, PureEffectRow())
+
+    def test_concrete_subset(self) -> None:
+        io = ConcreteEffectRow(frozenset({EffectInstance("IO", ())}))
+        io_state = ConcreteEffectRow(frozenset({
+            EffectInstance("IO", ()),
+            EffectInstance("State", (INT,)),
+        }))
+        assert is_effect_subtype(io, io_state)
+
+    def test_concrete_not_superset(self) -> None:
+        io = ConcreteEffectRow(frozenset({EffectInstance("IO", ())}))
+        io_state = ConcreteEffectRow(frozenset({
+            EffectInstance("IO", ()),
+            EffectInstance("State", (INT,)),
+        }))
+        assert not is_effect_subtype(io_state, io)
+
+    def test_concrete_reflexive(self) -> None:
+        io = ConcreteEffectRow(frozenset({EffectInstance("IO", ())}))
+        assert is_effect_subtype(io, io)
+
+    def test_concrete_disjoint(self) -> None:
+        io = ConcreteEffectRow(frozenset({EffectInstance("IO", ())}))
+        state = ConcreteEffectRow(frozenset({
+            EffectInstance("State", (INT,)),
+        }))
+        assert not is_effect_subtype(io, state)
+
+    def test_row_var_permissive(self) -> None:
+        """Open row variable on sub side is permissive (deferred to #55)."""
+        open_row = ConcreteEffectRow(
+            frozenset({EffectInstance("IO", ())}), row_var="E")
+        io = ConcreteEffectRow(frozenset({EffectInstance("IO", ())}))
+        assert is_effect_subtype(open_row, io)
+
+    def test_empty_concrete_subtype_of_pure(self) -> None:
+        empty = ConcreteEffectRow(frozenset())
+        assert is_effect_subtype(empty, PureEffectRow())
+
+
+class TestFunctionTypeSubtyping:
+    """Tests for FunctionType subtyping including effects."""
+
+    def test_pure_fn_subtype_of_effectful(self) -> None:
+        pure_fn = FunctionType((INT,), BOOL, PureEffectRow())
+        io_fn = FunctionType((INT,), BOOL,
+                             ConcreteEffectRow(frozenset({
+                                 EffectInstance("IO", ())})))
+        assert is_subtype(pure_fn, io_fn)
+
+    def test_effectful_fn_not_subtype_of_pure(self) -> None:
+        pure_fn = FunctionType((INT,), BOOL, PureEffectRow())
+        io_fn = FunctionType((INT,), BOOL,
+                             ConcreteEffectRow(frozenset({
+                                 EffectInstance("IO", ())})))
+        assert not is_subtype(io_fn, pure_fn)
+
+    def test_fn_same_effects_subtype(self) -> None:
+        io_fn1 = FunctionType((INT,), BOOL,
+                              ConcreteEffectRow(frozenset({
+                                  EffectInstance("IO", ())})))
+        io_fn2 = FunctionType((INT,), BOOL,
+                              ConcreteEffectRow(frozenset({
+                                  EffectInstance("IO", ())})))
+        assert is_subtype(io_fn1, io_fn2)
+
+    def test_fn_different_params_not_subtype(self) -> None:
+        fn1 = FunctionType((INT,), BOOL, PureEffectRow())
+        fn2 = FunctionType((BOOL,), BOOL, PureEffectRow())
+        assert not is_subtype(fn1, fn2)
 
 
 # =====================================================================

--- a/vera/README.md
+++ b/vera/README.md
@@ -494,7 +494,7 @@ Methods in `transform.py` are named after grammar rules and receive already-tran
 
 ### 6. Effect row infrastructure
 
-The type system includes open effect rows (`row_var` field in `ConcreteEffectRow`) for future row polymorphism (`forall<E> fn(...) effects(<E>)`). Currently, effect checking is basic — pure functions can't call effectful operations, and handlers discharge their declared effect. The infrastructure is in place for richer effect tracking in later phases.
+The type system includes open effect rows (`row_var` field in `ConcreteEffectRow`) for row polymorphism (`forall<E> fn(...) effects(<E>)`). Effect checking enforces subeffecting (Spec Section 7.8): `effects(pure) <: effects(<IO>) <: effects(<IO, State<Int>>)`. A function can only be called from a context whose effect row contains all of the callee's effects (`is_effect_subtype` in `types.py`, call-site check in `checker/calls.py`, error code E125). Handlers discharge their declared effect by temporarily adding it to the context. Row variable unification for `forall<E>` polymorphism is permissive pending bidirectional type checking (#55).
 
 ### 7. LLM-oriented diagnostics
 
@@ -527,7 +527,7 @@ Honest inventory of what the compiler cannot do, and where each limitation is ad
 | Limitation | Why | Planned |
 |-----------|-----|---------|
 | **Module system limitations** | Module system complete (C7a-C7f); remaining issue: flat-compilation name collisions | [#110](https://github.com/aallan/vera/issues/110) |
-| **Limited effect checking** | Pure vs effectful only; no subeffecting or row unification | [#21](https://github.com/aallan/vera/issues/21) |
+| **No effect row variable unification** | Subeffecting implemented; `forall<E>` row variables permissive pending bidirectional checking | [#55](https://github.com/aallan/vera/issues/55) |
 | **No quantifier termination** | `decreases` verified for self-recursive and mutual recursion (where-blocks); no support for lexicographic ordering or non-structural measures | [#45](https://github.com/aallan/vera/issues/45) |
 | **No quantifier verification** | `forall`/`exists` in contracts always Tier 3 | [#13](https://github.com/aallan/vera/issues/13) |
 | **Minimal type inference** | Call-site generic instantiation only, no Hindley-Milner | [#55](https://github.com/aallan/vera/issues/55) |

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.53"
+__version__ = "0.0.54"

--- a/vera/checker/calls.py
+++ b/vera/checker/calls.py
@@ -21,7 +21,9 @@ from vera.types import (
     TypeVar,
     UnknownType,
     contains_typevar,
+    is_effect_subtype,
     is_subtype,
+    pretty_effect,
     pretty_type,
     substitute,
 )
@@ -120,6 +122,26 @@ class CallsMixin:
             if isinstance(fn_info.effect, ConcreteEffectRow):
                 for ei in fn_info.effect.effects:
                     self._effect_ops_used.add(ei.name)
+
+        # Call-site effect check: callee's effects must be permitted
+        # by the caller's context (Spec §7.8 subeffecting).
+        if self.env.current_effect_row is not None:
+            if not is_effect_subtype(fn_info.effect,
+                                     self.env.current_effect_row):
+                self._error(
+                    node,
+                    f"Function '{fn_info.name}' requires "
+                    f"{pretty_effect(fn_info.effect)} but call site only "
+                    f"allows {pretty_effect(self.env.current_effect_row)}.",
+                    rationale="A function can only be called from a context "
+                              "that permits all of its declared effects "
+                              "(subeffecting).",
+                    fix=f"Either add the missing effects to the calling "
+                        f"function's effects clause, or handle the effects "
+                        f"with a handler.",
+                    spec_ref='Chapter 7, Section 7.8 "Effect Subtyping"',
+                    error_code="E125",
+                )
 
         return return_type
 

--- a/vera/errors.py
+++ b/vera/errors.py
@@ -424,6 +424,7 @@ ERROR_CODES: dict[str, str] = {
     "E122": "Pure function performs effects",
     "E123": "Precondition predicate not Bool",
     "E124": "Postcondition predicate not Bool",
+    "E125": "Call-site effect mismatch",
     "E130": "Unresolved slot reference",
     "E131": "Result ref outside ensures",
     "E140": "Arithmetic requires numeric operands",

--- a/vera/types.py
+++ b/vera/types.py
@@ -208,6 +208,7 @@ def is_subtype(sub: Type, sup: Type) -> bool:
     6. RefinedType(base, _) <: T if base <: T
     7. T <: RefinedType(base, _) if T <: base (predicate enforced by verifier)
     8. UnknownType is compatible with everything (error recovery)
+    9. FunctionType: params contravariant, return covariant, effects covariant
 
     TypeVar is NOT compatible with concrete types.  TypeVar equality is
     handled by reflexivity (rule 1).  At call sites, type inference
@@ -251,6 +252,65 @@ def is_subtype(sub: Type, sup: Type) -> bool:
     if isinstance(sup, RefinedType):
         return is_subtype(sub, sup.base)
 
+    # FunctionType subtyping: params contravariant, return covariant,
+    # effects covariant (Spec §7.8).
+    if isinstance(sub, FunctionType) and isinstance(sup, FunctionType):
+        if len(sub.params) != len(sup.params):
+            return False
+        # Params: contravariant (sup params <: sub params)
+        if not all(is_subtype(sp, sbp)
+                   for sp, sbp in zip(sup.params, sub.params)):
+            return False
+        # Return: covariant (sub return <: sup return)
+        if not is_subtype(sub.return_type, sup.return_type):
+            return False
+        # Effects: covariant (sub effects <: sup effects)
+        return is_effect_subtype(sub.effect, sup.effect)
+
+    return False
+
+
+def is_effect_subtype(sub: EffectRowType, sup: EffectRowType) -> bool:
+    """Check if effect row *sub* <: *sup* (subeffecting).
+
+    Rules (Spec Chapter 7, Section 7.8):
+    1. Reflexivity: E <: E
+    2. Pure is bottom: effects(pure) <: effects(<...>)
+    3. Subset: effects(<A, B>) <: effects(<A, B, C>)
+    4. Open rows: if *sub* has an unresolved row variable, be permissive
+       (full row-variable unification is deferred to #55).
+    """
+    # Both pure
+    if isinstance(sub, PureEffectRow) and isinstance(sup, PureEffectRow):
+        return True
+
+    # Pure is subtype of everything
+    if isinstance(sub, PureEffectRow):
+        return True
+
+    # Concrete <: Pure only if the concrete row is empty
+    if isinstance(sup, PureEffectRow):
+        if isinstance(sub, ConcreteEffectRow):
+            return len(sub.effects) == 0
+        return False
+
+    # Both concrete: sub.effects must be a subset of sup.effects
+    if isinstance(sub, ConcreteEffectRow) and isinstance(sup, ConcreteEffectRow):
+        # Unresolved row variable — be permissive until #55
+        if sub.row_var is not None:
+            return True
+        # If sup has a row variable, the concrete effects must still subset
+        return sub.effects.issubset(sup.effects)
+
+    return False
+
+
+def effects_equal(a: EffectRowType, b: EffectRowType) -> bool:
+    """Structural equality for effect rows."""
+    if isinstance(a, PureEffectRow) and isinstance(b, PureEffectRow):
+        return True
+    if isinstance(a, ConcreteEffectRow) and isinstance(b, ConcreteEffectRow):
+        return a.effects == b.effects and a.row_var == b.row_var
     return False
 
 
@@ -271,7 +331,8 @@ def types_equal(a: Type, b: Type) -> bool:
         return (len(a.params) == len(b.params)
                 and all(types_equal(x, y)
                         for x, y in zip(a.params, b.params))
-                and types_equal(a.return_type, b.return_type))
+                and types_equal(a.return_type, b.return_type)
+                and effects_equal(a.effect, b.effect))
     if isinstance(a, RefinedType) and isinstance(b, RefinedType):
         return types_equal(a.base, b.base)
     if isinstance(a, TypeVar) and isinstance(b, TypeVar):


### PR DESCRIPTION
## Summary
- Implements effect row subtyping from Spec Section 7.8: `effects(pure) <: effects(<IO>) <: effects(<IO, State<Int>>)`
- Adds call-site effect checking: calling a function whose effects exceed the caller's context is now an error (E125)
- Adds `FunctionType` subtyping with effect covariance: a pure function can be passed where `fn(A -> B) effects(<IO>)` is expected
- Handler bodies unaffected: handlers temporarily add their effect to the context, so the check works correctly inside `handle` blocks
- Effect row variables (`forall<E>`) remain permissive pending #55 (bidirectional type checking)
- 20 new tests (13 unit, 7 integration), 1,320 tests total

Closes #21

## Test plan
- [x] 1,320 tests pass (`pytest tests/ -v`)
- [x] mypy clean (`mypy vera/`)
- [x] All 15 examples pass (`python scripts/check_examples.py`)
- [x] All spec code blocks pass (`python scripts/check_spec_examples.py`)
- [x] All README code blocks pass (`python scripts/check_readme_examples.py`)
- [x] Version sync verified (`python scripts/check_version_sync.py`)
- [x] Tagged v0.0.54 on branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)