### PR TITLE
Fix stale spec cross-reference and remove unused hypothesis dep (#141, #138)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.59] - 2026-03-03
+
+### Fixed
+- **Stale spec cross-reference** ([#141](https://github.com/aallan/vera/issues/141)):
+  Updated `spec/09-standard-library.md` reference from "Section 11.16" to
+  "Section 11.17" (section numbering shifted after chapter edits). Added the
+  compound-type array limitation ([#132](https://github.com/aallan/vera/issues/132))
+  to the limitations table in `spec/11-compilation.md`.
+
+### Removed
+- **Unused `hypothesis` dependency** ([#138](https://github.com/aallan/vera/issues/138)):
+  Removed `hypothesis>=6.0` from `pyproject.toml` dev dependencies — it was
+  declared but never imported in the test suite.
+
 ## [0.0.58] - 2026-03-03
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.58"
+version = "0.0.59"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"
@@ -34,7 +34,6 @@ dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
     "mypy>=1.0",
-    "hypothesis>=6.0",
     "pre-commit>=3.0",
 ]
 

--- a/spec/09-standard-library.md
+++ b/spec/09-standard-library.md
@@ -102,7 +102,7 @@ let @Array<Int> = [1, 2, 3];
 - Zero-indexed: the first element is at index 0.
 - Bounds-checked: indexing with an out-of-range index causes a runtime trap (see Chapter 12).
 
-**Element types:** Arrays can contain any type for which a WASM representation exists: `Int`, `Nat`, `Bool`, `Byte`, `Float64`. Arrays of compound types (`Array<Array<Int>>`, `Array<Option<Int>>`) are not yet supported (see Section 11.16).
+**Element types:** Arrays can contain any type for which a WASM representation exists: `Int`, `Nat`, `Bool`, `Byte`, `Float64`. Arrays of compound types (`Array<Array<Int>>`, `Array<Option<Int>>`) are not yet supported (see Section 11.17).
 
 **Length:** The `length` built-in function returns the number of elements (see Section 9.6.1).
 

--- a/spec/11-compilation.md
+++ b/spec/11-compilation.md
@@ -577,3 +577,4 @@ The current compilation model has the following limitations, each tracked as a G
 | No garbage collection | [#51](https://github.com/aallan/vera/issues/51) | Bump allocator only; linear memory is not reclaimed |
 | String constants only | [#52](https://github.com/aallan/vera/issues/52) | No dynamic string construction |
 | Only State\<T\> handlers | [#53](https://github.com/aallan/vera/issues/53) | Exn\<E\> and custom effect handlers not yet compilable |
+| Arrays of compound types | [#132](https://github.com/aallan/vera/issues/132) | Only primitive element types (`Int`, `Nat`, `Bool`, `Byte`, `Float64`); compound types like `Array<Array<Int>>` or `Array<Option<Int>>` not yet supported |

--- a/vera/README.md
+++ b/vera/README.md
@@ -598,7 +598,7 @@ To add a new WASM type mapping, update `wasm_type()` in `wasm/helpers.py` and th
 
 ### Development
 
-`pytest`, `pytest-cov` (testing), `mypy` (strict type checking), `hypothesis` (property testing, declared but not yet used), `pre-commit` (commit hooks).
+`pytest`, `pytest-cov` (testing), `mypy` (strict type checking), `pre-commit` (commit hooks).
 
 ---
 

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.58"
+__version__ = "0.0.59"


### PR DESCRIPTION
## Summary

- **Fixed stale cross-reference** (#141): `spec/09-standard-library.md` referenced "Section 11.16" for the compound-type array limitation, but section numbering shifted — 11.16 is now "Cross-Module Compilation". Updated to point at Section 11.17 (Limitations) and added the compound-type array limitation (#132) to the limitations table in `spec/11-compilation.md`.
- **Removed unused `hypothesis` dependency** (#138): `hypothesis>=6.0` was declared in `pyproject.toml` dev dependencies but never imported in the test suite. Removed from `pyproject.toml` and updated the dev-dependencies note in `vera/README.md`.

## Test plan

- [x] `python scripts/check_spec_examples.py` — all spec code blocks pass
- [x] `python scripts/check_examples.py` — all 15 examples pass
- [x] `pytest tests/ -q` — 1,347 tests pass
- [x] `mypy vera/` — clean
- [x] `python scripts/check_version_sync.py` — version 0.0.59 consistent

Closes #141
Closes #138

Generated with [Claude Code](https://claude.ai/code)