### PR TITLE
Add SKILL.md validation to CI lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,3 +73,6 @@ jobs:
 
       - name: Check README code blocks parse correctly
         run: python scripts/check_readme_examples.py
+
+      - name: Check SKILL.md code blocks parse correctly
+        run: python scripts/check_skill_examples.py

--- a/TESTING.md
+++ b/TESTING.md
@@ -232,7 +232,7 @@ GitHub Actions ([`.github/workflows/ci.yml`](.github/workflows/ci.yml)) runs thr
 | **test** | Python 3.11, 3.12, 3.13 x Ubuntu, macOS (6 combos) | `pytest -v` passes on all combinations |
 | **test** (coverage) | Python 3.12 x Ubuntu only | `pytest --cov=vera --cov-fail-under=80` |
 | **typecheck** | Python 3.12 x Ubuntu | `mypy vera/` clean in strict mode |
-| **lint** | Python 3.12 x Ubuntu | `check_examples.py`, `check_version_sync.py`, `check_spec_examples.py`, `check_readme_examples.py` |
+| **lint** | Python 3.12 x Ubuntu | `check_examples.py`, `check_version_sync.py`, `check_spec_examples.py`, `check_readme_examples.py`, `check_skill_examples.py` |
 
 The coverage threshold of **80%** is enforced in CI. Current coverage is 90%.
 


### PR DESCRIPTION
## Summary
- Add `check_skill_examples.py` to the CI lint job so SKILL.md code block regressions are caught in PRs
- The pre-commit hook already existed but CI was not running it
- Update TESTING.md to reflect the addition

Generated with [Claude Code](https://claude.com/claude-code)