### PR TITLE
Fix #243: nested generic constructor inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,11 +183,7 @@ The language specification is in draft across 13 chapters:
 
 ### Testing
 
-Testing is organized in three layers: **unit tests** (1,673 tests across 20 files, testing compiler internals), a **conformance suite** (39 programs across 7 spec chapters, systematically validating every language feature against the spec), and **example programs** (18 end-to-end demos). The compiler has 90% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations. Every commit validates all conformance programs, example programs, and 95 specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference -- coverage tables, conformance suite details, CI pipeline, and infrastructure.
-
-### Known Bugs
-
-- [#243](https://github.com/aallan/vera/issues/243) — **Nested generic constructor inference**: constructing nested generic values like `Cons(None, Nil)` fails type inference, though pattern matching on the same shape works
+Testing is organized in three layers: **unit tests** (1,677 tests across 20 files, testing compiler internals), a **conformance suite** (39 programs across 7 spec chapters, systematically validating every language feature against the spec), and **example programs** (18 end-to-end demos). The compiler has 90% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations. Every commit validates all conformance programs, example programs, and 95 specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference -- coverage tables, conformance suite details, CI pipeline, and infrastructure.
 
 ## Roadmap
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -150,10 +150,6 @@ The pytest runner (`test_conformance.py`) parametrizes over every manifest entry
 
 When implementing a new language feature, the conformance program should be written *first* — this is test-driven development against the spec.
 
-### Known limitations
-
-[#243](https://github.com/aallan/vera/issues/243) tracks a type inference limitation where nested generic constructors (e.g. `Cons(None, Nil)`) fail to infer inner types from context. All 39 conformance programs currently pass at their declared level.
-
 ## Compiler Code Coverage
 
 Coverage by module, measured by `pytest --cov=vera`:

--- a/scripts/check_readme_examples.py
+++ b/scripts/check_readme_examples.py
@@ -36,7 +36,7 @@ ALLOWLIST: dict[int, tuple[str, str]] = {
     # =================================================================
 
     # Section "Where this is going" — depends on #57 (Http), #61 (Inference), #147 (Markdown)
-    407: ("FUTURE", "Vision example uses MdBlock, Http, Inference (issues #57, #61, #147)"),
+    403: ("FUTURE", "Vision example uses MdBlock, Http, Inference (issues #57, #61, #147)"),
 }
 
 

--- a/tests/conformance/ch04_match_nested.vera
+++ b/tests/conformance/ch04_match_nested.vera
@@ -22,6 +22,32 @@ private fn first_some(@List<Option<Int>> -> @Int)
   }
 }
 
+-- Nested generic constructor expressions (#243)
+-- These test bidirectional inference for constructor-as-argument paths.
+private fn id_list(@List<Option<Int>> -> @List<Option<Int>>)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  @List<Option<Int>>.0
+}
+
+private fn wrap_list(-> @List<Option<Int>>)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  Cons(None, Nil)
+}
+
+private fn wrap_list_arg(-> @List<Option<Int>>)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  id_list(Cons(None, Nil))
+}
+
 public fn main(@Unit -> @Int)
   requires(true)
   ensures(@Int.result == 42)

--- a/tests/conformance/manifest.json
+++ b/tests/conformance/manifest.json
@@ -195,7 +195,7 @@
     "title": "Nested match patterns",
     "level": "run",
     "spec_ref": "Section 4.4",
