### PR TITLE
Add name collision detection for flat module compilation (#110)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.57] - 2026-03-03
+
+### Added
+- **Name collision detection for flat module compilation** (C8e, [#110](https://github.com/aallan/vera/issues/110)):
+  When two imported modules define a function, data type, or constructor with
+  the same name, the compiler now reports a clear error (E608/E609/E610) listing
+  both conflicting modules. Previously, the first module registered silently won
+  and the second was ignored, producing silently wrong code.
+  - Provenance tracking in `_register_modules` detects collisions across functions,
+    ADT types, and constructors
+  - New error codes: E608 (function collision), E609 (ADT type collision),
+    E610 (constructor collision)
+  - Local definitions continue to shadow imported names without error
+  - Same-module duplicates (module imported twice) are not treated as collisions
+  - 7 new tests, 1,344 tests total
+
 ## [0.0.56] - 2026-03-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ The language specification is in draft across 13 chapters:
 
 ### Testing
 
-The compiler has 1,337 tests with 88% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations. Every commit validates all 15 example programs and 96 specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference -- coverage tables, test helpers, CI pipeline, and infrastructure details.
+The compiler has 1,344 tests with 88% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations. Every commit validates all 15 example programs and 96 specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference -- coverage tables, test helpers, CI pipeline, and infrastructure details.
 
 ## Roadmap
 
@@ -274,7 +274,7 @@ C8 addresses the accumulated technical debt and UX gaps before v0.1.0. Open issu
 **C8e — Codegen gaps** — extend WASM compilation
 
 - [#154](https://github.com/aallan/vera/issues/154) `list_ops.vera` runtime failure — recursive generic ADT codegen
-- [#110](https://github.com/aallan/vera/issues/110) name collision detection for flat module compilation
+- ~~[#110](https://github.com/aallan/vera/issues/110) name collision detection for flat module compilation~~ — [v0.0.57](https://github.com/aallan/vera/releases/tag/v0.0.57)
 - ~~[#131](https://github.com/aallan/vera/issues/131) nested constructor pattern codegen~~ — [v0.0.56](https://github.com/aallan/vera/releases/tag/v0.0.56)
 - [#53](https://github.com/aallan/vera/issues/53) `Exn<E>` and custom effect handler compilation
 - [#51](https://github.com/aallan/vera/issues/51) garbage collection for WASM linear memory
@@ -290,6 +290,7 @@ C8 addresses the accumulated technical debt and UX gaps before v0.1.0. Open issu
 Module refinements, lexical extensions, and IO runtime — completing the existing language before adding new features.
 
 - [#127](https://github.com/aallan/vera/issues/127) module re-exports
+- [#187](https://github.com/aallan/vera/issues/187) module-qualified call disambiguation via name mangling
 - [#135](https://github.com/aallan/vera/issues/135) IO operations (read_line, read_file, write_file)
 - [#139](https://github.com/aallan/vera/issues/139) scientific notation for float literals
 - [#169](https://github.com/aallan/vera/issues/169) `vera test` Float64 and compound type input generation

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -627,11 +627,13 @@ Imported function contracts are verified at call sites by the SMT solver. Precon
 
 Cross-module compilation uses a flattening strategy: imported function bodies are compiled into the same WASM module as the importing program. The result is a single self-contained `.wasm` binary. Imported functions are internal (not exported); only the importing program's `public` functions are WASM exports.
 
+If two imported modules define a function, data type, or constructor with the same name, the compiler reports an error (E608/E609/E610) listing both conflicting modules. Rename one of the conflicting declarations in the source module to resolve the collision. Local definitions shadow imported names without error.
+
 Type aliases and effect declarations are module-local and cannot be imported. If another module needs the same alias or effect, it must declare its own copy.
 
-Module-qualified calls use `::` between the module path and the function name: `vera.math::abs(42)`. The dot-separated path identifies the module and `::` separates it from the function name. This syntax can be used anywhere a function call is valid, and always resolves against the specific module's public declarations — it is not affected by local shadowing.
+Module-qualified calls use `::` between the module path and the function name: `vera.math::abs(42)`. The dot-separated path identifies the module and `::` separates it from the function name. This syntax can be used anywhere a function call is valid, and always resolves against the specific module's public declarations — it is not affected by local shadowing. Note: module-qualified calls (`math::abs(42)`) are available for readability but do not yet resolve name collisions in flat compilation — the compiler will still report a collision error. A future version will support qualified-call disambiguation via name mangling.
 
-There is no import aliasing (`import m(abs as math_abs)`) and no wildcard exclusion (`import m hiding(x)`). These are intentional design decisions, not limitations. When names clash, use selective imports to pick the names you need, and use `::` syntax to disambiguate: `vera.math::abs(x)`. This preserves the one-canonical-form principle — every function has exactly one name.
+There is no import aliasing (`import m(abs as math_abs)`) and no wildcard exclusion (`import m hiding(x)`). These are intentional design decisions, not limitations. When names clash across modules, rename the conflicting declaration in one of the source modules. This preserves the one-canonical-form principle — every function has exactly one name.
 
 There are no raw strings (`r"..."`) or multi-line string literals. Use escape sequences (`\\`, `\n`, `\t`, `\"`) for special characters. This is by design — alternative string syntaxes would create two representations for the same value.
 
@@ -866,11 +868,13 @@ WRONG — Vera does not support renaming imports:
 import vera.math(abs as math_abs);
 ```
 
-CORRECT — use selective import and `::` syntax to disambiguate:
+CORRECT — use selective import and qualified calls for readability:
 ```vera
 import vera.math(abs);
 vera.math::abs(-5)
 ```
+
+Note: if two imported modules define the same name, the compiler reports a collision error (E608/E609/E610). Rename the conflicting declaration in one of the source modules.
 
 ### Trying to use wildcard exclusion
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,7 +6,7 @@ This is the single source of truth for Vera's testing infrastructure, coverage d
 
 | Metric | Value |
 |--------|-------|
-| **Tests** | 1,337 across 19 files (~17,000 lines of test code) |
+| **Tests** | 1,344 across 19 files (~17,000 lines of test code) |
 | **Compiler code coverage** | 88% of 6,861 statements (CI minimum: 80%) |
 | **Example programs** | 15, all validated through `vera check` + `vera verify` |
 | **Spec code blocks** | 96 parseable blocks from 13 spec chapters: 72 parse, 57 type-check, 56 verify |
@@ -47,7 +47,7 @@ python scripts/check_version_sync.py                 # version consistency
 | `test_codegen_contracts.py` | 32 | 576 | Runtime pre/postconditions, contract fail messages, old/new state postconditions |
 | `test_codegen_monomorphize.py` | 17 | 360 | Generic instantiation, type inference, monomorphization edge cases |
 | `test_codegen_closures.py` | 17 | 416 | Closure lifting, captured variables, higher-order functions |
-| `test_codegen_modules.py` | 11 | 349 | Cross-module guard rail, cross-module codegen |
+| `test_codegen_modules.py` | 18 | 530 | Cross-module guard rail, cross-module codegen, name collision detection (E608/E609/E610) |
 | `test_codegen_coverage.py` | 5 | 249 | Defensive error paths: E600, E601, E605, E606, unknown module calls |
 | `test_errors.py` | 34 | 287 | Error code registry, diagnostic formatting, serialisation, SourceLocation |
 | `test_formatter.py` | 62 | 554 | Comment extraction, expression/declaration formatting, idempotency, parenthesization, spec rules |
@@ -133,6 +133,7 @@ How Vera language features (by spec chapter) map to test files and example progr
 | Ch 2: Types | Bidirectional type checking (local inference) | test_checker | — |
 | Ch 4: Expressions | Nested constructor patterns in match | test_codegen | pattern_matching |
 | Ch 8: Modules | Imports, cross-module typing and codegen | test_codegen_modules, test_resolver | modules |
+| Ch 11: Compilation | Cross-module name collision detection (E608/E609/E610) | test_codegen_modules | — |
 | Ch 11: Compilation | Contract-driven testing (Z3 input gen + WASM execution) | test_tester, test_cli | safe_divide, factorial |
 
 ## Test Helpers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.56"
+version = "0.0.57"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/scripts/check_readme_examples.py
+++ b/scripts/check_readme_examples.py
@@ -36,7 +36,7 @@ ALLOWLIST: dict[int, tuple[str, str]] = {
     # =================================================================
 
     # Section "Where this is going" — depends on #57 (Http), #61 (Inference), #147 (Markdown)
-    324: ("FUTURE", "Vision example uses MdBlock, Http, Inference (issues #57, #61, #147)"),
+    325: ("FUTURE", "Vision example uses MdBlock, Http, Inference (issues #57, #61, #147)"),
 }
 
 

--- a/spec/11-compilation.md
+++ b/spec/11-compilation.md
@@ -565,7 +565,7 @@ The compilation process:
 
 Imported functions are **not** exported from the WASM module — only the importing program's `public` functions are exports.
 
-**Known limitation**: If two imported modules define functions with the same name, the flat namespace may produce collisions ([#110](https://github.com/aallan/vera/issues/110)).
+**Name collision detection**: If two imported modules define a function (E608), data type (E609), or constructor (E610) with the same name, the compiler reports an error listing both modules. Rename the conflicting declaration in one of the source modules to resolve the collision. Qualified-call disambiguation via name mangling is planned for a future version.
 
 ## 11.17 Limitations
 
@@ -573,7 +573,7 @@ The current compilation model has the following limitations, each tracked as a G
 
 | Limitation | Issue | Notes |
 |-----------|-------|-------|
-| Flat module compilation | [#110](https://github.com/aallan/vera/issues/110) | Imported functions are compiled into the importing module; name collisions between modules are not yet detected |
+| Flat module compilation | [#110](https://github.com/aallan/vera/issues/110) | Imported functions are compiled into the importing module; name collisions are detected (E608/E609/E610); qualified-call disambiguation via name mangling is tracked separately |
 | No garbage collection | [#51](https://github.com/aallan/vera/issues/51) | Bump allocator only; linear memory is not reclaimed |
 | String constants only | [#52](https://github.com/aallan/vera/issues/52) | No dynamic string construction |
 | Only State\<T\> handlers | [#53](https://github.com/aallan/vera/issues/53) | Exn\<E\> and custom effect handlers not yet compilable |

--- a/tests/test_codegen_modules.py
+++ b/tests/test_codegen_modules.py
@@ -347,3 +347,183 @@ public fn main(-> @Int)
 { pick() }
 """, [mod], fn="main")
         assert val == 42
+
+
+# =====================================================================
+# Name collision detection (#110)
+# =====================================================================
+
+
+class TestNameCollisionDetection:
+    """Name collisions across imported modules produce diagnostics."""
+
+    @staticmethod
+    def _resolved(
+        path: tuple[str, ...], source: str,
+    ) -> "ResolvedModule":
+        """Build a ResolvedModule from source text."""
+        return TestCrossModuleCodegen._resolved(path, source)
+
+    @classmethod
+    def _compile_mod(
+        cls, source: str, modules: list,
+    ) -> CompileResult:
+        """Compile with resolved modules."""
+        return TestCrossModuleCodegen._compile_mod(source, modules)
+
+    def test_fn_collision_two_modules(self) -> None:
+        """Same function name in two imported modules produces E608."""
+        mod_a = self._resolved(("mod_a",), """\
+public fn process(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 + 1 }
+""")
+        mod_b = self._resolved(("mod_b",), """\
+public fn process(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 + 2 }
+""")
+        result = self._compile_mod("""\
+import mod_a(process);
+import mod_b(process);
+public fn main(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ process(@Int.0) }
+""", [mod_a, mod_b])
+        errors = [d for d in result.diagnostics if d.severity == "error"]
+        assert len(errors) >= 1
+        assert "process" in errors[0].description
+        assert "mod_a" in errors[0].description
+        assert "mod_b" in errors[0].description
+        assert errors[0].error_code == "E608"
+        assert result.ok is False
+
+    def test_private_helper_collision(self) -> None:
+        """Private helpers with same name across modules produce E608."""
+        mod_a = self._resolved(("mod_a",), """\
+public fn double(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ helper(@Int.0) + helper(@Int.0) }
+private fn helper(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 }
+""")
+        mod_b = self._resolved(("mod_b",), """\
+public fn triple(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ helper(@Int.0) + helper(@Int.0) + helper(@Int.0) }
+private fn helper(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 }
+""")
+        result = self._compile_mod("""\
+import mod_a(double);
+import mod_b(triple);
+public fn main(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ double(@Int.0) + triple(@Int.0) }
+""", [mod_a, mod_b])
+        errors = [d for d in result.diagnostics if d.severity == "error"]
+        assert any(
+            e.error_code == "E608" and "helper" in e.description
+            for e in errors
+        )
+
+    def test_adt_type_collision(self) -> None:
+        """Same ADT name in two modules produces E609."""
+        mod_a = self._resolved(("mod_a",), """\
+public data Color { Red, Green, Blue }
+""")
+        mod_b = self._resolved(("mod_b",), """\
+public data Color { Cyan, Magenta, Yellow }
+""")
+        result = self._compile_mod("""\
+import mod_a(Color);
+import mod_b(Color);
+public fn main(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{ 0 }
+""", [mod_a, mod_b])
+        errors = [d for d in result.diagnostics if d.severity == "error"]
+        assert any(
+            e.error_code == "E609" and "Color" in e.description
+            for e in errors
+        )
+
+    def test_ctor_collision_across_adts(self) -> None:
+        """Same constructor name in different ADTs produces E610."""
+        mod_a = self._resolved(("colors",), """\
+public data Color { Red, Green, Blue }
+""")
+        mod_b = self._resolved(("shapes",), """\
+public data Shape { Red, Green, Triangle }
+""")
+        result = self._compile_mod("""\
+import colors(Color);
+import shapes(Shape);
+public fn main(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{ 0 }
+""", [mod_a, mod_b])
+        errors = [d for d in result.diagnostics if d.severity == "error"]
+        assert any(
+            e.error_code == "E610" and "Red" in e.description
+            for e in errors
+        )
+        assert any(
+            e.error_code == "E610" and "Green" in e.description
+            for e in errors
+        )
+
+    def test_local_shadows_import_no_collision(self) -> None:
+        """Local definition shadowing an import is NOT a collision."""
+        mod = self._resolved(("math",), TestCrossModuleCodegen.MATH_MODULE)
+        result = self._compile_mod("""\
+import math(abs);
+public fn abs(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ 999 }
+public fn main(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{ abs(42) }
+""", [mod])
+        errors = [d for d in result.diagnostics if d.severity == "error"]
+        assert not errors, (
+            f"Local shadow should not produce collision: {errors}"
+        )
+
+    def test_same_module_no_collision(self) -> None:
+        """Same module path in resolved list twice is not a collision."""
+        mod = self._resolved(("math",), TestCrossModuleCodegen.MATH_MODULE)
+        result = self._compile_mod("""\
+import math(abs);
+public fn main(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ abs(@Int.0) }
+""", [mod, mod])
+        errors = [d for d in result.diagnostics if d.severity == "error"]
+        assert not errors
+
+    def test_collision_message_includes_both_modules(self) -> None:
+        """Collision diagnostic mentions both conflicting module paths."""
+        mod_a = self._resolved(("alpha",), """\
+public fn compute(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 }
+""")
+        mod_b = self._resolved(("beta",), """\
+public fn compute(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ @Int.0 }
+""")
+        result = self._compile_mod("""\
+import alpha(compute);
+import beta(compute);
+public fn main(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{ 0 }
+""", [mod_a, mod_b])
+        errors = [d for d in result.diagnostics if d.severity == "error"]
+        assert len(errors) >= 1
+        desc = errors[0].description
+        assert "alpha" in desc and "beta" in desc

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -19,7 +19,7 @@ README = Path(__file__).parent.parent / "README.md"
 # Each key is the 1-based line number of the opening ```vera fence.
 ALLOWLIST: dict[int, str] = {
     # "Where this is going" — depends on #57 (Http), #61 (Inference), #147 (Markdown)
-    324: "Vision example uses MdBlock, Http, Inference (issues #57, #61, #147)",
+    325: "Vision example uses MdBlock, Http, Inference (issues #57, #61, #147)",
 }
 
 

--- a/vera/README.md
+++ b/vera/README.md
@@ -498,7 +498,7 @@ The type system includes open effect rows (`row_var` field in `ConcreteEffectRow
 
 ### 7. LLM-oriented diagnostics
 
-Every diagnostic includes a description (what went wrong), rationale (which language rule), fix (corrected code), spec reference, and a stable error code (`E001`–`E607`). The compiler's output is designed to be fed directly back to the model as corrective context. See spec Chapter 0, Section 0.5 "Diagnostics as Instructions" for the philosophy.
+Every diagnostic includes a description (what went wrong), rationale (which language rule), fix (corrected code), spec reference, and a stable error code (`E001`–`E610`). The compiler's output is designed to be fed directly back to the model as corrective context. See spec Chapter 0, Section 0.5 "Diagnostics as Instructions" for the philosophy.
 
 ### 8. Stable error code taxonomy
 
@@ -526,7 +526,7 @@ Honest inventory of what the compiler cannot do, and where each limitation is ad
 
 | Limitation | Why | Planned |
 |-----------|-----|---------|
-| **Module system limitations** | Module system complete (C7a-C7f); remaining issue: flat-compilation name collisions | [#110](https://github.com/aallan/vera/issues/110) |
+| **Module system limitations** | Module system complete (C7a-C7f); name collisions detected (E608-E610); qualified-call disambiguation pending | Done ([#110](https://github.com/aallan/vera/issues/110)) |
 | **No effect row variable unification** | Subeffecting implemented; `forall<E>` row variables permissive (full row-variable unification deferred) | — |
 | **No quantifier termination** | `decreases` verified for self-recursive and mutual recursion (where-blocks); no support for lexicographic ordering or non-structural measures | [#45](https://github.com/aallan/vera/issues/45) |
 | **No quantifier verification** | `forall`/`exists` in contracts always Tier 3 | [#13](https://github.com/aallan/vera/issues/13) |

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.56"
+__version__ = "0.0.57"

--- a/vera/codegen/modules.py
+++ b/vera/codegen/modules.py
@@ -20,9 +20,10 @@ class CrossModuleMixin:
         1. Build import-name filter from ImportDecl nodes.
         2. For each resolved module, register in isolation and harvest
            function signatures, ADT layouts, and type aliases.
-        3. Inject into ``self._fn_sigs`` via ``setdefault`` so local
+        3. Detect name collisions across modules (E608/E609/E610).
+        4. Inject into ``self._fn_sigs`` via ``setdefault`` so local
            definitions shadow imported names.
-        4. Collect all imported FnDecls for compilation in Pass 2.5.
+        5. Collect all imported FnDecls for compilation in Pass 2.5.
         """
         if not self._resolved_modules:
             return
@@ -35,6 +36,11 @@ class CrossModuleMixin:
             import_names[imp.path] = (
                 set(imp.names) if imp.names is not None else None
             )
+
+        # Provenance tracking for collision detection
+        fn_provenance: dict[str, tuple[str, ...]] = {}
+        adt_provenance: dict[str, tuple[str, ...]] = {}
+        ctor_provenance: dict[str, tuple[tuple[str, ...], str]] = {}
 
         # 2. Register each module in isolation
         for mod in self._resolved_modules:
@@ -53,6 +59,18 @@ class CrossModuleMixin:
             # private helpers called by imported public fns are available.
             name_filter = import_names.get(mod.path)
             for fn_name, sig in temp._fn_sigs.items():
+                # Collision detection: same name from different module
+                if fn_name in fn_provenance:
+                    prev_path = fn_provenance[fn_name]
+                    if prev_path != mod.path:
+                        self._emit_collision_error(
+                            program, fn_name, "Function",
+                            prev_path, mod.path, "E608",
+                        )
+                        continue
+                else:
+                    fn_provenance[fn_name] = mod.path
+
                 # For bare-call injection: only public + in import filter
                 is_public = vis_map.get(fn_name) == "public"
                 in_filter = (
@@ -70,7 +88,35 @@ class CrossModuleMixin:
                 in_filter = (
                     name_filter is None or adt_name in name_filter
                 )
-                if is_public and in_filter:
+
+                # ADT type name collision detection
+                if adt_name in adt_provenance:
+                    prev_path = adt_provenance[adt_name]
+                    if prev_path != mod.path:
+                        self._emit_collision_error(
+                            program, adt_name, "Data type",
+                            prev_path, mod.path, "E609",
+                        )
+                        continue
+                else:
+                    adt_provenance[adt_name] = mod.path
+
+                # Constructor name collision detection
+                ctor_collision = False
+                for ctor_name in layouts:
+                    if ctor_name in ctor_provenance:
+                        prev_path, prev_adt = ctor_provenance[ctor_name]
+                        if prev_path != mod.path:
+                            self._emit_ctor_collision_error(
+                                program, ctor_name,
+                                prev_path, prev_adt,
+                                mod.path, adt_name,
+                            )
+                            ctor_collision = True
+                    else:
+                        ctor_provenance[ctor_name] = (mod.path, adt_name)
+
+                if not ctor_collision and is_public and in_filter:
                     self._adt_layouts.setdefault(adt_name, layouts)
                     self._needs_alloc = True
                     self._needs_memory = True
@@ -87,6 +133,91 @@ class CrossModuleMixin:
                     if tld.decl.where_fns:
                         for wfn in tld.decl.where_fns:
                             self._imported_fn_decls.append(wfn)
+
+    # -----------------------------------------------------------------
+    # Name collision diagnostics
+    # -----------------------------------------------------------------
+
+    def _emit_collision_error(
+        self,
+        program: ast.Program,
+        name: str,
+        kind: str,
+        path_a: tuple[str, ...],
+        path_b: tuple[str, ...],
+        error_code: str,
+    ) -> None:
+        """Emit a diagnostic for a name collision between imported modules."""
+        mod_a = ".".join(path_a)
+        mod_b = ".".join(path_b)
+        imp_node = self._find_import_node(program, path_b)
+        loc = SourceLocation(file=self.file)
+        if imp_node and imp_node.span:
+            loc.line = imp_node.span.line
+            loc.column = imp_node.span.column
+        self.diagnostics.append(Diagnostic(
+            description=(
+                f"{kind} '{name}' is defined in both imported module "
+                f"'{mod_a}' and '{mod_b}'."
+            ),
+            location=loc,
+            source_line=self._get_source_line(loc.line),
+            rationale=(
+                "The flat compilation strategy (C7e) compiles all imported "
+                "functions into a single WASM namespace. Names must be "
+                "unique across imported modules to avoid silent overwrites."
+            ),
+            fix=f"Rename '{name}' in one of the source modules.",
+            spec_ref="Chapter 11, Section 11.16",
+            severity="error",
+            error_code=error_code,
+        ))
+
+    def _emit_ctor_collision_error(
+        self,
+        program: ast.Program,
+        ctor_name: str,
+        path_a: tuple[str, ...],
+        adt_a: str,
+        path_b: tuple[str, ...],
+        adt_b: str,
+    ) -> None:
+        """Emit a diagnostic for a constructor name collision."""
+        mod_a = ".".join(path_a)
+        mod_b = ".".join(path_b)
+        imp_node = self._find_import_node(program, path_b)
+        loc = SourceLocation(file=self.file)
+        if imp_node and imp_node.span:
+            loc.line = imp_node.span.line
+            loc.column = imp_node.span.column
+        self.diagnostics.append(Diagnostic(
+            description=(
+                f"Constructor '{ctor_name}' is defined in both imported "
+                f"module '{mod_a}' (data {adt_a}) and "
+                f"'{mod_b}' (data {adt_b})."
+            ),
+            location=loc,
+            source_line=self._get_source_line(loc.line),
+            rationale=(
+                "The flat compilation strategy (C7e) compiles all ADT "
+                "constructors into a single namespace. Duplicate constructor "
+                "names cause incorrect pattern matching and memory layouts."
+            ),
+            fix=f"Rename constructor '{ctor_name}' in one of the data types.",
+            spec_ref="Chapter 11, Section 11.16",
+            severity="error",
+            error_code="E610",
+        ))
+
+    @staticmethod
+    def _find_import_node(
+        program: ast.Program, path: tuple[str, ...],
+    ) -> ast.ImportDecl | None:
+        """Find the ImportDecl for a given module path."""
+        for imp in program.imports:
+            if imp.path == path:
+                return imp
+        return None
 
     # -----------------------------------------------------------------
     # Cross-module call detection

--- a/vera/errors.py
+++ b/vera/errors.py
@@ -496,6 +496,9 @@ ERROR_CODES: dict[str, str] = {
     "E605": "Unsupported state type parameter",
     "E606": "State without proper effect declaration",
     "E607": "State with unsupported operations",
+    "E608": "Name collision: function",
+    "E609": "Name collision: ADT type",
+    "E610": "Name collision: constructor",
     # E7xx — Testing
     "E700": "Contract violation during testing",
     "E701": "Cannot generate test inputs",


### PR DESCRIPTION
## Summary

- When two imported modules define a function, data type, or constructor with the same name, the compiler now reports a clear error (E608/E609/E610) listing both conflicting modules
- Previously, the first module registered silently won and the second was ignored, producing silently wrong code
- Provenance tracking in `_register_modules` detects collisions across functions, ADT types, and constructors
- Local definitions continue to shadow imported names without error
- Same-module duplicates (module imported twice) are not treated as collisions
- Follow-up issue #187 tracks qualified-call disambiguation via name mangling

## Files changed (13)

| File | Change |
|------|--------|
| `vera/codegen/modules.py` | Provenance tracking, collision detection, 3 new helper methods |
| `vera/errors.py` | Add E608, E609, E610 |
| `tests/test_codegen_modules.py` | 7 new tests in TestNameCollisionDetection |
| `SKILLS.md` | Update modules section re: collision errors and :: limitation |
| `vera/README.md` | Error code range, limitations table |
| `spec/11-compilation.md` | Update known-limitation text and limitations table |
| `CHANGELOG.md` | v0.0.57 entry |
| `README.md` | Test count (1,344), roadmap strikeout, #187 in C8.5 |
| `TESTING.md` | Test count, feature coverage row |
| `vera/__init__.py` | Version 0.0.57 |
| `pyproject.toml` | Version 0.0.57 |
| `tests/test_readme.py` | Allowlist line number shift |
| `scripts/check_readme_examples.py` | Allowlist line number shift |

## Test plan

- [x] 7 new collision detection tests pass
- [x] All 1,344 tests pass (`pytest tests/ -q`)
- [x] mypy clean (`mypy vera/`)
- [x] All 15 examples pass (`python scripts/check_examples.py`)
- [x] Version sync check passes (`python scripts/check_version_sync.py`)
- [x] Pre-commit hooks pass (mypy, pytest, examples, readme)

Closes #110

:robot: Generated with [Claude Code](https://claude.com/claude-code)