### PR TITLE
Fix LICENSE for GitHub auto-detection

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,5 @@
 MIT License
 
-Vera is licensed under the MIT License.
-
 Copyright (c) 2026 Alasdair Allan
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
Remove extra descriptive line that prevented GitHub's Licensee from recognising the file as standard MIT.

Generated with [Claude Code](https://claude.com/claude-code)