### PR TITLE
Fix #241 (Byte literal coercion) and #242 (array_push codegen)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.69] - 2026-03-06
+
+### Fixed
+- **Close #241: Byte literal coercion** ([#241](https://github.com/aallan/vera/issues/241)):
+  Integer literals 0–255 are now accepted as `Byte` when the expected type is
+  `Byte` (bidirectional type checking). The `ch01_byte_literals` conformance test
+  is promoted from `check` to `run` level.
+- **Close #242: `array_push` codegen** ([#242](https://github.com/aallan/vera/issues/242)):
+  `array_push(array, elem)` is now a fully implemented builtin — registered in the
+  type environment with a generic `(Array<T>, T) -> Array<T>` signature and compiled
+  to WASM with proper allocation, element copying, and GC shadow stack integration.
+  The `ch04_array_ops` conformance test now exercises `array_push`.
+
+### Changed
+- Conformance suite: `ch01_byte_literals` promoted from `check` to `run` level;
+  `ch04_array_ops` now includes `array_push` in its feature coverage
+- Documentation updated across TESTING.md, SKILL.md, and README.md to reflect
+  resolved bugs and new builtin
+
 ## [0.0.68] - 2026-03-05
 
 ### Added
@@ -1062,7 +1081,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Grammar: handler body simplified to avoid LALR reduce/reduce conflict
 - `pyproject.toml`: corrected build backend, package discovery, PEP 639 compliance
 
-[Unreleased]: https://github.com/aallan/vera/compare/v0.0.68...HEAD
+[Unreleased]: https://github.com/aallan/vera/compare/v0.0.69...HEAD
+[0.0.69]: https://github.com/aallan/vera/compare/v0.0.68...v0.0.69
 [0.0.68]: https://github.com/aallan/vera/compare/v0.0.67...v0.0.68
 [0.0.67]: https://github.com/aallan/vera/compare/v0.0.66...v0.0.67
 [0.0.66]: https://github.com/aallan/vera/compare/v0.0.65...v0.0.66

