### PR TITLE
Add universal to-string conversion builtins (#106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.64] - 2026-03-04
+
+### Added
+- **Close #106: universal to-string conversion** (C8e, [#106](https://github.com/aallan/vera/issues/106)):
+  Added 5 new string conversion builtins for all primitive types:
+  `bool_to_string(Bool -> String)`, `nat_to_string(Nat -> String)`,
+  `byte_to_string(Byte -> String)`, `float_to_string(Float64 -> String)`,
+  and `int_to_string(Int -> String)` (alias for existing `to_string`).
+  ADT/compound type Show deferred to abilities (#60).
+
+### Changed
+- Moved #56 (incremental compilation) from C8e to C8.5 in the roadmap
+
 ## [0.0.63] - 2026-03-04
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -282,13 +282,13 @@ C8 addresses the accumulated technical debt and UX gaps before v0.1.0. Open issu
 - ~~[#52](https://github.com/aallan/vera/issues/52) dynamic string construction~~ ([v0.0.63](https://github.com/aallan/vera/releases/tag/v0.0.63))
 - ~~[#134](https://github.com/aallan/vera/issues/134) string built-in operations (length, concat, slice)~~ ([v0.0.50](https://github.com/aallan/vera/releases/tag/v0.0.50))
 - ~~[#174](https://github.com/aallan/vera/issues/174) `parse_nat` should return `Result<Nat, String>` per spec~~ ([v0.0.60](https://github.com/aallan/vera/releases/tag/v0.0.60))
-- [#106](https://github.com/aallan/vera/issues/106) universal to-string conversion (Show/Display)
-- [#56](https://github.com/aallan/vera/issues/56) incremental compilation
+- ~~[#106](https://github.com/aallan/vera/issues/106) universal to-string conversion (Show/Display)~~ ([v0.0.64](https://github.com/aallan/vera/releases/tag/v0.0.64))
 
 ### C8.5 — Completeness
 
 Module refinements, lexical extensions, and IO runtime — completing the existing language before adding new features.
 
+- [#56](https://github.com/aallan/vera/issues/56) incremental compilation
 - [#127](https://github.com/aallan/vera/issues/127) module re-exports
 - [#187](https://github.com/aallan/vera/issues/187) module-qualified call disambiguation via name mangling
 - [#135](https://github.com/aallan/vera/issues/135) IO operations (read_line, read_file, write_file)

--- a/SKILL.md
+++ b/SKILL.md
@@ -402,6 +402,11 @@ char_code(@String.0, @Int.0)            -- returns Nat (ASCII code at index)
 parse_nat(@String.0)                    -- returns Result<Nat, String>
 parse_float64(@String.0)                -- returns Float64
 to_string(@Int.0)                       -- returns String (integer to decimal)
+int_to_string(@Int.0)                   -- returns String (alias for to_string)
+bool_to_string(@Bool.0)                 -- returns String ("true" or "false")
+nat_to_string(@Nat.0)                   -- returns String (natural to decimal)
+byte_to_string(@Byte.0)                 -- returns String (single character)
+float_to_string(@Float64.0)             -- returns String (decimal representation)
 strip(@String.0)                        -- returns String (trim whitespace)
 ```
 

--- a/examples/string_ops.vera
+++ b/examples/string_ops.vera
@@ -1,4 +1,4 @@
--- String operations: length, concat, slice, char_code, parse, convert, strip
+-- String operations and type-to-string conversions
 
 effect IO {
   op print(String -> Unit);
@@ -43,6 +43,18 @@ public fn main(@Unit -> @Unit)
     Ok(@Nat) -> to_string(@Nat.0),
     Err(_) -> "error"
   });
+
+  -- bool_to_string
+  IO.print(bool_to_string(true));
+
+  -- nat_to_string
+  IO.print(nat_to_string(42));
+
+  -- int_to_string (alias for to_string)
+  IO.print(int_to_string(-7));
+
+  -- float_to_string
+  IO.print(float_to_string(3.14));
 
   ()
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.63"
+version = "0.0.64"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/spec/04-expressions.md
+++ b/spec/04-expressions.md
@@ -310,6 +310,11 @@ char_code(@String.0, @Int.0)            -- returns Nat (ASCII code at index)
 parse_nat(@String.0)                    -- returns Result<Nat, String>
 parse_float64(@String.0)                -- returns Float64
 to_string(@Int.0)                       -- returns String
+int_to_string(@Int.0)                   -- returns String (alias for to_string)
+bool_to_string(@Bool.0)                 -- returns String ("true" or "false")
+nat_to_string(@Nat.0)                   -- returns String
+byte_to_string(@Byte.0)                 -- returns String (single character)
+float_to_string(@Float64.0)             -- returns String
 strip(@String.0)                        -- returns String (trim whitespace)
 ```
 

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -2488,6 +2488,76 @@ private fn f(@String -> @String)
 { strip(@String.0) }
 """)
 
+    def test_bool_to_string_ok(self) -> None:
+        _check_ok("""
+private fn f(@Bool -> @String)
+  requires(true) ensures(true) effects(pure)
+{ bool_to_string(@Bool.0) }
+""")
+
+    def test_bool_to_string_wrong_arg(self) -> None:
+        _check_err("""
+private fn f(@Int -> @String)
+  requires(true) ensures(true) effects(pure)
+{ bool_to_string(@Int.0) }
+""", "type")
+
+    def test_nat_to_string_ok(self) -> None:
+        _check_ok("""
+private fn f(@Nat -> @String)
+  requires(true) ensures(true) effects(pure)
+{ nat_to_string(@Nat.0) }
+""")
+
+    def test_nat_to_string_wrong_arg(self) -> None:
+        _check_err("""
+private fn f(@Bool -> @String)
+  requires(true) ensures(true) effects(pure)
+{ nat_to_string(@Bool.0) }
+""", "type")
+
+    def test_byte_to_string_ok(self) -> None:
+        _check_ok("""
+private fn f(@Byte -> @String)
+  requires(true) ensures(true) effects(pure)
+{ byte_to_string(@Byte.0) }
+""")
+
+    def test_byte_to_string_wrong_arg(self) -> None:
+        _check_err("""
+private fn f(@Int -> @String)
+  requires(true) ensures(true) effects(pure)
+{ byte_to_string(@Int.0) }
+""", "type")
+
+    def test_int_to_string_ok(self) -> None:
+        _check_ok("""
+private fn f(@Int -> @String)
+  requires(true) ensures(true) effects(pure)
+{ int_to_string(@Int.0) }
+""")
+
+    def test_int_to_string_wrong_arg(self) -> None:
+        _check_err("""
+private fn f(@Bool -> @String)
+  requires(true) ensures(true) effects(pure)
+{ int_to_string(@Bool.0) }
+""", "type")
+
+    def test_float_to_string_ok(self) -> None:
+        _check_ok("""
+private fn f(@Float64 -> @String)
+  requires(true) ensures(true) effects(pure)
+{ float_to_string(@Float64.0) }
+""")
+
+    def test_float_to_string_wrong_arg(self) -> None:
+        _check_err("""
+private fn f(@Int -> @String)
+  requires(true) ensures(true) effects(pure)
+{ float_to_string(@Int.0) }
+""", "type")
+
 
 # =====================================================================
 # Bidirectional type inference (issue #55)

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -4102,6 +4102,153 @@ public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
 
 
 # =====================================================================
+# C8e: Universal to-string conversion (#106)
+# =====================================================================
+
+
+class TestBoolToString:
+    def test_true(self) -> None:
+        src = """
+effect IO { op print(String -> Unit); }
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  IO.print(bool_to_string(true))
+}
+"""
+        assert _run_io(src) == "true"
+
+    def test_false(self) -> None:
+        src = """
+effect IO { op print(String -> Unit); }
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  IO.print(bool_to_string(false))
+}
+"""
+        assert _run_io(src) == "false"
+
+
+class TestNatToString:
+    def test_basic(self) -> None:
+        src = """
+effect IO { op print(String -> Unit); }
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  IO.print(nat_to_string(42))
+}
+"""
+        assert _run_io(src) == "42"
+
+    def test_zero(self) -> None:
+        src = """
+effect IO { op print(String -> Unit); }
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  IO.print(nat_to_string(0))
+}
+"""
+        assert _run_io(src) == "0"
+
+
+class TestByteToString:
+    def test_letter_a(self) -> None:
+        src = """
+effect IO { op print(String -> Unit); }
+public fn f(@Byte -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  IO.print(byte_to_string(@Byte.0))
+}
+"""
+        assert _run_io(src, fn="f", args=[65]) == "A"
+
+    def test_digit(self) -> None:
+        src = """
+effect IO { op print(String -> Unit); }
+public fn f(@Byte -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  IO.print(byte_to_string(@Byte.0))
+}
+"""
+        assert _run_io(src, fn="f", args=[48]) == "0"
+
+
+class TestIntToStringAlias:
+    def test_same_as_to_string(self) -> None:
+        src = """
+effect IO { op print(String -> Unit); }
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  IO.print(int_to_string(42))
+}
+"""
+        assert _run_io(src) == "42"
+
+    def test_negative(self) -> None:
+        src = """
+effect IO { op print(String -> Unit); }
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  IO.print(int_to_string(-7))
+}
+"""
+        assert _run_io(src) == "-7"
+
+
+class TestFloatToString:
+    def test_pi(self) -> None:
+        src = """
+effect IO { op print(String -> Unit); }
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  IO.print(float_to_string(3.14))
+}
+"""
+        assert _run_io(src) == "3.14"
+
+    def test_zero(self) -> None:
+        src = """
+effect IO { op print(String -> Unit); }
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  IO.print(float_to_string(0.0))
+}
+"""
+        assert _run_io(src) == "0.0"
+
+    def test_negative(self) -> None:
+        src = """
+effect IO { op print(String -> Unit); }
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  IO.print(float_to_string(-2.5))
+}
+"""
+        assert _run_io(src) == "-2.5"
+
+    def test_integer_float(self) -> None:
+        src = """
+effect IO { op print(String -> Unit); }
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  IO.print(float_to_string(42.0))
+}
+"""
+        assert _run_io(src) == "42.0"
+
+
+# =====================================================================
 # C8e: Arrays of compound types (#132)
 # =====================================================================
 

--- a/vera/README.md
+++ b/vera/README.md
@@ -300,6 +300,11 @@ Context flags (`in_ensures`, `in_contract`, `current_return_type`, `current_effe
 | `parse_nat` | Function | `String → Result<Nat, String>`, pure |
 | `parse_float64` | Function | `String → Float64`, pure |
 | `to_string` | Function | `Int → String`, pure |
+| `int_to_string` | Function | `Int → String`, pure (alias for `to_string`) |
+| `bool_to_string` | Function | `Bool → String`, pure |
+| `nat_to_string` | Function | `Nat → String`, pure |
+| `byte_to_string` | Function | `Byte → String`, pure |
+| `float_to_string` | Function | `Float64 → String`, pure |
 | `strip` | Function | `String → String`, pure (zero-copy) |
 
 Additionally, `resume` is bound as a temporary function inside handler clause bodies (in `_check_handle()`). Its type is derived from the operation: for `op(params) → ReturnType`, `resume` has type `fn(ReturnType) → Unit effects(pure)`. The binding is added to `env.functions` before checking the clause body and removed afterward.

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.63"
+__version__ = "0.0.64"

--- a/vera/codegen/modules.py
+++ b/vera/codegen/modules.py
@@ -239,7 +239,9 @@ class CrossModuleMixin:
             "length", "apply_fn", "get", "put", "throw", "resume",
             "string_length", "string_concat", "string_slice",
             "char_code", "parse_nat", "parse_float64",
-            "to_string", "strip",
+            "to_string", "int_to_string", "bool_to_string",
+            "nat_to_string", "byte_to_string", "float_to_string",
+            "strip",
         })
 
         seen: set[str] = set()  # deduplicate by function name

--- a/vera/environment.py
+++ b/vera/environment.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass, field
 
 from vera.types import (
     BOOL,
+    BYTE,
     FLOAT64,
     INT,
     NAT,
@@ -254,6 +255,41 @@ class TypeEnv:
             name="to_string",
             forall_vars=None,
             param_types=(INT,),
+            return_type=STRING,
+            effect=PureEffectRow(),
+        )
+        self.functions["int_to_string"] = FunctionInfo(
+            name="int_to_string",
+            forall_vars=None,
+            param_types=(INT,),
+            return_type=STRING,
+            effect=PureEffectRow(),
+        )
+        self.functions["bool_to_string"] = FunctionInfo(
+            name="bool_to_string",
+            forall_vars=None,
+            param_types=(BOOL,),
+            return_type=STRING,
+            effect=PureEffectRow(),
+        )
+        self.functions["nat_to_string"] = FunctionInfo(
+            name="nat_to_string",
+            forall_vars=None,
+            param_types=(NAT,),
+            return_type=STRING,
+            effect=PureEffectRow(),
+        )
+        self.functions["byte_to_string"] = FunctionInfo(
+            name="byte_to_string",
+            forall_vars=None,
+            param_types=(BYTE,),
+            return_type=STRING,
+            effect=PureEffectRow(),
+        )
+        self.functions["float_to_string"] = FunctionInfo(
+            name="float_to_string",
+            forall_vars=None,
+            param_types=(FLOAT64,),
             return_type=STRING,
             effect=PureEffectRow(),
         )

--- a/vera/wasm/calls.py
+++ b/vera/wasm/calls.py
@@ -44,6 +44,16 @@ class CallsMixin:
                 return self._translate_parse_float64(call.args[0], env)
             if call.name == "to_string" and len(call.args) == 1:
                 return self._translate_to_string(call.args[0], env)
+            if call.name == "int_to_string" and len(call.args) == 1:
+                return self._translate_to_string(call.args[0], env)
+            if call.name == "nat_to_string" and len(call.args) == 1:
+                return self._translate_to_string(call.args[0], env)
+            if call.name == "bool_to_string" and len(call.args) == 1:
+                return self._translate_bool_to_string(call.args[0], env)
+            if call.name == "byte_to_string" and len(call.args) == 1:
+                return self._translate_byte_to_string(call.args[0], env)
+            if call.name == "float_to_string" and len(call.args) == 1:
+                return self._translate_float_to_string(call.args[0], env)
             if call.name == "strip" and len(call.args) == 1:
                 return self._translate_strip(call.args[0], env)
 
@@ -943,6 +953,365 @@ class CallsMixin:
         instructions.append(f"local.get {pos}")
         instructions.append("i32.add")
         instructions.append(f"local.get {slen}")
+        return instructions
+
+    def _translate_bool_to_string(
+        self, arg: ast.Expr, env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """Translate bool_to_string(b) → String (i32_pair).
+
+        Returns the interned string "true" or "false" depending on
+        the boolean value.  No heap allocation needed.
+        """
+        arg_instrs = self.translate_expr(arg, env)
+        if arg_instrs is None:
+            return None
+
+        true_off, true_len = self.string_pool.intern("true")
+        false_off, false_len = self.string_pool.intern("false")
+
+        instructions: list[str] = []
+        instructions.extend(arg_instrs)
+        # Bool is i32: 1 = true, 0 = false
+        instructions.append(f"if (result i32 i32)")
+        instructions.append(f"  i32.const {true_off}")
+        instructions.append(f"  i32.const {true_len}")
+        instructions.append("else")
+        instructions.append(f"  i32.const {false_off}")
+        instructions.append(f"  i32.const {false_len}")
+        instructions.append("end")
+        return instructions
+
+    def _translate_byte_to_string(
+        self, arg: ast.Expr, env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """Translate byte_to_string(b) → String (i32_pair).
+
+        Allocates a 1-byte buffer and stores the byte value as a
+        single character.
+        """
+        arg_instrs = self.translate_expr(arg, env)
+        if arg_instrs is None:
+            return None
+
+        self.needs_alloc = True
+
+        bval = self.alloc_local("i32")
+        dst = self.alloc_local("i32")
+
+        instructions: list[str] = []
+        instructions.extend(arg_instrs)
+        # Byte is i32 in WASM (unlike Nat which is i64)
+        instructions.append(f"local.set {bval}")
+
+        # Allocate 1 byte
+        instructions.append("i32.const 1")
+        instructions.append("call $alloc")
+        instructions.append(f"local.set {dst}")
+
+        # Store the byte value
+        instructions.append(f"local.get {dst}")
+        instructions.append(f"local.get {bval}")
+        instructions.append("i32.store8 offset=0")
+
+        # Return (ptr, 1)
+        instructions.append(f"local.get {dst}")
+        instructions.append("i32.const 1")
+        return instructions
+
+    def _translate_float_to_string(
+        self, arg: ast.Expr, env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """Translate float_to_string(f) → String (i32_pair).
+
+        Converts a Float64 to its decimal string representation.
+        Uses a 32-byte buffer.  Writes sign, integer digits, decimal
+        point, then up to 6 fractional digits (trailing zeros trimmed,
+        but at least one decimal digit kept so 42.0 stays "42.0").
+        """
+        arg_instrs = self.translate_expr(arg, env)
+        if arg_instrs is None:
+            return None
+
+        self.needs_alloc = True
+
+        fval = self.alloc_local("f64")
+        ival = self.alloc_local("i64")
+        buf = self.alloc_local("i32")
+        pos = self.alloc_local("i32")   # write position (forward)
+        is_neg = self.alloc_local("i32")
+        digit = self.alloc_local("i64")
+        # For integer-part digit reversal
+        tbuf = self.alloc_local("i32")  # temp buffer for int digits
+        tpos = self.alloc_local("i32")  # position in temp buffer
+        tlen = self.alloc_local("i32")
+        idx = self.alloc_local("i32")
+        frac_val = self.alloc_local("i64")
+
+        instructions: list[str] = []
+
+        # Evaluate argument
+        instructions.extend(arg_instrs)
+        instructions.append(f"local.set {fval}")
+
+        # Allocate 32-byte output buffer
+        instructions.append("i32.const 32")
+        instructions.append("call $alloc")
+        instructions.append(f"local.set {buf}")
+        instructions.append("i32.const 0")
+        instructions.append(f"local.set {pos}")
+
+        # Check for negative
+        instructions.append("i32.const 0")
+        instructions.append(f"local.set {is_neg}")
+        instructions.append(f"local.get {fval}")
+        instructions.append("f64.const 0")
+        instructions.append("f64.lt")
+        instructions.append("if")
+        instructions.append("  i32.const 1")
+        instructions.append(f"  local.set {is_neg}")
+        instructions.append(f"  local.get {fval}")
+        instructions.append("  f64.neg")
+        instructions.append(f"  local.set {fval}")
+        instructions.append("end")
+
+        # Write '-' if negative
+        instructions.append(f"local.get {is_neg}")
+        instructions.append("if")
+        instructions.append(f"  local.get {buf}")
+        instructions.append(f"  local.get {pos}")
+        instructions.append("  i32.add")
+        instructions.append("  i32.const 45")  # '-'
+        instructions.append("  i32.store8 offset=0")
+        instructions.append(f"  local.get {pos}")
+        instructions.append("  i32.const 1")
+        instructions.append("  i32.add")
+        instructions.append(f"  local.set {pos}")
+        instructions.append("end")
+
+        # Extract integer part: ival = i64.trunc_f64_s(fval)
+        instructions.append(f"local.get {fval}")
+        instructions.append("i64.trunc_f64_s")
+        instructions.append(f"local.set {ival}")
+
+        # Write integer digits using a temp buffer (reverse then copy)
+        # Allocate 20-byte temp buffer for int digits
+        instructions.append("i32.const 20")
+        instructions.append("call $alloc")
+        instructions.append(f"local.set {tbuf}")
+        instructions.append("i32.const 20")
+        instructions.append(f"local.set {tpos}")
+
+        # Handle zero integer part
+        instructions.append(f"local.get {ival}")
+        instructions.append("i64.const 0")
+        instructions.append("i64.eq")
+        instructions.append("if")
+        instructions.append(f"  local.get {tpos}")
+        instructions.append("  i32.const 1")
+        instructions.append("  i32.sub")
+        instructions.append(f"  local.set {tpos}")
+        instructions.append(f"  local.get {tbuf}")
+        instructions.append(f"  local.get {tpos}")
+        instructions.append("  i32.add")
+        instructions.append("  i32.const 48")
+        instructions.append("  i32.store8 offset=0")
+        instructions.append("else")
+        # Extract digits in reverse
+        instructions.append("  block $brk_fi")
+        instructions.append("  loop $lp_fi")
+        instructions.append(f"    local.get {ival}")
+        instructions.append("    i64.const 0")
+        instructions.append("    i64.le_s")
+        instructions.append("    br_if $brk_fi")
+        instructions.append(f"    local.get {ival}")
+        instructions.append("    i64.const 10")
+        instructions.append("    i64.rem_u")
+        instructions.append(f"    local.set {digit}")
+        instructions.append(f"    local.get {ival}")
+        instructions.append("    i64.const 10")
+        instructions.append("    i64.div_u")
+        instructions.append(f"    local.set {ival}")
+        instructions.append(f"    local.get {tpos}")
+        instructions.append("    i32.const 1")
+        instructions.append("    i32.sub")
+        instructions.append(f"    local.set {tpos}")
+        instructions.append(f"    local.get {tbuf}")
+        instructions.append(f"    local.get {tpos}")
+        instructions.append("    i32.add")
+        instructions.append(f"    local.get {digit}")
+        instructions.append("    i32.wrap_i64")
+        instructions.append("    i32.const 48")
+        instructions.append("    i32.add")
+        instructions.append("    i32.store8 offset=0")
+        instructions.append("    br $lp_fi")
+        instructions.append("  end")
+        instructions.append("  end")
+        instructions.append("end")
+
+        # Copy integer digits from tbuf[tpos..20] to buf[pos..]
+        # tlen = 20 - tpos
+        instructions.append("i32.const 20")
+        instructions.append(f"local.get {tpos}")
+        instructions.append("i32.sub")
+        instructions.append(f"local.set {tlen}")
+        instructions.append("i32.const 0")
+        instructions.append(f"local.set {idx}")
+        instructions.append("block $brk_cp")
+        instructions.append("loop $lp_cp")
+        instructions.append(f"  local.get {idx}")
+        instructions.append(f"  local.get {tlen}")
+        instructions.append("  i32.ge_u")
+        instructions.append("  br_if $brk_cp")
+        # buf[pos + idx] = tbuf[tpos + idx]
+        instructions.append(f"  local.get {buf}")
+        instructions.append(f"  local.get {pos}")
+        instructions.append("  i32.add")
+        instructions.append(f"  local.get {idx}")
+        instructions.append("  i32.add")
+        instructions.append(f"  local.get {tbuf}")
+        instructions.append(f"  local.get {tpos}")
+        instructions.append("  i32.add")
+        instructions.append(f"  local.get {idx}")
+        instructions.append("  i32.add")
+        instructions.append("  i32.load8_u offset=0")
+        instructions.append("  i32.store8 offset=0")
+        instructions.append(f"  local.get {idx}")
+        instructions.append("  i32.const 1")
+        instructions.append("  i32.add")
+        instructions.append(f"  local.set {idx}")
+        instructions.append("  br $lp_cp")
+        instructions.append("end")
+        instructions.append("end")
+        # pos += tlen
+        instructions.append(f"local.get {pos}")
+        instructions.append(f"local.get {tlen}")
+        instructions.append("i32.add")
+        instructions.append(f"local.set {pos}")
+
+        # Write decimal point
+        instructions.append(f"local.get {buf}")
+        instructions.append(f"local.get {pos}")
+        instructions.append("i32.add")
+        instructions.append("i32.const 46")  # '.'
+        instructions.append("i32.store8 offset=0")
+        instructions.append(f"local.get {pos}")
+        instructions.append("i32.const 1")
+        instructions.append("i32.add")
+        instructions.append(f"local.set {pos}")
+
+        # Fractional part: frac = (fval - floor(fval)) * 1_000_000
+        # Re-extract integer part as f64 for subtraction
+        instructions.append(f"local.get {fval}")
+        instructions.append(f"local.get {fval}")
+        instructions.append("f64.floor")
+        instructions.append("f64.sub")
+        instructions.append("f64.const 1000000")
+        instructions.append("f64.mul")
+        # Round to nearest integer
+        instructions.append("f64.const 0.5")
+        instructions.append("f64.add")
+        instructions.append("i64.trunc_f64_s")
+        instructions.append(f"local.set {frac_val}")
+
+        # Write exactly 6 fractional digits (will trim trailing zeros after)
+        # We write them in reverse into tbuf, then copy forward
+        instructions.append("i32.const 6")
+        instructions.append(f"local.set {tlen}")
+        instructions.append("i32.const 6")
+        instructions.append(f"local.set {tpos}")
+
+        instructions.append("block $brk_fd")
+        instructions.append("loop $lp_fd")
+        instructions.append(f"  local.get {tpos}")
+        instructions.append("  i32.const 0")
+        instructions.append("  i32.le_s")
+        instructions.append("  br_if $brk_fd")
+        instructions.append(f"  local.get {tpos}")
+        instructions.append("  i32.const 1")
+        instructions.append("  i32.sub")
+        instructions.append(f"  local.set {tpos}")
+        instructions.append(f"  local.get {tbuf}")
+        instructions.append(f"  local.get {tpos}")
+        instructions.append("  i32.add")
+        instructions.append(f"  local.get {frac_val}")
+        instructions.append("  i64.const 10")
+        instructions.append("  i64.rem_u")
+        instructions.append("  i32.wrap_i64")
+        instructions.append("  i32.const 48")
+        instructions.append("  i32.add")
+        instructions.append("  i32.store8 offset=0")
+        instructions.append(f"  local.get {frac_val}")
+        instructions.append("  i64.const 10")
+        instructions.append("  i64.div_u")
+        instructions.append(f"  local.set {frac_val}")
+        instructions.append("  br $lp_fd")
+        instructions.append("end")
+        instructions.append("end")
+
+        # Trim trailing zeros: tlen = 6, but keep at least 1 digit
+        # Scan from position 5 down to 1
+        instructions.append("block $brk_tz")
+        instructions.append("loop $lp_tz")
+        # If tlen <= 1, stop (keep at least 1 fractional digit)
+        instructions.append(f"  local.get {tlen}")
+        instructions.append("  i32.const 1")
+        instructions.append("  i32.le_s")
+        instructions.append("  br_if $brk_tz")
+        # Check if tbuf[tlen - 1] == '0' (48)
+        instructions.append(f"  local.get {tbuf}")
+        instructions.append(f"  local.get {tlen}")
+        instructions.append("  i32.const 1")
+        instructions.append("  i32.sub")
+        instructions.append("  i32.add")
+        instructions.append("  i32.load8_u offset=0")
+        instructions.append("  i32.const 48")
+        instructions.append("  i32.ne")
+        instructions.append("  br_if $brk_tz")
+        instructions.append(f"  local.get {tlen}")
+        instructions.append("  i32.const 1")
+        instructions.append("  i32.sub")
+        instructions.append(f"  local.set {tlen}")
+        instructions.append("  br $lp_tz")
+        instructions.append("end")
+        instructions.append("end")
+
+        # Copy tlen fractional digits from tbuf[0..tlen] to buf[pos..]
+        instructions.append("i32.const 0")
+        instructions.append(f"local.set {idx}")
+        instructions.append("block $brk_cf")
+        instructions.append("loop $lp_cf")
+        instructions.append(f"  local.get {idx}")
+        instructions.append(f"  local.get {tlen}")
+        instructions.append("  i32.ge_u")
+        instructions.append("  br_if $brk_cf")
+        instructions.append(f"  local.get {buf}")
+        instructions.append(f"  local.get {pos}")
+        instructions.append("  i32.add")
+        instructions.append(f"  local.get {idx}")
+        instructions.append("  i32.add")
+        instructions.append(f"  local.get {tbuf}")
+        instructions.append(f"  local.get {idx}")
+        instructions.append("  i32.add")
+        instructions.append("  i32.load8_u offset=0")
+        instructions.append("  i32.store8 offset=0")
+        instructions.append(f"  local.get {idx}")
+        instructions.append("  i32.const 1")
+        instructions.append("  i32.add")
+        instructions.append(f"  local.set {idx}")
+        instructions.append("  br $lp_cf")
+        instructions.append("end")
+        instructions.append("end")
+
+        # Final length = pos + tlen
+        instructions.append(f"local.get {pos}")
+        instructions.append(f"local.get {tlen}")
+        instructions.append("i32.add")
+        instructions.append(f"local.set {pos}")
+
+        # Return (buf, pos) where pos is now the total length
+        instructions.append(f"local.get {buf}")
+        instructions.append(f"local.get {pos}")
         return instructions
 
     def _translate_strip(

--- a/vera/wasm/inference.py
+++ b/vera/wasm/inference.py
@@ -173,7 +173,9 @@ class InferenceMixin:
             return "i64"
         # string_concat / string_slice / strip → String (i32_pair)
         if expr.name in ("string_concat", "string_slice", "strip",
-                          "to_string"):
+                          "to_string", "int_to_string",
+                          "bool_to_string", "nat_to_string",
+                          "byte_to_string", "float_to_string"):
             return "i32_pair"
         # char_code → Nat (i64)
         if expr.name == "char_code":
@@ -312,7 +314,9 @@ class InferenceMixin:
         if call.name == "string_length":
             return "Int"
         if call.name in ("string_concat", "string_slice", "strip",
-                          "to_string"):
+                          "to_string", "int_to_string",
+                          "bool_to_string", "nat_to_string",
+                          "byte_to_string", "float_to_string"):
             return "String"
         if call.name == "char_code":
             return "Nat"


### PR DESCRIPTION
## Summary
- Added 5 new string conversion builtins for all primitive types: `bool_to_string(Bool -> String)`, `nat_to_string(Nat -> String)`, `byte_to_string(Byte -> String)`, `float_to_string(Float64 -> String)`, and `int_to_string(Int -> String)` (alias for existing `to_string`)
- ADT/compound type Show deferred to abilities (#60)
- Moved #56 (incremental compilation) from C8e to C8.5 in the roadmap

## Implementation details
- `bool_to_string`: Zero allocation — uses interned "true"/"false" from StringPool
- `byte_to_string`: 1-byte heap allocation, stores byte value as single character
- `float_to_string`: 32-byte buffer, integer + fractional digit extraction, trailing zero trimming (keeps at least 1 decimal digit)
- `nat_to_string` and `int_to_string`: Reuse existing `_translate_to_string` implementation

## Files changed (14)
- `vera/environment.py` — 5 new FunctionInfo entries
- `vera/wasm/calls.py` — Dispatch + 3 new translate methods
- `vera/wasm/inference.py` — WASM + Vera return type inference
- `vera/codegen/modules.py` — Cross-module call resolution
- `tests/test_codegen.py` — 12 new tests (5 classes)
- `tests/test_checker.py` — 10 new type checker tests
- `examples/string_ops.vera` — New conversion demos
- `spec/04-expressions.md`, `SKILL.md`, `vera/README.md` — Doc updates
- `README.md` — Strikethrough #106, move #56 to C8.5
- `CHANGELOG.md`, `vera/__init__.py`, `pyproject.toml` — v0.0.64

## Test plan
- [x] 1402 tests pass (`pytest tests/ -q`)
- [x] mypy clean (`mypy vera/`)
- [x] All 15 examples pass (`python scripts/check_examples.py`)
- [x] Version sync verified (`python scripts/check_version_sync.py`)

Closes #106