### PR TITLE
Make parse_nat return Result<Nat, String> per spec (#174)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.60] - 2026-03-03
+
+### Changed
+- **`parse_nat` returns `Result<Nat, String>`** (C8e, [#174](https://github.com/aallan/vera/issues/174)):
+  `parse_nat` now returns `Ok(n)` on valid decimal input and `Err(msg)` on
+  empty or invalid input, matching the spec (Section 9).  Previously it
+  returned bare `Nat` and silently produced garbage for non-numeric strings.
+  - Digit validation: bytes must be in ASCII 48–57; leading/trailing spaces
+    are tolerated; empty/whitespace-only strings return `Err("empty string")`
+  - Built-in Result and Option ADT layouts are now registered in codegen so
+    match on `Ok`/`Err` works without a user `data Result` declaration
+  - Match extraction supports String pair bindings inside ADT constructors
+    (e.g. `Err(@String)`)
+  - 6 new tests, 1,353 tests total
+
 ## [0.0.59] - 2026-03-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ The language specification is in draft across 13 chapters:
 
 ### Testing
 
-The compiler has 1,347 tests with 88% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations. Every commit validates all 15 example programs and 96 specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference -- coverage tables, test helpers, CI pipeline, and infrastructure details.
+The compiler has 1,353 tests with 88% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations. Every commit validates all 15 example programs and 96 specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference -- coverage tables, test helpers, CI pipeline, and infrastructure details.
 
 ## Roadmap
 
@@ -281,7 +281,7 @@ C8 addresses the accumulated technical debt and UX gaps before v0.1.0. Open issu
 - [#132](https://github.com/aallan/vera/issues/132) arrays of compound types in codegen
 - [#52](https://github.com/aallan/vera/issues/52) dynamic string construction
 - ~~[#134](https://github.com/aallan/vera/issues/134) string built-in operations (length, concat, slice)~~ — [v0.0.50](https://github.com/aallan/vera/releases/tag/v0.0.50)
-- [#174](https://github.com/aallan/vera/issues/174) `parse_nat` should return `Result<Nat, String>` per spec
+- ~~[#174](https://github.com/aallan/vera/issues/174) `parse_nat` should return `Result<Nat, String>` per spec~~ — [v0.0.60](https://github.com/aallan/vera/releases/tag/v0.0.60)
 - [#106](https://github.com/aallan/vera/issues/106) universal to-string conversion (Show/Display)
 - [#56](https://github.com/aallan/vera/issues/56) incremental compilation
 

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -376,13 +376,13 @@ string_length(@String.0)                -- returns Nat
 string_concat(@String.0, @String.1)     -- returns String
 string_slice(@String.0, @Nat.0, @Nat.1) -- returns String (start, end)
 char_code(@String.0, @Int.0)            -- returns Nat (ASCII code at index)
-parse_nat(@String.0)                    -- returns Nat (decimal string to number)
+parse_nat(@String.0)                    -- returns Result<Nat, String>
 parse_float64(@String.0)                -- returns Float64
 to_string(@Int.0)                       -- returns String (integer to decimal)
 strip(@String.0)                        -- returns String (trim whitespace)
 ```
 
-String functions use the bump allocator (`$alloc`). `strip` is zero-copy (returns a view into the original string). `parse_nat` skips leading spaces.
+String functions use the bump allocator (`$alloc`). `strip` is zero-copy (returns a view into the original string). `parse_nat` returns `Ok(n)` on valid decimal input and `Err(msg)` on empty or invalid input; leading and trailing spaces are tolerated.
 
 **Shadowing**: If you define a function with the same name as a built-in (e.g. `length` for a custom list type), your definition takes priority. The built-in is only used when no user-defined function with that name exists.
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,7 +6,7 @@ This is the single source of truth for Vera's testing infrastructure, coverage d
 
 | Metric | Value |
 |--------|-------|
-| **Tests** | 1,347 across 19 files (~17,000 lines of test code) |
+| **Tests** | 1,353 across 19 files (~17,000 lines of test code) |
 | **Compiler code coverage** | 88% of 6,861 statements (CI minimum: 80%) |
 | **Example programs** | 15, all validated through `vera check` + `vera verify` |
 | **Spec code blocks** | 96 parseable blocks from 13 spec chapters: 72 parse, 57 type-check, 56 verify |
@@ -41,9 +41,9 @@ python scripts/check_version_sync.py                 # version consistency
 |------|------:|------:|----------------|
 | `test_parser.py` | 103 | 888 | Grammar rules, operator precedence, parse errors |
 | `test_ast.py` | 87 | 935 | AST transformation, node structure, serialisation |
-| `test_checker.py` | 188 | 2,482 | Type synthesis, slot resolution, effects, effect subtyping, contracts, exhaustiveness, cross-module typing, visibility, error codes, string built-ins, generic rejection |
+| `test_checker.py` | 189 | 2,482 | Type synthesis, slot resolution, effects, effect subtyping, contracts, exhaustiveness, cross-module typing, visibility, error codes, string built-ins, generic rejection |
 | `test_verifier.py` | 97 | 1,580 | Z3 verification, counterexamples, tier classification, call-site preconditions, pipe operator, cross-module contracts, match/ADT verification, decreases verification, mutual recursion |
-| `test_codegen.py` | 325 | 3,900 | WASM compilation, arithmetic, Float64, Byte, arrays, ADTs, match (incl. nested patterns), generics, State\<T\>, control flow, strings, IO, bounds checking, quantifiers, assert/assume, refinement type aliases, pipe operator, string built-ins, built-in shadowing, example round-trips |
+| `test_codegen.py` | 330 | 3,900 | WASM compilation, arithmetic, Float64, Byte, arrays, ADTs, match (incl. nested patterns), generics, State\<T\>, control flow, strings, IO, bounds checking, quantifiers, assert/assume, refinement type aliases, pipe operator, string built-ins, built-in shadowing, parse\_nat Result, example round-trips |
 | `test_codegen_contracts.py` | 32 | 576 | Runtime pre/postconditions, contract fail messages, old/new state postconditions |
 | `test_codegen_monomorphize.py` | 17 | 360 | Generic instantiation, type inference, monomorphization edge cases |
 | `test_codegen_closures.py` | 17 | 416 | Closure lifting, captured variables, higher-order functions |

--- a/examples/string_ops.vera
+++ b/examples/string_ops.vera
@@ -4,6 +4,8 @@ effect IO {
   op print(String -> Unit);
 }
 
+private data Result<T, E> { Ok(T), Err(E) }
+
 public fn main(@Unit -> @Unit)
   requires(true)
   ensures(true)
@@ -21,8 +23,11 @@ public fn main(@Unit -> @Unit)
   -- char_code: 'A' = 65
   let @Nat = char_code("A", 0);
 
-  -- parse_nat
-  let @Nat = parse_nat("42");
+  -- parse_nat (returns Result<Nat, String>)
+  let @Nat = match parse_nat("42") {
+    Ok(@Nat) -> @Nat.0,
+    Err(_) -> 0
+  };
 
   -- parse_float64
   let @Float64 = parse_float64("3.14");
@@ -34,7 +39,10 @@ public fn main(@Unit -> @Unit)
   IO.print(strip("  hello  "));
 
   -- compose: parse then convert back
-  IO.print(to_string(parse_nat("99")));
+  IO.print(match parse_nat("99") {
+    Ok(@Nat) -> to_string(@Nat.0),
+    Err(_) -> "error"
+  });
 
   ()
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.59"
+version = "0.0.60"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/spec/04-expressions.md
+++ b/spec/04-expressions.md
@@ -307,15 +307,13 @@ string_length(@String.0)                -- returns Nat
 string_concat(@String.0, @String.1)     -- returns String
 string_slice(@String.0, @Nat.0, @Nat.1) -- returns String
 char_code(@String.0, @Int.0)            -- returns Nat (ASCII code at index)
-parse_nat(@String.0)                    -- returns Nat (see note below)
+parse_nat(@String.0)                    -- returns Result<Nat, String>
 parse_float64(@String.0)                -- returns Float64
 to_string(@Int.0)                       -- returns String
 strip(@String.0)                        -- returns String (trim whitespace)
 ```
 
 String concatenation uses a function, not an operator. There is no `+` on strings.
-
-> **Note:** `parse_nat` currently returns bare `Nat`. Per Section 9, it should return `Result<Nat, String>` to handle invalid input. This is tracked in [#174](https://github.com/aallan/vera/issues/174).
 
 String memory is allocated via the bump allocator and is not freed. Garbage collection for WASM linear memory is tracked in [#51](https://github.com/aallan/vera/issues/51). See Chapter 11, Section 11.5 for the string pool implementation.
 

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -2455,10 +2455,17 @@ private fn f(@String, @Int -> @Nat)
 
     def test_parse_nat_ok(self) -> None:
         _check_ok("""
-private fn f(@String -> @Nat)
+private fn f(@String -> @Result<Nat, String>)
   requires(true) ensures(true) effects(pure)
 { parse_nat(@String.0) }
 """)
+
+    def test_parse_nat_bare_nat_mismatch(self) -> None:
+        _check_err("""
+private fn f(@String -> @Nat)
+  requires(true) ensures(true) effects(pure)
+{ parse_nat(@String.0) }
+""", "expected Nat")
 
     def test_parse_float64_ok(self) -> None:
         _check_ok("""

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -3688,37 +3688,68 @@ public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
 
 
 class TestParseNat:
-    def test_basic(self) -> None:
-        src = """
-public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
-  parse_nat("42")
-}
+    """parse_nat returns Result<Nat, String>."""
+
+    _PREAMBLE = """
+private data Result<T, E> { Ok(T), Err(E) }
 """
-        assert _run(src) == 42
+
+    def _ok_prog(self, literal: str) -> str:
+        return self._PREAMBLE + f"""
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {{
+  match parse_nat("{literal}") {{
+    Ok(@Nat) -> @Nat.0,
+    Err(_) -> 0 - 1
+  }}
+}}
+"""
+
+    def _err_prog(self, literal: str) -> str:
+        return self._PREAMBLE + f"""
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {{
+  match parse_nat("{literal}") {{
+    Ok(_) -> 0,
+    Err(_) -> 1
+  }}
+}}
+"""
+
+    def test_basic(self) -> None:
+        assert _run(self._ok_prog("42")) == 42
 
     def test_zero(self) -> None:
-        src = """
-public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
-  parse_nat("0")
-}
-"""
-        assert _run(src) == 0
+        assert _run(self._ok_prog("0")) == 0
 
     def test_large(self) -> None:
-        src = """
-public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
-  parse_nat("12345")
-}
-"""
-        assert _run(src) == 12345
+        assert _run(self._ok_prog("12345")) == 12345
 
     def test_leading_spaces(self) -> None:
-        src = """
+        assert _run(self._ok_prog("  99")) == 99
+
+    def test_trailing_spaces(self) -> None:
+        assert _run(self._ok_prog("77  ")) == 77
+
+    def test_empty_string_err(self) -> None:
+        assert _run(self._err_prog("")) == 1
+
+    def test_invalid_digit_err(self) -> None:
+        assert _run(self._err_prog("abc")) == 1
+
+    def test_mixed_invalid_err(self) -> None:
+        assert _run(self._err_prog("12x3")) == 1
+
+    def test_err_string_extraction(self) -> None:
+        """Err arm can bind and use the error string."""
+        src = self._PREAMBLE + """
 public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
-  parse_nat("  99")
+  match parse_nat("abc") {
+    Ok(_) -> 0,
+    Err(@String) -> string_length(@String.0)
+  }
 }
 """
-        assert _run(src) == 99
+        # "invalid digit" has length 13
+        assert _run(src) == 13
 
 
 class TestParseFloat64:
@@ -3810,8 +3841,13 @@ public fn main(@Unit -> @Unit)
 
     def test_roundtrip(self) -> None:
         src = """
+private data Result<T, E> { Ok(T), Err(E) }
+
 public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
-  parse_nat(to_string(123))
+  match parse_nat(to_string(123)) {
+    Ok(@Nat) -> @Nat.0,
+    Err(_) -> 0 - 1
+  }
 }
 """
         assert _run(src) == 123
@@ -3872,8 +3908,13 @@ public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
 
     def test_strip_then_parse(self) -> None:
         src = """
+private data Result<T, E> { Ok(T), Err(E) }
+
 public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
-  parse_nat(strip("  42  "))
+  match parse_nat(strip("  42  ")) {
+    Ok(@Nat) -> @Nat.0,
+    Err(_) -> 0 - 1
+  }
 }
 """
         assert _run(src) == 42

--- a/vera/README.md
+++ b/vera/README.md
@@ -297,7 +297,7 @@ Context flags (`in_ensures`, `in_contract`, `current_return_type`, `current_effe
 | `string_concat` | Function | `String, String → String`, pure |
 | `string_slice` | Function | `String, Nat, Nat → String`, pure |
 | `char_code` | Function | `String, Int → Nat`, pure |
-| `parse_nat` | Function | `String → Nat`, pure (see [#174](https://github.com/aallan/vera/issues/174)) |
+| `parse_nat` | Function | `String → Result<Nat, String>`, pure |
 | `parse_float64` | Function | `String → Float64`, pure |
 | `to_string` | Function | `Int → String`, pure |
 | `strip` | Function | `String → String`, pure (zero-copy) |

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.59"
+__version__ = "0.0.60"

--- a/vera/codegen/registration.py
+++ b/vera/codegen/registration.py
@@ -15,6 +15,7 @@ class RegistrationMixin:
 
     def _register_all(self, program: ast.Program) -> None:
         """Register all function signatures, ADT layouts, and type aliases."""
+        self._register_builtin_adts()
         for tld in program.declarations:
             decl = tld.decl
             if isinstance(decl, ast.FnDecl):
@@ -38,6 +39,30 @@ class RegistrationMixin:
         if decl.where_fns:
             for wfn in decl.where_fns:
                 self._register_fn(wfn)
+
+    def _register_builtin_adts(self) -> None:
+        """Register minimal ADT layouts for built-in types (Option, Result).
+
+        Tags and generic i32 field offsets enable match dispatch and
+        wildcard offset advancement.  Concrete sizes are recomputed at
+        construction / extraction time from actual types.  If the user
+        writes an explicit ``data Result`` or ``data Option`` declaration,
+        ``_register_data`` will overwrite these entries.
+        """
+        self._adt_layouts["Option"] = {
+            "None": ConstructorLayout(tag=0, field_offsets=(), total_size=8),
+            "Some": ConstructorLayout(
+                tag=1, field_offsets=((4, "i32"),), total_size=8,
+            ),
+        }
+        self._adt_layouts["Result"] = {
+            "Ok": ConstructorLayout(
+                tag=0, field_offsets=((4, "i32"),), total_size=8,
+            ),
+            "Err": ConstructorLayout(
+                tag=1, field_offsets=((4, "i32"),), total_size=8,
+            ),
+        }
 
     def _register_data(self, decl: ast.DataDecl) -> None:
         """Register an ADT and precompute constructor layouts."""

--- a/vera/environment.py
+++ b/vera/environment.py
@@ -240,7 +240,7 @@ class TypeEnv:
             name="parse_nat",
             forall_vars=None,
             param_types=(STRING,),
-            return_type=NAT,
+            return_type=AdtType("Result", (NAT, STRING)),
             effect=PureEffectRow(),
         )
         self.functions["parse_float64"] = FunctionInfo(

--- a/vera/wasm/calls.py
+++ b/vera/wasm/calls.py
@@ -437,81 +437,165 @@ class CallsMixin:
     def _translate_parse_nat(
         self, arg: ast.Expr, env: WasmSlotEnv,
     ) -> list[str] | None:
-        """Translate parse_nat(s) → Nat (i64).
+        """Translate parse_nat(s) → Result<Nat, String> (i32 pointer).
 
-        Parses a decimal string to a non-negative integer.
-        Iterates through bytes: result = result * 10 + (byte - 48).
-        Skips leading spaces.
+        Returns an ADT heap object:
+          Ok(Nat):     [tag=0 : i32] [pad 4] [value : i64]   (16 bytes)
+          Err(String): [tag=1 : i32] [ptr : i32] [len : i32]  (16 bytes)
+
+        Validates that the input contains at least one digit (0-9) and
+        only digits/spaces.  Skips leading and trailing spaces.
         """
         arg_instrs = self.translate_expr(arg, env)
         if arg_instrs is None:
             return None
+
+        self.needs_alloc = True
 
         ptr = self.alloc_local("i32")
         slen = self.alloc_local("i32")
         idx = self.alloc_local("i32")
         result = self.alloc_local("i64")
         byte = self.alloc_local("i32")
+        out = self.alloc_local("i32")
+        has_digit = self.alloc_local("i32")
 
-        instructions: list[str] = []
+        # Intern error strings
+        empty_off, empty_len = self.string_pool.intern("empty string")
+        invalid_off, invalid_len = self.string_pool.intern("invalid digit")
 
-        # Evaluate string -> (ptr, len)
-        instructions.extend(arg_instrs)
-        instructions.append(f"local.set {slen}")
-        instructions.append(f"local.set {ptr}")
+        ins: list[str] = []
 
-        # result = 0, idx = 0
-        instructions.append("i64.const 0")
-        instructions.append(f"local.set {result}")
-        instructions.append("i32.const 0")
-        instructions.append(f"local.set {idx}")
+        # Evaluate string → (ptr, len)
+        ins.extend(arg_instrs)
+        ins.append(f"local.set {slen}")
+        ins.append(f"local.set {ptr}")
 
-        # Loop through bytes
-        instructions.append("block $brk_pn")
-        instructions.append("  loop $lp_pn")
-        # Check idx < len
-        instructions.append(f"    local.get {idx}")
-        instructions.append(f"    local.get {slen}")
-        instructions.append("    i32.ge_u")
-        instructions.append("    br_if $brk_pn")
+        # Initialise: result = 0, idx = 0, has_digit = 0
+        ins.append("i64.const 0")
+        ins.append(f"local.set {result}")
+        ins.append("i32.const 0")
+        ins.append(f"local.set {idx}")
+        ins.append("i32.const 0")
+        ins.append(f"local.set {has_digit}")
+
+        # -- block structure: block $done { block $err { parse } Err }
+        ins.append("block $done_pn")
+        ins.append("block $err_pn")
+
+        # -- Parse loop ------------------------------------------------
+        ins.append("block $brk_pn")
+        ins.append("  loop $lp_pn")
+        # idx >= len → break
+        ins.append(f"    local.get {idx}")
+        ins.append(f"    local.get {slen}")
+        ins.append("    i32.ge_u")
+        ins.append("    br_if $brk_pn")
         # Load byte
-        instructions.append(f"    local.get {ptr}")
-        instructions.append(f"    local.get {idx}")
-        instructions.append("    i32.add")
-        instructions.append("    i32.load8_u offset=0")
-        instructions.append(f"    local.set {byte}")
-        # Skip spaces (byte 32)
-        instructions.append(f"    local.get {byte}")
-        instructions.append("    i32.const 32")
-        instructions.append("    i32.eq")
-        instructions.append("    if")
-        instructions.append(f"      local.get {idx}")
-        instructions.append("      i32.const 1")
-        instructions.append("      i32.add")
-        instructions.append(f"      local.set {idx}")
-        instructions.append("      br $lp_pn")
-        instructions.append("    end")
-        # result = result * 10 + (byte - 48)
-        instructions.append(f"    local.get {result}")
-        instructions.append("    i64.const 10")
-        instructions.append("    i64.mul")
-        instructions.append(f"    local.get {byte}")
-        instructions.append("    i32.const 48")
-        instructions.append("    i32.sub")
-        instructions.append("    i64.extend_i32_u")
-        instructions.append("    i64.add")
-        instructions.append(f"    local.set {result}")
+        ins.append(f"    local.get {ptr}")
+        ins.append(f"    local.get {idx}")
+        ins.append("    i32.add")
+        ins.append("    i32.load8_u offset=0")
+        ins.append(f"    local.set {byte}")
+        # Skip space (byte 32)
+        ins.append(f"    local.get {byte}")
+        ins.append("    i32.const 32")
+        ins.append("    i32.eq")
+        ins.append("    if")
+        ins.append(f"      local.get {idx}")
+        ins.append("      i32.const 1")
+        ins.append("      i32.add")
+        ins.append(f"      local.set {idx}")
+        ins.append("      br $lp_pn")
+        ins.append("    end")
+        # Check byte < '0' (48) → error
+        ins.append(f"    local.get {byte}")
+        ins.append("    i32.const 48")
+        ins.append("    i32.lt_u")
+        ins.append("    br_if $err_pn")
+        # Check byte > '9' (57) → error
+        ins.append(f"    local.get {byte}")
+        ins.append("    i32.const 57")
+        ins.append("    i32.gt_u")
+        ins.append("    br_if $err_pn")
+        # Digit: result = result * 10 + (byte - 48)
+        ins.append(f"    local.get {result}")
+        ins.append("    i64.const 10")
+        ins.append("    i64.mul")
+        ins.append(f"    local.get {byte}")
+        ins.append("    i32.const 48")
+        ins.append("    i32.sub")
+        ins.append("    i64.extend_i32_u")
+        ins.append("    i64.add")
+        ins.append(f"    local.set {result}")
+        # Mark that we saw a digit
+        ins.append("    i32.const 1")
+        ins.append(f"    local.set {has_digit}")
         # idx++
-        instructions.append(f"    local.get {idx}")
-        instructions.append("    i32.const 1")
-        instructions.append("    i32.add")
-        instructions.append(f"    local.set {idx}")
-        instructions.append("    br $lp_pn")
-        instructions.append("  end")
-        instructions.append("end")
+        ins.append(f"    local.get {idx}")
+        ins.append("    i32.const 1")
+        ins.append("    i32.add")
+        ins.append(f"    local.set {idx}")
+        ins.append("    br $lp_pn")
+        ins.append("  end")   # loop
+        ins.append("end")     # block $brk_pn
 
-        instructions.append(f"local.get {result}")
-        return instructions
+        # -- After loop: no digits seen → error
+        ins.append(f"local.get {has_digit}")
+        ins.append("i32.eqz")
+        ins.append("br_if $err_pn")
+
+        # -- Ok path: allocate 16 bytes, tag=0, Nat at offset 8 ----------
+        ins.append("i32.const 16")
+        ins.append("call $alloc")
+        ins.append(f"local.tee {out}")
+        ins.append("i32.const 0")
+        ins.append("i32.store")           # tag = 0 (Ok)
+        ins.append(f"local.get {out}")
+        ins.append(f"local.get {result}")
+        ins.append("i64.store offset=8")  # Nat value
+        ins.append("br $done_pn")
+
+        ins.append("end")  # block $err_pn
+
+        # -- Err path: allocate 16 bytes, tag=1, String at offsets 4,8 ---
+        # Choose error message: if idx < slen the loop exited early on an
+        # invalid character → "invalid digit"; otherwise the string was
+        # empty or all spaces → "empty string".
+        ins.append(f"local.get {idx}")
+        ins.append(f"local.get {slen}")
+        ins.append("i32.lt_u")
+        ins.append("if (result i32)")
+        ins.append(f"  i32.const {invalid_off}")
+        ins.append("else")
+        ins.append(f"  i32.const {empty_off}")
+        ins.append("end")
+        ins.append(f"local.set {idx}")   # reuse idx for err string ptr
+        ins.append(f"local.get {idx}")   # idx now holds the err string ptr
+        ins.append(f"i32.const {invalid_off}")
+        ins.append("i32.eq")
+        ins.append("if (result i32)")
+        ins.append(f"  i32.const {invalid_len}")
+        ins.append("else")
+        ins.append(f"  i32.const {empty_len}")
+        ins.append("end")
+        ins.append(f"local.set {byte}")  # reuse byte for err string len
+        ins.append("i32.const 16")
+        ins.append("call $alloc")
+        ins.append(f"local.tee {out}")
+        ins.append("i32.const 1")
+        ins.append("i32.store")           # tag = 1 (Err)
+        ins.append(f"local.get {out}")
+        ins.append(f"local.get {idx}")
+        ins.append("i32.store offset=4")  # string ptr
+        ins.append(f"local.get {out}")
+        ins.append(f"local.get {byte}")
+        ins.append("i32.store offset=8")  # string len
+
+        ins.append("end")  # block $done_pn
+
+        ins.append(f"local.get {out}")
+        return ins
 
     def _translate_parse_float64(
         self, arg: ast.Expr, env: WasmSlotEnv,

--- a/vera/wasm/data.py
+++ b/vera/wasm/data.py
@@ -332,6 +332,21 @@ class DataMixin:
                 type_name = self._type_expr_to_slot_name(sub_pat.type_expr)
                 if type_name is None:
                     return None
+                # Pair types (String, Array<T>): two consecutive i32 locals
+                if self._is_pair_type_name(type_name):
+                    align = _aligns.get("i32", 4)
+                    offset = (offset + align - 1) & ~(align - 1)
+                    ptr_local = self.alloc_local("i32")
+                    len_local = self.alloc_local("i32")
+                    instrs.append(f"local.get {scr_local}")
+                    instrs.append(f"i32.load offset={offset}")
+                    instrs.append(f"local.set {ptr_local}")
+                    instrs.append(f"local.get {scr_local}")
+                    instrs.append(f"i32.load offset={offset + 4}")
+                    instrs.append(f"local.set {len_local}")
+                    new_env = new_env.push(type_name, ptr_local)
+                    offset += 8  # two i32s
+                    continue
                 wt = self._slot_name_to_wasm_type(type_name)
                 if wt is None:
                     return None

--- a/vera/wasm/inference.py
+++ b/vera/wasm/inference.py
@@ -175,9 +175,12 @@ class InferenceMixin:
         if expr.name in ("string_concat", "string_slice", "strip",
                           "to_string"):
             return "i32_pair"
-        # char_code / parse_nat → Nat (i64)
-        if expr.name in ("char_code", "parse_nat"):
+        # char_code → Nat (i64)
+        if expr.name == "char_code":
             return "i64"
+        # parse_nat → Result<Nat, String> (i32 heap pointer)
+        if expr.name == "parse_nat":
+            return "i32"
         # parse_float64 → Float64 (f64)
         if expr.name == "parse_float64":
             return "f64"
@@ -307,8 +310,10 @@ class InferenceMixin:
         if call.name in ("string_concat", "string_slice", "strip",
                           "to_string"):
             return "String"
-        if call.name in ("char_code", "parse_nat"):
+        if call.name == "char_code":
             return "Nat"
+        if call.name == "parse_nat":
+            return "Result"
         if call.name == "parse_float64":
             return "Float64"
         if call.name in self._generic_fn_info:


### PR DESCRIPTION
## Summary

- **Breaking change**: `parse_nat` now returns `Result<Nat, String>` instead of bare `Nat`, matching the spec (Section 9). Returns `Ok(n)` on valid decimal input, `Err("empty string")` on empty/whitespace-only input, and `Err("invalid digit")` on non-numeric characters.
- **Digit validation**: input bytes are checked against ASCII 48-57; leading and trailing spaces are tolerated.
- **Built-in ADT layouts**: Result and Option constructor layouts are now registered in codegen, so match on `Ok`/`Err`/`Some`/`None` works without a user `data` declaration.
- **String pair extraction**: `_extract_constructor_fields` now handles String (pair type) bindings inside ADT constructors, enabling `Err(@String)` match arms.

## Test plan

- [x] `vera run examples/string_ops.vera` produces correct output
- [x] 6 new tests: Ok path (basic, zero, large, leading/trailing spaces), Err path (empty, invalid, mixed, string extraction)
- [x] Updated `test_roundtrip` and `test_strip_then_parse` to match on Result
- [x] All 1,353 tests pass, mypy clean, all 15 examples pass

Closes #174

Generated with [Claude Code](https://claude.ai/code)