### PR TITLE
Support Exn<E> exception handler compilation (#53)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This document is for AI agents working with the Vera codebase. There are two aud
 
 ## For agents writing Vera code
 
-Read `SKILLS.md` for the full language reference. It covers syntax, slot references, contracts, effects, common mistakes, and working examples that all parse correctly.
+Read `SKILL.md` for the full language reference. It covers syntax, slot references, contracts, effects, common mistakes, and working examples that all parse correctly.
 
 ### Workflow
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.62] - 2026-03-04
+
+### Added
+- **Exn\<E\> exception handler compilation** (C8e, [#53](https://github.com/aallan/vera/issues/53)):
+  `handle[Exn<E>]` expressions now compile to WASM using the exception handling
+  proposal (`try_table`/`catch`/`throw`). Enables compile-and-run for programs
+  using exception-style error handling.
+  - Exception tags declared per `Exn<E>` type parameter
+  - `throw(value)` compiles to WASM `throw` instruction
+  - Cross-function throws work via WASM stack unwinding
+  - Nested `handle[Exn<E>]` expressions with unique labels
+  - `examples/effect_handler.vera` extended with safe division via `Exn<Int>`
+  - 10 new tests, 1,380 tests total
+- **Renamed `SKILLS.md` to `SKILL.md`**: matches the Claude Code skill file naming
+  convention. All references updated across README, AGENTS.md, CLAUDE.md,
+  docs site, and vera/README.md. CHANGELOG historic references preserved.
+- **Added installation instructions to `SKILL.md`**: agents consuming the skill
+  file now get setup instructions (clone, venv, pip install, verify)
+
 ## [0.0.61] - 2026-03-04
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ python scripts/check_version_sync.py  # Verify version consistency
 
 ## Writing Vera code
 
-Read `SKILLS.md` for the full language reference. It covers syntax, slot references, contracts, effects, common mistakes, and working examples.
+Read `SKILL.md` for the full language reference. It covers syntax, slot references, contracts, effects, common mistakes, and working examples.
 
 ## Working on the compiler
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ public fn increment(@Unit -> @Unit)
 }
 ```
 
-> [`examples/increment.vera`](examples/increment.vera) — this example uses `State<Int>` effects, which require effect handler compilation ([#53](https://github.com/aallan/vera/issues/53)) before `vera run` can execute them
+> [`examples/increment.vera`](examples/increment.vera) — this example uses `State<Int>` effects with handler compilation. Compile it with `vera compile examples/increment.vera` or run the function with `vera run examples/increment.vera --fn increment`
 
 ## What Errors Look Like
 
@@ -163,7 +163,7 @@ The language specification is in draft across 13 chapters:
 
 ### Testing
 
-The compiler has 1,370 tests with 88% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations. Every commit validates all 15 example programs and 96 specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference -- coverage tables, test helpers, CI pipeline, and infrastructure details.
+The compiler has 1,380 tests with 88% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations. Every commit validates all 15 example programs and 96 specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference -- coverage tables, test helpers, CI pipeline, and infrastructure details.
 
 ## Roadmap
 
@@ -273,15 +273,15 @@ C8 addresses the accumulated technical debt and UX gaps before v0.1.0. Open issu
 
 **C8e — Codegen gaps** — extend WASM compilation
 
-- ~~[#154](https://github.com/aallan/vera/issues/154) `list_ops.vera` runtime failure — recursive generic ADT codegen~~ — [v0.0.58](https://github.com/aallan/vera/releases/tag/v0.0.58)
-- ~~[#110](https://github.com/aallan/vera/issues/110) name collision detection for flat module compilation~~ — [v0.0.57](https://github.com/aallan/vera/releases/tag/v0.0.57)
-- ~~[#131](https://github.com/aallan/vera/issues/131) nested constructor pattern codegen~~ — [v0.0.56](https://github.com/aallan/vera/releases/tag/v0.0.56)
-- [#53](https://github.com/aallan/vera/issues/53) `Exn<E>` and custom effect handler compilation
+- ~~[#154](https://github.com/aallan/vera/issues/154) `list_ops.vera` runtime failure — recursive generic ADT codegen~~ ([v0.0.58](https://github.com/aallan/vera/releases/tag/v0.0.58))
+- ~~[#110](https://github.com/aallan/vera/issues/110) name collision detection for flat module compilation~~ ([v0.0.57](https://github.com/aallan/vera/releases/tag/v0.0.57))
+- ~~[#131](https://github.com/aallan/vera/issues/131) nested constructor pattern codegen~~ ([v0.0.56](https://github.com/aallan/vera/releases/tag/v0.0.56))
+- ~~[#53](https://github.com/aallan/vera/issues/53) `Exn<E>` and custom effect handler compilation~~ ([v0.0.62](https://github.com/aallan/vera/releases/tag/v0.0.62))
 - [#51](https://github.com/aallan/vera/issues/51) garbage collection for WASM linear memory
-- ~~[#132](https://github.com/aallan/vera/issues/132) arrays of compound types in codegen~~ — [v0.0.61](https://github.com/aallan/vera/releases/tag/v0.0.61)
+- ~~[#132](https://github.com/aallan/vera/issues/132) arrays of compound types in codegen~~ ([v0.0.61](https://github.com/aallan/vera/releases/tag/v0.0.61))
 - [#52](https://github.com/aallan/vera/issues/52) dynamic string construction
-- ~~[#134](https://github.com/aallan/vera/issues/134) string built-in operations (length, concat, slice)~~ — [v0.0.50](https://github.com/aallan/vera/releases/tag/v0.0.50)
-- ~~[#174](https://github.com/aallan/vera/issues/174) `parse_nat` should return `Result<Nat, String>` per spec~~ — [v0.0.60](https://github.com/aallan/vera/releases/tag/v0.0.60)
+- ~~[#134](https://github.com/aallan/vera/issues/134) string built-in operations (length, concat, slice)~~ ([v0.0.50](https://github.com/aallan/vera/releases/tag/v0.0.50))
+- ~~[#174](https://github.com/aallan/vera/issues/174) `parse_nat` should return `Result<Nat, String>` per spec~~ ([v0.0.60](https://github.com/aallan/vera/releases/tag/v0.0.60))
 - [#106](https://github.com/aallan/vera/issues/106) universal to-string conversion (Show/Display)
 - [#56](https://github.com/aallan/vera/issues/56) incremental compilation
 
@@ -372,10 +372,10 @@ OK: examples/absolute_value.vera
 ```
 $ vera verify examples/safe_divide.vera
 OK: examples/safe_divide.vera
-Verification: 2 verified (Tier 1)
+Verification: 4 verified (Tier 1)
 ```
 
-`vera verify` runs the type checker and then verifies contracts using Z3. Tier 1 contracts (decidable arithmetic, comparisons, Boolean logic, match expressions, ADT constructors, and decreases clauses) are proved automatically. Contracts that Z3 cannot decide are reported as Tier 3 (runtime checks) with a warning. Across all 15 examples, 96 of 99 contracts (97.0%) are verified statically.
+`vera verify` runs the type checker and then verifies contracts using Z3. Tier 1 contracts (decidable arithmetic, comparisons, Boolean logic, match expressions, ADT constructors, and decreases clauses) are proved automatically. Contracts that Z3 cannot decide are reported as Tier 3 (runtime checks) with a warning. Across all 15 examples, 100 of 105 contracts (95.2%) are verified statically.
 
 ### Format a program
 
@@ -479,7 +479,7 @@ See `examples/` for more programs, and the [language specification](spec/) for t
 
 Vera ships with three files for LLM agents:
 
-- [`SKILLS.md`](SKILLS.md) — Complete language reference for agents writing Vera code. Covers syntax, slot references, contracts, effects, common mistakes, and working examples.
+- [`SKILL.md`](SKILL.md) — Complete language reference for agents writing Vera code. Covers syntax, slot references, contracts, effects, common mistakes, and working examples.
 - [`AGENTS.md`](AGENTS.md) — Instructions for any agent system (Copilot, Cursor, Windsurf, custom). Covers both writing Vera code and working on the compiler.
 - [`CLAUDE.md`](CLAUDE.md) — Project orientation for Claude Code. Key commands, layout, workflows, and invariants.
 
@@ -487,18 +487,18 @@ Vera ships with three files for LLM agents:
 
 #### Claude Code
 
-If you're working in this repo, Claude Code discovers `SKILLS.md` and `CLAUDE.md` automatically. For other projects, install the skill manually:
+If you're working in this repo, Claude Code discovers `SKILL.md` and `CLAUDE.md` automatically. For other projects, install the skill manually:
 
 ```bash
 mkdir -p ~/.claude/skills/vera-language
-cp /path/to/vera/SKILLS.md ~/.claude/skills/vera-language/SKILL.md
+cp /path/to/vera/SKILL.md ~/.claude/skills/vera-language/SKILL.md
 ```
 
 The skill is now available across all your Claude Code projects. Claude will read it automatically when you ask it to write Vera code.
 
 #### Claude.ai
 
-1. Create a folder called `vera-language` containing a single file named `Skill.md` (copy `SKILLS.md` into this folder and rename it to `Skill.md`)
+1. Create a folder called `vera-language` containing a single file named `Skill.md` (copy `SKILL.md` into this folder)
 2. Compress the folder into a ZIP file — the structure should be `vera-language.zip → vera-language/ → Skill.md`
 3. In Claude.ai, go to **Settings > Capabilities > Skills** and upload the ZIP file
 4. The skill is now available in your conversations — Claude will use it automatically when you ask it to write Vera code
@@ -512,7 +512,7 @@ client = anthropic.Anthropic()
 
 skill = client.beta.skills.create(
     display_title="Vera Language",
-    files=[("SKILL.md", open("SKILLS.md", "rb"))],
+    files=[("SKILL.md", open("SKILL.md", "rb"))],
     betas=["skills-2025-10-02"],
 )
 
@@ -529,11 +529,11 @@ response = client.beta.messages.create(
 
 #### Other Models
 
-Point the model at `SKILLS.md` by including it in the system prompt, as a file attachment, or as a retrieval document. The file is self-contained and works with any model that can read markdown.
+Point the model at `SKILL.md` by including it in the system prompt, as a file attachment, or as a retrieval document. The file is self-contained and works with any model that can read markdown.
 
 ### Agent Quickstart
 
-If you are an LLM agent, read [`SKILLS.md`](SKILLS.md) for the full language reference. Here is the minimal workflow:
+If you are an LLM agent, read [`SKILL.md`](SKILL.md) for the full language reference. Here is the minimal workflow:
 
 Install (if not already available):
 
@@ -568,7 +568,7 @@ If the check or verification fails, the error message tells you exactly what wen
 
 ```
 vera/
-├── SKILLS.md                      # Language reference for LLM agents
+├── SKILL.md                       # Language reference for LLM agents
 ├── AGENTS.md                      # Instructions for any AI agent system
 ├── CLAUDE.md                      # Project orientation for Claude Code
 ├── TESTING.md                     # Testing reference (single source of truth)

--- a/SKILL.md
+++ b/SKILL.md
@@ -7,6 +7,29 @@ description: Write programs in the Vera programming language. Use when asked to 
 
 Vera is a programming language designed for LLMs to write. It uses typed slot references instead of variable names, requires contracts on every function, and makes all effects explicit.
 
+## Installation
+
+Vera requires Python 3.11 or later. Install it from the repository:
+
+```bash
+git clone https://github.com/aallan/vera.git && cd vera
+python -m venv .venv && source .venv/bin/activate
+pip install -e .
+```
+
+This installs the `vera` command and all runtime dependencies (Lark parser, Z3 solver, wasmtime). After installation, verify it works:
+
+```bash
+vera check examples/hello_world.vera    # should print "OK: examples/hello_world.vera"
+vera run examples/hello_world.vera      # should print "Hello, World!"
+```
+
+If you are working on the compiler itself, install development dependencies too:
+
+```bash
+pip install -e ".[dev]"
+```
+
 ## Toolchain
 
 ```bash

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,12 +6,12 @@ This is the single source of truth for Vera's testing infrastructure, coverage d
 
 | Metric | Value |
 |--------|-------|
-| **Tests** | 1,370 across 19 files (~17,000 lines of test code) |
+| **Tests** | 1,380 across 19 files (~17,000 lines of test code) |
 | **Compiler code coverage** | 88% of 6,861 statements (CI minimum: 80%) |
 | **Example programs** | 15, all validated through `vera check` + `vera verify` |
 | **Spec code blocks** | 96 parseable blocks from 13 spec chapters: 72 parse, 57 type-check, 56 verify |
 | **README code blocks** | 6 Vera blocks (5 validated, 1 allowlisted future syntax) |
-| **Contract verification** | 96 of 99 contracts (97.0%) verified statically (Tier 1) |
+| **Contract verification** | 100 of 105 contracts (95.2%) verified statically (Tier 1) |
 | **CI matrix** | 6 combinations (Python 3.11/3.12/3.13 x Ubuntu/macOS) |
 
 ## Running Tests
@@ -43,7 +43,7 @@ python scripts/check_version_sync.py                 # version consistency
 | `test_ast.py` | 87 | 935 | AST transformation, node structure, serialisation |
 | `test_checker.py` | 189 | 2,482 | Type synthesis, slot resolution, effects, effect subtyping, contracts, exhaustiveness, cross-module typing, visibility, error codes, string built-ins, generic rejection |
 | `test_verifier.py` | 97 | 1,580 | Z3 verification, counterexamples, tier classification, call-site preconditions, pipe operator, cross-module contracts, match/ADT verification, decreases verification, mutual recursion |
-| `test_codegen.py` | 343 | 4,095 | WASM compilation, arithmetic, Float64, Byte, arrays (incl. compound element types), ADTs, match (incl. nested patterns), generics, State\<T\>, control flow, strings, IO, bounds checking, quantifiers, assert/assume, refinement type aliases, pipe operator, string built-ins, built-in shadowing, parse\_nat Result, example round-trips |
+| `test_codegen.py` | 353 | 4,276 | WASM compilation, arithmetic, Float64, Byte, arrays (incl. compound element types), ADTs, match (incl. nested patterns), generics, State\<T\>, Exn\<E\> handlers, control flow, strings, IO, bounds checking, quantifiers, assert/assume, refinement type aliases, pipe operator, string built-ins, built-in shadowing, parse\_nat Result, example round-trips |
 | `test_codegen_contracts.py` | 32 | 576 | Runtime pre/postconditions, contract fail messages, old/new state postconditions |
 | `test_codegen_monomorphize.py` | 17 | 360 | Generic instantiation, type inference, monomorphization edge cases |
 | `test_codegen_closures.py` | 17 | 416 | Closure lifting, captured variables, higher-order functions |
@@ -93,17 +93,19 @@ Across all 15 example programs:
 
 | Metric | Value |
 |--------|-------|
-| **Tier 1 (static)** | 96 contracts — proved automatically by Z3 |
-| **Tier 3 (runtime)** | 3 contracts — verified at runtime via assertion checks |
-| **Total** | 99 contracts (97.0% static) |
+| **Tier 1 (static)** | 100 contracts — proved automatically by Z3 |
+| **Tier 3 (runtime)** | 5 contracts — verified at runtime via assertion checks |
+| **Total** | 105 contracts (95.2% static) |
 
-The 3 remaining Tier 3 contracts and why they cannot be promoted:
+The 5 remaining Tier 3 contracts and why they cannot be promoted:
 
 | Example | Contract | Reason |
 |---------|----------|--------|
 | generics.vera | `ensures(@T.result == @T.0)` | Generic type parameters have no Z3 sort |
 | generics.vera | `ensures(@A.result == @A.0)` | Generic type parameters have no Z3 sort |
 | increment.vera | `ensures(new(State<Int>) == old(State<Int>) + 1)` | `old`/`new` state modeling not yet implemented |
+| modules.vera | postcondition in `abs_max` | Cross-module call outside decidable fragment |
+| modules.vera | postcondition in `qualified_abs` | Cross-module call outside decidable fragment |
 
 The Tier 1 fragment covers: integer/boolean arithmetic, comparisons, if/else, let bindings, match expressions, ADT constructors, function calls (modular postcondition), `length`, and `decreases` clauses (self-recursive, mutual recursion via where-blocks, Nat and structural ADT measures).
 
@@ -128,7 +130,7 @@ How Vera language features (by spec chapter) map to test files and example progr
 | Ch 6: Contracts | Decreases clauses, assert/assume | test_verifier, test_codegen | factorial |
 | Ch 6: Contracts | Quantifiers (forall, exists) | test_codegen, test_verifier | quantifiers |
 | Ch 7: Effects | Pure, IO, State\<T\> | test_codegen, test_checker | hello_world, increment |
-| Ch 7: Effects | Effect handlers (handle/resume) | test_codegen, test_checker | effect_handler |
+| Ch 7: Effects | Effect handlers (State\<T\>, Exn\<E\>) | test_codegen, test_checker | effect_handler |
 | Ch 7: Effects | Effect subtyping (§7.8), call-site checking | test_types, test_checker | — |
 | Ch 2: Types | Bidirectional type checking (local inference) | test_checker | — |
 | Ch 4: Expressions | Nested constructor patterns in match | test_codegen | pattern_matching |
@@ -196,10 +198,10 @@ These run in both pre-commit hooks and CI, so issues are caught locally before t
 | Stage | Pass | Allowlisted | Categories |
 |-------|-----:|------------:|------------|
 | **Parse** | 72 | 24 | FUTURE (9), FRAGMENT (15) |
-| **Type-check** | 57 | 15 | INCOMPLETE (13), FUTURE (2) |
+| **Type-check** | 57 | 15 | INCOMPLETE (14), FUTURE (1) |
 | **Verify** | 56 | 1 | ILLUSTRATIVE (1) |
 
-Allowlisted entries have stale-detection: when a feature lands or a spec edit shifts line numbers, CI flags the entry for removal. The 13 INCOMPLETE check entries reference functions, types, or imports not defined in the block (e.g. `abs`, `Tuple`, `IO.print`, `array_map`). The 2 FUTURE check entries use `Exn` exception handling and `async/await`. The 1 ILLUSTRATIVE verify entry is a spec example demonstrating multiple postconditions syntax where the contract is intentionally imprecise.
+Allowlisted entries have stale-detection: when a feature lands or a spec edit shifts line numbers, CI flags the entry for removal. The 14 INCOMPLETE check entries reference functions, types, or imports not defined in the block (e.g. `abs`, `Tuple`, `IO.print`, `array_map`, `parse_int`). The 1 FUTURE check entry uses `async/await`. The 1 ILLUSTRATIVE verify entry is a spec example demonstrating multiple postconditions syntax where the contract is intentionally imprecise.
 
 ## Pre-commit Hooks
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -460,8 +460,8 @@
         GitHub
       </a>
       <a href="#install" class="cta-btn secondary">Install</a>
-      <a href="https://raw.githubusercontent.com/aallan/vera/main/SKILLS.md" class="cta-btn outline">
-        For Agents → SKILLS.md
+      <a href="https://raw.githubusercontent.com/aallan/vera/main/SKILL.md" class="cta-btn outline">
+        For Agents → SKILL.md
       </a>
     </div>
   </div>
@@ -654,17 +654,17 @@ vera run examples/hello_world.vera</pre>
       <h3 style="font-family: 'DM Serif Display', Georgia, serif; font-size: 1.35rem; color: var(--brown-900); margin-top: 2.5rem; margin-bottom: 0.75rem;">For Agents</h3>
       <p style="color: var(--brown-500); margin-bottom: 1rem; font-size: 0.95rem;">Vera ships with three files for LLM agents:</p>
       <div style="margin-bottom: 1.25rem;">
-        <p style="color: var(--brown-500); font-size: 0.95rem; margin-bottom: 0.5rem;"><a href="https://raw.githubusercontent.com/aallan/vera/main/SKILLS.md"><code>SKILLS.md</code></a> &mdash; Complete language reference for agents writing Vera code. Covers syntax, slot references, contracts, effects, common mistakes, and working examples.</p>
+        <p style="color: var(--brown-500); font-size: 0.95rem; margin-bottom: 0.5rem;"><a href="https://raw.githubusercontent.com/aallan/vera/main/SKILL.md"><code>SKILL.md</code></a> &mdash; Complete language reference for agents writing Vera code. Covers syntax, slot references, contracts, effects, common mistakes, and working examples.</p>
         <p style="color: var(--brown-500); font-size: 0.95rem; margin-bottom: 0.5rem;"><a href="https://github.com/aallan/vera/blob/main/AGENTS.md"><code>AGENTS.md</code></a> &mdash; Instructions for any agent system (Copilot, Cursor, Windsurf, custom). Covers both writing Vera code and working on the compiler.</p>
         <p style="color: var(--brown-500); font-size: 0.95rem;"><a href="https://github.com/aallan/vera/blob/main/CLAUDE.md"><code>CLAUDE.md</code></a> &mdash; Project orientation for Claude Code. Key commands, layout, workflows, and invariants.</p>
       </div>
 
-      <p style="color: var(--brown-500); margin-bottom: 0.75rem; font-size: 0.95rem;">If you're working in the Vera repo, Claude Code discovers <a href="https://raw.githubusercontent.com/aallan/vera/main/SKILLS.md"><code>SKILLS.md</code></a> and <a href="https://github.com/aallan/vera/blob/main/CLAUDE.md"><code>CLAUDE.md</code></a> automatically. For other projects to give Claude access to the Vera language you can install the skill manually:</p>
+      <p style="color: var(--brown-500); margin-bottom: 0.75rem; font-size: 0.95rem;">If you're working in the Vera repo, Claude Code discovers <a href="https://raw.githubusercontent.com/aallan/vera/main/SKILL.md"><code>SKILL.md</code></a> and <a href="https://github.com/aallan/vera/blob/main/CLAUDE.md"><code>CLAUDE.md</code></a> automatically. For other projects to give Claude access to the Vera language you can install the skill manually:</p>
       <div class="install-steps" style="margin-bottom: 1rem;">
 <pre>mkdir -p ~/.claude/skills/vera-language
-cp /path/to/vera/SKILLS.md ~/.claude/skills/vera-language/SKILL.md</pre>
+cp /path/to/vera/SKILL.md ~/.claude/skills/vera-language/SKILL.md</pre>
       </div>
-      <p style="color: var(--brown-500); font-size: 0.95rem;">The skill is now available across all your Claude Code projects. Claude will read it automatically when you ask it to write Vera code. For other models, point the model at <a href="https://raw.githubusercontent.com/aallan/vera/main/SKILLS.md"><code>SKILLS.md</code></a> by including it in the system prompt, as a file attachment, or as a retrieval document. The file is self-contained and works with any model that can read markdown.</p>
+      <p style="color: var(--brown-500); font-size: 0.95rem;">The skill is now available across all your Claude Code projects. Claude will read it automatically when you ask it to write Vera code. For other models, point the model at <a href="https://raw.githubusercontent.com/aallan/vera/main/SKILL.md"><code>SKILL.md</code></a> by including it in the system prompt, as a file attachment, or as a retrieval document. The file is self-contained and works with any model that can read markdown.</p>
     </div>
   </section>
 
@@ -692,7 +692,7 @@ cp /path/to/vera/SKILLS.md ~/.claude/skills/vera-language/SKILL.md</pre>
       <div class="footer-links">
         <a href="https://github.com/aallan/vera">GitHub</a>
         <a href="https://github.com/aallan/vera/blob/main/spec/">Specification</a>
-        <a href="https://raw.githubusercontent.com/aallan/vera/main/SKILLS.md">SKILLS.md</a>
+        <a href="https://raw.githubusercontent.com/aallan/vera/main/SKILL.md">SKILL.md</a>
         <a href="https://github.com/aallan/vera/blob/main/AGENTS.md">AGENTS.md</a>
         <a href="https://github.com/aallan/vera/blob/main/LICENSE">MIT Licence</a>
       </div>

--- a/examples/effect_handler.vera
+++ b/examples/effect_handler.vera
@@ -65,12 +65,44 @@ public fn test_put_get(@Unit -> @Int)
   }
 }
 
--- Exception effect (demonstrates non-State handler, not compilable)
+-- Exception effect — Exn<E> has one operation: throw(E -> Never)
+-- The handler catches thrown values using WASM exception handling
 effect Exn<E> {
-  op throw(E -> Unit);
+  op throw(E -> Never);
 }
 
 private data Option<T> {
   None,
   Some(T)
+}
+
+-- A function that may throw an Int exception
+private fn checked_div(@Int, @Int -> @Int)
+  requires(true)
+  ensures(true)
+  effects(<Exn<Int>>)
+{
+  if @Int.1 == 0 then { throw(0 - 1) } else { @Int.0 / @Int.1 }
+}
+
+-- Handle the exception: return -1 on division by zero
+public fn safe_div(@Int, @Int -> @Int)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  handle[Exn<Int>] {
+    throw(@Int) -> { @Int.0 }
+  } in {
+    checked_div(@Int.0, @Int.1)
+  }
+}
+
+-- Entry point: demonstrate Exn<E> handlers
+public fn main(@Unit -> @Int)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  safe_div(10, 2) + safe_div(7, 0)
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.61"
+version = "0.0.62"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/scripts/check_spec_examples.py
+++ b/scripts/check_spec_examples.py
@@ -170,8 +170,8 @@ CHECK_ALLOWLIST: dict[tuple[str, int], str] = {
     # FUTURE — uses features not yet implemented in the checker
     # =================================================================
 
-    # Chapter 7 — Exn effect handler (exception handling not implemented)
-    ("07-effects.md", 202): "FUTURE",        # handle[Exn<String>] + parse_int
+    # Chapter 7 — Exn handler references parse_int (not defined in block)
+    ("07-effects.md", 202): "INCOMPLETE",    # handle[Exn<String>] + parse_int
 
     # Chapter 9 — async/await (future feature, tracked in spec as not implemented)
     ("09-standard-library.md", 227): "FUTURE",  # async, await, Http, Future

--- a/spec/11-compilation.md
+++ b/spec/11-compilation.md
@@ -452,9 +452,17 @@ Handler clauses (e.g. `get(@Unit) -> { resume(@Int.0) }`) describe the handler's
 
 A `handle[State<T>]` expression discharges the `State<T>` effect. This means a function can be declared `effects(pure)` and still use `get`/`put` operations within a handler body. The compiler registers the State<T> host imports by scanning the function body for handle expressions, not just the function's declared effects.
 
-### 11.11.4 Unsupported Handlers
+### 11.11.4 Exn\<E\> Exception Handlers
 
-Handler types other than `State<T>` (e.g. `Exn<E>`, custom effects) are not yet compilable. Functions containing unsupported handler types are skipped with a warning.
+`Exn<E>` handlers compile to WASM using the exception handling proposal (`try_table`/`catch`/`throw`). The compiler generates:
+
+1. A `tag` declaration for each unique `Exn<E>` type parameter (e.g. `(tag $exn_Int (param i64))`)
+2. `throw` instructions where `throw(value)` is called
+3. `try_table`/`catch` blocks wrapping the handler body, with the caught value bound to a local for the handler clause
+
+Cross-function throws work via WASM stack unwinding — no additional codegen is needed for functions that declare `effects(<Exn<E>>)` and call `throw`.
+
+Custom effect handlers (general continuations) are not yet compilable. Functions containing unsupported handler types are skipped with a warning.
 
 ## 11.12 Array Compilation
 
@@ -576,5 +584,5 @@ The current compilation model has the following limitations, each tracked as a G
 | Flat module compilation | [#110](https://github.com/aallan/vera/issues/110) | Imported functions are compiled into the importing module; name collisions are detected (E608/E609/E610); qualified-call disambiguation via name mangling is tracked separately |
 | No garbage collection | [#51](https://github.com/aallan/vera/issues/51) | Bump allocator only; linear memory is not reclaimed |
 | String constants only | [#52](https://github.com/aallan/vera/issues/52) | No dynamic string construction |
-| Only State\<T\> handlers | [#53](https://github.com/aallan/vera/issues/53) | Exn\<E\> and custom effect handlers not yet compilable |
+| ~~Only State\<T\> handlers~~ | ~~[#53](https://github.com/aallan/vera/issues/53)~~ | ~~Resolved in v0.0.62 — Exn\<E\> handlers now compile via WASM exception handling; custom effect handlers still unsupported~~ |
 | ~~Arrays of compound types~~ | ~~[#132](https://github.com/aallan/vera/issues/132)~~ | ~~Resolved in v0.0.61 — arrays now support all element types including ADTs, Strings, and nested arrays~~ |

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -2565,11 +2565,11 @@ public fn test(@Unit -> @Int)
         assert "state_put_Int" in result.wat
         assert "(import" in result.wat
 
-    def test_unsupported_handler_skipped(self) -> None:
-        """Non-State handler causes function to be skipped."""
+    def test_exn_handler_compiles(self) -> None:
+        """Exn<E> handler compiles to WASM using exception handling."""
         src = """\
 effect Exn<E> {
-  op throw(E -> Unit);
+  op throw(E -> Never);
 }
 private data Option<T> { None, Some(T) }
 public fn test(@Int -> @Option<Int>)
@@ -2583,8 +2583,9 @@ public fn test(@Int -> @Option<Int>)
 }
 """
         result = _compile(src)
-        # Function should be skipped (Exn handler not supported)
-        assert "test" not in result.exports
+        assert "test" in result.exports
+        assert "try_table" in result.wat
+        assert "tag $exn_Int" in result.wat
 
     def test_effect_handler_example_compiles(self) -> None:
         """examples/effect_handler.vera compiles without errors."""
@@ -2620,6 +2621,186 @@ public fn test(@Int -> @Option<Int>)
         result = _compile_ok(source)
         exec_result = execute(result, fn_name="test_put_get")
         assert exec_result.value == 99
+
+    def test_effect_handler_example_safe_div(self) -> None:
+        """examples/effect_handler.vera safe_div(10, 2) returns 5."""
+        from pathlib import Path
+        path = Path(__file__).parent.parent / "examples" / "effect_handler.vera"
+        source = path.read_text()
+        result = _compile_ok(source)
+        exec_result = execute(result, fn_name="safe_div", args=[10, 2])
+        assert exec_result.value == 5
+
+    def test_effect_handler_example_safe_div_zero(self) -> None:
+        """examples/effect_handler.vera safe_div(7, 0) returns -1."""
+        from pathlib import Path
+        path = Path(__file__).parent.parent / "examples" / "effect_handler.vera"
+        source = path.read_text()
+        result = _compile_ok(source)
+        exec_result = execute(result, fn_name="safe_div", args=[7, 0])
+        assert exec_result.value == -1
+
+    def test_effect_handler_example_main(self) -> None:
+        """examples/effect_handler.vera main returns 4."""
+        from pathlib import Path
+        path = Path(__file__).parent.parent / "examples" / "effect_handler.vera"
+        source = path.read_text()
+        result = _compile_ok(source)
+        exec_result = execute(result, fn_name="main")
+        assert exec_result.value == 4
+
+
+# =====================================================================
+# Exn<E> exception handler compilation
+# =====================================================================
+
+
+class TestExnHandlers:
+    """Tests for Exn<E> effect handler compilation using WASM exceptions."""
+
+    def test_exn_throw_caught(self) -> None:
+        """Body throws, handler catches and transforms the value."""
+        src = """\
+effect Exn<E> {
+  op throw(E -> Never);
+}
+public fn test(@Unit -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  handle[Exn<Int>] {
+    throw(@Int) -> { @Int.0 + 100 }
+  } in {
+    throw(42)
+  }
+}
+"""
+        assert _run(src, fn="test") == 142
+
+    def test_exn_no_throw(self) -> None:
+        """Body completes normally, handler clause is not invoked."""
+        src = """\
+effect Exn<E> {
+  op throw(E -> Never);
+}
+public fn test(@Unit -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  handle[Exn<Int>] {
+    throw(@Int) -> { @Int.0 + 100 }
+  } in {
+    99
+  }
+}
+"""
+        assert _run(src, fn="test") == 99
+
+    def test_exn_cross_function(self) -> None:
+        """Function with Exn effect throws, caller catches via handle."""
+        src = """\
+effect Exn<E> {
+  op throw(E -> Never);
+}
+private fn risky(@Int -> @Int)
+  requires(true) ensures(true) effects(<Exn<Int>>)
+{
+  if @Int.0 > 0 then { throw(@Int.0) } else { 0 }
+}
+public fn test(@Unit -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  handle[Exn<Int>] {
+    throw(@Int) -> { @Int.0 * 2 }
+  } in {
+    risky(21)
+  }
+}
+"""
+        assert _run(src, fn="test") == 42
+
+    def test_exn_no_throw_cross_function(self) -> None:
+        """Cross-function call that doesn't throw."""
+        src = """\
+effect Exn<E> {
+  op throw(E -> Never);
+}
+private fn safe(@Int -> @Int)
+  requires(true) ensures(true) effects(<Exn<Int>>)
+{
+  if @Int.0 > 100 then { throw(@Int.0) } else { @Int.0 + 1 }
+}
+public fn test(@Unit -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  handle[Exn<Int>] {
+    throw(@Int) -> { 0 - 1 }
+  } in {
+    safe(10)
+  }
+}
+"""
+        assert _run(src, fn="test") == 11
+
+    def test_exn_with_io(self) -> None:
+        """Exn handler inside a function with IO effects."""
+        src = """\
+effect Exn<E> {
+  op throw(E -> Never);
+}
+public fn test(@Unit -> @Int)
+  requires(true) ensures(true) effects(<IO>)
+{
+  handle[Exn<Int>] {
+    throw(@Int) -> { @Int.0 }
+  } in {
+    IO.print("before throw");
+    throw(77)
+  }
+}
+"""
+        result = _compile_ok(src)
+        exec_result = execute(result, fn_name="test")
+        assert exec_result.value == 77
+        assert exec_result.stdout == "before throw"
+
+    def test_exn_nested_inner_catches(self) -> None:
+        """Nested handlers — inner catches, outer not triggered."""
+        src = """\
+effect Exn<E> {
+  op throw(E -> Never);
+}
+public fn test(@Unit -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  handle[Exn<Int>] {
+    throw(@Int) -> { 0 - 1 }
+  } in {
+    handle[Exn<Int>] {
+      throw(@Int) -> { @Int.0 + 500 }
+    } in {
+      throw(10)
+    }
+  }
+}
+"""
+        assert _run(src, fn="test") == 510
+
+    def test_exn_nat_type(self) -> None:
+        """Exn<Nat> with Nat exception value."""
+        src = """\
+effect Exn<E> {
+  op throw(E -> Never);
+}
+public fn test(@Unit -> @Nat)
+  requires(true) ensures(true) effects(pure)
+{
+  handle[Exn<Nat>] {
+    throw(@Nat) -> { @Nat.0 + 1000 }
+  } in {
+    throw(42)
+  }
+}
+"""
+        assert _run(src, fn="test") == 1042
 
 
 # =====================================================================

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -1478,9 +1478,9 @@ private fn sum(@List<Int> -> @Int)
             t1 += result.summary.tier1_verified
             t3 += result.summary.tier3_runtime
             total += result.summary.total
-        assert t1 == 94, f"Expected 94 T1, got {t1}"
+        assert t1 == 100, f"Expected 100 T1, got {t1}"
         assert t3 == 5, f"Expected 5 T3, got {t3}"
-        assert total == 99, f"Expected 99 total, got {total}"
+        assert total == 105, f"Expected 105 total, got {total}"
 
 
 # =====================================================================

--- a/vera/README.md
+++ b/vera/README.md
@@ -4,7 +4,7 @@ Architecture documentation for the Vera compiler (`vera/` package). This is for 
 
 For other documentation:
 - [Root README](../README.md) — project overview, getting started, language examples
-- [SKILLS.md](../SKILLS.md) — language reference for LLM agents writing Vera code
+- [SKILL.md](../SKILL.md) — language reference for LLM agents writing Vera code
 - [spec/](../spec/) — formal language specification (13 chapters, 0-12)
 - [CONTRIBUTING.md](../CONTRIBUTING.md) — contributor workflow and conventions
 
@@ -602,4 +602,4 @@ To add a new WASM type mapping, update `wasm_type()` in `wasm/helpers.py` and th
 
 ---
 
-**See also:** [Project README](../README.md) · [Language spec](../spec/) · [SKILLS.md](../SKILLS.md) · [CONTRIBUTING.md](../CONTRIBUTING.md)
+**See also:** [Project README](../README.md) · [Language spec](../spec/) · [SKILL.md](../SKILL.md) · [CONTRIBUTING.md](../CONTRIBUTING.md)

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.61"
+__version__ = "0.0.62"

--- a/vera/codegen/api.py
+++ b/vera/codegen/api.py
@@ -127,7 +127,9 @@ def execute(
     if not result.ok:
         raise RuntimeError("Cannot execute: compilation had errors")
 
-    engine = wasmtime.Engine()
+    config = wasmtime.Config()
+    config.wasm_exceptions = True
+    engine = wasmtime.Engine(config)
     module = wasmtime.Module(engine, result.wat)
     linker = wasmtime.Linker(engine)
     store = wasmtime.Store(engine)

--- a/vera/codegen/assembly.py
+++ b/vera/codegen/assembly.py
@@ -39,6 +39,12 @@ class AssemblyMixin:
                 f"(func $vera.state_put_{type_name} (param {wasm_t})))"
             )
 
+        # Exception tags for Exn<E>
+        for type_name, wasm_t in self._exn_types:
+            parts.append(
+                f"  (tag $exn_{type_name} (param {wasm_t}))"
+            )
+
         # Memory (for string data and heap)
         if self._needs_memory or self.string_pool.has_strings():
             parts.append('  (memory (export "memory") 1)')

--- a/vera/codegen/compilability.py
+++ b/vera/codegen/compilability.py
@@ -33,6 +33,10 @@ class CompilabilityMixin:
                         # State<T> — T must be a compilable primitive
                         if not self._check_state_type(decl, eff):
                             return False
+                    elif eff.name == "Exn":
+                        # Exn<E> — E must be a compilable type
+                        if not self._check_exn_type(decl, eff):
+                            return False
                     else:
                         self._warning(
                             decl,
@@ -106,21 +110,63 @@ class CompilabilityMixin:
             self._state_types.append((type_name, wt))
         return True
 
-    def _scan_body_for_state_handlers(self, node: ast.Node) -> None:
-        """Walk a function body looking for handle[State<T>] expressions.
+    def _check_exn_type(
+        self, decl: ast.FnDecl, eff: ast.EffectRef
+    ) -> bool:
+        """Validate an Exn<E> effect and register its type.
 
-        When found, registers the State<T> type for host import generation.
+        Returns True if compilable, False otherwise.
+        """
+        if not eff.type_args or len(eff.type_args) != 1:
+            self._warning(
+                decl,
+                f"Function '{decl.name}' uses Exn without "
+                f"a type argument — skipped.",
+                rationale="Exn<E> requires exactly one type argument.",
+                error_code="E611",
+            )
+            return False
+        type_arg = eff.type_args[0]
+        wt = self._type_expr_to_wasm_type(type_arg)
+        if wt is None or wt == "unsupported":
+            self._warning(
+                decl,
+                f"Function '{decl.name}' uses Exn with "
+                f"unsupported type — skipped.",
+                rationale="Exn<E> requires a compilable type "
+                "(Int, Nat, Bool, Float64, String).",
+                error_code="E612",
+            )
+            return False
+        type_name = self._type_expr_to_slot_name(type_arg)
+        if type_name and (type_name, wt) not in self._exn_types:
+            self._exn_types.append((type_name, wt))
+        return True
+
+    def _scan_body_for_state_handlers(self, node: ast.Node) -> None:
+        """Walk a function body looking for handle expressions.
+
+        Registers State<T> types for host import generation and
+        Exn<E> types for exception tag generation.
         """
         if isinstance(node, ast.HandleExpr):
-            if (isinstance(node.effect, ast.EffectRef)
-                    and node.effect.name == "State"):
-                if node.effect.type_args and len(node.effect.type_args) == 1:
-                    type_arg = node.effect.type_args[0]
-                    wt = self._type_expr_to_wasm_type(type_arg)
-                    if wt and wt not in ("unsupported", "i32_pair"):
-                        type_name = self._type_expr_to_slot_name(type_arg)
-                        if type_name and (type_name, wt) not in self._state_types:
-                            self._state_types.append((type_name, wt))
+            if isinstance(node.effect, ast.EffectRef):
+                if node.effect.name == "State":
+                    if node.effect.type_args and len(node.effect.type_args) == 1:
+                        type_arg = node.effect.type_args[0]
+                        wt = self._type_expr_to_wasm_type(type_arg)
+                        if wt and wt not in ("unsupported", "i32_pair"):
+                            type_name = self._type_expr_to_slot_name(type_arg)
+                            if type_name and (type_name, wt) not in self._state_types:
+                                self._state_types.append((type_name, wt))
+                elif node.effect.name == "Exn":
+                    if node.effect.type_args and len(node.effect.type_args) == 1:
+                        type_arg = node.effect.type_args[0]
+                        wt = self._type_expr_to_wasm_type(type_arg)
+                        if wt and wt != "unsupported":
+                            type_name = self._type_expr_to_slot_name(type_arg)
+                            if type_name and (type_name, wt) not in self._exn_types:
+                                self._exn_types.append((type_name, wt))
             self._scan_expr_for_handlers(node.body)
             return
         self._scan_expr_for_handlers(node)

--- a/vera/codegen/core.py
+++ b/vera/codegen/core.py
@@ -72,6 +72,7 @@ class CodeGenerator(
         self._needs_contract_fail: bool = False
         self._needs_memory: bool = False
         self._state_types: list[tuple[str, str]] = []  # (type_name, wasm_type)
+        self._exn_types: list[tuple[str, str]] = []  # (type_name, wasm_type)
 
         # ADT layout metadata (populated during registration)
         self._adt_layouts: dict[str, dict[str, ConstructorLayout]] = {}

--- a/vera/codegen/functions.py
+++ b/vera/codegen/functions.py
@@ -25,7 +25,7 @@ class FunctionCompilationMixin:
         if not self._is_compilable(decl):
             return None
 
-        # Build effect_ops mapping for State<T> operations
+        # Build effect_ops mapping for State<T> and Exn<E> operations
         effect_ops: dict[str, tuple[str, bool]] = {}
         if isinstance(decl.effect, ast.EffectSet):
             for eff in decl.effect.effects:
@@ -42,6 +42,13 @@ class FunctionCompilationMixin:
                             effect_ops["put"] = (
                                 f"$vera.state_put_{type_name}", True
                             )
+                elif (isinstance(eff, ast.EffectRef) and eff.name == "Exn"
+                        and eff.type_args and len(eff.type_args) == 1):
+                    type_name = self._type_expr_to_slot_name(eff.type_args[0])
+                    if type_name and "throw" not in self._fn_sigs:
+                        effect_ops["throw"] = (
+                            f"$exn_{type_name}", False
+                        )
 
         # Flatten ADT layouts into ctor_name -> layout for WasmContext
         ctor_layouts = {}

--- a/vera/codegen/modules.py
+++ b/vera/codegen/modules.py
@@ -236,7 +236,7 @@ class CrossModuleMixin:
             known.update(layouts.keys())
         # Built-in names handled specially in _translate_call
         known.update({
-            "length", "apply_fn", "get", "put", "resume",
+            "length", "apply_fn", "get", "put", "throw", "resume",
             "string_length", "string_concat", "string_slice",
             "char_code", "parse_nat", "parse_float64",
             "to_string", "strip",

--- a/vera/errors.py
+++ b/vera/errors.py
@@ -499,6 +499,8 @@ ERROR_CODES: dict[str, str] = {
     "E608": "Name collision: function",
     "E609": "Name collision: ADT type",
     "E610": "Name collision: constructor",
+    "E611": "Exn without type argument",
+    "E612": "Exn with unsupported type",
     # E7xx — Testing
     "E700": "Contract violation during testing",
     "E701": "Cannot generate test inputs",

--- a/vera/wasm/calls.py
+++ b/vera/wasm/calls.py
@@ -51,16 +51,20 @@ class CallsMixin:
         if call.name == "apply_fn" and len(call.args) >= 2:
             return self._translate_apply_fn(call, env)
 
-        # Check if this is an effect operation (e.g. get/put)
+        # Check if this is an effect operation (e.g. get/put/throw)
         if call.name in self._effect_ops:
-            import_name, _is_void = self._effect_ops[call.name]
+            target_name, _is_void = self._effect_ops[call.name]
             instructions: list[str] = []
             for arg in call.args:
                 arg_instrs = self.translate_expr(arg, env)
                 if arg_instrs is None:
                     return None
                 instructions.extend(arg_instrs)
-            instructions.append(f"call {import_name}")
+            # throw uses WASM throw instruction, not call
+            if call.name == "throw":
+                instructions.append(f"throw {target_name}")
+            else:
+                instructions.append(f"call {target_name}")
             return instructions
 
         # Resolve call target — rewrite generic calls to mangled names
@@ -1066,7 +1070,8 @@ class CallsMixin:
     ) -> list[str] | None:
         """Translate a handle expression to WASM.
 
-        Currently supports State<T> handlers via host imports.
+        Supports State<T> handlers via host imports and Exn<E>
+        handlers via WASM exception handling (try_table/catch/throw).
         Other handler types cause the function to be skipped.
         """
         effect = expr.effect
@@ -1075,6 +1080,9 @@ class CallsMixin:
 
         if effect.name == "State" and effect.type_args and len(effect.type_args) == 1:
             return self._translate_handle_state(expr, env)
+
+        if effect.name == "Exn" and effect.type_args and len(effect.type_args) == 1:
+            return self._translate_handle_exn(expr, env)
 
         # Unsupported handler type
         return None
@@ -1127,4 +1135,95 @@ class CallsMixin:
             return None
 
         instructions.extend(body_instrs)
+        return instructions
+
+    def _translate_handle_exn(
+        self, expr: ast.HandleExpr, env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """Translate handle[Exn<E>] { throw(@E) -> handler } in { body }.
+
+        Uses WASM exception handling (try_table/catch/throw):
+          block $done (result T)
+            block $catch (result E)
+              try_table (result T) (catch $exn_E $catch)
+                <body>
+              end
+              br $done
+            end
+            ;; caught value on stack
+            local.set $thrown
+            <handler clause body>
+          end
+        """
+        assert isinstance(expr.effect, ast.EffectRef)
+        type_arg = expr.effect.type_args[0]  # type: ignore[index]
+        if not isinstance(type_arg, ast.NamedType):
+            return None
+        type_name = type_arg.name
+        tag_name = f"$exn_{type_name}"
+        thrown_wt = self._type_name_to_wasm(type_name)
+
+        # Unique label ids for nested handlers
+        hid = self._next_handle_id
+        self._next_handle_id += 1
+        done_label = f"$hd_{hid}"
+        catch_label = f"$hc_{hid}"
+
+        # Infer result type: try handler clause first (body may always
+        # throw, making its inferred type None), then fall back to body.
+        result_wt = None
+        if expr.clauses:
+            clause_body = expr.clauses[0].body
+            if isinstance(clause_body, ast.Block):
+                result_wt = self._infer_block_result_type(clause_body)
+        if result_wt is None:
+            result_wt = self._infer_block_result_type(expr.body)
+
+        # Save/inject throw as an effect op for the body
+        saved_ops = dict(self._effect_ops)
+        self._effect_ops["throw"] = (tag_name, False)
+
+        # Compile body
+        body_instrs = self.translate_block(expr.body, env)
+
+        # Restore effect_ops
+        self._effect_ops = saved_ops
+
+        if body_instrs is None:
+            return None
+
+        # Compile handler clause body
+        if not expr.clauses:
+            return None
+        clause = expr.clauses[0]  # Exn<E> has exactly one op: throw
+
+        # Allocate a local for the caught exception value
+        thrown_local = self.alloc_local(thrown_wt)
+
+        # Push caught value into slot env for handler body
+        handler_env = env.push(type_name, thrown_local)
+        handler_instrs = self.translate_expr(clause.body, handler_env)
+        if handler_instrs is None:
+            return None
+
+        # Assemble the try_table structure
+        result_spec = f" (result {result_wt})" if result_wt else ""
+        thrown_spec = f" (result {thrown_wt})" if thrown_wt else ""
+
+        instructions: list[str] = []
+        instructions.append(f"block {done_label}{result_spec}")
+        instructions.append(f"  block {catch_label}{thrown_spec}")
+        instructions.append(
+            f"    try_table{result_spec}"
+            f" (catch {tag_name} {catch_label})"
+        )
+        instructions.extend(f"      {i}" for i in body_instrs)
+        instructions.append("    end")
+        instructions.append(f"    br {done_label}")
+        instructions.append("  end")
+        # Caught value is on the stack — store it in the local
+        instructions.append(f"  local.set {thrown_local}")
+        instructions.extend(f"  {i}" for i in handler_instrs)
+        instructions.append("end")
+
         return instructions

--- a/vera/wasm/context.py
+++ b/vera/wasm/context.py
@@ -112,6 +112,8 @@ class WasmContext(
         self._next_closure_id: int = 0
         # Next quantifier label id (for unique block/loop labels)
         self._next_quant_id: int = 0
+        # Next handle expression label id (for unique try_table labels)
+        self._next_handle_id: int = 0
         # Old state snapshots: type_name -> local_idx (for old() in postconditions)
         self._old_state_locals: dict[str, int] = {}
 

--- a/vera/wasm/operators.py
+++ b/vera/wasm/operators.py
@@ -177,10 +177,11 @@ class OperatorsMixin:
         if cond is None or then is None or else_ is None:
             return None
 
-        # Determine result type from then branch
-        # For now, assume the type is the same for both branches
-        # We use the then_branch's last expression type
+        # Determine result type from branches — try then first, fall back
+        # to else (handles cases where one branch ends with throw/unreachable)
         result_type = self._infer_block_result_type(expr.then_branch)
+        if result_type is None and expr.else_branch is not None:
+            result_type = self._infer_block_result_type(expr.else_branch)
         if result_type is None:
             # Unit result — no (result) annotation
             return (


### PR DESCRIPTION
## Summary

- Compile `handle[Exn<E>]` expressions to WASM using the exception handling proposal (`try_table`/`catch`/`throw`)
- Cross-function throws work via WASM stack unwinding — no special codegen needed for callers
- Extend `examples/effect_handler.vera` with safe division via `Exn<Int>` (runnable end-to-end)
- Rename `SKILLS.md` → `SKILL.md` to match Claude Code convention; add installation instructions
- Fix README example outputs (safe_divide verify count, contract stats)

## Test plan

- [x] 10 new tests in `TestExnHandlers` covering: basic throw/catch, no-throw path, cross-function throws, combined IO+Exn, nested handlers, Nat type
- [x] 3 new example execution tests for `effect_handler.vera` (safe_div, safe_div_zero, main)
- [x] `pytest tests/ -q` — 1,380 tests pass
- [x] `mypy vera/` — clean
- [x] `python scripts/check_examples.py` — all 15 examples pass
- [x] `python scripts/check_spec_examples.py` — all spec blocks pass
- [x] `python scripts/check_version_sync.py` — version consistent
- [x] `vera run examples/effect_handler.vera` — prints `4`
- [x] All 11 pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)