-    "features": ["nested_pattern", "constructor_pattern"]
+    "features": ["nested_pattern", "constructor_pattern", "nested_constructor"]
   },
   {
     "id": "ch04_pipe_operator",

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -2766,6 +2766,59 @@ private fn succeed(-> @Result<Int, String>)
 { Ok(42) }
 """)
 
+    # ---- Nested generic constructors (#243) ----------------------------
+
+    def test_nested_generic_ctor_let_binding(self) -> None:
+        """Cons(None, Nil) resolves via annotated let binding (#243)."""
+        _check_ok("""
+private data Option<T> { None, Some(T) }
+private data List<T> { Nil, Cons(T, List<T>) }
+
+private fn f(-> @List<Option<Int>>)
+  requires(true) ensures(true) effects(pure)
+{
+  let @List<Option<Int>> = Cons(None, Nil);
+  @List<Option<Int>>.0
+}
+""")
+
+    def test_nested_generic_ctor_fn_arg(self) -> None:
+        """Cons(None, Nil) resolves as non-generic function argument (#243)."""
+        _check_ok("""
+private data Option<T> { None, Some(T) }
+private data List<T> { Nil, Cons(T, List<T>) }
+
+private fn id(@List<Option<Int>> -> @List<Option<Int>>)
+  requires(true) ensures(true) effects(pure)
+{ @List<Option<Int>>.0 }
+
+private fn test(-> @List<Option<Int>>)
+  requires(true) ensures(true) effects(pure)
+{ id(Cons(None, Nil)) }
+""")
+
+    def test_nested_generic_ctor_return_context(self) -> None:
+        """Cons(None, Nil) resolves from return type context (#243)."""
+        _check_ok("""
+private data Option<T> { None, Some(T) }
+private data List<T> { Nil, Cons(T, List<T>) }
+
+private fn f(-> @List<Option<Int>>)
+  requires(true) ensures(true) effects(pure)
+{ Cons(None, Nil) }
+""")
+
+    def test_deeper_nested_generic_ctor(self) -> None:
+        """Cons(Some(None), Nil) resolves deeper nesting (#243)."""
+        _check_ok("""
+private data Option<T> { None, Some(T) }
+private data List<T> { Nil, Cons(T, List<T>) }
+
+private fn f(-> @List<Option<Option<Int>>>)
+  requires(true) ensures(true) effects(pure)
+{ Cons(Some(None), Nil) }
+""")
+
 
 # =====================================================================
 # IO built-in operations (C8.5 — #135)

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -19,7 +19,7 @@ README = Path(__file__).parent.parent / "README.md"
 # Each key is the 1-based line number of the opening ```vera fence.
 ALLOWLIST: dict[int, str] = {
     # "Where this is going" — depends on #57 (Http), #61 (Inference), #147 (Markdown)
-    407: "Vision example uses MdBlock, Http, Inference (issues #57, #61, #147)",
+    403: "Vision example uses MdBlock, Http, Inference (issues #57, #61, #147)",
 }
 
 

--- a/vera/checker/calls.py
+++ b/vera/checker/calls.py
@@ -72,10 +72,18 @@ class CallsMixin:
                                  args: tuple[ast.Expr, ...],
                                  node: ast.Node) -> Type | None:
         """Check a call against a known function signature."""
-        # Synth arg types
+        # Synth arg types.  For non-generic functions pass the declared
+        # param type as *expected* so that nested constructors can resolve
+        # TypeVars from context (fixes #243).
         arg_types: list[Type | None] = []
-        for arg in args:
-            arg_types.append(self._synth_expr(arg))
+        for i, arg in enumerate(args):
+            exp: Type | None = None
+            if (not fn_info.forall_vars
+                    and i < len(fn_info.param_types)):
+                pt = fn_info.param_types[i]
+                if not contains_typevar(pt):
+                    exp = pt
+            arg_types.append(self._synth_expr(arg, expected=exp))
 
         # Arity check
         if len(args) != len(fn_info.param_types):
@@ -291,8 +299,9 @@ class CallsMixin:
                 continue
             if isinstance(field_ty, (TypeVar, UnknownType)):
                 continue
-            # Re-synth if arg still has unresolved TypeVars
-            if contains_typevar(arg_ty) and not contains_typevar(field_ty):
+            # Re-synth if arg still has unresolved TypeVars and the
+            # subtype check would fail (e.g. List<T$2> vs List<Option<Int>>).
+            if contains_typevar(arg_ty) and not is_subtype(arg_ty, field_ty):
                 arg_ty = self._synth_expr(expr.args[i], expected=field_ty)
                 if arg_ty is None or isinstance(arg_ty, UnknownType):
                     continue
@@ -327,6 +336,16 @@ class CallsMixin:
 
         return self._ctor_result_type(ci, [], expected=expected)
 
+    def _fresh_typevar(self, name: str) -> TypeVar:
+        """Return a TypeVar with a unique name derived from *name*.
+
+        Fresh names prevent self-referential mappings when constructors
+        from different ADTs share a type parameter name (e.g. both
+        Option<T> and List<T> use ``T``).
+        """
+        self._fresh_id += 1
+        return TypeVar(f"{name}${self._fresh_id}")
+
     def _ctor_result_type(self, ci: ConstructorInfo,
                           arg_types: list[Type | None], *,
                           expected: Type | None = None) -> Type:
@@ -334,6 +353,7 @@ class CallsMixin:
 
         When *expected* is an AdtType with the same parent name, unresolved
         TypeVars are filled from the expected type args (bidirectional).
+        Remaining unresolved TypeVars are freshened to avoid collisions.
         """
         if ci.parent_type_params:
             # Try to infer type args from argument types
@@ -348,15 +368,14 @@ class CallsMixin:
                     if tv not in mapping and not isinstance(exp_arg, TypeVar):
                         mapping[tv] = exp_arg
 
-            if mapping:
-                args = tuple(
-                    mapping.get(tv, TypeVar(tv))
-                    for tv in ci.parent_type_params
-                )
-                return AdtType(ci.parent_type, args)
-            # Leave as type vars
-            return AdtType(ci.parent_type, tuple(
-                TypeVar(tv) for tv in ci.parent_type_params))
+            # Use fresh TypeVars for any that remain unresolved — prevents
+            # self-referential mappings when different ADTs share a param
+            # name (e.g. both Option<T> and List<T> use "T").
+            args = tuple(
+                mapping.get(tv, self._fresh_typevar(tv))
+                for tv in ci.parent_type_params
+            )
+            return AdtType(ci.parent_type, args)
         return AdtType(ci.parent_type, ())
 
     def _infer_ctor_type_args(self, ci: ConstructorInfo,

--- a/vera/checker/core.py
+++ b/vera/checker/core.py
@@ -137,6 +137,10 @@ class TypeChecker(
         ] = {}
         # De-dup removed-alias errors (emitted once per alias name).
         self._reported_alias_errors: set[str] = set()
+        # Monotonic counter for fresh TypeVar names (prevents
+        # self-referential mappings when different ADTs share a type
+        # parameter name — see #243).
+        self._fresh_id: int = 0
 
     @staticmethod
     def _is_public(visibility: str | None) -> bool:


### PR DESCRIPTION
## Summary

- **Pass expected types from function calls to arg synthesis** — when a non-generic function receives a constructor expression, the declared parameter type is now threaded as `expected` so nested nullary constructors (like `None`, `Nil`) can resolve their TypeVars from context
- **Freshen unresolved TypeVars** — constructors from different ADTs that share type parameter names (e.g. both `Option<T>` and `List<T>` use `T`) now get unique fresh names (`T$1`, `T$2`) preventing self-referential mappings during unification
- **Relax re-synth guard** — re-synthesis now fires whenever the subtype check would fail (not only when `field_ty` is fully concrete), enabling recovery even when fresh TypeVars are present

Closes #243

## Test plan

- [x] 4 new unit tests in `test_checker.py` (let binding, fn arg, return context, deeper nesting)
- [x] Extended conformance test `ch04_match_nested.vera` with constructor expression tests
- [x] Full test suite: 1,677 passed, 6 skipped
- [x] All 39 conformance programs pass
- [x] All 18 examples pass (check + verify)
- [x] mypy clean
- [x] All documentation validators pass
- [x] Removed #243 from README Known Bugs and TESTING.md Known Limitations

🤖 Generated with [Claude Code](https://claude.com/claude-code)