### PR TITLE
Implement nested constructor pattern codegen (#131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.56] - 2026-03-03
+
+### Added
+- **Nested constructor pattern codegen** (C8e, [#131](https://github.com/aallan/vera/issues/131)):
+  Match expressions with nested constructor patterns (e.g. `Cons(Some(@Int), _)`)
+  now compile to WASM correctly. Previously, any sub-pattern that was a
+  `ConstructorPattern` or `NullaryPattern` caused the entire function to be
+  silently skipped.
+  - `_collect_nested_tag_checks` recursively emits tag comparisons for nested
+    constructors, AND-chained into the arm condition
+  - `_extract_constructor_fields` recursively loads nested field pointers and
+    binds their sub-patterns
+  - `_sub_pattern_wasm_type` helper resolves WASM types for offset computation
+  - `examples/pattern_matching.vera` `first_some` now compiles and runs
+  - 5 new tests (nested Some, nested None, multi-field, different arms, fallthrough)
+  - 1,337 tests total
+
 ## [0.0.55] - 2026-03-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ The language specification is in draft across 13 chapters:
 
 ### Testing
 
-The compiler has 1,332 tests with 88% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations. Every commit validates all 15 example programs and 96 specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference -- coverage tables, test helpers, CI pipeline, and infrastructure details.
+The compiler has 1,337 tests with 88% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations. Every commit validates all 15 example programs and 96 specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference -- coverage tables, test helpers, CI pipeline, and infrastructure details.
 
 ## Roadmap
 
@@ -275,7 +275,7 @@ C8 addresses the accumulated technical debt and UX gaps before v0.1.0. Open issu
 
 - [#154](https://github.com/aallan/vera/issues/154) `list_ops.vera` runtime failure — recursive generic ADT codegen
 - [#110](https://github.com/aallan/vera/issues/110) name collision detection for flat module compilation
-- [#131](https://github.com/aallan/vera/issues/131) nested constructor pattern codegen
+- ~~[#131](https://github.com/aallan/vera/issues/131) nested constructor pattern codegen~~ — [v0.0.56](https://github.com/aallan/vera/releases/tag/v0.0.56)
 - [#53](https://github.com/aallan/vera/issues/53) `Exn<E>` and custom effect handler compilation
 - [#51](https://github.com/aallan/vera/issues/51) garbage collection for WASM linear memory
 - [#132](https://github.com/aallan/vera/issues/132) arrays of compound types in codegen

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,7 +6,7 @@ This is the single source of truth for Vera's testing infrastructure, coverage d
 
 | Metric | Value |
 |--------|-------|
-| **Tests** | 1,332 across 19 files (~17,000 lines of test code) |
+| **Tests** | 1,337 across 19 files (~17,000 lines of test code) |
 | **Compiler code coverage** | 88% of 6,861 statements (CI minimum: 80%) |
 | **Example programs** | 15, all validated through `vera check` + `vera verify` |
 | **Spec code blocks** | 96 parseable blocks from 13 spec chapters: 72 parse, 57 type-check, 56 verify |
@@ -43,7 +43,7 @@ python scripts/check_version_sync.py                 # version consistency
 | `test_ast.py` | 87 | 935 | AST transformation, node structure, serialisation |
 | `test_checker.py` | 188 | 2,482 | Type synthesis, slot resolution, effects, effect subtyping, contracts, exhaustiveness, cross-module typing, visibility, error codes, string built-ins, generic rejection |
 | `test_verifier.py` | 97 | 1,580 | Z3 verification, counterexamples, tier classification, call-site preconditions, pipe operator, cross-module contracts, match/ADT verification, decreases verification, mutual recursion |
-| `test_codegen.py` | 317 | 3,725 | WASM compilation, arithmetic, Float64, Byte, arrays, ADTs, match, generics, State\<T\>, control flow, strings, IO, bounds checking, quantifiers, assert/assume, refinement type aliases, pipe operator, string built-ins, example round-trips |
+| `test_codegen.py` | 322 | 3,825 | WASM compilation, arithmetic, Float64, Byte, arrays, ADTs, match (incl. nested patterns), generics, State\<T\>, control flow, strings, IO, bounds checking, quantifiers, assert/assume, refinement type aliases, pipe operator, string built-ins, example round-trips |
 | `test_codegen_contracts.py` | 32 | 576 | Runtime pre/postconditions, contract fail messages, old/new state postconditions |
 | `test_codegen_monomorphize.py` | 17 | 360 | Generic instantiation, type inference, monomorphization edge cases |
 | `test_codegen_closures.py` | 17 | 416 | Closure lifting, captured variables, higher-order functions |
@@ -131,6 +131,7 @@ How Vera language features (by spec chapter) map to test files and example progr
 | Ch 7: Effects | Effect handlers (handle/resume) | test_codegen, test_checker | effect_handler |
 | Ch 7: Effects | Effect subtyping (§7.8), call-site checking | test_types, test_checker | — |
 | Ch 2: Types | Bidirectional type checking (local inference) | test_checker | — |
+| Ch 4: Expressions | Nested constructor patterns in match | test_codegen | pattern_matching |
 | Ch 8: Modules | Imports, cross-module typing and codegen | test_codegen_modules, test_resolver | modules |
 | Ch 11: Compilation | Contract-driven testing (Z3 input gen + WASM execution) | test_tester, test_cli | safe_divide, factorial |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.55"
+version = "0.0.56"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -2298,6 +2298,98 @@ public fn unwrap_or(@Option<Int> -> @Int)
         result = _compile_ok(source)
         assert "unwrap_or" in result.exports
 
+    def test_match_nested_some(self) -> None:
+        """Nested constructor: Cons(Some(@Int), _) extracts the inner Int."""
+        source = """\
+private data Option<T> { None, Some(T) }
+private data List<T> { Nil, Cons(T, List<T>) }
+
+public fn first_val(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  let @List<Option<Int>> = Cons(Some(42), Nil);
+  match @List<Option<Int>>.0 {
+    Cons(Some(@Int), _) -> @Int.0,
+    _ -> 0
+  }
+}
+"""
+        assert _run(source, fn="first_val") == 42
+
+    def test_match_nested_none(self) -> None:
+        """Nested nullary: Cons(None, _) arm is selected."""
+        source = """\
+private data Option<T> { None, Some(T) }
+private data List<T> { Nil, Cons(T, List<T>) }
+
+public fn test_none(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  let @List<Option<Int>> = Cons(None, Nil);
+  match @List<Option<Int>>.0 {
+    Cons(Some(@Int), _) -> @Int.0,
+    Cons(None, _) -> 99,
+    _ -> 0
+  }
+}
+"""
+        assert _run(source, fn="test_none") == 99
+
+    def test_match_nested_multi_field(self) -> None:
+        """Nested constructor with both fields used."""
+        source = """\
+private data Option<T> { None, Some(T) }
+private data Pair<A, B> { MkPair(A, B) }
+
+public fn test(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  let @Pair<Option<Int>, Int> = MkPair(Some(10), 5);
+  match @Pair<Option<Int>, Int>.0 {
+    MkPair(Some(@Int), _) -> @Int.0,
+    _ -> 0
+  }
+}
+"""
+        assert _run(source, fn="test") == 10
+
+    def test_match_nested_different_arms(self) -> None:
+        """Different nesting per arm selects correct arm."""
+        source = """\
+private data Option<T> { None, Some(T) }
+private data List<T> { Nil, Cons(T, List<T>) }
+
+public fn test(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  let @List<Option<Int>> = Cons(Some(77), Nil);
+  match @List<Option<Int>>.0 {
+    Cons(None, _) -> 0,
+    Cons(Some(@Int), _) -> @Int.0,
+    _ -> 99
+  }
+}
+"""
+        assert _run(source, fn="test") == 77
+
+    def test_match_nested_fallthrough(self) -> None:
+        """Nested Some doesn't match None, falls through to wildcard."""
+        source = """\
+private data Option<T> { None, Some(T) }
+private data List<T> { Nil, Cons(T, List<T>) }
+
+public fn test(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  let @List<Option<Int>> = Cons(None, Nil);
+  match @List<Option<Int>>.0 {
+    Cons(Some(@Int), _) -> @Int.0,
+    _ -> 55
+  }
+}
+"""
+        assert _run(source, fn="test") == 55
+
 
 # =====================================================================
 # C6j: Effect Handlers

--- a/vera/README.md
+++ b/vera/README.md
@@ -98,7 +98,7 @@ execute(compile_result, ...)    # → run WASM via wasmtime
 | ` ├ operators.py` | 430 | | Binary/unary operators, if, quantifiers, assert/assume, old/new | |
 | ` ├ calls.py` | 223 | | Function calls, generic resolution, effect handlers | |
 | ` ├ closures.py` | 248 | | Closures, anonymous functions, free variable analysis | |
-| ` └ data.py` | 460 | | Constructors, match expressions, arrays, indexing | |
+| ` └ data.py` | 590 | | Constructors, match expressions (incl. nested patterns), arrays, indexing | |
 | `codegen/` | 2,140 | Compile | Codegen orchestrator (mixin package) | `compile()`, `execute()` |
 | `  api.py` | 265 | | Public API, dataclasses, host bindings, `execute()` | |
 | `  core.py` | 285 | | CodeGenerator class, orchestration, type helpers | |

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.55"
+__version__ = "0.0.56"

--- a/vera/wasm/data.py
+++ b/vera/wasm/data.py
@@ -236,12 +236,23 @@ class DataMixin:
             layout = self._ctor_layouts.get(name)
             if layout is None:
                 return None
-            return [
+            instrs = [
                 f"local.get {scr_local}",
                 "i32.load",
                 f"i32.const {layout.tag}",
                 "i32.eq",
             ]
+            # AND-chain nested tag checks for constructor sub-patterns
+            if isinstance(pattern, ast.ConstructorPattern):
+                nested = self._collect_nested_tag_checks(
+                    pattern, scr_local, layout,
+                )
+                if nested is None:
+                    return None
+                for check in nested:
+                    instrs.extend(check)
+                    instrs.append("i32.and")
+            return instrs
 
         if isinstance(pattern, ast.BoolPattern):
             if pattern.value:
@@ -343,11 +354,130 @@ class DataMixin:
                     offset = (offset + align - 1) & ~(align - 1)
                     offset += _sizes.get(generic_wt, 8)
 
+            elif isinstance(sub_pat, ast.ConstructorPattern):
+                # Nested constructor: load the field pointer (i32),
+                # look up its layout, and recurse to extract its fields.
+                align = _aligns.get("i32", 4)
+                offset = (offset + align - 1) & ~(align - 1)
+                sub_layout = self._ctor_layouts.get(sub_pat.name)
+                if sub_layout is None:
+                    return None
+                sub_local = self.alloc_local("i32")
+                instrs.append(f"local.get {scr_local}")
+                instrs.append(f"i32.load offset={offset}")
+                instrs.append(f"local.set {sub_local}")
+                # Recurse into the nested constructor's sub-patterns
+                nested = self._extract_constructor_fields(
+                    sub_pat, sub_local, sub_layout, new_env,
+                )
+                if nested is None:
+                    return None
+                nested_instrs, new_env = nested
+                instrs.extend(nested_instrs)
+                offset += _sizes.get("i32", 4)
+
+            elif isinstance(sub_pat, ast.NullaryPattern):
+                # Nullary: tag was already checked in the condition phase.
+                # Just advance offset by i32 size (ADT pointer).
+                align = _aligns.get("i32", 4)
+                offset = (offset + align - 1) & ~(align - 1)
+                offset += _sizes.get("i32", 4)
+
             else:
-                # Nested constructor patterns — deferred
+                # Unknown sub-pattern type
                 return None
 
         return (instrs, new_env)
+
+    # -----------------------------------------------------------------
+    # Nested pattern helpers
+    # -----------------------------------------------------------------
+
+    def _sub_pattern_wasm_type(
+        self,
+        sub_pat: ast.Pattern,
+        field_index: int,
+        layout: ConstructorLayout,
+    ) -> str | None:
+        """Return the WASM type for a sub-pattern's field.
+
+        Used for offset computation when walking nested patterns.
+        """
+        if isinstance(sub_pat, ast.BindingPattern):
+            type_name = self._type_expr_to_slot_name(sub_pat.type_expr)
+            if type_name is None:
+                return None
+            return self._slot_name_to_wasm_type(type_name)
+        if isinstance(sub_pat, ast.WildcardPattern):
+            if field_index < len(layout.field_offsets):
+                _, generic_wt = layout.field_offsets[field_index]
+                return generic_wt
+            return None
+        if isinstance(sub_pat, (ast.ConstructorPattern, ast.NullaryPattern)):
+            return "i32"  # ADT = heap pointer
+        return None
+
+    def _collect_nested_tag_checks(
+        self,
+        pattern: ast.ConstructorPattern,
+        scr_local: int,
+        layout: ConstructorLayout,
+    ) -> list[list[str]] | None:
+        """Collect tag checks for nested constructor/nullary sub-patterns.
+
+        Walks *pattern.sub_patterns* and for each that is a
+        ``ConstructorPattern`` or ``NullaryPattern``, emits a sequence of
+        WASM instructions that (a) loads the field pointer from the parent,
+        (b) loads the tag from that pointer, (c) compares to the expected
+        tag.  For ``ConstructorPattern`` it recurses to collect deeper
+        checks.
+
+        Returns a list of instruction-lists, each producing an ``i32``
+        boolean on the stack.  Returns ``None`` on layout lookup failure.
+        """
+        _sizes = {"i32": 4, "i64": 8, "f64": 8}
+        _aligns = {"i32": 4, "i64": 8, "f64": 8}
+        offset = 4  # after tag
+
+        checks: list[list[str]] = []
+
+        for i, sub_pat in enumerate(pattern.sub_patterns):
+            wt = self._sub_pattern_wasm_type(sub_pat, i, layout)
+            if wt is None:
+                return None
+            align = _aligns.get(wt, 8)
+            offset = (offset + align - 1) & ~(align - 1)
+
+            if isinstance(sub_pat, (ast.ConstructorPattern, ast.NullaryPattern)):
+                name = sub_pat.name
+                sub_layout = self._ctor_layouts.get(name)
+                if sub_layout is None:
+                    return None
+                # Load the nested ADT pointer, stash in a temp,
+                # then load the tag and compare.
+                tmp = self.alloc_local("i32")
+                check: list[str] = [
+                    f"local.get {scr_local}",
+                    f"i32.load offset={offset}",
+                    f"local.tee {tmp}",
+                    "i32.load",
+                    f"i32.const {sub_layout.tag}",
+                    "i32.eq",
+                ]
+                checks.append(check)
+
+                # Recurse for deeper nesting
+                if isinstance(sub_pat, ast.ConstructorPattern):
+                    deeper = self._collect_nested_tag_checks(
+                        sub_pat, tmp, sub_layout,
+                    )
+                    if deeper is None:
+                        return None
+                    checks.extend(deeper)
+
+            offset += _sizes.get(wt, 8)
+
+        return checks
 
     # -----------------------------------------------------------------
     # Array literals


### PR DESCRIPTION
## Summary
- Nested constructor patterns in match expressions now compile to WASM
- Previously silently skipped; now first_some in pattern_matching.vera works
- 5 new tests, 1337 total

## Test plan
- [x] All 1337 tests pass
- [x] All 15 examples pass
- [x] mypy clean

Closes #131