### PR TITLE
Release v0.0.70: numeric math builtins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.70] - 2026-03-09
+
 ### Added
 - **Close #199: Numeric math builtins** ([#199](https://github.com/aallan/vera/issues/199)):
   Eight new built-in functions for common mathematical operations: `abs` (Int→Nat),
@@ -1093,7 +1095,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Grammar: handler body simplified to avoid LALR reduce/reduce conflict
 - `pyproject.toml`: corrected build backend, package discovery, PEP 639 compliance
 
-[Unreleased]: https://github.com/aallan/vera/compare/v0.0.69...HEAD
+[Unreleased]: https://github.com/aallan/vera/compare/v0.0.70...HEAD
+[0.0.70]: https://github.com/aallan/vera/compare/v0.0.69...v0.0.70
 [0.0.69]: https://github.com/aallan/vera/compare/v0.0.68...v0.0.69
 [0.0.68]: https://github.com/aallan/vera/compare/v0.0.67...v0.0.68
 [0.0.67]: https://github.com/aallan/vera/compare/v0.0.66...v0.0.67

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ Module refinements, lexical extensions, and IO runtime — completing the existi
 
 **Builtin extensions** — independent of each other, no module deps
 
-- [#199](https://github.com/aallan/vera/issues/199) numeric math builtins
+- <del>[#199](https://github.com/aallan/vera/issues/199) numeric math builtins</del> ([v0.0.70](https://github.com/aallan/vera/releases/tag/v0.0.70))
 - [#200](https://github.com/aallan/vera/issues/200) parsing completeness (parse_int, parse_bool, safe parse_float64)
 - [#198](https://github.com/aallan/vera/issues/198) string search and transformation builtins
 - [#208](https://github.com/aallan/vera/issues/208) numeric type conversions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.69"
+version = "0.0.70"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.69"
+__version__ = "0.0.70"


### PR DESCRIPTION
## Summary
- Bump version 0.0.69 → 0.0.70 across `__init__.py`, `pyproject.toml`, and `CHANGELOG.md`
- Move Unreleased content to `[0.0.70] - 2026-03-09` section
- Strike through #199 in README roadmap with version link
- Add CHANGELOG link references for the new tag

## Test plan
- [x] `python scripts/check_version_sync.py` — version consistent
- [x] `pytest tests/ -v` — 1,723 passed, 6 skipped
- [x] `mypy vera/` — clean
- [x] `python scripts/check_conformance.py` — 40/40 pass
- [x] `python scripts/check_examples.py` — 18/18 pass
- [x] All pre-commit hooks pass

After merge: tag `v0.0.70` at merge commit, push tag, create GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)