### PR TITLE
Support arrays of compound types in codegen (#132)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.61] - 2026-03-04
+
+### Added
+- **Arrays of compound types** (C8e, [#132](https://github.com/aallan/vera/issues/132)):
+  Arrays now support all element types, not just the five primitives (`Int`,
+  `Nat`, `Float64`, `Bool`, `Byte`).  This includes ADT types
+  (`Array<Option<Int>>`, `Array<Result<Int, String>>`), `String`
+  (`Array<String>`), and nested arrays (`Array<Array<Int>>`).
+  - ADT elements are stored as i32 heap pointers (4 bytes each)
+  - String and nested-array elements are stored as (ptr, len) pairs (8 bytes each)
+  - Chained indexing works for nested arrays (`@Array<Array<Int>>.0[0][1]`)
+  - Constructor pair-type field storage fixed (e.g. `Err("msg")` with String field)
+  - 17 new tests, 1,370 tests total
+
 ## [0.0.60] - 2026-03-03
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ The language specification is in draft across 13 chapters:
 
 ### Testing
 
-The compiler has 1,353 tests with 88% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations. Every commit validates all 15 example programs and 96 specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference -- coverage tables, test helpers, CI pipeline, and infrastructure details.
+The compiler has 1,370 tests with 88% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations. Every commit validates all 15 example programs and 96 specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference -- coverage tables, test helpers, CI pipeline, and infrastructure details.
 
 ## Roadmap
 
@@ -278,7 +278,7 @@ C8 addresses the accumulated technical debt and UX gaps before v0.1.0. Open issu
 - ~~[#131](https://github.com/aallan/vera/issues/131) nested constructor pattern codegen~~ — [v0.0.56](https://github.com/aallan/vera/releases/tag/v0.0.56)
 - [#53](https://github.com/aallan/vera/issues/53) `Exn<E>` and custom effect handler compilation
 - [#51](https://github.com/aallan/vera/issues/51) garbage collection for WASM linear memory
-- [#132](https://github.com/aallan/vera/issues/132) arrays of compound types in codegen
+- ~~[#132](https://github.com/aallan/vera/issues/132) arrays of compound types in codegen~~ — [v0.0.61](https://github.com/aallan/vera/releases/tag/v0.0.61)
 - [#52](https://github.com/aallan/vera/issues/52) dynamic string construction
 - ~~[#134](https://github.com/aallan/vera/issues/134) string built-in operations (length, concat, slice)~~ — [v0.0.50](https://github.com/aallan/vera/releases/tag/v0.0.50)
 - ~~[#174](https://github.com/aallan/vera/issues/174) `parse_nat` should return `Result<Nat, String>` per spec~~ — [v0.0.60](https://github.com/aallan/vera/releases/tag/v0.0.60)

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,7 +6,7 @@ This is the single source of truth for Vera's testing infrastructure, coverage d
 
 | Metric | Value |
 |--------|-------|
-| **Tests** | 1,353 across 19 files (~17,000 lines of test code) |
+| **Tests** | 1,370 across 19 files (~17,000 lines of test code) |
 | **Compiler code coverage** | 88% of 6,861 statements (CI minimum: 80%) |
 | **Example programs** | 15, all validated through `vera check` + `vera verify` |
 | **Spec code blocks** | 96 parseable blocks from 13 spec chapters: 72 parse, 57 type-check, 56 verify |
@@ -43,7 +43,7 @@ python scripts/check_version_sync.py                 # version consistency
 | `test_ast.py` | 87 | 935 | AST transformation, node structure, serialisation |
 | `test_checker.py` | 189 | 2,482 | Type synthesis, slot resolution, effects, effect subtyping, contracts, exhaustiveness, cross-module typing, visibility, error codes, string built-ins, generic rejection |
 | `test_verifier.py` | 97 | 1,580 | Z3 verification, counterexamples, tier classification, call-site preconditions, pipe operator, cross-module contracts, match/ADT verification, decreases verification, mutual recursion |
-| `test_codegen.py` | 330 | 3,900 | WASM compilation, arithmetic, Float64, Byte, arrays, ADTs, match (incl. nested patterns), generics, State\<T\>, control flow, strings, IO, bounds checking, quantifiers, assert/assume, refinement type aliases, pipe operator, string built-ins, built-in shadowing, parse\_nat Result, example round-trips |
+| `test_codegen.py` | 343 | 4,095 | WASM compilation, arithmetic, Float64, Byte, arrays (incl. compound element types), ADTs, match (incl. nested patterns), generics, State\<T\>, control flow, strings, IO, bounds checking, quantifiers, assert/assume, refinement type aliases, pipe operator, string built-ins, built-in shadowing, parse\_nat Result, example round-trips |
 | `test_codegen_contracts.py` | 32 | 576 | Runtime pre/postconditions, contract fail messages, old/new state postconditions |
 | `test_codegen_monomorphize.py` | 17 | 360 | Generic instantiation, type inference, monomorphization edge cases |
 | `test_codegen_closures.py` | 17 | 416 | Closure lifting, captured variables, higher-order functions |
@@ -55,7 +55,7 @@ python scripts/check_version_sync.py                 # version consistency
 | `test_resolver.py` | 15 | 412 | Module resolution, path lookup, parse caching, circular import detection |
 | `test_types.py` | 73 | 390 | Type operations: subtyping, effect subtyping, equality, substitution, pretty-printing, canonical names |
 | `test_wasm.py` | 22 | 255 | WASM internals: StringPool, WasmSlotEnv, translation edge cases via full pipeline |
-| `test_wasm_coverage.py` | 109 | 1,720 | WASM coverage gaps: helpers unit tests, inference branches, closure free-var walking, operator/data/context edge cases |
+| `test_wasm_coverage.py` | 113 | 1,738 | WASM coverage gaps: helpers unit tests, inference branches, closure free-var walking, operator/data/context edge cases |
 | `test_tester.py` | 13 | 320 | Contract-driven testing: tier classification, input generation, test execution |
 | `test_readme.py` | 2 | 68 | README code sample parsing |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.60"
+version = "0.0.61"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/spec/09-standard-library.md
+++ b/spec/09-standard-library.md
@@ -102,7 +102,7 @@ let @Array<Int> = [1, 2, 3];
 - Zero-indexed: the first element is at index 0.
 - Bounds-checked: indexing with an out-of-range index causes a runtime trap (see Chapter 12).
 
-**Element types:** Arrays can contain any type for which a WASM representation exists: `Int`, `Nat`, `Bool`, `Byte`, `Float64`. Arrays of compound types (`Array<Array<Int>>`, `Array<Option<Int>>`) are not yet supported (see Section 11.17).
+**Element types:** Arrays can contain any type for which a WASM representation exists, including primitives (`Int`, `Nat`, `Bool`, `Byte`, `Float64`), ADT types (`Option<Int>`, `Result<Nat, String>`), `String`, and nested arrays (`Array<Array<Int>>`).
 
 **Length:** The `length` built-in function returns the number of elements (see Section 9.6.1).
 
@@ -348,7 +348,7 @@ This approach keeps the core language small while providing ergonomic JSON suppo
 
 ### 9.7.3 Markdown (Future)
 
-> **Status: Not yet implemented.** Tracked in [#147](https://github.com/aallan/vera/issues/147). Depends on dynamic string construction ([#52](https://github.com/aallan/vera/issues/52)), string built-in operations ([#134](https://github.com/aallan/vera/issues/134)), and arrays of compound types ([#132](https://github.com/aallan/vera/issues/132)). Does **not** depend on `Map<K, V>`.
+> **Status: Not yet implemented.** Tracked in [#147](https://github.com/aallan/vera/issues/147). Depends on dynamic string construction ([#52](https://github.com/aallan/vera/issues/52)) and string built-in operations ([#134](https://github.com/aallan/vera/issues/134)). Does **not** depend on `Map<K, V>`.
 
 Markdown is the lingua franca of large language models — they understand it natively and generate it naturally. A typed Markdown ADT makes document structure visible to the type system, enabling contracts that verify the structural properties of agent output.
 

--- a/spec/11-compilation.md
+++ b/spec/11-compilation.md
@@ -577,4 +577,4 @@ The current compilation model has the following limitations, each tracked as a G
 | No garbage collection | [#51](https://github.com/aallan/vera/issues/51) | Bump allocator only; linear memory is not reclaimed |
 | String constants only | [#52](https://github.com/aallan/vera/issues/52) | No dynamic string construction |
 | Only State\<T\> handlers | [#53](https://github.com/aallan/vera/issues/53) | Exn\<E\> and custom effect handlers not yet compilable |
-| Arrays of compound types | [#132](https://github.com/aallan/vera/issues/132) | Only primitive element types (`Int`, `Nat`, `Bool`, `Byte`, `Float64`); compound types like `Array<Array<Int>>` or `Array<Option<Int>>` not yet supported |
+| ~~Arrays of compound types~~ | ~~[#132](https://github.com/aallan/vera/issues/132)~~ | ~~Resolved in v0.0.61 — arrays now support all element types including ADTs, Strings, and nested arrays~~ |

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -3918,3 +3918,178 @@ public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
 }
 """
         assert _run(src) == 42
+
+
+# =====================================================================
+# C8e: Arrays of compound types (#132)
+# =====================================================================
+
+
+class TestCompoundArrays:
+    """Test arrays with compound element types (ADTs, Strings, nested arrays)."""
+
+    def test_option_array_some(self) -> None:
+        """Array<Option<Int>> — construct and index Some element."""
+        src = """
+private data Option<T> { None, Some(T) }
+
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  let @Array<Option<Int>> = [Some(10), None, Some(30)];
+  match @Array<Option<Int>>.0[0] {
+    Some(@Int) -> @Int.0,
+    None -> 0 - 1
+  }
+}
+"""
+        assert _run(src) == 10
+
+    def test_option_array_none(self) -> None:
+        """Array<Option<Int>> — index None element."""
+        src = """
+private data Option<T> { None, Some(T) }
+
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  let @Array<Option<Int>> = [Some(10), None, Some(30)];
+  match @Array<Option<Int>>.0[1] {
+    Some(@Int) -> @Int.0,
+    None -> 0 - 1
+  }
+}
+"""
+        assert _run(src) == -1
+
+    def test_option_array_index_2(self) -> None:
+        """Array<Option<Int>> — index third element."""
+        src = """
+private data Option<T> { None, Some(T) }
+
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  let @Array<Option<Int>> = [Some(10), None, Some(30)];
+  match @Array<Option<Int>>.0[2] {
+    Some(@Int) -> @Int.0,
+    None -> 0 - 1
+  }
+}
+"""
+        assert _run(src) == 30
+
+    def test_option_array_length(self) -> None:
+        """length() on Array<Option<Int>>."""
+        src = """
+private data Option<T> { None, Some(T) }
+
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  let @Array<Option<Int>> = [Some(1), None, Some(3), None];
+  length(@Array<Option<Int>>.0)
+}
+"""
+        assert _run(src) == 4
+
+    def test_string_array(self) -> None:
+        """Array<String> — construct and index, check string_length."""
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  let @Array<String> = ["hello", "world", "!"];
+  string_length(@Array<String>.0[0])
+}
+"""
+        assert _run(src) == 5
+
+    def test_string_array_index_1(self) -> None:
+        """Array<String> — index second element."""
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  let @Array<String> = ["hello", "world", "!"];
+  string_length(@Array<String>.0[1])
+}
+"""
+        assert _run(src) == 5
+
+    def test_string_array_index_2(self) -> None:
+        """Array<String> — index third element."""
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  let @Array<String> = ["hello", "world", "!"];
+  string_length(@Array<String>.0[2])
+}
+"""
+        assert _run(src) == 1
+
+    def test_string_array_length(self) -> None:
+        """length() on Array<String>."""
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  let @Array<String> = ["a", "bb", "ccc"];
+  length(@Array<String>.0)
+}
+"""
+        assert _run(src) == 3
+
+    def test_string_array_io(self) -> None:
+        """Array<String> — print indexed element."""
+        src = """
+effect IO {
+  op print(String -> Unit);
+}
+
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  let @Array<String> = ["hello", "world"];
+  IO.print(@Array<String>.0[1]);
+  ()
+}
+"""
+        assert _run_io(src) == "world"
+
+    def test_nested_array(self) -> None:
+        """Array<Array<Int>> — construct nested, index outer, then inner."""
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  let @Array<Int> = [10, 20];
+  let @Array<Array<Int>> = [@Array<Int>.0, @Array<Int>.0];
+  @Array<Array<Int>>.0[0][1]
+}
+"""
+        assert _run(src) == 20
+
+    def test_nested_array_length(self) -> None:
+        """length() on Array<Array<Int>>."""
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  let @Array<Int> = [1, 2, 3];
+  let @Array<Array<Int>> = [@Array<Int>.0, @Array<Int>.0, @Array<Int>.0];
+  length(@Array<Array<Int>>.0)
+}
+"""
+        assert _run(src) == 3
+
+    def test_result_array(self) -> None:
+        """Array<Result<Int, String>> — construct and match on indexed element."""
+        src = """
+private data Result<T, E> { Ok(T), Err(E) }
+
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  let @Array<Result<Int, String>> = [Ok(42), Err("bad")];
+  match @Array<Result<Int, String>>.0[0] {
+    Ok(@Int) -> @Int.0,
+    Err(_) -> 0 - 1
+  }
+}
+"""
+        assert _run(src) == 42
+
+    def test_result_array_err(self) -> None:
+        """Array<Result<Int, String>> — index Err element."""
+        src = """
+private data Result<T, E> { Ok(T), Err(E) }
+
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  let @Array<Result<Int, String>> = [Ok(42), Err("bad")];
+  match @Array<Result<Int, String>>.0[1] {
+    Ok(@Int) -> @Int.0,
+    Err(_) -> 0 - 1
+  }
+}
+"""
+        assert _run(src) == -1

--- a/tests/test_wasm_coverage.py
+++ b/tests/test_wasm_coverage.py
@@ -199,19 +199,37 @@ class TestHelperFunctions:
 
     # -- _element_* edge cases --
 
-    def test_element_mem_size_unknown(self) -> None:
-        assert _element_mem_size("String") is None
+    def test_element_mem_size_string(self) -> None:
+        """String element: pair type → 8 bytes."""
+        assert _element_mem_size("String") == 8
 
-    def test_element_load_op_unknown(self) -> None:
-        """Unknown element type falls back to i64.load."""
-        assert _element_load_op("Unknown") == "i64.load"
+    def test_element_mem_size_adt(self) -> None:
+        """ADT element: i32 heap pointer → 4 bytes."""
+        assert _element_mem_size("Option") == 4
 
-    def test_element_store_op_unknown(self) -> None:
-        """Unknown element type falls back to i64.store."""
-        assert _element_store_op("Unknown") == "i64.store"
+    def test_element_load_op_adt(self) -> None:
+        """ADT element type → i32.load."""
+        assert _element_load_op("Unknown") == "i32.load"
 
-    def test_element_wasm_type_unknown(self) -> None:
-        assert _element_wasm_type("String") is None
+    def test_element_load_op_string(self) -> None:
+        """String element: pair type → None (special handling)."""
+        assert _element_load_op("String") is None
+
+    def test_element_store_op_adt(self) -> None:
+        """ADT element type → i32.store."""
+        assert _element_store_op("Unknown") == "i32.store"
+
+    def test_element_store_op_string(self) -> None:
+        """String element: pair type → None (special handling)."""
+        assert _element_store_op("String") is None
+
+    def test_element_wasm_type_string(self) -> None:
+        """String element → i32_pair."""
+        assert _element_wasm_type("String") == "i32_pair"
+
+    def test_element_wasm_type_adt(self) -> None:
+        """ADT element → i32."""
+        assert _element_wasm_type("Option") == "i32"
 
     def test_element_wasm_type_float64(self) -> None:
         assert _element_wasm_type("Float64") == "f64"

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.60"
+__version__ = "0.0.61"

--- a/vera/wasm/data.py
+++ b/vera/wasm/data.py
@@ -10,6 +10,7 @@ from vera.wasm.helpers import (
     _element_mem_size,
     _element_load_op,
     _element_store_op,
+    _is_pair_element_type,
 )
 
 if TYPE_CHECKING:
@@ -72,8 +73,8 @@ class DataMixin:
             arg_wasm_types.append(arg_wt)
 
         # Compute field offsets from concrete argument types
-        _sizes = {"i32": 4, "i64": 8, "f64": 8}
-        _aligns = {"i32": 4, "i64": 8, "f64": 8}
+        _sizes = {"i32": 4, "i64": 8, "f64": 8, "i32_pair": 8}
+        _aligns = {"i32": 4, "i64": 8, "f64": 8, "i32_pair": 4}
         offset = 4  # after tag (i32, 4 bytes)
         field_offsets: list[tuple[int, str]] = []
         for wt in arg_wasm_types:
@@ -94,9 +95,23 @@ class DataMixin:
 
         # Store each field at its computed offset
         for i, (fo, wt) in enumerate(field_offsets):
-            instructions.append(f"local.get {tmp}")
-            instructions.extend(arg_instrs_list[i])
-            instructions.append(f"{wt}.store offset={fo}")
+            if wt == "i32_pair":
+                # Pair type (String, Array<T>): store (ptr, len) as two i32s
+                tmp_val_ptr = self.alloc_local("i32")
+                tmp_val_len = self.alloc_local("i32")
+                instructions.extend(arg_instrs_list[i])
+                instructions.append(f"local.set {tmp_val_len}")
+                instructions.append(f"local.set {tmp_val_ptr}")
+                instructions.append(f"local.get {tmp}")
+                instructions.append(f"local.get {tmp_val_ptr}")
+                instructions.append(f"i32.store offset={fo}")
+                instructions.append(f"local.get {tmp}")
+                instructions.append(f"local.get {tmp_val_len}")
+                instructions.append(f"i32.store offset={fo + 4}")
+            else:
+                instructions.append(f"local.get {tmp}")
+                instructions.extend(arg_instrs_list[i])
+                instructions.append(f"{wt}.store offset={fo}")
 
         # Leave pointer as result
         instructions.append(f"local.get {tmp}")
@@ -514,8 +529,12 @@ class DataMixin:
         if elem_type is None:
             return None
         elem_size = _element_mem_size(elem_type)
+        if elem_size is None:
+            return None
+        is_pair = _is_pair_element_type(elem_type)
         store_op = _element_store_op(elem_type)
-        if elem_size is None or store_op is None:
+        # store_op is None only for pair types — handled below
+        if store_op is None and not is_pair:
             return None
 
         self.needs_alloc = True
@@ -534,9 +553,26 @@ class DataMixin:
             if elem_instrs is None:
                 return None
             offset = i * elem_size
-            instructions.append(f"local.get {tmp_ptr}")
-            instructions.extend(elem_instrs)
-            instructions.append(f"{store_op} offset={offset}")
+            if is_pair:
+                # Pair type (String, Array<T>): element pushes (ptr, len)
+                # Store into two consecutive i32 slots
+                tmp_val_ptr = self.alloc_local("i32")
+                tmp_val_len = self.alloc_local("i32")
+                instructions.extend(elem_instrs)
+                instructions.append(f"local.set {tmp_val_len}")
+                instructions.append(f"local.set {tmp_val_ptr}")
+                # Store ptr at offset
+                instructions.append(f"local.get {tmp_ptr}")
+                instructions.append(f"local.get {tmp_val_ptr}")
+                instructions.append(f"i32.store offset={offset}")
+                # Store len at offset+4
+                instructions.append(f"local.get {tmp_ptr}")
+                instructions.append(f"local.get {tmp_val_len}")
+                instructions.append(f"i32.store offset={offset + 4}")
+            else:
+                instructions.append(f"local.get {tmp_ptr}")
+                instructions.extend(elem_instrs)
+                instructions.append(f"{store_op} offset={offset}")
 
         # Push (ptr, len)
         instructions.append(f"local.get {tmp_ptr}")
@@ -555,8 +591,12 @@ class DataMixin:
         if elem_type is None:
             return None
         elem_size = _element_mem_size(elem_type)
+        if elem_size is None:
+            return None
+        is_pair = _is_pair_element_type(elem_type)
         load_op = _element_load_op(elem_type)
-        if elem_size is None or load_op is None:
+        # load_op is None only for pair types — handled below
+        if load_op is None and not is_pair:
             return None
 
         # Evaluate collection → (ptr, len) on stack
@@ -601,5 +641,15 @@ class DataMixin:
             instructions.append("i32.mul")
             instructions.append("i32.add")
         # Load element
-        instructions.append(load_op)
+        if is_pair:
+            # Pair type (String, Array<T>): load (ptr, len) from two
+            # consecutive i32 slots.  Save computed address first.
+            tmp_addr = self.alloc_local("i32")
+            instructions.append(f"local.set {tmp_addr}")
+            instructions.append(f"local.get {tmp_addr}")
+            instructions.append("i32.load offset=0")
+            instructions.append(f"local.get {tmp_addr}")
+            instructions.append("i32.load offset=4")
+        else:
+            instructions.append(load_op)  # type: ignore[arg-type]
         return instructions

--- a/vera/wasm/helpers.py
+++ b/vera/wasm/helpers.py
@@ -163,8 +163,24 @@ def is_compilable_type(t: Type) -> bool:
 # Array element helpers
 # =====================================================================
 
+def _is_pair_element_type(elem_type: str) -> bool:
+    """Check if an array element type is a pair type (ptr, len).
+
+    String and Array<T> elements are represented as two consecutive
+    i32 values (pointer + length), requiring 8 bytes of storage.
+    Bare "Array" (without type args) also matches, since the element
+    type name from _infer_vera_type may not include type parameters.
+    """
+    return elem_type == "String" or elem_type == "Array" or elem_type.startswith("Array<")
+
+
 def _element_mem_size(elem_type: str) -> int | None:
-    """Get memory size in bytes for an array element type."""
+    """Get memory size in bytes for an array element type.
+
+    Primitive types have fixed sizes.  Pair types (String, Array<T>)
+    use 8 bytes (ptr + len).  All other compound types (ADTs) use
+    4 bytes (i32 heap pointer).
+    """
     sizes = {
         "Int": 8,
         "Nat": 8,
@@ -172,11 +188,22 @@ def _element_mem_size(elem_type: str) -> int | None:
         "Bool": 1,
         "Byte": 1,
     }
-    return sizes.get(elem_type)
+    size = sizes.get(elem_type)
+    if size is not None:
+        return size
+    # Pair types: (ptr, len) = 8 bytes
+    if _is_pair_element_type(elem_type):
+        return 8
+    # ADT / other compound types: i32 heap pointer = 4 bytes
+    return 4
 
 
-def _element_load_op(elem_type: str) -> str:
-    """Get the WASM load instruction for an array element type."""
+def _element_load_op(elem_type: str) -> str | None:
+    """Get the WASM load instruction for an array element type.
+
+    Returns None for pair types (String, Array<T>) which require
+    special two-load handling in the caller.
+    """
     ops = {
         "Int": "i64.load",
         "Nat": "i64.load",
@@ -184,11 +211,22 @@ def _element_load_op(elem_type: str) -> str:
         "Bool": "i32.load8_u",
         "Byte": "i32.load8_u",
     }
-    return ops.get(elem_type, "i64.load")
+    op = ops.get(elem_type)
+    if op is not None:
+        return op
+    # Pair types need two loads — caller must handle specially
+    if _is_pair_element_type(elem_type):
+        return None
+    # ADT / other compound types: single i32 load
+    return "i32.load"
 
 
-def _element_store_op(elem_type: str) -> str:
-    """Get the WASM store instruction for an array element type."""
+def _element_store_op(elem_type: str) -> str | None:
+    """Get the WASM store instruction for an array element type.
+
+    Returns None for pair types (String, Array<T>) which require
+    special two-store handling in the caller.
+    """
     ops = {
         "Int": "i64.store",
         "Nat": "i64.store",
@@ -196,11 +234,22 @@ def _element_store_op(elem_type: str) -> str:
         "Bool": "i32.store8",
         "Byte": "i32.store8",
     }
-    return ops.get(elem_type, "i64.store")
+    op = ops.get(elem_type)
+    if op is not None:
+        return op
+    # Pair types need two stores — caller must handle specially
+    if _is_pair_element_type(elem_type):
+        return None
+    # ADT / other compound types: single i32 store
+    return "i32.store"
 
 
 def _element_wasm_type(elem_type: str) -> str | None:
-    """Get the WASM value type for an array element type."""
+    """Get the WASM value type for an array element type.
+
+    Returns "i32_pair" for pair types (String, Array<T>),
+    "i32" for ADT/compound types, or the native type for primitives.
+    """
     types = {
         "Int": "i64",
         "Nat": "i64",
@@ -208,4 +257,11 @@ def _element_wasm_type(elem_type: str) -> str | None:
         "Bool": "i32",
         "Byte": "i32",
     }
-    return types.get(elem_type)
+    wt = types.get(elem_type)
+    if wt is not None:
+        return wt
+    # Pair types: (ptr, len) represented as i32_pair
+    if _is_pair_element_type(elem_type):
+        return "i32_pair"
+    # ADT / other compound types: i32 heap pointer
+    return "i32"

--- a/vera/wasm/inference.py
+++ b/vera/wasm/inference.py
@@ -294,6 +294,10 @@ class InferenceMixin:
             return self._infer_vera_type(expr.operand)
         if isinstance(expr, ast.FnCall):
             return self._infer_fncall_vera_type(expr)
+        if isinstance(expr, ast.StringLit):
+            return "String"
+        if isinstance(expr, ast.ArrayLit):
+            return "Array"
         return None
 
     def _infer_fncall_vera_type(self, call: ast.FnCall) -> str | None:
@@ -378,13 +382,34 @@ class InferenceMixin:
 
         The collection should be a slot ref like @Array<Int>.0, whose
         type_name is "Array" with type_args (NamedType("Int"),).
+        Also handles chained indexing (e.g. @Array<Array<Int>>.0[0][1])
+        by recursively resolving the inner collection's element type.
+        """
+        te = self._infer_index_element_type_expr(expr)
+        return te.name if te is not None else None
+
+    def _infer_index_element_type_expr(
+        self, expr: ast.IndexExpr,
+    ) -> ast.NamedType | None:
+        """Get the full NamedType of the element from an IndexExpr.
+
+        Returns the NamedType so that chained indexing can inspect
+        nested type_args (e.g. Array<Array<Int>> → Array<Int> → Int).
         """
         coll = expr.collection
         if isinstance(coll, ast.SlotRef):
             if coll.type_name == "Array" and coll.type_args:
                 ta = coll.type_args[0]
                 if isinstance(ta, ast.NamedType):
-                    return ta.name
+                    return ta
+        # Chained indexing: collection is itself an IndexExpr
+        if isinstance(coll, ast.IndexExpr):
+            inner_te = self._infer_index_element_type_expr(coll)
+            if (inner_te is not None
+                    and inner_te.name == "Array" and inner_te.type_args):
+                ta = inner_te.type_args[0]
+                if isinstance(ta, ast.NamedType):
+                    return ta
         return None
 
     def _get_arg_type_info_wasm(


### PR DESCRIPTION
## Summary
- Extend array codegen to handle all element types: ADTs (i32 pointer, 4 bytes), Strings (ptr+len pair, 8 bytes), and nested arrays (ptr+len pair, 8 bytes)
- Fix constructor pair-type field storage (e.g. `Err("msg")` with String field)
- Add chained indexing for nested arrays (`@Array<Array<Int>>.0[0][1]`)
- 17 new tests (13 compound array + 4 updated helper tests), 1,370 tests total

## Test plan
- [x] `pytest tests/ -q` — 1,370 passed
- [x] `mypy vera/` — clean
- [x] `python scripts/check_examples.py` — all 15 examples pass
- [x] `python scripts/check_version_sync.py` — version 0.0.61 consistent

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)