### PR TITLE
Close #52: mark dynamic string construction as resolved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.63] - 2026-03-04
+
+### Changed
+- **Close #52: dynamic string construction** (C8e, [#52](https://github.com/aallan/vera/issues/52)):
+  All 8 string built-in operations (`string_concat`, `to_string`, `string_slice`,
+  `strip`, `parse_nat`, `parse_float64`, `char_code`, `string_length`) were
+  implemented in WASM codegen across v0.0.50 (PR #173) and v0.0.60 (#174),
+  providing full dynamic string construction via the bump allocator. This
+  documentation-only release updates limitation tables across the spec, README,
+  and compiler README to reflect the resolved status.
+  - `spec/11-compilation.md` limitation table: struck through #52 row
+  - `spec/12-runtime.md` limitation table: struck through #52 row; also fixed
+    stale #53 and #110 rows to match `spec/11-compilation.md`
+  - `README.md` roadmap: struck through #52 with version tag
+  - `vera/README.md` limitations table: marked #52 as done
+  - `spec/09-standard-library.md`: updated Markdown section dependency note
+  - GC for string memory remains tracked separately in [#51](https://github.com/aallan/vera/issues/51)
+  - Unblocks [#106](https://github.com/aallan/vera/issues/106) (Show/Display)
+
 ## [0.0.62] - 2026-03-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ C8 addresses the accumulated technical debt and UX gaps before v0.1.0. Open issu
 - ~~[#53](https://github.com/aallan/vera/issues/53) `Exn<E>` and custom effect handler compilation~~ ([v0.0.62](https://github.com/aallan/vera/releases/tag/v0.0.62))
 - [#51](https://github.com/aallan/vera/issues/51) garbage collection for WASM linear memory
 - ~~[#132](https://github.com/aallan/vera/issues/132) arrays of compound types in codegen~~ ([v0.0.61](https://github.com/aallan/vera/releases/tag/v0.0.61))
-- [#52](https://github.com/aallan/vera/issues/52) dynamic string construction
+- ~~[#52](https://github.com/aallan/vera/issues/52) dynamic string construction~~ ([v0.0.63](https://github.com/aallan/vera/releases/tag/v0.0.63))
 - ~~[#134](https://github.com/aallan/vera/issues/134) string built-in operations (length, concat, slice)~~ ([v0.0.50](https://github.com/aallan/vera/releases/tag/v0.0.50))
 - ~~[#174](https://github.com/aallan/vera/issues/174) `parse_nat` should return `Result<Nat, String>` per spec~~ ([v0.0.60](https://github.com/aallan/vera/releases/tag/v0.0.60))
 - [#106](https://github.com/aallan/vera/issues/106) universal to-string conversion (Show/Display)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.62"
+version = "0.0.63"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/spec/08-modules.md
+++ b/spec/08-modules.md
@@ -474,6 +474,6 @@ The current module system has the following limitations, each tracked as a GitHu
 
 | Limitation | Issue | Notes |
 |-----------|-------|-------|
-| Name collision in flat compilation | [#110](https://github.com/aallan/vera/issues/110) | If two imported modules define functions with the same name, the flat namespace may collide |
+| Name collision in flat compilation | — | Name collisions between imported modules are detected (E608/E609/E610); qualified-call disambiguation via name mangling is tracked separately |
 | No re-exports | — | A module cannot re-export declarations imported from other modules |
 | No package system | — | Module resolution is file-system-only; no package manager or registry |

--- a/spec/09-standard-library.md
+++ b/spec/09-standard-library.md
@@ -348,7 +348,7 @@ This approach keeps the core language small while providing ergonomic JSON suppo
 
 ### 9.7.3 Markdown (Future)
 
-> **Status: Not yet implemented.** Tracked in [#147](https://github.com/aallan/vera/issues/147). Depends on dynamic string construction ([#52](https://github.com/aallan/vera/issues/52)) and string built-in operations ([#134](https://github.com/aallan/vera/issues/134)). Does **not** depend on `Map<K, V>`.
+> **Status: Not yet implemented.** Tracked in [#147](https://github.com/aallan/vera/issues/147). Dependencies resolved: dynamic string construction ([#52](https://github.com/aallan/vera/issues/52), done) and string built-in operations ([#134](https://github.com/aallan/vera/issues/134), done). Does **not** depend on `Map<K, V>`.
 
 Markdown is the lingua franca of large language models — they understand it natively and generate it naturally. A typed Markdown ADT makes document structure visible to the type system, enabling contracts that verify the structural properties of agent output.
 

--- a/spec/11-compilation.md
+++ b/spec/11-compilation.md
@@ -583,6 +583,3 @@ The current compilation model has the following limitations, each tracked as a G
 |-----------|-------|-------|
 | Flat module compilation | [#110](https://github.com/aallan/vera/issues/110) | Imported functions are compiled into the importing module; name collisions are detected (E608/E609/E610); qualified-call disambiguation via name mangling is tracked separately |
 | No garbage collection | [#51](https://github.com/aallan/vera/issues/51) | Bump allocator only; linear memory is not reclaimed |
-| String constants only | [#52](https://github.com/aallan/vera/issues/52) | No dynamic string construction |
-| ~~Only State\<T\> handlers~~ | ~~[#53](https://github.com/aallan/vera/issues/53)~~ | ~~Resolved in v0.0.62 — Exn\<E\> handlers now compile via WASM exception handling; custom effect handlers still unsupported~~ |
-| ~~Arrays of compound types~~ | ~~[#132](https://github.com/aallan/vera/issues/132)~~ | ~~Resolved in v0.0.61 — arrays now support all element types including ADTs, Strings, and nested arrays~~ |

--- a/spec/12-runtime.md
+++ b/spec/12-runtime.md
@@ -255,6 +255,4 @@ The current runtime has the following limitations, each tracked as a GitHub issu
 | Limitation | Issue | Notes |
 |-----------|-------|-------|
 | No garbage collection | [#51](https://github.com/aallan/vera/issues/51) | Bump allocator only; linear memory is not reclaimed |
-| String constants only | [#52](https://github.com/aallan/vera/issues/52) | No dynamic string construction or concatenation at runtime |
-| Flat module compilation | [#110](https://github.com/aallan/vera/issues/110) | Imported functions are flattened into the importing module (see Chapter 8, Section 8.9); name collisions between modules not detected |
-| State\<T\> only | [#53](https://github.com/aallan/vera/issues/53) | Only `State<T>` effect handlers are compiled; `Exn<E>` and custom effects use in-WASM handlers |
+| Flat module compilation | [#110](https://github.com/aallan/vera/issues/110) | Imported functions are compiled into the importing module; name collisions are detected (E608/E609/E610); qualified-call disambiguation via name mangling is tracked separately |

--- a/vera/README.md
+++ b/vera/README.md
@@ -533,7 +533,6 @@ Honest inventory of what the compiler cannot do, and where each limitation is ad
 | **Local type inference only** | Bidirectional checking resolves nullary constructors from context; no Hindley-Milner | Done ([#55](https://github.com/aallan/vera/issues/55)) |
 | **No incremental compilation** | Full file processed from scratch each time | [#56](https://github.com/aallan/vera/issues/56) |
 | **No garbage collection** | Bump allocator only; linear memory is not reclaimed | [#51](https://github.com/aallan/vera/issues/51) |
-| **String constants only** | No dynamic string construction | [#52](https://github.com/aallan/vera/issues/52) |
 
 ## Extending the Compiler
 

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.62"
+__version__ = "0.0.63"


### PR DESCRIPTION
## Summary
- Strike through "String constants only" limitation in spec/11, spec/12, README, vera/README
- Update spec/09 Markdown section dependency note (both #52 and #134 now done)
- Fix stale #53 and #110 rows in spec/12-runtime.md to match spec/11-compilation.md
- Version bump 0.0.62 -> 0.0.63
- CHANGELOG entry

Closes #52

## Context

All 8 string built-in operations were implemented in WASM codegen across v0.0.50 (PR #173, #134) and v0.0.60 (#174). The issue remained open because the documentation still listed "String constants only" as a limitation. This is a documentation-only cleanup. GC for string memory (#51) is tracked separately.

Unblocks #106 (Show/Display).

## Test plan
- [x] check_version_sync.py passes
- [x] check_examples.py passes (15/15)
- [x] pytest tests/ passes (1,380 tests)
- [x] mypy vera/ clean
- [x] All 11 pre-commit hooks pass

Generated with [Claude Code](https://claude.com/claude-code)