### PR TITLE
Fix list_ops.vera runtime failure — built-in name shadowing (#154)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.58] - 2026-03-03
+
+### Fixed
+- **`list_ops.vera` runtime failure — built-in name shadowing** (C8e, [#154](https://github.com/aallan/vera/issues/154)):
+  User-defined functions now take priority over built-in intrinsics in WASM
+  codegen. Previously, a user-defined `length(@List<Int> -> @Nat)` was
+  incorrectly intercepted by the array-length built-in handler, producing
+  invalid WASM. The fix guards all 9 built-in handlers (`length`,
+  `string_length`, `string_concat`, `string_slice`, `char_code`, `parse_nat`,
+  `parse_float64`, `to_string`, `strip`) so they only activate when no
+  user-defined function with the same name exists.
+  - `examples/list_ops.vera` now compiles and runs correctly
+  - 3 new tests, 1,347 tests total
+
 ## [0.0.57] - 2026-03-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ The language specification is in draft across 13 chapters:
 
 ### Testing
 
-The compiler has 1,344 tests with 88% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations. Every commit validates all 15 example programs and 96 specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference -- coverage tables, test helpers, CI pipeline, and infrastructure details.
+The compiler has 1,347 tests with 88% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations. Every commit validates all 15 example programs and 96 specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference -- coverage tables, test helpers, CI pipeline, and infrastructure details.
 
 ## Roadmap
 
@@ -273,7 +273,7 @@ C8 addresses the accumulated technical debt and UX gaps before v0.1.0. Open issu
 
 **C8e — Codegen gaps** — extend WASM compilation
 
-- [#154](https://github.com/aallan/vera/issues/154) `list_ops.vera` runtime failure — recursive generic ADT codegen
+- ~~[#154](https://github.com/aallan/vera/issues/154) `list_ops.vera` runtime failure — recursive generic ADT codegen~~ — [v0.0.58](https://github.com/aallan/vera/releases/tag/v0.0.58)
 - ~~[#110](https://github.com/aallan/vera/issues/110) name collision detection for flat module compilation~~ — [v0.0.57](https://github.com/aallan/vera/releases/tag/v0.0.57)
 - ~~[#131](https://github.com/aallan/vera/issues/131) nested constructor pattern codegen~~ — [v0.0.56](https://github.com/aallan/vera/releases/tag/v0.0.56)
 - [#53](https://github.com/aallan/vera/issues/53) `Exn<E>` and custom effect handler compilation

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -384,6 +384,8 @@ strip(@String.0)                        -- returns String (trim whitespace)
 
 String functions use the bump allocator (`$alloc`). `strip` is zero-copy (returns a view into the original string). `parse_nat` skips leading spaces.
 
+**Shadowing**: If you define a function with the same name as a built-in (e.g. `length` for a custom list type), your definition takes priority. The built-in is only used when no user-defined function with that name exists.
+
 Example:
 
 ```vera

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,7 +6,7 @@ This is the single source of truth for Vera's testing infrastructure, coverage d
 
 | Metric | Value |
 |--------|-------|
-| **Tests** | 1,344 across 19 files (~17,000 lines of test code) |
+| **Tests** | 1,347 across 19 files (~17,000 lines of test code) |
 | **Compiler code coverage** | 88% of 6,861 statements (CI minimum: 80%) |
 | **Example programs** | 15, all validated through `vera check` + `vera verify` |
 | **Spec code blocks** | 96 parseable blocks from 13 spec chapters: 72 parse, 57 type-check, 56 verify |
@@ -43,7 +43,7 @@ python scripts/check_version_sync.py                 # version consistency
 | `test_ast.py` | 87 | 935 | AST transformation, node structure, serialisation |
 | `test_checker.py` | 188 | 2,482 | Type synthesis, slot resolution, effects, effect subtyping, contracts, exhaustiveness, cross-module typing, visibility, error codes, string built-ins, generic rejection |
 | `test_verifier.py` | 97 | 1,580 | Z3 verification, counterexamples, tier classification, call-site preconditions, pipe operator, cross-module contracts, match/ADT verification, decreases verification, mutual recursion |
-| `test_codegen.py` | 322 | 3,825 | WASM compilation, arithmetic, Float64, Byte, arrays, ADTs, match (incl. nested patterns), generics, State\<T\>, control flow, strings, IO, bounds checking, quantifiers, assert/assume, refinement type aliases, pipe operator, string built-ins, example round-trips |
+| `test_codegen.py` | 325 | 3,900 | WASM compilation, arithmetic, Float64, Byte, arrays, ADTs, match (incl. nested patterns), generics, State\<T\>, control flow, strings, IO, bounds checking, quantifiers, assert/assume, refinement type aliases, pipe operator, string built-ins, built-in shadowing, example round-trips |
 | `test_codegen_contracts.py` | 32 | 576 | Runtime pre/postconditions, contract fail messages, old/new state postconditions |
 | `test_codegen_monomorphize.py` | 17 | 360 | Generic instantiation, type inference, monomorphization edge cases |
 | `test_codegen_closures.py` | 17 | 416 | Closure lifting, captured variables, higher-order functions |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.57"
+version = "0.0.58"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -2908,6 +2908,68 @@ public fn g(-> @Int) requires(true) ensures(true) effects(pure) {
 
 
 # =====================================================================
+# User-defined functions shadow built-in intrinsics (#154)
+# =====================================================================
+
+
+class TestBuiltinShadowing:
+    """User-defined functions take priority over built-in intrinsics."""
+
+    def test_user_length_over_adt(self) -> None:
+        """User-defined length() over a recursive ADT compiles and runs."""
+        src = """
+private data List<T> { Nil, Cons(T, List<T>) }
+
+private fn length(@List<Int> -> @Nat)
+  requires(true) ensures(@Nat.result >= 0)
+  decreases(@List<Int>.0) effects(pure)
+{
+  match @List<Int>.0 {
+    Nil -> 0,
+    Cons(@Int, @List<Int>) -> 1 + length(@List<Int>.0)
+  }
+}
+
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  let @List<Int> = Cons(1, Cons(2, Cons(3, Nil)));
+  length(@List<Int>.0)
+}
+"""
+        assert _run(src) == 3
+
+    def test_user_length_single_element(self) -> None:
+        """User-defined length returns 1 for a single-element list."""
+        src = """
+private data List<T> { Nil, Cons(T, List<T>) }
+
+private fn length(@List<Int> -> @Nat)
+  requires(true) ensures(@Nat.result >= 0)
+  decreases(@List<Int>.0) effects(pure)
+{
+  match @List<Int>.0 {
+    Nil -> 0,
+    Cons(@Int, @List<Int>) -> 1 + length(@List<Int>.0)
+  }
+}
+
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  length(Cons(42, Nil))
+}
+"""
+        assert _run(src) == 1
+
+    def test_builtin_length_still_works(self) -> None:
+        """Array length built-in works when no user-defined length exists."""
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  let @Array<Int> = [10, 20, 30];
+  length(@Array<Int>.0)
+}
+"""
+        assert _run(src) == 3
+
+
+# =====================================================================
 # C6l: Assert and assume
 # =====================================================================
 

--- a/tests/test_codegen_monomorphize.py
+++ b/tests/test_codegen_monomorphize.py
@@ -352,9 +352,10 @@ public fn main(-> @Int)
         assert result.ok
 
     def test_list_ops_example_file(self) -> None:
-        """examples/list_ops.vera still compiles (concrete, not generic)."""
+        """examples/list_ops.vera compiles and runs correctly (#154)."""
         from pathlib import Path
         path = Path(__file__).parent.parent / "examples" / "list_ops.vera"
         source = path.read_text()
-        result = _compile(source)
-        assert result.ok
+        result = _compile_ok(source)
+        exec_result = execute(result, fn_name="test_list")
+        assert exec_result.value == 60

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.57"
+__version__ = "0.0.58"

--- a/vera/wasm/calls.py
+++ b/vera/wasm/calls.py
@@ -17,33 +17,35 @@ class CallsMixin:
         If the call name matches an effect operation (e.g. get/put for
         State<T>), redirects to the corresponding host import.
         """
-        # Built-in: length(array) → Int
-        if call.name == "length" and len(call.args) == 1:
-            return self._translate_length(call.args[0], env)
-
-        # Built-in string operations
-        if call.name == "string_length" and len(call.args) == 1:
-            return self._translate_string_length(call.args[0], env)
-        if call.name == "string_concat" and len(call.args) == 2:
-            return self._translate_string_concat(
-                call.args[0], call.args[1], env,
-            )
-        if call.name == "string_slice" and len(call.args) == 3:
-            return self._translate_string_slice(
-                call.args[0], call.args[1], call.args[2], env,
-            )
-        if call.name == "char_code" and len(call.args) == 2:
-            return self._translate_char_code(
-                call.args[0], call.args[1], env,
-            )
-        if call.name == "parse_nat" and len(call.args) == 1:
-            return self._translate_parse_nat(call.args[0], env)
-        if call.name == "parse_float64" and len(call.args) == 1:
-            return self._translate_parse_float64(call.args[0], env)
-        if call.name == "to_string" and len(call.args) == 1:
-            return self._translate_to_string(call.args[0], env)
-        if call.name == "strip" and len(call.args) == 1:
-            return self._translate_strip(call.args[0], env)
+        # Built-in intrinsics — only when no user-defined function
+        # with the same name exists.  User definitions take priority
+        # so that e.g. a user-defined length(@List<Int> -> @Nat) is
+        # not mistakenly compiled as the array-length built-in.
+        if call.name not in self._known_fns:
+            if call.name == "length" and len(call.args) == 1:
+                return self._translate_length(call.args[0], env)
+            if call.name == "string_length" and len(call.args) == 1:
+                return self._translate_string_length(call.args[0], env)
+            if call.name == "string_concat" and len(call.args) == 2:
+                return self._translate_string_concat(
+                    call.args[0], call.args[1], env,
+                )
+            if call.name == "string_slice" and len(call.args) == 3:
+                return self._translate_string_slice(
+                    call.args[0], call.args[1], call.args[2], env,
+                )
+            if call.name == "char_code" and len(call.args) == 2:
+                return self._translate_char_code(
+                    call.args[0], call.args[1], env,
+                )
+            if call.name == "parse_nat" and len(call.args) == 1:
+                return self._translate_parse_nat(call.args[0], env)
+            if call.name == "parse_float64" and len(call.args) == 1:
+                return self._translate_parse_float64(call.args[0], env)
+            if call.name == "to_string" and len(call.args) == 1:
+                return self._translate_to_string(call.args[0], env)
+            if call.name == "strip" and len(call.args) == 1:
+                return self._translate_strip(call.args[0], env)
 
         # Check if this is a closure application: apply_fn(closure, args...)
         if call.name == "apply_fn" and len(call.args) >= 2:


### PR DESCRIPTION
## Summary

- **Fixed**: built-in intrinsic handlers (like `length`) in `vera/wasm/calls.py` unconditionally intercepted calls by function name, even when the user defined their own function with that name. User-defined functions now take priority over built-in intrinsics.
- **Root cause**: The array-length built-in assumed an `(i32, i32)` pair on the WASM stack, but a user-defined `length(@List<Int> -> @Nat)` passes a single `i32` ADT pointer, producing invalid WASM.
- **Guard**: All 9 built-in handlers are now wrapped in `if call.name not in self._known_fns:`, so user definitions always shadow built-ins.

## Test plan

- [x] `vera run examples/list_ops.vera` returns 60 (was crashing with type mismatch)
- [x] 3 new tests in `TestBuiltinShadowing` (user-defined length over ADT, single element, built-in still works)
- [x] `test_list_ops_example_file` upgraded from compile-only to runtime assertion
- [x] All 1,347 tests pass, mypy clean, all 15 examples pass

Closes #154

Generated with [Claude Code](https://claude.ai/code)