### PR TITLE
Implement bidirectional type checking (#55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.55] - 2026-03-03
+
+### Added
+- **Bidirectional type checking** (C8d, [#55](https://github.com/aallan/vera/issues/55)):
+  Adds local type inference via an `expected` parameter threaded through
+  expression synthesis. Nullary constructors of parameterised ADTs (`None`
+  for `Option<T>`, `Nil` for `List<T>`) now resolve their TypeVars from
+  context — return types, let bindings, if/match branches, and function
+  arguments.
+  - `_synth_expr` gains optional `expected: Type | None` parameter
+  - Constructors resolve unresolved TypeVars from expected type in
+    `_ctor_result_type` and `_check_constructor_call`
+  - Nested constructors (`Some(None)` for `Option<Option<Int>>`) resolve
+    via field-type propagation
+  - Function call arguments with TypeVars are re-synthesised with the
+    substituted parameter type as expected
+  - If/match branches with TypeVars are re-synthesised using the concrete
+    branch as expected, replacing the previous `contains_typevar` guards
+  - `_check_fn` passes `expected=return_type` to body synthesis, removing
+    the `contains_typevar` workaround guard from v0.0.53
+  - No changes to function signatures, parser, AST, or spec
+  - 12 new tests (TestBidirectionalInference)
+  - 1,332 tests total
+
 ## [0.0.54] - 2026-03-02
 
 ### Added
@@ -811,7 +835,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Grammar: handler body simplified to avoid LALR reduce/reduce conflict
 - `pyproject.toml`: corrected build backend, package discovery, PEP 639 compliance
 
-[Unreleased]: https://github.com/aallan/vera/compare/v0.0.54...HEAD
+[Unreleased]: https://github.com/aallan/vera/compare/v0.0.55...HEAD
+[0.0.55]: https://github.com/aallan/vera/compare/v0.0.54...v0.0.55
 [0.0.54]: https://github.com/aallan/vera/compare/v0.0.53...v0.0.54
 [0.0.53]: https://github.com/aallan/vera/compare/v0.0.52...v0.0.53
 [0.0.52]: https://github.com/aallan/vera/compare/v0.0.51...v0.0.52

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ The language specification is in draft across 13 chapters:
 
 ### Testing
 
-The compiler has 1,320 tests with 88% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations. Every commit validates all 15 example programs and 96 specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference -- coverage tables, test helpers, CI pipeline, and infrastructure details.
+The compiler has 1,332 tests with 88% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations. Every commit validates all 15 example programs and 96 specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference -- coverage tables, test helpers, CI pipeline, and infrastructure details.
 
 ## Roadmap
 
@@ -269,7 +269,7 @@ C8 addresses the accumulated technical debt and UX gaps before v0.1.0. Open issu
 
 - <del>[#20](https://github.com/aallan/vera/issues/20) TypeVar subtyping</del> ([v0.0.53](https://github.com/aallan/vera/releases/tag/v0.0.53))
 - <del>[#21](https://github.com/aallan/vera/issues/21) effect row unification and subeffecting</del> ([v0.0.54](https://github.com/aallan/vera/releases/tag/v0.0.54))
-- [#55](https://github.com/aallan/vera/issues/55) minimal type inference
+- <del>[#55](https://github.com/aallan/vera/issues/55) minimal type inference</del> ([v0.0.55](https://github.com/aallan/vera/releases/tag/v0.0.55))
 
 **C8e — Codegen gaps** — extend WASM compilation
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,7 +6,7 @@ This is the single source of truth for Vera's testing infrastructure, coverage d
 
 | Metric | Value |
 |--------|-------|
-| **Tests** | 1,320 across 19 files (~17,000 lines of test code) |
+| **Tests** | 1,332 across 19 files (~17,000 lines of test code) |
 | **Compiler code coverage** | 88% of 6,861 statements (CI minimum: 80%) |
 | **Example programs** | 15, all validated through `vera check` + `vera verify` |
 | **Spec code blocks** | 96 parseable blocks from 13 spec chapters: 72 parse, 57 type-check, 56 verify |
@@ -130,6 +130,7 @@ How Vera language features (by spec chapter) map to test files and example progr
 | Ch 7: Effects | Pure, IO, State\<T\> | test_codegen, test_checker | hello_world, increment |
 | Ch 7: Effects | Effect handlers (handle/resume) | test_codegen, test_checker | effect_handler |
 | Ch 7: Effects | Effect subtyping (§7.8), call-site checking | test_types, test_checker | — |
+| Ch 2: Types | Bidirectional type checking (local inference) | test_checker | — |
 | Ch 8: Modules | Imports, cross-module typing and codegen | test_codegen_modules, test_resolver | modules |
 | Ch 11: Compilation | Contract-driven testing (Z3 input gen + WASM execution) | test_tester, test_cli | safe_divide, factorial |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.54"
+version = "0.0.55"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -2480,3 +2480,151 @@ private fn f(@String -> @String)
   requires(true) ensures(true) effects(pure)
 { strip(@String.0) }
 """)
+
+
+# =====================================================================
+# Bidirectional type inference (issue #55)
+# =====================================================================
+
+class TestBidirectionalInference:
+    """Bidirectional type checking: expected types resolve TypeVars in
+    nullary constructors of parameterised ADTs."""
+
+    def test_none_return_resolves_option(self) -> None:
+        """None as function return resolves to Option<Int>."""
+        _check_ok("""
+private data Option<T> { None, Some(T) }
+
+private fn nothing(-> @Option<Int>)
+  requires(true) ensures(true) effects(pure)
+{ None }
+""")
+
+    def test_if_none_some_resolves(self) -> None:
+        """If-else with None/Some(42): None resolves from Some branch."""
+        _check_ok("""
+private data Option<T> { None, Some(T) }
+
+private fn maybe(@Bool -> @Option<Int>)
+  requires(true) ensures(true) effects(pure)
+{
+  if @Bool.0 then { Some(42) } else { None }
+}
+""")
+
+    def test_if_some_none_resolves(self) -> None:
+        """If-else with Some(42)/None: None resolves from Some branch."""
+        _check_ok("""
+private data Option<T> { None, Some(T) }
+
+private fn maybe(@Bool -> @Option<Int>)
+  requires(true) ensures(true) effects(pure)
+{
+  if @Bool.0 then { None } else { Some(42) }
+}
+""")
+
+    def test_match_none_arm_resolves(self) -> None:
+        """Match arm returning None resolves from expected return type."""
+        _check_ok("""
+private data Option<T> { None, Some(T) }
+
+private fn flip(@Option<Int> -> @Option<Int>)
+  requires(true) ensures(true) effects(pure)
+{
+  match @Option<Int>.0 {
+    Some(@Int) -> None,
+    None -> Some(0)
+  }
+}
+""")
+
+    def test_let_binding_resolves(self) -> None:
+        """let @Option<Int> = None resolves TypeVar from declared type."""
+        _check_ok("""
+private data Option<T> { None, Some(T) }
+
+private fn f(-> @Option<Int>)
+  requires(true) ensures(true) effects(pure)
+{
+  let @Option<Int> = None;
+  @Option<Int>.0
+}
+""")
+
+    def test_nil_resolves_list(self) -> None:
+        """Nil resolves to List<Int> from return type context."""
+        _check_ok("""
+private data List<T> { Nil, Cons(T, List<T>) }
+
+private fn empty(-> @List<Int>)
+  requires(true) ensures(true) effects(pure)
+{ Nil }
+""")
+
+    def test_err_resolves_result(self) -> None:
+        """Err(msg) resolves T in Result<Int, String> from return type."""
+        _check_ok("""
+private data Result<T, E> { Ok(T), Err(E) }
+
+private fn fail(@String -> @Result<Int, String>)
+  requires(true) ensures(true) effects(pure)
+{ Err(@String.0) }
+""")
+
+    def test_nested_some_none_resolves(self) -> None:
+        """Nested Some(None) resolves from Option<Option<Int>>."""
+        _check_ok("""
+private data Option<T> { None, Some(T) }
+
+private fn nested(-> @Option<Option<Int>>)
+  requires(true) ensures(true) effects(pure)
+{ Some(None) }
+""")
+
+    def test_none_as_fn_arg_resolves(self) -> None:
+        """None passed as function argument resolves from param type."""
+        _check_ok("""
+private data Option<T> { None, Some(T) }
+
+private fn id(@Option<Int> -> @Option<Int>)
+  requires(true) ensures(true) effects(pure)
+{ @Option<Int>.0 }
+
+private fn test(-> @Option<Int>)
+  requires(true) ensures(true) effects(pure)
+{ id(None) }
+""")
+
+    def test_none_with_wrong_expected_errors(self) -> None:
+        """None resolved to Option<Int> should not match Int return."""
+        _check_err("""
+private data Option<T> { None, Some(T) }
+
+private fn bad(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{ None }
+""", "body has type")
+
+    def test_block_threads_expected(self) -> None:
+        """Expected type threads through block to tail expression."""
+        _check_ok("""
+private data Option<T> { None, Some(T) }
+
+private fn f(@Int -> @Option<Int>)
+  requires(true) ensures(true) effects(pure)
+{
+  let @Int = @Int.0;
+  None
+}
+""")
+
+    def test_ok_resolves_result(self) -> None:
+        """Ok(42) resolves E in Result<Int, String> from return type."""
+        _check_ok("""
+private data Result<T, E> { Ok(T), Err(E) }
+
+private fn succeed(-> @Result<Int, String>)
+  requires(true) ensures(true) effects(pure)
+{ Ok(42) }
+""")

--- a/vera/README.md
+++ b/vera/README.md
@@ -85,9 +85,9 @@ execute(compile_result, ...)    # → run WASM via wasmtime
 | `  resolution.py` | 190 | | AST TypeExpr → semantic Type, inference | |
 | `  modules.py` | 153 | | Cross-module registration (C7b/C7c) | |
 | `  registration.py` | 138 | | Pass 1 forward declarations | |
-| `  expressions.py` | 548 | | Expression synthesis, operators, statements | |
-| `  calls.py` | 405 | | Function/constructor/module calls | |
-| `  control.py` | 453 | | If/match, patterns, effect handlers | |
+| `  expressions.py` | 555 | | Expression synthesis (bidirectional), operators, statements | |
+| `  calls.py` | 486 | | Function/constructor/module calls | |
+| `  control.py` | 482 | | If/match, patterns, effect handlers | |
 | `resolver.py` | 213 | Resolve | Module path resolution, parse cache | `ModuleResolver` |
 | `smt.py` | 547 | Verify | Z3 translation layer | `SmtContext`, `SlotEnv` |
 | `verifier.py` | 703 | Verify | Contract verification | `verify()` |
@@ -527,10 +527,10 @@ Honest inventory of what the compiler cannot do, and where each limitation is ad
 | Limitation | Why | Planned |
 |-----------|-----|---------|
 | **Module system limitations** | Module system complete (C7a-C7f); remaining issue: flat-compilation name collisions | [#110](https://github.com/aallan/vera/issues/110) |
-| **No effect row variable unification** | Subeffecting implemented; `forall<E>` row variables permissive pending bidirectional checking | [#55](https://github.com/aallan/vera/issues/55) |
+| **No effect row variable unification** | Subeffecting implemented; `forall<E>` row variables permissive (full row-variable unification deferred) | — |
 | **No quantifier termination** | `decreases` verified for self-recursive and mutual recursion (where-blocks); no support for lexicographic ordering or non-structural measures | [#45](https://github.com/aallan/vera/issues/45) |
 | **No quantifier verification** | `forall`/`exists` in contracts always Tier 3 | [#13](https://github.com/aallan/vera/issues/13) |
-| **Minimal type inference** | Call-site generic instantiation only, no Hindley-Milner | [#55](https://github.com/aallan/vera/issues/55) |
+| **Local type inference only** | Bidirectional checking resolves nullary constructors from context; no Hindley-Milner | Done ([#55](https://github.com/aallan/vera/issues/55)) |
 | **No incremental compilation** | Full file processed from scratch each time | [#56](https://github.com/aallan/vera/issues/56) |
 | **No garbage collection** | Bump allocator only; linear memory is not reclaimed | [#51](https://github.com/aallan/vera/issues/51) |
 | **String constants only** | No dynamic string construction | [#52](https://github.com/aallan/vera/issues/52) |

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.54"
+__version__ = "0.0.55"

--- a/vera/checker/calls.py
+++ b/vera/checker/calls.py
@@ -105,8 +105,12 @@ class CallsMixin:
                 continue
             if isinstance(param_ty, (TypeVar, UnknownType)):
                 continue
-            if contains_typevar(arg_ty):
-                continue
+            # Re-synth if arg still has unresolved TypeVars (bidirectional)
+            if contains_typevar(arg_ty) and not contains_typevar(param_ty):
+                arg_ty = self._synth_expr(args[i], expected=param_ty)
+                if arg_ty is None or isinstance(arg_ty, UnknownType):
+                    continue
+                arg_types[i] = arg_ty
             if not is_subtype(arg_ty, param_ty):
                 self._error(
                     args[i],
@@ -199,7 +203,8 @@ class CallsMixin:
     # Constructors
     # -----------------------------------------------------------------
 
-    def _check_constructor_call(self, expr: ast.ConstructorCall) -> Type | None:
+    def _check_constructor_call(self, expr: ast.ConstructorCall, *,
+                                expected: Type | None = None) -> Type | None:
         """Type-check a constructor call: Ctor(args)."""
         ci = self.env.lookup_constructor(expr.name)
         if ci is None:
@@ -213,10 +218,33 @@ class CallsMixin:
                 self._synth_expr(arg)
             return UnknownType()
 
-        # Synth arg types
+        # Build expected-type mapping for bidirectional inference
+        expected_mapping: dict[str, Type] = {}
+        if (isinstance(expected, AdtType)
+                and ci.parent_type_params
+                and expected.name == ci.parent_type
+                and len(expected.type_args) == len(ci.parent_type_params)):
+            for tv, exp_arg in zip(ci.parent_type_params,
+                                   expected.type_args):
+                if not isinstance(exp_arg, TypeVar):
+                    expected_mapping[tv] = exp_arg
+
+        # Compute field types with expected-type substitution so we can
+        # pass them as expected to nested constructor args (e.g. Some(None))
+        field_types_for_expected: tuple[Type, ...] | None = None
+        if ci.field_types is not None and expected_mapping:
+            field_types_for_expected = tuple(
+                substitute(ft, expected_mapping) for ft in ci.field_types)
+
+        # Synth arg types, passing resolved field type as expected
         arg_types: list[Type | None] = []
-        for arg in expr.args:
-            arg_types.append(self._synth_expr(arg))
+        for i, arg in enumerate(expr.args):
+            field_expected: Type | None = None
+            if field_types_for_expected and i < len(field_types_for_expected):
+                ft = field_types_for_expected[i]
+                if not contains_typevar(ft):
+                    field_expected = ft
+            arg_types.append(self._synth_expr(arg, expected=field_expected))
 
         if ci.field_types is None:
             if expr.args:
@@ -226,7 +254,7 @@ class CallsMixin:
                     f"{len(expr.args)} argument(s).",
                     error_code="E211",
                 )
-            return self._ctor_result_type(ci, arg_types)
+            return self._ctor_result_type(ci, arg_types, expected=expected)
 
         if len(expr.args) != len(ci.field_types):
             self._error(
@@ -235,10 +263,16 @@ class CallsMixin:
                 f"{len(ci.field_types)} field(s), got {len(expr.args)}.",
                 error_code="E212",
             )
-            return self._ctor_result_type(ci, arg_types)
+            return self._ctor_result_type(ci, arg_types, expected=expected)
 
-        # Infer type args for parameterised ADTs
+        # Infer type args for parameterised ADTs from arg types
         mapping = self._infer_ctor_type_args(ci, arg_types)
+
+        # Merge expected-type mapping for unresolved vars
+        for tv, exp_ty in expected_mapping.items():
+            if tv not in mapping:
+                mapping[tv] = exp_ty
+
         field_types = ci.field_types
         if mapping:
             field_types = tuple(substitute(ft, mapping) for ft in field_types)
@@ -248,8 +282,12 @@ class CallsMixin:
                 continue
             if isinstance(field_ty, (TypeVar, UnknownType)):
                 continue
-            if contains_typevar(arg_ty):
-                continue
+            # Re-synth if arg still has unresolved TypeVars
+            if contains_typevar(arg_ty) and not contains_typevar(field_ty):
+                arg_ty = self._synth_expr(expr.args[i], expected=field_ty)
+                if arg_ty is None or isinstance(arg_ty, UnknownType):
+                    continue
+                arg_types[i] = arg_ty
             if not is_subtype(arg_ty, field_ty):
                 self._error(
                     expr.args[i],
@@ -259,9 +297,10 @@ class CallsMixin:
                     error_code="E213",
                 )
 
-        return self._ctor_result_type(ci, arg_types)
+        return self._ctor_result_type(ci, arg_types, expected=expected)
 
-    def _check_nullary_constructor(self, expr: ast.NullaryConstructor) -> Type | None:
+    def _check_nullary_constructor(self, expr: ast.NullaryConstructor, *,
+                                    expected: Type | None = None) -> Type | None:
         """Type-check a nullary constructor: None, Nil, etc."""
         ci = self.env.lookup_constructor(expr.name)
         if ci is None:
@@ -277,14 +316,29 @@ class CallsMixin:
                 error_code="E215",
             )
 
-        return self._ctor_result_type(ci, [])
+        return self._ctor_result_type(ci, [], expected=expected)
 
     def _ctor_result_type(self, ci: ConstructorInfo,
-                          arg_types: list[Type | None]) -> Type:
-        """Compute the result type of a constructor call."""
+                          arg_types: list[Type | None], *,
+                          expected: Type | None = None) -> Type:
+        """Compute the result type of a constructor call.
+
+        When *expected* is an AdtType with the same parent name, unresolved
+        TypeVars are filled from the expected type args (bidirectional).
+        """
         if ci.parent_type_params:
             # Try to infer type args from argument types
             mapping = self._infer_ctor_type_args(ci, arg_types)
+
+            # Fill unresolved TypeVars from expected type (bidirectional)
+            if (isinstance(expected, AdtType)
+                    and expected.name == ci.parent_type
+                    and len(expected.type_args) == len(ci.parent_type_params)):
+                for tv, exp_arg in zip(ci.parent_type_params,
+                                       expected.type_args):
+                    if tv not in mapping and not isinstance(exp_arg, TypeVar):
+                        mapping[tv] = exp_arg
+
             if mapping:
                 args = tuple(
                     mapping.get(tv, TypeVar(tv))

--- a/vera/checker/control.py
+++ b/vera/checker/control.py
@@ -29,7 +29,8 @@ class ControlFlowMixin:
     # Control flow
     # -----------------------------------------------------------------
 
-    def _check_if(self, expr: ast.IfExpr) -> Type | None:
+    def _check_if(self, expr: ast.IfExpr, *,
+                  expected: Type | None = None) -> Type | None:
         """Type-check if-then-else."""
         cond_ty = self._synth_expr(expr.condition)
         if cond_ty and not isinstance(cond_ty, UnknownType):
@@ -42,8 +43,8 @@ class ControlFlowMixin:
                     error_code="E300",
                 )
 
-        then_ty = self._synth_expr(expr.then_branch)
-        else_ty = self._synth_expr(expr.else_branch)
+        then_ty = self._synth_expr(expr.then_branch, expected=expected)
+        else_ty = self._synth_expr(expr.else_branch, expected=expected)
 
         if then_ty is None or else_ty is None:
             return then_ty or else_ty
@@ -64,10 +65,21 @@ class ControlFlowMixin:
         if is_subtype(else_ty, then_ty):
             return then_ty
 
-        # Unresolved TypeVars from nullary constructors — pick the
-        # branch with concrete types when possible.
-        if contains_typevar(then_ty) or contains_typevar(else_ty):
-            return else_ty if contains_typevar(then_ty) else then_ty
+        # Re-synthesis fallback: if one branch has unresolved TypeVars,
+        # re-synth it with the concrete branch as expected.
+        if contains_typevar(then_ty) and not contains_typevar(else_ty):
+            then_ty = self._synth_expr(
+                expr.then_branch, expected=else_ty)
+            if then_ty and is_subtype(then_ty, else_ty):
+                return else_ty
+        elif contains_typevar(else_ty) and not contains_typevar(then_ty):
+            else_ty = self._synth_expr(
+                expr.else_branch, expected=then_ty)
+            if else_ty and is_subtype(else_ty, then_ty):
+                return then_ty
+        elif contains_typevar(then_ty) and contains_typevar(else_ty):
+            # Both have TypeVars — pick either (both unresolved)
+            return then_ty
 
         self._error(
             expr,
@@ -81,7 +93,8 @@ class ControlFlowMixin:
         )
         return then_ty  # use then-branch type as best guess
 
-    def _check_match(self, expr: ast.MatchExpr) -> Type | None:
+    def _check_match(self, expr: ast.MatchExpr, *,
+                     expected: Type | None = None) -> Type | None:
         """Type-check a match expression."""
         scrutinee_ty = self._synth_expr(expr.scrutinee)
         if scrutinee_ty is None:
@@ -97,8 +110,8 @@ class ControlFlowMixin:
             for b in bindings:
                 self.env.bind(b.type_name, b.resolved_type, "match")
 
-            # Synth arm body type
-            arm_ty = self._synth_expr(arm.body)
+            # Synth arm body type (pass expected for bidirectional)
+            arm_ty = self._synth_expr(arm.body, expected=expected)
             self.env.pop_scope()
 
             if arm_ty is None or isinstance(arm_ty, UnknownType):
@@ -109,12 +122,18 @@ class ControlFlowMixin:
             elif types_equal(result_type, NEVER):
                 result_type = arm_ty
             elif not types_equal(arm_ty, NEVER):
-                if contains_typevar(arm_ty) or contains_typevar(result_type):
-                    # Prefer the concrete type over the TypeVar-bearing one
-                    if contains_typevar(result_type) and not contains_typevar(arm_ty):
-                        result_type = arm_ty
-                elif not (is_subtype(arm_ty, result_type)
-                          or is_subtype(result_type, arm_ty)):
+                # Re-synthesis fallback for unresolved TypeVars
+                if contains_typevar(arm_ty) and not contains_typevar(result_type):
+                    arm_ty = self._synth_expr(
+                        arm.body, expected=result_type)
+                    if arm_ty is None or isinstance(arm_ty, UnknownType):
+                        continue
+                elif contains_typevar(result_type) and not contains_typevar(arm_ty):
+                    result_type = arm_ty
+                    continue
+
+                if not (is_subtype(arm_ty, result_type)
+                        or is_subtype(result_type, arm_ty)):
                     self._error(
                         arm.body if hasattr(arm, 'body') else expr,
                         f"Match arm type {pretty_type(arm_ty)} is "

--- a/vera/checker/core.py
+++ b/vera/checker/core.py
@@ -37,7 +37,6 @@ from vera.types import (
     TypeVar,
     UnknownType,
     canonical_type_name,
-    contains_typevar,
     is_subtype,
     pretty_type,
 )
@@ -253,12 +252,10 @@ class TypeChecker(
         for contract in decl.contracts:
             self._check_contract(contract, decl)
 
-        # 6. Check body
-        body_type = self._synth_expr(decl.body)
+        # 6. Check body (pass return type as expected for bidirectional)
+        body_type = self._synth_expr(decl.body, expected=return_type)
         if body_type and not isinstance(body_type, UnknownType):
-            if contains_typevar(body_type) and not decl.forall_vars:
-                pass  # Unresolved TypeVars from constructors — skip
-            elif not is_subtype(body_type, return_type):
+            if not is_subtype(body_type, return_type):
                 self._error(
                     decl.body,
                     f"Function '{decl.name}' body has type "

--- a/vera/checker/expressions.py
+++ b/vera/checker/expressions.py
@@ -37,8 +37,14 @@ class ExpressionsMixin:
     # Expression type synthesis
     # -----------------------------------------------------------------
 
-    def _synth_expr(self, expr: ast.Expr) -> Type | None:
-        """Synthesise the type of an expression.  Returns None on error."""
+    def _synth_expr(self, expr: ast.Expr, *,
+                    expected: Type | None = None) -> Type | None:
+        """Synthesise the type of an expression.  Returns None on error.
+
+        When *expected* is provided, it is threaded to constructors,
+        if/match, and blocks so that nullary constructors of parameterised
+        ADTs can resolve their TypeVars from context (bidirectional checking).
+        """
         if isinstance(expr, ast.IntLit):
             # Non-negative integer literals are Nat (which is a subtype of
             # Int).  This lets literals like 0, 1, 42 satisfy Nat parameters
@@ -65,19 +71,19 @@ class ExpressionsMixin:
         if isinstance(expr, ast.FnCall):
             return self._check_fn_call(expr)
         if isinstance(expr, ast.ConstructorCall):
-            return self._check_constructor_call(expr)
+            return self._check_constructor_call(expr, expected=expected)
         if isinstance(expr, ast.NullaryConstructor):
-            return self._check_nullary_constructor(expr)
+            return self._check_nullary_constructor(expr, expected=expected)
         if isinstance(expr, ast.QualifiedCall):
             return self._check_qualified_call(expr)
         if isinstance(expr, ast.ModuleCall):
             return self._check_module_call(expr)
         if isinstance(expr, ast.IfExpr):
-            return self._check_if(expr)
+            return self._check_if(expr, expected=expected)
         if isinstance(expr, ast.MatchExpr):
-            return self._check_match(expr)
+            return self._check_match(expr, expected=expected)
         if isinstance(expr, ast.Block):
-            return self._check_block(expr)
+            return self._check_block(expr, expected=expected)
         if isinstance(expr, ast.AnonFn):
             return self._check_anon_fn(expr)
         if isinstance(expr, ast.HandleExpr):
@@ -359,12 +365,13 @@ class ExpressionsMixin:
     # Blocks and statements
     # -----------------------------------------------------------------
 
-    def _check_block(self, block: ast.Block) -> Type | None:
+    def _check_block(self, block: ast.Block, *,
+                     expected: Type | None = None) -> Type | None:
         """Type-check a block expression."""
         self.env.push_scope()
         for stmt in block.statements:
             self._check_stmt(stmt)
-        result = self._synth_expr(block.expr)
+        result = self._synth_expr(block.expr, expected=expected)
         self.env.pop_scope()
         return result
 
@@ -380,7 +387,7 @@ class ExpressionsMixin:
     def _check_let(self, stmt: ast.LetStmt) -> None:
         """Type-check a let binding."""
         declared_type = self._resolve_type(stmt.type_expr)
-        val_type = self._synth_expr(stmt.value)
+        val_type = self._synth_expr(stmt.value, expected=declared_type)
 
         if val_type and not isinstance(val_type, UnknownType):
             if not isinstance(declared_type, UnknownType):
@@ -420,7 +427,7 @@ class ExpressionsMixin:
             tname = self._type_expr_to_slot_name(param_te)
             self.env.bind(tname, param_ty, "param")
 
-        body_type = self._synth_expr(expr.body)
+        body_type = self._synth_expr(expr.body, expected=ret_type)
         self.env.pop_scope()
 
         if body_type and not isinstance(body_type, UnknownType):


### PR DESCRIPTION
## Summary

Implements [#55](https://github.com/aallan/vera/issues/55) -- minimal type inference via bidirectional type checking.

- Adds optional `expected: Type | None` parameter to `_synth_expr`, threaded to constructors, if/match, blocks, let bindings, and function call arguments
- Nullary constructors of parameterised ADTs (`None` for `Option<T>`, `Nil` for `List<T>`) now resolve their TypeVars from context (return types, let declarations, if/match branches, function arguments)
- Nested constructors (`Some(None)` for `Option<Option<Int>>`) resolve via field-type propagation
- Replaces all 5 `contains_typevar` workaround guards from v0.0.53 with proper bidirectional resolution
- No changes to function signatures, parser, AST, or spec

## Test plan

- [x] 12 new tests in `TestBidirectionalInference` covering: None as return, if-else with None/Some, match arms, let binding, Nil for List, Err/Ok for Result, nested Some(None), None as function argument, wrong-type error, block threading, Ok resolving E
- [x] All 1,332 tests pass (`pytest tests/ -v`)
- [x] All 15 examples pass (`python scripts/check_examples.py`)
- [x] Spec examples pass (`python scripts/check_spec_examples.py`)
- [x] README examples pass (`python scripts/check_readme_examples.py`)
- [x] mypy clean (`mypy vera/`)
- [x] Version sync verified (`python scripts/check_version_sync.py`)