--- a/README.md
+++ b/README.md
@@ -187,10 +187,6 @@ Testing is organized in three layers: **unit tests** (1,473 tests across 19 file
 
 ### Known Bugs
 
-These are known compiler issues discovered during conformance suite development:
-
-- [#241](https://github.com/aallan/vera/issues/241) — **Byte literal coercion**: integer literals (e.g. `65`) are typed as `Nat`, and there is no implicit `Nat` to `Byte` coercion, so functions returning `Byte` cannot return integer literals directly
-- [#242](https://github.com/aallan/vera/issues/242) — **`array_push` codegen**: `array_push` type-checks correctly but is not implemented in the WASM code generator
 - [#243](https://github.com/aallan/vera/issues/243) — **Nested generic constructor inference**: constructing nested generic values like `Cons(None, Nil)` fails type inference, though pattern matching on the same shape works
 
 ## Roadmap

--- a/SKILL.md
+++ b/SKILL.md
@@ -393,7 +393,8 @@ Statements end with `;`. The final expression (no `;`) is the block's value.
 ### Array operations
 
 ```vera
-length(@Array<Int>.0)  -- returns Int (always >= 0)
+length(@Array<Int>.0)                   -- returns Int (always >= 0)
+array_push(@Array<Int>.0, @Int.0)       -- returns Array<Int> (new array with element appended)
 ```
 
 ### String operations

--- a/TESTING.md
+++ b/TESTING.md
@@ -90,11 +90,11 @@ Each conformance program declares the deepest pipeline stage it must pass:
 | Level | What it validates | Count |
 |-------|-------------------|------:|
 | `parse` | Source text is syntactically valid | 0 |
-| `check` | Parses and type-checks cleanly | 1 |
+| `check` | Parses and type-checks cleanly | 0 |
 | `verify` | Type-checks and all contracts verified by Z3 | 6 |
-| `run` | Compiles to WASM and executes correctly | 32 |
+| `run` | Compiles to WASM and executes correctly | 33 |
 
-Most programs are at the `run` level — they compile and execute, producing correct results. Programs at the `verify` level test contract verification features (preconditions, postconditions, decreases) that don't need runtime execution. The `check` level is used for `ch01_byte_literals` which exercises a type that currently has a coercion limitation ([#241](https://github.com/aallan/vera/issues/241)).
+Most programs are at the `run` level — they compile and execute, producing correct results. Programs at the `verify` level test contract verification features (preconditions, postconditions, decreases) that don't need runtime execution.
 
 ### Directory structure
 
@@ -152,14 +152,7 @@ When implementing a new language feature, the conformance program should be writ
 
 ### Known limitations
 
-Two conformance programs have reduced test levels due to known compiler limitations:
-
-| Program | Level | Expected | Issue |
-|---------|-------|----------|-------|
-| `ch01_byte_literals` | check | run | [#241](https://github.com/aallan/vera/issues/241) — Byte literal coercion |
-| `ch04_array_ops` | run | run | [#242](https://github.com/aallan/vera/issues/242) — `array_push` not in codegen (test omits `array_push`) |
-
-Additionally, [#243](https://github.com/aallan/vera/issues/243) tracks a type inference limitation where nested generic constructors (e.g. `Cons(None, Nil)`) fail to infer inner types from context.
+[#243](https://github.com/aallan/vera/issues/243) tracks a type inference limitation where nested generic constructors (e.g. `Cons(None, Nil)`) fail to infer inner types from context. All 39 conformance programs currently pass at their declared level.
 
 ## Compiler Code Coverage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.68"
+version = "0.0.69"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/scripts/check_readme_examples.py
+++ b/scripts/check_readme_examples.py
@@ -36,7 +36,7 @@ ALLOWLIST: dict[int, tuple[str, str]] = {
     # =================================================================
 
     # Section "Where this is going" — depends on #57 (Http), #61 (Inference), #147 (Markdown)
-    411: ("FUTURE", "Vision example uses MdBlock, Http, Inference (issues #57, #61, #147)"),
+    407: ("FUTURE", "Vision example uses MdBlock, Http, Inference (issues #57, #61, #147)"),
 }
 
 

--- a/scripts/check_skill_examples.py
+++ b/scripts/check_skill_examples.py
@@ -37,51 +37,51 @@ ALLOWLIST: dict[int, tuple[str, str]] = {
     395: ("FRAGMENT", "Array built-in examples, bare calls"),
 
     # String operations — bare function calls
-    401: ("FRAGMENT", "String built-in examples, bare calls"),
+    402: ("FRAGMENT", "String built-in examples, bare calls"),
 
     # Contracts section — requires/ensures fragments
-    439: ("FRAGMENT", "Requires clause example, not full function"),
-    448: ("FRAGMENT", "Ensures clause example, not full function"),
-    475: ("FRAGMENT", "Quantified requires clause, not full function"),
+    440: ("FRAGMENT", "Requires clause example, not full function"),
+    449: ("FRAGMENT", "Ensures clause example, not full function"),
+    476: ("FRAGMENT", "Quantified requires clause, not full function"),
 
     # Effects section — bare effect rows
-    493: ("FRAGMENT", "Effect row examples, bare annotations"),
+    494: ("FRAGMENT", "Effect row examples, bare annotations"),
 
     # Effect handler syntax template
-    630: ("FRAGMENT", "Handler syntax template, not real code"),
+    631: ("FRAGMENT", "Handler syntax template, not real code"),
 
     # Qualified calls and handler fragments — bare expressions
-    642: ("FRAGMENT", "Handler with clause, bare expression"),
-    652: ("FRAGMENT", "Qualified call examples, bare expressions"),
+    643: ("FRAGMENT", "Handler with clause, bare expression"),
+    653: ("FRAGMENT", "Qualified call examples, bare expressions"),
 
     # Module declaration and import syntax
-    702: ("FRAGMENT", "Module declaration and import example"),
+    703: ("FRAGMENT", "Module declaration and import example"),
 
     # Line comments — bare comments
-    741: ("FRAGMENT", "Comment syntax example"),
+    742: ("FRAGMENT", "Comment syntax example"),
 
     # Common mistakes section — intentionally wrong code
-    769: ("FRAGMENT", "Wrong: missing contracts"),
-    776: ("FRAGMENT", "Wrong: incorrect contract syntax"),
-    789: ("FRAGMENT", "Wrong: missing requires"),
-    799: ("FRAGMENT", "Wrong: missing effects clause"),
-    812: ("FRAGMENT", "Wrong: wrong effect declared"),
-    823: ("FRAGMENT", "Wrong: bare expression without indices"),
-    836: ("FRAGMENT", "Wrong: bare expression no indices"),
-    841: ("FRAGMENT", "Correct: expression with indices (not full fn)"),
-    931: ("FRAGMENT", "Wrong: match arm with incorrect return"),
-    938: ("FRAGMENT", "Correct: match arm example"),
-    948: ("FRAGMENT", "Wrong: if/else without braces (bare expression)"),
-    953: ("FRAGMENT", "Correct: if/else with braces"),
+    770: ("FRAGMENT", "Wrong: missing contracts"),
+    777: ("FRAGMENT", "Wrong: incorrect contract syntax"),
+    790: ("FRAGMENT", "Wrong: missing requires"),
+    800: ("FRAGMENT", "Wrong: missing effects clause"),
+    813: ("FRAGMENT", "Wrong: wrong effect declared"),
+    824: ("FRAGMENT", "Wrong: bare expression without indices"),
+    837: ("FRAGMENT", "Wrong: bare expression no indices"),
+    842: ("FRAGMENT", "Correct: expression with indices (not full fn)"),
+    932: ("FRAGMENT", "Wrong: match arm with incorrect return"),
+    939: ("FRAGMENT", "Correct: match arm example"),
+    949: ("FRAGMENT", "Wrong: if/else without braces (bare expression)"),
+    954: ("FRAGMENT", "Correct: if/else with braces"),
 
     # Import syntax — intentionally unsupported
-    964: ("FRAGMENT", "Wrong: import aliasing not supported"),
-    969: ("FRAGMENT", "Correct: import syntax example"),
-    979: ("FRAGMENT", "Wrong: import hiding not supported"),
-    984: ("FRAGMENT", "Correct: multi-import syntax"),
+    965: ("FRAGMENT", "Wrong: import aliasing not supported"),
+    970: ("FRAGMENT", "Correct: import syntax example"),
+    980: ("FRAGMENT", "Wrong: import hiding not supported"),
+    985: ("FRAGMENT", "Correct: multi-import syntax"),
 
     # String escapes — bare expression
-    998: ("FRAGMENT", "String escape example"),
+    999: ("FRAGMENT", "String escape example"),
 
     # =================================================================
     # MISMATCH — uses syntax the parser doesn't handle in isolation.

--- a/tests/conformance/ch01_byte_literals.vera
+++ b/tests/conformance/ch01_byte_literals.vera
@@ -1,5 +1,29 @@
 -- Conformance: Byte type (Chapter 1)
--- Tests: Byte as parameter and return type, Byte equality
+-- Tests: Byte literal coercion, identity, equality
+public fn byte_from_literal(-> @Byte)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  65
+}
+
+public fn byte_zero(-> @Byte)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  0
+}
+
+public fn byte_max(-> @Byte)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  255
+}
+
 public fn byte_identity(@Byte -> @Byte)
   requires(true)
   ensures(true)
@@ -16,10 +40,11 @@ public fn byte_eq(@Byte, @Byte -> @Bool)
   @Byte.0 == @Byte.1
 }
 
-public fn main(@Byte -> @Byte)
+public fn main(@Unit -> @Bool)
   requires(true)
   ensures(true)
   effects(pure)
 {
-  @Byte.0
+  let @Byte = byte_from_literal();
+  byte_eq(@Byte.0, byte_identity(@Byte.0))
 }

--- a/tests/conformance/ch04_array_ops.vera
+++ b/tests/conformance/ch04_array_ops.vera
@@ -1,5 +1,5 @@
 -- Conformance: array operations (Chapter 4)
--- Tests: array literal, length, array_get, array_set, array_push
+-- Tests: array literal, length, array_get, array_push
 public fn test_length(@Unit -> @Int)
   requires(true)
   ensures(@Int.result == 3)
@@ -17,10 +17,19 @@ public fn test_get(@Unit -> @Int)
   @Array<Int>.0[1]
 }
 
-public fn main(@Unit -> @Int)
+public fn test_push(@Unit -> @Int)
   requires(true)
-  ensures(@Int.result == 3)
+  ensures(@Int.result == 4)
   effects(pure)
 {
-  length([1, 2, 3])
+  length(array_push([1, 2, 3], 4))
+}
+
+public fn main(@Unit -> @Bool)
+  requires(true)
+  ensures(@Bool.result == true)
+  effects(pure)
+{
+  let @Int = test_push(());
+  @Int.0 == 4
 }

--- a/tests/conformance/manifest.json
+++ b/tests/conformance/manifest.json
@@ -40,9 +40,9 @@
     "file": "ch01_byte_literals.vera",
     "chapter": 1,
     "title": "Byte type",
-    "level": "check",
+    "level": "run",
     "spec_ref": "Section 1.1",
-    "features": ["byte_type"]
+    "features": ["byte_type", "byte_coercion"]
   },
   {
     "id": "ch01_comments",
@@ -222,7 +222,7 @@
     "title": "Array operations",
     "level": "run",
     "spec_ref": "Section 4.7",
-    "features": ["array_literal", "array_length", "array_get"]
+    "features": ["array_literal", "array_length", "array_get", "array_push"]
   },
   {
     "id": "ch05_basic_function",

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -167,6 +167,48 @@ private fn foo(@Unit -> @Float)
 { 3.14 }
 """, "'Float' is not a type. Did you mean 'Float64'?")
 
+    # --- Byte literal coercion (#241) ---
+
+    def test_byte_lit_coercion(self) -> None:
+        """Integer literal 0–255 accepted as Byte when expected type is Byte."""
+        _check_ok("""
+private fn foo(@Unit -> @Byte)
+  requires(true) ensures(true) effects(pure)
+{ 65 }
+""")
+
+    def test_byte_lit_zero(self) -> None:
+        """Boundary: 0 accepted as Byte."""
+        _check_ok("""
+private fn foo(@Unit -> @Byte)
+  requires(true) ensures(true) effects(pure)
+{ 0 }
+""")
+
+    def test_byte_lit_max(self) -> None:
+        """Boundary: 255 accepted as Byte."""
+        _check_ok("""
+private fn foo(@Unit -> @Byte)
+  requires(true) ensures(true) effects(pure)
+{ 255 }
+""")
+
+    def test_byte_lit_overflow_rejected(self) -> None:
+        """256 is out of Byte range — should be rejected."""
+        _check_err("""
+private fn foo(@Unit -> @Byte)
+  requires(true) ensures(true) effects(pure)
+{ 256 }
+""", "body has type")
+
+    def test_byte_lit_negative_rejected(self) -> None:
+        """Negative integer is not a valid Byte."""
+        _check_err("""
+private fn foo(@Unit -> @Byte)
+  requires(true) ensures(true) effects(pure)
+{ 0 - 1 }
+""", "body has type")
+
 
 # =====================================================================
 # Slot references
@@ -1307,6 +1349,24 @@ private fn bad(@Int -> @Int)
   requires(true) ensures(true) effects(pure)
 { @Int.0[0] }
 """, "Cannot index")
+
+    # --- array_push (#242) ---
+
+    def test_array_push_type_checks(self) -> None:
+        """array_push(Array<T>, T) -> Array<T> type-checks cleanly."""
+        _check_ok("""
+private fn foo(@Unit -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ length(array_push([1, 2, 3], 4)) }
+""")
+
+    def test_array_push_string(self) -> None:
+        """array_push works with String element type."""
+        _check_ok("""
+private fn foo(@Unit -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ length(array_push(["a", "b"], "c")) }
+""")
 
 
 # =====================================================================

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -3306,6 +3306,47 @@ public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
 """
         assert _run(src) == 5
 
+    # --- array_push (#242) ---
+
+    def test_array_push_length(self) -> None:
+        """array_push returns an array with length + 1."""
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  length(array_push([1, 2, 3], 4))
+}
+"""
+        assert _run(src) == 4
+
+    def test_array_push_element_value(self) -> None:
+        """The pushed element is accessible at the last index."""
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  let @Array<Int> = array_push([10, 20, 30], 99);
+  @Array<Int>.0[3]
+}
+"""
+        assert _run(src) == 99
+
+    def test_array_push_preserves_existing(self) -> None:
+        """array_push preserves all existing elements."""
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  let @Array<Int> = array_push([10, 20, 30], 99);
+  @Array<Int>.0[1]
+}
+"""
+        assert _run(src) == 20
+
+    def test_array_push_empty(self) -> None:
+        """array_push onto empty array produces [elem]."""
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  let @Array<Int> = array_push([], 42);
+  @Array<Int>.0[0]
+}
+"""
+        assert _run(src) == 42
+
     def test_array_fn_param_compiles(self) -> None:
         """Functions with Array params should compile with pair params."""
         src = """

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -19,7 +19,7 @@ README = Path(__file__).parent.parent / "README.md"
 # Each key is the 1-based line number of the opening ```vera fence.
 ALLOWLIST: dict[int, str] = {
     # "Where this is going" — depends on #57 (Http), #61 (Inference), #147 (Markdown)
-    411: "Vision example uses MdBlock, Http, Inference (issues #57, #61, #147)",
+    407: "Vision example uses MdBlock, Http, Inference (issues #57, #61, #147)",
 }
 
 

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.68"
+__version__ = "0.0.69"

--- a/vera/checker/calls.py
+++ b/vera/checker/calls.py
@@ -111,6 +111,15 @@ class CallsMixin:
                 if arg_ty is None or isinstance(arg_ty, UnknownType):
                     continue
                 arg_types[i] = arg_ty
+            # Re-synth with expected type when subtype check would fail —
+            # enables bidirectional coercion (e.g. IntLit → Byte).
+            if (not is_subtype(arg_ty, param_ty)
+                    and not contains_typevar(param_ty)):
+                re = self._synth_expr(args[i], expected=param_ty)
+                if re is not None and not isinstance(re, UnknownType):
+                    if is_subtype(re, param_ty):
+                        arg_ty = re
+                        arg_types[i] = re
             if not is_subtype(arg_ty, param_ty):
                 self._error(
                     args[i],

--- a/vera/checker/expressions.py
+++ b/vera/checker/expressions.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from vera import ast
 from vera.types import (
     BOOL,
+    BYTE,
     FLOAT64,
     INT,
     NAT,
@@ -19,6 +20,7 @@ from vera.types import (
     STRING,
     UNIT,
     AdtType,
+    PrimitiveType,
     EffectInstance,
     FunctionType,
     Type,
@@ -46,6 +48,13 @@ class ExpressionsMixin:
         ADTs can resolve their TypeVars from context (bidirectional checking).
         """
         if isinstance(expr, ast.IntLit):
+            # Byte coercion: integer literals 0–255 accepted as Byte when
+            # the expected type is Byte (bidirectional checking).
+            if (expected is not None
+                    and isinstance(expected, PrimitiveType)
+                    and expected.name == "Byte"
+                    and 0 <= expr.value <= 255):
+                return BYTE
             # Non-negative integer literals are Nat (which is a subtype of
             # Int).  This lets literals like 0, 1, 42 satisfy Nat parameters
             # without refinement verification.

--- a/vera/codegen/modules.py
+++ b/vera/codegen/modules.py
@@ -236,7 +236,8 @@ class CrossModuleMixin:
             known.update(layouts.keys())
         # Built-in names handled specially in _translate_call
         known.update({
-            "length", "apply_fn", "get", "put", "throw", "resume",
+            "length", "array_push",
+            "apply_fn", "get", "put", "throw", "resume",
             "string_length", "string_concat", "string_slice",
             "char_code", "parse_nat", "parse_float64",
             "to_string", "int_to_string", "bool_to_string",

--- a/vera/environment.py
+++ b/vera/environment.py
@@ -228,6 +228,18 @@ class TypeEnv:
             effect=PureEffectRow(),
         )
 
+        # Built-in function: array_push
+        self.functions["array_push"] = FunctionInfo(
+            name="array_push",
+            forall_vars=("T",),
+            param_types=(
+                AdtType("Array", (TypeVar("T"),)),
+                TypeVar("T"),
+            ),
+            return_type=AdtType("Array", (TypeVar("T"),)),
+            effect=PureEffectRow(),
+        )
+
         # Built-in string operations
         self.functions["string_length"] = FunctionInfo(
             name="string_length",

--- a/vera/wasm/calls.py
+++ b/vera/wasm/calls.py
@@ -3,7 +3,13 @@
 from __future__ import annotations
 
 from vera import ast
-from vera.wasm.helpers import WasmSlotEnv, gc_shadow_push
+from vera.wasm.helpers import (
+    WasmSlotEnv,
+    _element_mem_size,
+    _element_store_op,
+    _is_pair_element_type,
+    gc_shadow_push,
+)
 
 
 class CallsMixin:
@@ -56,6 +62,10 @@ class CallsMixin:
                 return self._translate_float_to_string(call.args[0], env)
             if call.name == "strip" and len(call.args) == 1:
                 return self._translate_strip(call.args[0], env)
+            if call.name == "array_push" and len(call.args) == 2:
+                return self._translate_array_push(
+                    call.args[0], call.args[1], env,
+                )
 
         # Check if this is a closure application: apply_fn(closure, args...)
         if call.name == "apply_fn" and len(call.args) >= 2:
@@ -194,6 +204,136 @@ class CallsMixin:
         instructions.append("drop")
         instructions.append(f"local.get {tmp_len}")
         instructions.append("i64.extend_i32_u")
+        return instructions
+
+    def _translate_array_push(
+        self,
+        arr_arg: ast.Expr,
+        elem_arg: ast.Expr,
+        env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """Translate array_push(array, element) → Array<T>.
+
+        Allocates a new array of size (len + 1), copies the old elements
+        byte-by-byte, appends the new element, and returns (new_ptr, new_len).
+        """
+        arr_instrs = self.translate_expr(arr_arg, env)
+        elem_instrs = self.translate_expr(elem_arg, env)
+        if arr_instrs is None or elem_instrs is None:
+            return None
+
+        # Infer element type from the pushed element
+        elem_type = self._infer_vera_type(elem_arg)
+        if elem_type is None:
+            return None
+        elem_size = _element_mem_size(elem_type)
+        if elem_size is None:
+            return None
+
+        is_pair = _is_pair_element_type(elem_type)
+        store_op = _element_store_op(elem_type)
+        if store_op is None and not is_pair:
+            return None
+
+        self.needs_alloc = True
+
+        # Locals for old array
+        ptr_arr = self.alloc_local("i32")
+        len_arr = self.alloc_local("i32")
+        # Locals for new element
+        if is_pair:
+            elem_ptr = self.alloc_local("i32")
+            elem_len = self.alloc_local("i32")
+        else:
+            elem_val = self.alloc_local(
+                "i64" if elem_type in ("Int", "Nat") else
+                "f64" if elem_type == "Float64" else "i32"
+            )
+        # Locals for copy loop and destination
+        dst = self.alloc_local("i32")
+        idx = self.alloc_local("i32")
+        old_bytes = self.alloc_local("i32")
+
+        instructions: list[str] = []
+
+        # Evaluate array arg → (ptr, len), save to locals
+        instructions.extend(arr_instrs)
+        instructions.append(f"local.set {len_arr}")
+        instructions.append(f"local.set {ptr_arr}")
+
+        # Evaluate element arg, save to locals
+        instructions.extend(elem_instrs)
+        if is_pair:
+            instructions.append(f"local.set {elem_len}")
+            instructions.append(f"local.set {elem_ptr}")
+        else:
+            instructions.append(f"local.set {elem_val}")
+
+        # Compute old_bytes = len_arr * elem_size
+        instructions.append(f"local.get {len_arr}")
+        instructions.append(f"i32.const {elem_size}")
+        instructions.append("i32.mul")
+        instructions.append(f"local.set {old_bytes}")
+
+        # Allocate: (len_arr + 1) * elem_size = old_bytes + elem_size
+        instructions.append(f"local.get {old_bytes}")
+        instructions.append(f"i32.const {elem_size}")
+        instructions.append("i32.add")
+        instructions.append("call $alloc")
+        instructions.append(f"local.set {dst}")
+        instructions.extend(gc_shadow_push(dst))
+
+        # Copy old elements: byte-by-byte loop
+        instructions.append("i32.const 0")
+        instructions.append(f"local.set {idx}")
+        instructions.append("block $brk_copy")
+        instructions.append("  loop $lp_copy")
+        instructions.append(f"    local.get {idx}")
+        instructions.append(f"    local.get {old_bytes}")
+        instructions.append("    i32.ge_u")
+        instructions.append("    br_if $brk_copy")
+        instructions.append(f"    local.get {dst}")
+        instructions.append(f"    local.get {idx}")
+        instructions.append("    i32.add")
+        instructions.append(f"    local.get {ptr_arr}")
+        instructions.append(f"    local.get {idx}")
+        instructions.append("    i32.add")
+        instructions.append("    i32.load8_u offset=0")
+        instructions.append("    i32.store8 offset=0")
+        instructions.append(f"    local.get {idx}")
+        instructions.append("    i32.const 1")
+        instructions.append("    i32.add")
+        instructions.append(f"    local.set {idx}")
+        instructions.append("    br $lp_copy")
+        instructions.append("  end")
+        instructions.append("end")
+
+        # Store new element at dst + old_bytes
+        if is_pair:
+            # Store ptr at old_bytes offset
+            instructions.append(f"local.get {dst}")
+            instructions.append(f"local.get {old_bytes}")
+            instructions.append("i32.add")
+            instructions.append(f"local.get {elem_ptr}")
+            instructions.append("i32.store offset=0")
+            # Store len at old_bytes + 4
+            instructions.append(f"local.get {dst}")
+            instructions.append(f"local.get {old_bytes}")
+            instructions.append("i32.add")
+            instructions.append(f"local.get {elem_len}")
+            instructions.append("i32.store offset=4")
+        else:
+            instructions.append(f"local.get {dst}")
+            instructions.append(f"local.get {old_bytes}")
+            instructions.append("i32.add")
+            instructions.append(f"local.get {elem_val}")
+            instructions.append(f"{store_op} offset=0")
+
+        # Push result: (new_ptr, new_len)
+        instructions.append(f"local.get {dst}")
+        instructions.append(f"local.get {len_arr}")
+        instructions.append("i32.const 1")
+        instructions.append("i32.add")
         return instructions
 
     def _translate_string_length(


### PR DESCRIPTION
## Summary

- **#241 — Byte literal coercion**: Integer literals 0–255 are now accepted as `Byte` when the expected type is `Byte` (bidirectional type checking in both return position and function call argument position)
- **#242 — `array_push` codegen**: `array_push(array, elem)` is now a fully implemented builtin with generic `(Array<T>, T) -> Array<T>` signature and complete WASM codegen (allocation, element copying, GC shadow stack)
- Conformance suite updated: `ch01_byte_literals` promoted from `check` → `run`; `ch04_array_ops` now exercises `array_push`
- 11 new unit tests (5 checker + 2 checker + 4 codegen), documentation updated across TESTING.md, SKILL.md, README.md

### Files changed (19)

**Compiler fixes:**
- `vera/checker/expressions.py` — Byte coercion in `_synth_expr` IntLit branch
- `vera/checker/calls.py` — Re-synth with expected type in function call arguments
- `vera/environment.py` — `array_push` builtin type registration
- `vera/wasm/calls.py` — `array_push` WASM codegen dispatch + implementation
- `vera/codegen/modules.py` — `array_push` added to known builtins set

**Tests:**
- `tests/conformance/ch01_byte_literals.vera` — Promoted to `run` level with coercion tests
- `tests/conformance/ch04_array_ops.vera` — Added `test_push` function
- `tests/conformance/manifest.json` — Updated levels and features
- `tests/test_checker.py` — 7 new unit tests for Byte coercion and array_push
- `tests/test_codegen.py` — 4 new end-to-end tests for array_push

**Documentation:**
- `TESTING.md` — Removed #241/#242 from known limitations, updated level counts
- `README.md` — Removed #241/#242 from Known Bugs section
- `SKILL.md` — Added `array_push` to Array operations reference
- `CHANGELOG.md` — v0.0.69 entry

## Test plan

- [x] `pytest tests/ -v` — 1673 passed, 6 skipped
- [x] `mypy vera/` — clean (41 files)
- [x] `python scripts/check_conformance.py` — all 39 pass
- [x] `python scripts/check_examples.py` — all 18 pass
- [x] `python scripts/check_version_sync.py` — v0.0.69 consistent
- [x] All code block validators pass (spec, README, SKILL.md)

Closes #241, closes #242.

🤖 Generated with [Claude Code](https://claude.com/claude-code)