### PR TITLE
Add #163 to C10 roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ New effects, types, abilities, and standard library extensions (spec §0.8).
 - [#56](https://github.com/aallan/vera/issues/56) incremental compilation
 - [#130](https://github.com/aallan/vera/issues/130) package system and registry
 - [#143](https://github.com/aallan/vera/issues/143) comprehensive example programs
+- [#163](https://github.com/aallan/vera/issues/163) standalone WASM runtime package
 - [#181](https://github.com/aallan/vera/issues/181) signature refactoring (mechanical slot index rewriting)
 - [#183](https://github.com/aallan/vera/issues/183) human-readable slot annotations (display layer for `@T.n` references)
 

--- a/scripts/check_readme_examples.py
+++ b/scripts/check_readme_examples.py
@@ -36,7 +36,7 @@ ALLOWLIST: dict[int, tuple[str, str]] = {
     # =================================================================
 
     # Section "Where this is going" — depends on #57 (Http), #61 (Inference), #147 (Markdown)
-    342: ("FUTURE", "Vision example uses MdBlock, Http, Inference (issues #57, #61, #147)"),
+    343: ("FUTURE", "Vision example uses MdBlock, Http, Inference (issues #57, #61, #147)"),
 }
 
 

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -19,7 +19,7 @@ README = Path(__file__).parent.parent / "README.md"
 # Each key is the 1-based line number of the opening ```vera fence.
 ALLOWLIST: dict[int, str] = {
     # "Where this is going" — depends on #57 (Http), #61 (Inference), #147 (Markdown)
-    342: "Vision example uses MdBlock, Http, Inference (issues #57, #61, #147)",
+    343: "Vision example uses MdBlock, Http, Inference (issues #57, #61, #147)",
 }
 
 


### PR DESCRIPTION
## Summary
- Add [#163](https://github.com/aallan/vera/issues/163) (standalone WASM runtime package) to the C10 — Ecosystem section of the roadmap
- Add C10 label to the issue
- Update README allowlists for shifted line numbers (342 → 343)

All 23 open issues are now tracked in the roadmap.

Generated with [Claude Code](https://claude.com/claude-code)