### PR TITLE
Remove #139 and #214 from roadmap (wontfix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,6 @@ New effects, types, abilities, and standard library extensions (spec §0.8).
 - [#59](https://github.com/aallan/vera/issues/59) `<Async>` futures and promises
 - [#61](https://github.com/aallan/vera/issues/61) `<Inference>` LLM inference effect
 - [#211](https://github.com/aallan/vera/issues/211) Option and Result combinators
-- [#214](https://github.com/aallan/vera/issues/214) bitwise operations
 
 ### C10 — Ecosystem
 

--- a/scripts/check_readme_examples.py
+++ b/scripts/check_readme_examples.py
@@ -36,7 +36,7 @@ ALLOWLIST: dict[int, tuple[str, str]] = {
     # =================================================================
 
     # Section "Where this is going" — depends on #57 (Http), #61 (Inference), #147 (Markdown)
-    370: ("FUTURE", "Vision example uses MdBlock, Http, Inference (issues #57, #61, #147)"),
+    369: ("FUTURE", "Vision example uses MdBlock, Http, Inference (issues #57, #61, #147)"),
 }
 
 

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -19,7 +19,7 @@ README = Path(__file__).parent.parent / "README.md"
 # Each key is the 1-based line number of the opening ```vera fence.
 ALLOWLIST: dict[int, str] = {
     # "Where this is going" — depends on #57 (Http), #61 (Inference), #147 (Markdown)
-    370: "Vision example uses MdBlock, Http, Inference (issues #57, #61, #147)",
+    369: "Vision example uses MdBlock, Http, Inference (issues #57, #61, #147)",
 }
 
 


### PR DESCRIPTION
## Summary
- Remove #139 (scientific notation for float literals) from the roadmap — conflicts with one-canonical-form principle
- Remove #214 (bitwise operations) from the roadmap — adds surface area with no verification benefit
- Both closed as wontfix with rationale comments on the issues
- Auto-fix allowlist line numbers that shifted from the removals

## Test plan
- [x] All pre-commit hooks pass
- [x] README code blocks still parse

Generated with [Claude Code](https://claude.com/claude-code)
