### PR TITLE
Add numeric type conversions (closes #208)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Read `SKILL.md` for the full language reference. It covers syntax, slot referenc
 
 ### Conformance programs as reference
 
-The conformance suite in `tests/conformance/` contains 40 small, self-contained programs — one per language feature — that all parse, type-check, verify, and (mostly) run correctly. These are the best minimal working examples of each feature. When you need to see how a specific construct works (e.g. effect handlers, match expressions, closures), check the corresponding conformance program before reading the spec. The `manifest.json` file maps features to programs.
+The conformance suite in `tests/conformance/` contains 41 small, self-contained programs — one per language feature — that all parse, type-check, verify, and (mostly) run correctly. These are the best minimal working examples of each feature. When you need to see how a specific construct works (e.g. effect handlers, match expressions, closures), check the corresponding conformance program before reading the spec. The `manifest.json` file maps features to programs.
 
 ### Workflow
 
@@ -140,7 +140,7 @@ Each stage is a module with a single public API function (`parse_file`, `transfo
 pytest tests/ -v                       # Run all tests (see TESTING.md)
 pytest tests/test_conformance.py -v    # Conformance suite only
 mypy vera/                             # Type-check the compiler
-python scripts/check_conformance.py    # All 40 conformance programs must pass
+python scripts/check_conformance.py    # All 41 conformance programs must pass
 python scripts/check_examples.py       # All 18 examples must pass
 ```
 
@@ -150,7 +150,7 @@ When implementing a new language feature, write the conformance program *first* 
 
 ### Invariants
 
-- All 40 conformance programs in `tests/conformance/` must pass their declared level
+- All 41 conformance programs in `tests/conformance/` must pass their declared level
 - All 18 examples in `examples/` must pass `vera check` and `vera verify`
 - `mypy vera/` must be clean
 - `pytest tests/ -v` must pass

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.71] - 2026-03-09
+
+### Added
+- **Close #208: Numeric type conversions** ([#208](https://github.com/aallan/vera/issues/208)):
+  Six new built-in functions for explicit conversion between numeric types:
+  `to_float` (Int→Float64), `float_to_int` (Float64→Int, truncation toward zero),
+  `nat_to_int` (Nat→Int, identity), `int_to_nat` (Int→Option\<Nat\>, checked),
+  `byte_to_int` (Byte→Int, zero-extension), and `int_to_byte` (Int→Option\<Byte\>,
+  checked). Widening conversions always succeed; narrowing conversions return
+  `Option` for safety. `nat_to_int` and `byte_to_int` are SMT-verifiable (Tier 1).
+- New conformance test `ch09_type_conversions` (conformance suite: 40→41 programs)
+- 38 new tests (12 type checker + 26 codegen end-to-end)
+- Spec Section 9.6.4 "Type Conversions" with full signatures and contracts
+
 ## [0.0.70] - 2026-03-09
 
 ### Added
@@ -1095,7 +1109,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Grammar: handler body simplified to avoid LALR reduce/reduce conflict
 - `pyproject.toml`: corrected build backend, package discovery, PEP 639 compliance
 
-[Unreleased]: https://github.com/aallan/vera/compare/v0.0.70...HEAD
+[Unreleased]: https://github.com/aallan/vera/compare/v0.0.71...HEAD
+[0.0.71]: https://github.com/aallan/vera/compare/v0.0.70...v0.0.71
 [0.0.70]: https://github.com/aallan/vera/compare/v0.0.69...v0.0.70
 [0.0.69]: https://github.com/aallan/vera/compare/v0.0.68...v0.0.69
 [0.0.68]: https://github.com/aallan/vera/compare/v0.0.67...v0.0.68

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ vera fmt --check file.vera        # Check if already canonical
 pytest tests/ -v                  # Run the test suite (see TESTING.md)
 mypy vera/                        # Type-check the compiler itself
 
-python scripts/check_conformance.py    # Verify all 40 conformance programs pass their declared level
+python scripts/check_conformance.py    # Verify all 41 conformance programs pass their declared level
 python scripts/check_examples.py      # Verify all 18 examples parse + check + verify
 python scripts/check_spec_examples.py # Verify spec code blocks parse
 python scripts/check_readme_examples.py # Verify README code blocks parse
@@ -56,7 +56,7 @@ python scripts/fix_allowlists.py --fix # Auto-fix stale allowlist line numbers
 - `vera/` — Reference compiler: grammar, parser, AST, transformer, type checker, verifier, codegen, CLI
 - `examples/` — 18 example Vera programs (all must pass `vera check` and `vera verify`)
 - `tests/` — Test suite (unit tests + conformance suite)
-- `tests/conformance/` — 40 conformance programs validating every language feature against the spec
+- `tests/conformance/` — 41 conformance programs validating every language feature against the spec
 - `scripts/` — CI and validation scripts
 
 ## Writing Vera code
@@ -74,7 +74,7 @@ Each stage is a module with a public API function and is independently testable.
 ## What not to break
 
 - Pre-commit hooks run mypy + pytest + conformance suite + example validation on every commit
-- All 40 conformance programs in `tests/conformance/` must pass their declared level
+- All 41 conformance programs in `tests/conformance/` must pass their declared level
 - All 18 examples in `examples/` must pass `vera check` and `vera verify`
 - Version must stay in sync across `vera/__init__.py`, `pyproject.toml`, and `CHANGELOG.md`
 - All tests must pass: `pytest tests/ -v`

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ The language specification is in draft across 13 chapters:
 
 ### Testing
 
-Testing is organized in three layers: **unit tests** (1,723 tests across 20 files, testing compiler internals), a **conformance suite** (40 programs across 8 spec chapters, systematically validating every language feature against the spec), and **example programs** (18 end-to-end demos). The compiler has 90% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations. Every commit validates all conformance programs, example programs, and 95 specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference -- coverage tables, conformance suite details, CI pipeline, and infrastructure.
+Testing is organized in three layers: **unit tests** (1,766 tests across 20 files, testing compiler internals), a **conformance suite** (41 programs across 8 spec chapters, systematically validating every language feature against the spec), and **example programs** (18 end-to-end demos). The compiler has 90% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations. Every commit validates all conformance programs, example programs, and 95 specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference -- coverage tables, conformance suite details, CI pipeline, and infrastructure.
 
 ## Roadmap
 
@@ -316,7 +316,7 @@ Module refinements, lexical extensions, and IO runtime — completing the existi
 - <del>[#199](https://github.com/aallan/vera/issues/199) numeric math builtins</del> ([v0.0.70](https://github.com/aallan/vera/releases/tag/v0.0.70))
 - [#200](https://github.com/aallan/vera/issues/200) parsing completeness (parse_int, parse_bool, safe parse_float64)
 - [#198](https://github.com/aallan/vera/issues/198) string search and transformation builtins
-- [#208](https://github.com/aallan/vera/issues/208) numeric type conversions
+- <del>[#208](https://github.com/aallan/vera/issues/208) numeric type conversions</del> ([v0.0.71](https://github.com/aallan/vera/releases/tag/v0.0.71))
 - [#209](https://github.com/aallan/vera/issues/209) array construction builtins (range, append, concat)
 - [#210](https://github.com/aallan/vera/issues/210) from_char_code builtin
 - [#212](https://github.com/aallan/vera/issues/212) Float64 special value operations (is_nan, is_infinite)

--- a/SKILL.md
+++ b/SKILL.md
@@ -432,6 +432,19 @@ pow(@Float64.0, @Int.0)             -- returns Float64 (exponentiation)
 
 `abs` returns `Nat` because absolute values are non-negative. `floor`, `ceil`, and `round` convert `Float64` to `Int`; they trap on NaN or out-of-range values (WASM semantics). `round` uses IEEE 754 roundTiesToEven (banker's rounding): `round(2.5)` is `2`, not `3`. `pow` takes an `Int` exponent — negative exponents produce reciprocals (`pow(2.0, -1)` is `0.5`). The integer builtins (`abs`, `min`, `max`) are fully verifiable by the SMT solver (Tier 1). The float builtins fall to Tier 3 (runtime).
 
+### Type conversions
+
+```vera
+to_float(@Int.0)                    -- returns Float64 (int to float)
+float_to_int(@Float64.0)           -- returns Int (truncation toward zero)
+nat_to_int(@Nat.0)                 -- returns Int (identity, both i64)
+int_to_nat(@Int.0)                 -- returns Option<Nat> (None if negative)
+byte_to_int(@Byte.0)              -- returns Int (zero-extension)
+int_to_byte(@Int.0)               -- returns Option<Byte> (None if out of 0..255)
+```
+
+Vera has no implicit numeric conversions — use these functions to convert between numeric types. `to_float`, `nat_to_int`, and `byte_to_int` are widening conversions that always succeed. `float_to_int` truncates toward zero and traps on NaN/Infinity. `int_to_nat` and `int_to_byte` are checked narrowing conversions that return `Option` — pattern match on the result to handle the failure case. `nat_to_int` and `byte_to_int` are SMT-verifiable (Tier 1); the rest are Tier 3 (runtime).
+
 **Shadowing**: If you define a function with the same name as a built-in (e.g. `length` for a custom list type), your definition takes priority. The built-in is only used when no user-defined function with that name exists.
 
 Example:

--- a/TESTING.md
+++ b/TESTING.md
@@ -8,7 +8,7 @@ This is the single source of truth for Vera's testing infrastructure, coverage d
 |--------|-------|
 | **Tests** | 1,673 across 20 files (~19,800 lines of test code) |
 | **Compiler code coverage** | 90% of 8,999 statements (CI minimum: 80%) |
-| **Conformance programs** | 40 programs across 8 spec chapters, validating every language feature |
+| **Conformance programs** | 41 programs across 8 spec chapters, validating every language feature |
 | **Example programs** | 18, all validated through `vera check` + `vera verify` |
 | **Spec code blocks** | 95 parseable blocks from 13 spec chapters: 71 parse, 59 type-check, 58 verify |
 | **README code blocks** | 7 Vera blocks (6 validated, 1 allowlisted future syntax) |
@@ -31,7 +31,7 @@ pytest tests/ --cov=vera --cov-report=term-missing   # with coverage
 mypy vera/                                           # strict mode
 
 # Validation scripts
-python scripts/check_conformance.py                  # conformance suite (40 programs)
+python scripts/check_conformance.py                  # conformance suite (41 programs)
 python scripts/check_examples.py                     # 18 example programs
 python scripts/check_spec_examples.py                # spec code blocks
 python scripts/check_readme_examples.py              # README code blocks
@@ -62,7 +62,7 @@ python scripts/fix_allowlists.py --fix               # auto-fix stale allowlists
 | `test_wasm.py` | 22 | 255 | WASM internals: StringPool, WasmSlotEnv, translation edge cases via full pipeline |
 | `test_wasm_coverage.py` | 113 | 1,738 | WASM coverage gaps: helpers unit tests, inference branches, closure free-var walking, operator/data/context edge cases |
 | `test_tester.py` | 13 | 345 | Contract-driven testing: tier classification, input generation, test execution |
-| `test_conformance.py` | 195 | ~250 | Parametrized conformance suite: parse, check, verify, run, format idempotency across 40 programs |
+| `test_conformance.py` | 195 | ~250 | Parametrized conformance suite: parse, check, verify, run, format idempotency across 41 programs |
 | `test_readme.py` | 2 | 78 | README code sample parsing |
 
 ## Conformance Suite
@@ -104,10 +104,11 @@ tests/conformance/
 ├── ch01_int_literals.vera     # Chapter 1: Integer literals
 ├── ch01_float_literals.vera   # Chapter 1: Float64 literals
 ├── ch01_string_escapes.vera   # Chapter 1: String escape sequences
-├── ...                        # 40 programs total, organized by spec chapter
+├── ...                        # 41 programs total, organized by spec chapter
 ├── ch07_state_handler.vera    # Chapter 7: State<T> effect handler
 ├── ch07_exn_handler.vera      # Chapter 7: Exn<E> effect handler
-└── ch09_numeric_builtins.vera # Chapter 9: Numeric built-in functions
+├── ch09_numeric_builtins.vera # Chapter 9: Numeric built-in functions
+└── ch09_type_conversions.vera # Chapter 9: Numeric type conversions
 ```
 
 ### Manifest
@@ -227,6 +228,7 @@ How Vera language features (by spec chapter) map to test files and example progr
 | Ch 7: Effects | Pure, IO, State\<T\> | test_codegen, test_checker | ch07_pure, ch07_io, ch07_state_handler | hello_world, increment, io_operations, file_io |
 | Ch 7: Effects | Effect handlers (State\<T\>, Exn\<E\>) | test_codegen, test_checker | ch07_state_handler, ch07_exn_handler | effect_handler |
 | Ch 9: Stdlib | Numeric builtins (abs, min, max, floor, ceil, round, sqrt, pow) | test_codegen, test_checker | ch09_numeric_builtins | — |
+| Ch 9: Stdlib | Type conversions (to_float, float_to_int, nat_to_int, int_to_nat, byte_to_int, int_to_byte) | test_codegen, test_checker | ch09_type_conversions | — |
 | Ch 7: Effects | Effect subtyping (§7.8), call-site checking | test_types, test_checker | — | — |
 | Ch 2: Types | Bidirectional type checking (local inference) | test_checker | — | — |
 | Ch 4: Expressions | Nested constructor patterns in match | test_codegen | ch04_match_nested | pattern_matching |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.70"
+version = "0.0.71"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/scripts/check_skill_examples.py
+++ b/scripts/check_skill_examples.py
@@ -43,48 +43,52 @@ ALLOWLIST: dict[int, tuple[str, str]] = {
     422: ("FRAGMENT", "Numeric built-in examples, bare calls"),
 
     # Contracts section — requires/ensures fragments
-    455: ("FRAGMENT", "Requires clause example, not full function"),
-    464: ("FRAGMENT", "Ensures clause example, not full function"),
-    491: ("FRAGMENT", "Quantified requires clause, not full function"),
+    468: ("FRAGMENT", "Requires clause example, not full function"),
+    477: ("FRAGMENT", "Ensures clause example, not full function"),
+    504: ("FRAGMENT", "Quantified requires clause, not full function"),
 
     # Effects section — bare effect rows
-    509: ("FRAGMENT", "Effect row examples, bare annotations"),
+    522: ("FRAGMENT", "Effect row examples, bare annotations"),
 
     # Effect handler syntax template
-    646: ("FRAGMENT", "Handler syntax template, not real code"),
+    659: ("FRAGMENT", "Handler syntax template, not real code"),
 
     # Qualified calls and handler fragments — bare expressions
-    658: ("FRAGMENT", "Handler with clause, bare expression"),
-    668: ("FRAGMENT", "Qualified call examples, bare expressions"),
+    671: ("FRAGMENT", "Handler with clause, bare expression"),
+    681: ("FRAGMENT", "Qualified call examples, bare expressions"),
 
     # Module declaration and import syntax
-    718: ("FRAGMENT", "Module declaration and import example"),
+    731: ("FRAGMENT", "Module declaration and import example"),
 
     # Line comments — bare comments
-    757: ("FRAGMENT", "Comment syntax example"),
+    770: ("FRAGMENT", "Comment syntax example"),
+
+    # Type conversions — bare function calls
+    437: ("FRAGMENT", "Type conversion examples, bare calls"),
 
     # Common mistakes section — intentionally wrong code
-    785: ("FRAGMENT", "Wrong: missing contracts"),
-    792: ("FRAGMENT", "Wrong: incorrect contract syntax"),
-    805: ("FRAGMENT", "Wrong: missing requires"),
-    815: ("FRAGMENT", "Wrong: missing effects clause"),
-    828: ("FRAGMENT", "Wrong: wrong effect declared"),
-    839: ("FRAGMENT", "Wrong: bare expression without indices"),
-    852: ("FRAGMENT", "Wrong: bare expression no indices"),
-    857: ("FRAGMENT", "Correct: expression with indices (not full fn)"),
+    798: ("FRAGMENT", "Wrong: missing contracts"),
+    805: ("FRAGMENT", "Wrong: incorrect contract syntax"),
+    818: ("FRAGMENT", "Wrong: missing requires"),
+    828: ("FRAGMENT", "Wrong: missing effects clause"),
+    841: ("FRAGMENT", "Wrong: wrong effect declared"),
+    852: ("FRAGMENT", "Wrong: bare expression without indices"),
+    865: ("FRAGMENT", "Wrong: bare expression no indices"),
+    870: ("FRAGMENT", "Correct: expression with indices (not full fn)"),
     947: ("FRAGMENT", "Wrong: match arm with incorrect return"),
-    954: ("FRAGMENT", "Correct: match arm example"),
-    964: ("FRAGMENT", "Wrong: if/else without braces (bare expression)"),
-    969: ("FRAGMENT", "Correct: if/else with braces"),
+    960: ("FRAGMENT", "Wrong: non-exhaustive match"),
+    967: ("FRAGMENT", "Correct: match arm example"),
+    977: ("FRAGMENT", "Wrong: if/else without braces (bare expression)"),
+    982: ("FRAGMENT", "Correct: if/else with braces"),
 
     # Import syntax — intentionally unsupported
-    980: ("FRAGMENT", "Wrong: import aliasing not supported"),
-    985: ("FRAGMENT", "Correct: import syntax example"),
-    995: ("FRAGMENT", "Wrong: import hiding not supported"),
-    1000: ("FRAGMENT", "Correct: multi-import syntax"),
+    993: ("FRAGMENT", "Wrong: import aliasing not supported"),
+    998: ("FRAGMENT", "Correct: import syntax example"),
+    1008: ("FRAGMENT", "Wrong: import hiding not supported"),
+    1013: ("FRAGMENT", "Correct: multi-import syntax"),
 
     # String escapes — bare expression
-    1014: ("FRAGMENT", "String escape example"),
+    1027: ("FRAGMENT", "String escape example"),
 
     # =================================================================
     # MISMATCH — uses syntax the parser doesn't handle in isolation.

--- a/scripts/check_spec_examples.py
+++ b/scripts/check_spec_examples.py
@@ -60,7 +60,7 @@ ALLOWLIST: dict[tuple[str, int], str] = {
     ("09-standard-library.md", 290): "FUTURE",   # fn classify — uses ++ (string concat)
     ("09-standard-library.md", 304): "FRAGMENT",  # length signature (no body)
     ("09-standard-library.md", 324): "FRAGMENT",  # array_push signature (no body)
-    ("09-standard-library.md", 484): "FRAGMENT",  # similarity signature (no body)
+    ("09-standard-library.md", 586): "FRAGMENT",  # similarity signature (no body)
 
     # =================================================================
     # FRAGMENT — heuristic false positives (look like declarations but
@@ -119,13 +119,21 @@ ALLOWLIST: dict[tuple[str, int], str] = {
     ("09-standard-library.md", 448): "FRAGMENT",  # sqrt signature (no body)
     ("09-standard-library.md", 465): "FRAGMENT",  # pow signature (no body)
 
+    # Chapter 9 — Numeric type conversion signatures (no body)
+    ("09-standard-library.md", 486): "FRAGMENT",  # to_float signature (no body)
+    ("09-standard-library.md", 501): "FRAGMENT",  # nat_to_int signature (no body)
+    ("09-standard-library.md", 516): "FRAGMENT",  # byte_to_int signature (no body)
+    ("09-standard-library.md", 531): "FRAGMENT",  # float_to_int signature (no body)
+    ("09-standard-library.md", 546): "FRAGMENT",  # int_to_nat signature (no body)
+    ("09-standard-library.md", 564): "FRAGMENT",  # int_to_byte signature (no body)
+
     # Chapter 9 — Markdown stdlib type (future, uses MdBlock/MdInline types)
-    ("09-standard-library.md", 588): "FUTURE",   # md_parse(@String -> @Result<MdBlock, String>)
-    ("09-standard-library.md", 597): "FUTURE",   # md_render(@MdBlock -> @String)
-    ("09-standard-library.md", 608): "FUTURE",   # md_has_heading(@MdBlock, @Nat -> @Bool)
-    ("09-standard-library.md", 617): "FUTURE",   # md_has_code_block(@MdBlock, @String -> @Bool)
-    ("09-standard-library.md", 626): "FUTURE",   # md_extract_code_blocks(@MdBlock, @String -> @Array<String>)
-    ("09-standard-library.md", 650): "FUTURE",   # convert_to_markdown(@String -> @Result<MdBlock, String>)
+    ("09-standard-library.md", 690): "FUTURE",   # md_parse(@String -> @Result<MdBlock, String>)
+    ("09-standard-library.md", 699): "FUTURE",   # md_render(@MdBlock -> @String)
+    ("09-standard-library.md", 710): "FUTURE",   # md_has_heading(@MdBlock, @Nat -> @Bool)
+    ("09-standard-library.md", 719): "FUTURE",   # md_has_code_block(@MdBlock, @String -> @Bool)
+    ("09-standard-library.md", 728): "FUTURE",   # md_extract_code_blocks(@MdBlock, @String -> @Array<String>)
+    ("09-standard-library.md", 752): "FUTURE",   # convert_to_markdown(@String -> @Result<MdBlock, String>)
 }
 
 

--- a/spec/09-standard-library.md
+++ b/spec/09-standard-library.md
@@ -9,7 +9,7 @@ The standard library comprises:
 - **Built-in ADTs**: `Option<T>` and `Result<T, E>` for representing partiality and fallibility.
 - **Built-in collections**: `Array<T>` for fixed-size homogeneous sequences, plus future collections (`Set<T>`, `Map<K, V>`).
 - **Built-in effects**: `IO` for output, `State<T>` for mutable state, plus future effects for networking, concurrency, and LLM inference.
-- **Built-in functions**: `length` for arrays, numeric operations (`abs`, `min`, `max`, `floor`, `ceil`, `round`, `sqrt`, `pow`), plus future functions for vector similarity.
+- **Built-in functions**: `length` for arrays, numeric operations (`abs`, `min`, `max`, `floor`, `ceil`, `round`, `sqrt`, `pow`), type conversions (`to_float`, `float_to_int`, `nat_to_int`, `int_to_nat`, `byte_to_int`, `int_to_byte`), plus future functions for vector similarity.
 - **Future types**: `Json` for structured data interchange, `Markdown` for agent-oriented document structure, `Decimal` for exact arithmetic.
 - **Future abilities**: Type constraints for generic programming (post-v0.1).
 
@@ -477,7 +477,109 @@ pow(2.0, 10)
 
 This expression evaluates to `1024.0`.
 
-### 9.6.4 similarity (Future)
+### 9.6.4 Type Conversions
+
+Vera has no implicit numeric conversions. The following built-in functions provide explicit conversions between numeric types.
+
+#### Widening conversions (always succeed)
+
+```
+public fn to_float(@Int -> @Float64)
+  requires(true)
+  ensures(true)
+  effects(pure)
+```
+
+Converts an integer to a floating-point number. Compiled to `f64.convert_i64_s`.
+
+```
+to_float(42)
+```
+
+This expression evaluates to `42.0`.
+
+```
+public fn nat_to_int(@Nat -> @Int)
+  requires(true)
+  ensures(@Int.result >= 0)
+  effects(pure)
+```
+
+Converts a natural number to a signed integer. This is a no-op at runtime — both types share the same representation (i64). The postcondition captures the invariant that the result is non-negative.
+
+```
+nat_to_int(abs(42))
+```
+
+This expression evaluates to `42`.
+
+```
+public fn byte_to_int(@Byte -> @Int)
+  requires(true)
+  ensures(@Int.result >= 0)
+  effects(pure)
+```
+
+Converts a byte (0–255) to a signed integer. Compiled to `i64.extend_i32_u` (unsigned zero-extension from i32 to i64).
+
+```
+byte_to_int(@Byte.0)
+```
+
+#### Narrowing conversions (may fail)
+
+```
+public fn float_to_int(@Float64 -> @Int)
+  requires(true)
+  ensures(true)
+  effects(pure)
+```
+
+Truncates a floating-point number toward zero. Traps on NaN or Infinity (consistent with `floor`, `ceil`, and `round`). Compiled to `i64.trunc_f64_s`.
+
+```
+float_to_int(3.9)
+```
+
+This expression evaluates to `3` (truncation toward zero, not rounding).
+
+```
+public fn int_to_nat(@Int -> @Option<Nat>)
+  requires(true)
+  ensures(true)
+  effects(pure)
+```
+
+Checked narrowing from signed integer to natural number. Returns `Some(n)` if the input is non-negative, `None` otherwise.
+
+```
+match int_to_nat(42) {
+  Some(@Nat) -> nat_to_int(@Nat.0),
+  None -> 0 - 1
+}
+```
+
+This expression evaluates to `42`.
+
+```
+public fn int_to_byte(@Int -> @Option<Byte>)
+  requires(true)
+  ensures(true)
+  effects(pure)
+```
+
+Checked narrowing from signed integer to byte. Returns `Some(b)` if the input is in the range 0–255, `None` otherwise.
+
+```
+match int_to_byte(65) {
+  Some(@Byte) -> byte_to_int(@Byte.0),
+  None -> 0 - 1
+}
+```
+
+This expression evaluates to `65`.
+
+### 9.6.5 similarity (Future)
 
 > **Status: Not yet implemented.** Will be introduced alongside the `Inference` effect ([#61](https://github.com/aallan/vera/issues/61)).
 

--- a/tests/conformance/ch09_type_conversions.vera
+++ b/tests/conformance/ch09_type_conversions.vera
@@ -1,0 +1,101 @@
+-- Conformance: numeric type conversion functions (Chapter 9)
+-- Tests: to_float, float_to_int, nat_to_int, int_to_nat, byte_to_int, int_to_byte
+public fn test_to_float(@Unit -> @Float64)
+  requires(true)
+  ensures(@Float64.result == 42.0)
+  effects(pure)
+{
+  to_float(42)
+}
+
+public fn test_to_float_negative(@Unit -> @Float64)
+  requires(true)
+  ensures(@Float64.result == -7.0)
+  effects(pure)
+{
+  to_float(0 - 7)
+}
+
+public fn test_float_to_int(@Unit -> @Int)
+  requires(true)
+  ensures(@Int.result == 3)
+  effects(pure)
+{
+  float_to_int(3.9)
+}
+
+public fn test_float_to_int_negative(@Unit -> @Int)
+  requires(true)
+  ensures(@Int.result == -3)
+  effects(pure)
+{
+  float_to_int(0.0 - 3.9)
+}
+
+public fn test_nat_to_int(@Unit -> @Int)
+  requires(true)
+  ensures(@Int.result == 42)
+  effects(pure)
+{
+  nat_to_int(abs(42))
+}
+
+public fn test_int_to_nat_some(@Unit -> @Int)
+  requires(true)
+  ensures(@Int.result == 10)
+  effects(pure)
+{
+  match int_to_nat(10) {
+    Some(@Nat) -> nat_to_int(@Nat.0),
+    None -> 0 - 1
+  }
+}
+
+public fn test_int_to_nat_none(@Unit -> @Int)
+  requires(true)
+  ensures(@Int.result == -1)
+  effects(pure)
+{
+  match int_to_nat(0 - 5) {
+    Some(@Nat) -> nat_to_int(@Nat.0),
+    None -> 0 - 1
+  }
+}
+
+public fn test_byte_to_int(@Byte -> @Int)
+  requires(true)
+  ensures(@Int.result == byte_to_int(@Byte.0))
+  effects(pure)
+{
+  byte_to_int(@Byte.0)
+}
+
+public fn test_int_to_byte_some(@Unit -> @Int)
+  requires(true)
+  ensures(@Int.result == 65)
+  effects(pure)
+{
+  match int_to_byte(65) {
+    Some(@Byte) -> byte_to_int(@Byte.0),
+    None -> 0 - 1
+  }
+}
+
+public fn test_int_to_byte_none(@Unit -> @Int)
+  requires(true)
+  ensures(@Int.result == -1)
+  effects(pure)
+{
+  match int_to_byte(256) {
+    Some(@Byte) -> byte_to_int(@Byte.0),
+    None -> 0 - 1
+  }
+}
+
+public fn main(@Unit -> @Int)
+  requires(true)
+  ensures(@Int.result == 42)
+  effects(pure)
+{
+  float_to_int(to_float(42))
+}

--- a/tests/conformance/manifest.json
+++ b/tests/conformance/manifest.json
@@ -358,5 +358,14 @@
     "level": "run",
     "spec_ref": "Section 9.6.3",
     "features": ["abs", "min", "max", "floor", "ceil", "round", "sqrt", "pow"]
+  },
+  {
+    "id": "ch09_type_conversions",
+    "file": "ch09_type_conversions.vera",
+    "chapter": 9,
+    "title": "Numeric type conversion functions",
+    "level": "run",
+    "spec_ref": "Section 9.6.4",
+    "features": ["to_float", "float_to_int", "nat_to_int", "int_to_nat", "byte_to_int", "int_to_byte"]
   }
 ]

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -2719,6 +2719,108 @@ private fn f(@Float64, @Float64 -> @Float64)
 
 
 # =====================================================================
+# Numeric type conversions (issue #208)
+# =====================================================================
+
+class TestTypeConversionBuiltins:
+    """Type-checking for numeric type conversion builtins."""
+
+    def test_to_float_ok(self) -> None:
+        _check_ok("""
+private fn f(@Int -> @Float64)
+  requires(true) ensures(true) effects(pure)
+{ to_float(@Int.0) }
+""")
+
+    def test_to_float_wrong_arg(self) -> None:
+        _check_err("""
+private fn f(@String -> @Float64)
+  requires(true) ensures(true) effects(pure)
+{ to_float(@String.0) }
+""", "type")
+
+    def test_float_to_int_ok(self) -> None:
+        _check_ok("""
+private fn f(@Float64 -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ float_to_int(@Float64.0) }
+""")
+
+    def test_float_to_int_wrong_arg(self) -> None:
+        _check_err("""
+private fn f(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ float_to_int(@Int.0) }
+""", "type")
+
+    def test_nat_to_int_ok(self) -> None:
+        _check_ok("""
+private fn f(@Nat -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ nat_to_int(@Nat.0) }
+""")
+
+    def test_nat_to_int_wrong_arg(self) -> None:
+        _check_err("""
+private fn f(@String -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ nat_to_int(@String.0) }
+""", "type")
+
+    def test_int_to_nat_ok(self) -> None:
+        _check_ok("""
+private fn f(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  match int_to_nat(@Int.0) {
+    Some(@Nat) -> nat_to_int(@Nat.0),
+    None -> 0
+  }
+}
+""")
+
+    def test_int_to_nat_wrong_arg(self) -> None:
+        _check_err("""
+private fn f(@Float64 -> @Option<Nat>)
+  requires(true) ensures(true) effects(pure)
+{ int_to_nat(@Float64.0) }
+""", "type")
+
+    def test_byte_to_int_ok(self) -> None:
+        _check_ok("""
+private fn f(@Byte -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ byte_to_int(@Byte.0) }
+""")
+
+    def test_byte_to_int_wrong_arg(self) -> None:
+        _check_err("""
+private fn f(@String -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ byte_to_int(@String.0) }
+""", "type")
+
+    def test_int_to_byte_ok(self) -> None:
+        _check_ok("""
+private fn f(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  match int_to_byte(@Int.0) {
+    Some(@Byte) -> byte_to_int(@Byte.0),
+    None -> 0
+  }
+}
+""")
+
+    def test_int_to_byte_wrong_arg(self) -> None:
+        _check_err("""
+private fn f(@Float64 -> @Option<Byte>)
+  requires(true) ensures(true) effects(pure)
+{ int_to_byte(@Float64.0) }
+""", "type")
+
+
+# =====================================================================
 # Bidirectional type inference (issue #55)
 # =====================================================================
 

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -4781,6 +4781,281 @@ public fn f(-> @Float64) requires(true) ensures(true) effects(pure) {
 
 
 # =====================================================================
+# Numeric type conversions (issue #208)
+# =====================================================================
+
+
+class TestToFloat:
+    """to_float(@Int -> @Float64)."""
+
+    def test_positive(self) -> None:
+        src = """
+public fn f(-> @Float64) requires(true) ensures(true) effects(pure) {
+  to_float(42)
+}
+"""
+        assert _run_float(src) == 42.0
+
+    def test_negative(self) -> None:
+        src = """
+public fn f(-> @Float64) requires(true) ensures(true) effects(pure) {
+  to_float(0 - 7)
+}
+"""
+        assert _run_float(src) == -7.0
+
+    def test_zero(self) -> None:
+        src = """
+public fn f(-> @Float64) requires(true) ensures(true) effects(pure) {
+  to_float(0)
+}
+"""
+        assert _run_float(src) == 0.0
+
+
+class TestFloatToInt:
+    """float_to_int(@Float64 -> @Int) — truncation toward zero."""
+
+    def test_positive_truncate(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  float_to_int(3.7)
+}
+"""
+        assert _run(src) == 3
+
+    def test_negative_truncate(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  float_to_int(0.0 - 3.7)
+}
+"""
+        assert _run(src) == -3
+
+    def test_exact(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  float_to_int(5.0)
+}
+"""
+        assert _run(src) == 5
+
+    def test_zero(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  float_to_int(0.0)
+}
+"""
+        assert _run(src) == 0
+
+
+class TestNatToInt:
+    """nat_to_int(@Nat -> @Int) — identity (both i64)."""
+
+    def test_basic(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  nat_to_int(abs(42))
+}
+"""
+        assert _run(src) == 42
+
+    def test_zero(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  nat_to_int(abs(0))
+}
+"""
+        assert _run(src) == 0
+
+    def test_large(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  nat_to_int(abs(999999))
+}
+"""
+        assert _run(src) == 999999
+
+
+class TestIntToNat:
+    """int_to_nat(@Int -> @Option<Nat>) — checked narrowing."""
+
+    def test_positive(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  match int_to_nat(42) {
+    Some(@Nat) -> nat_to_int(@Nat.0),
+    None -> 0 - 1
+  }
+}
+"""
+        assert _run(src) == 42
+
+    def test_zero(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  match int_to_nat(0) {
+    Some(@Nat) -> nat_to_int(@Nat.0),
+    None -> 0 - 1
+  }
+}
+"""
+        assert _run(src) == 0
+
+    def test_negative_returns_none(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  match int_to_nat(0 - 5) {
+    Some(@Nat) -> nat_to_int(@Nat.0),
+    None -> 0 - 1
+  }
+}
+"""
+        assert _run(src) == -1
+
+    def test_large_positive(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  match int_to_nat(1000000) {
+    Some(@Nat) -> nat_to_int(@Nat.0),
+    None -> 0 - 1
+  }
+}
+"""
+        assert _run(src) == 1000000
+
+
+class TestByteToInt:
+    """byte_to_int(@Byte -> @Int) — zero extension."""
+
+    def test_basic(self) -> None:
+        src = """
+public fn f(@Byte -> @Int) requires(true) ensures(true) effects(pure) {
+  byte_to_int(@Byte.0)
+}
+"""
+        assert _run(src, fn="f", args=[65]) == 65
+
+    def test_zero(self) -> None:
+        src = """
+public fn f(@Byte -> @Int) requires(true) ensures(true) effects(pure) {
+  byte_to_int(@Byte.0)
+}
+"""
+        assert _run(src, fn="f", args=[0]) == 0
+
+    def test_max(self) -> None:
+        src = """
+public fn f(@Byte -> @Int) requires(true) ensures(true) effects(pure) {
+  byte_to_int(@Byte.0)
+}
+"""
+        assert _run(src, fn="f", args=[255]) == 255
+
+
+class TestIntToByte:
+    """int_to_byte(@Int -> @Option<Byte>) — checked narrowing."""
+
+    def test_valid(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  match int_to_byte(65) {
+    Some(@Byte) -> byte_to_int(@Byte.0),
+    None -> 0 - 1
+  }
+}
+"""
+        assert _run(src) == 65
+
+    def test_zero(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  match int_to_byte(0) {
+    Some(@Byte) -> byte_to_int(@Byte.0),
+    None -> 0 - 1
+  }
+}
+"""
+        assert _run(src) == 0
+
+    def test_max_byte(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  match int_to_byte(255) {
+    Some(@Byte) -> byte_to_int(@Byte.0),
+    None -> 0 - 1
+  }
+}
+"""
+        assert _run(src) == 255
+
+    def test_negative_returns_none(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  match int_to_byte(0 - 1) {
+    Some(@Byte) -> byte_to_int(@Byte.0),
+    None -> 0 - 1
+  }
+}
+"""
+        assert _run(src) == -1
+
+    def test_overflow_returns_none(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  match int_to_byte(256) {
+    Some(@Byte) -> byte_to_int(@Byte.0),
+    None -> 0 - 1
+  }
+}
+"""
+        assert _run(src) == -1
+
+
+class TestTypeConversionRoundTrip:
+    """Round-trip and composition tests for type conversions."""
+
+    def test_int_float_roundtrip(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  float_to_int(to_float(42))
+}
+"""
+        assert _run(src) == 42
+
+    def test_nat_int_roundtrip(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  match int_to_nat(nat_to_int(abs(7))) {
+    Some(@Nat) -> nat_to_int(@Nat.0),
+    None -> 0 - 1
+  }
+}
+"""
+        assert _run(src) == 7
+
+    def test_byte_int_roundtrip(self) -> None:
+        src = """
+public fn f(@Byte -> @Int) requires(true) ensures(true) effects(pure) {
+  match int_to_byte(byte_to_int(@Byte.0)) {
+    Some(@Byte) -> byte_to_int(@Byte.0),
+    None -> 0 - 1
+  }
+}
+"""
+        assert _run(src, fn="f", args=[100]) == 100
+
+    def test_nat_to_float(self) -> None:
+        """Chain nat_to_int then to_float."""
+        src = """
+public fn f(-> @Float64) requires(true) ensures(true) effects(pure) {
+  to_float(nat_to_int(abs(10)))
+}
+"""
+        assert _run_float(src) == 10.0
+
+
+# =====================================================================
 # C8e: Arrays of compound types (#132)
 # =====================================================================
 

--- a/vera/README.md
+++ b/vera/README.md
@@ -314,6 +314,12 @@ Context flags (`in_ensures`, `in_contract`, `current_return_type`, `current_effe
 | `round` | Function | `Float64 → Int`, pure |
 | `sqrt` | Function | `Float64 → Float64`, pure |
 | `pow` | Function | `Float64, Int → Float64`, pure |
+| `to_float` | Function | `Int → Float64`, pure |
+| `float_to_int` | Function | `Float64 → Int`, pure |
+| `nat_to_int` | Function | `Nat → Int`, pure |
+| `int_to_nat` | Function | `Int → Option<Nat>`, pure |
+| `byte_to_int` | Function | `Byte → Int`, pure |
+| `int_to_byte` | Function | `Int → Option<Byte>`, pure |
 
 Additionally, `resume` is bound as a temporary function inside handler clause bodies (in `_check_handle()`). Its type is derived from the operation: for `op(params) → ReturnType`, `resume` has type `fn(ReturnType) → Unit effects(pure)`. The binding is added to `env.functions` before checking the clause body and removed afterward.
 
@@ -386,6 +392,8 @@ When a contract or function body contains constructs that can't be translated to
 | `abs(x)` | `z3.If(x >= 0, x, -x)` |
 | `min(a, b)` | `z3.If(a <= b, a, b)` |
 | `max(a, b)` | `z3.If(a >= b, a, b)` |
+| `nat_to_int(x)` | Identity (both IntSort) |
+| `byte_to_int(x)` | Identity (both IntSort) |
 | `let @T = v; body` | Push `v` onto `SlotEnv`, translate body |
 | `match ... { arms }` | Nested `z3.If` chain with recognizer conditions |
 | `Nil`, `Cons(a, b)` | Z3 ADT sort constructor applications |
@@ -559,7 +567,7 @@ The `ERROR_CODES` dict in `errors.py` maps every code to a short description (80
 
 ## Test Suite
 
-Testing is organized in three layers: **unit tests** (1,673 tests testing compiler internals), a **conformance suite** (40 programs in `tests/conformance/` validating every language feature against the spec), and **example programs** (18 end-to-end demos). The conformance suite is the definitive specification artifact — each program tests one feature and serves as a minimal working example.
+Testing is organized in three layers: **unit tests** (1,673 tests testing compiler internals), a **conformance suite** (41 programs in `tests/conformance/` validating every language feature against the spec), and **example programs** (18 end-to-end demos). The conformance suite is the definitive specification artifact — each program tests one feature and serves as a minimal working example.
 
 See **[TESTING.md](../TESTING.md)** for the comprehensive testing reference -- test file table, conformance suite details, compiler code coverage, language feature coverage, helper conventions, validation scripts, CI pipeline, and guidelines for adding tests.
 

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.70"
+__version__ = "0.0.71"

--- a/vera/codegen/modules.py
+++ b/vera/codegen/modules.py
@@ -244,6 +244,8 @@ class CrossModuleMixin:
             "nat_to_string", "byte_to_string", "float_to_string",
             "strip",
             "abs", "min", "max", "floor", "ceil", "round", "sqrt", "pow",
+            "to_float", "float_to_int", "nat_to_int", "int_to_nat",
+            "byte_to_int", "int_to_byte",
         })
 
         seen: set[str] = set()  # deduplicate by function name

--- a/vera/environment.py
+++ b/vera/environment.py
@@ -393,6 +393,50 @@ class TypeEnv:
             effect=PureEffectRow(),
         )
 
+        # Numeric type conversions
+        self.functions["to_float"] = FunctionInfo(
+            name="to_float",
+            forall_vars=None,
+            param_types=(INT,),
+            return_type=FLOAT64,
+            effect=PureEffectRow(),
+        )
+        self.functions["float_to_int"] = FunctionInfo(
+            name="float_to_int",
+            forall_vars=None,
+            param_types=(FLOAT64,),
+            return_type=INT,
+            effect=PureEffectRow(),
+        )
+        self.functions["nat_to_int"] = FunctionInfo(
+            name="nat_to_int",
+            forall_vars=None,
+            param_types=(NAT,),
+            return_type=INT,
+            effect=PureEffectRow(),
+        )
+        self.functions["int_to_nat"] = FunctionInfo(
+            name="int_to_nat",
+            forall_vars=None,
+            param_types=(INT,),
+            return_type=AdtType("Option", (NAT,)),
+            effect=PureEffectRow(),
+        )
+        self.functions["byte_to_int"] = FunctionInfo(
+            name="byte_to_int",
+            forall_vars=None,
+            param_types=(BYTE,),
+            return_type=INT,
+            effect=PureEffectRow(),
+        )
+        self.functions["int_to_byte"] = FunctionInfo(
+            name="int_to_byte",
+            forall_vars=None,
+            param_types=(INT,),
+            return_type=AdtType("Option", (BYTE,)),
+            effect=PureEffectRow(),
+        )
+
     # -----------------------------------------------------------------
     # Scope management
     # -----------------------------------------------------------------

--- a/vera/smt.py
+++ b/vera/smt.py
@@ -553,6 +553,14 @@ class SmtContext:
                 return z3mod.If(a >= b, a, b)
             return None
 
+        # Built-in: nat_to_int() — identity (both IntSort in Z3)
+        if call.name == "nat_to_int" and len(call.args) == 1:
+            return self.translate_expr(call.args[0], env)
+
+        # Built-in: byte_to_int() — identity (both IntSort in Z3)
+        if call.name == "byte_to_int" and len(call.args) == 1:
+            return self.translate_expr(call.args[0], env)
+
         # No function lookup → can't do modular verification
         if self._fn_lookup is None:
             return None

--- a/vera/wasm/calls.py
+++ b/vera/wasm/calls.py
@@ -89,6 +89,19 @@ class CallsMixin:
                 return self._translate_pow(
                     call.args[0], call.args[1], env,
                 )
+            # Numeric type conversions
+            if call.name == "to_float" and len(call.args) == 1:
+                return self._translate_to_float(call.args[0], env)
+            if call.name == "float_to_int" and len(call.args) == 1:
+                return self._translate_float_to_int(call.args[0], env)
+            if call.name == "nat_to_int" and len(call.args) == 1:
+                return self._translate_nat_to_int(call.args[0], env)
+            if call.name == "int_to_nat" and len(call.args) == 1:
+                return self._translate_int_to_nat(call.args[0], env)
+            if call.name == "byte_to_int" and len(call.args) == 1:
+                return self._translate_byte_to_int(call.args[0], env)
+            if call.name == "int_to_byte" and len(call.args) == 1:
+                return self._translate_int_to_byte(call.args[0], env)
 
         # Check if this is a closure application: apply_fn(closure, args...)
         if call.name == "apply_fn" and len(call.args) >= 2:
@@ -1915,6 +1928,161 @@ class CallsMixin:
         instructions.append("end")
         instructions.append(f"local.get {result_tmp}")
         return instructions
+
+    # ------------------------------------------------------------------
+    # Numeric type conversions
+    # ------------------------------------------------------------------
+
+    def _translate_to_float(
+        self, arg: ast.Expr, env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """Translate to_float(@Int) → @Float64.  WASM: f64.convert_i64_s."""
+        arg_instrs = self.translate_expr(arg, env)
+        if arg_instrs is None:
+            return None
+        instructions: list[str] = []
+        instructions.extend(arg_instrs)
+        instructions.append("f64.convert_i64_s")
+        return instructions
+
+    def _translate_float_to_int(
+        self, arg: ast.Expr, env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """Translate float_to_int(@Float64) → @Int.
+
+        WASM: i64.trunc_f64_s (truncation toward zero).
+        Traps on NaN/Infinity, consistent with floor/ceil/round.
+        """
+        arg_instrs = self.translate_expr(arg, env)
+        if arg_instrs is None:
+            return None
+        instructions: list[str] = []
+        instructions.extend(arg_instrs)
+        instructions.append("i64.trunc_f64_s")
+        return instructions
+
+    def _translate_nat_to_int(
+        self, arg: ast.Expr, env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """Translate nat_to_int(@Nat) → @Int.  Identity (both i64)."""
+        return self.translate_expr(arg, env)
+
+    def _translate_int_to_nat(
+        self, arg: ast.Expr, env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """Translate int_to_nat(@Int) → @Option<Nat> (i32 heap pointer).
+
+        Option<Nat> layout (16 bytes, uniform for both variants):
+          None:      [tag=0 : i32] [pad 12]
+          Some(Nat): [tag=1 : i32] [pad 4] [value : i64]
+        """
+        arg_instrs = self.translate_expr(arg, env)
+        if arg_instrs is None:
+            return None
+
+        self.needs_alloc = True
+        val = self.alloc_local("i64")
+        out = self.alloc_local("i32")
+
+        ins: list[str] = []
+        ins.extend(arg_instrs)
+        ins.append(f"local.set {val}")
+
+        # Allocate 16 bytes (largest variant: Some(i64))
+        ins.append("i32.const 16")
+        ins.append("call $alloc")
+        ins.append(f"local.set {out}")
+
+        # Check: val >= 0?
+        ins.append(f"local.get {val}")
+        ins.append("i64.const 0")
+        ins.append("i64.ge_s")
+        ins.append("if")
+        # -- Some path: tag=1, value at offset 8
+        ins.append(f"  local.get {out}")
+        ins.append("  i32.const 1")
+        ins.append("  i32.store")           # tag = 1 (Some)
+        ins.extend(f"  {x}" for x in gc_shadow_push(out))
+        ins.append(f"  local.get {out}")
+        ins.append(f"  local.get {val}")
+        ins.append("  i64.store offset=8")  # Nat value
+        ins.append("else")
+        # -- None path: tag=0
+        ins.append(f"  local.get {out}")
+        ins.append("  i32.const 0")
+        ins.append("  i32.store")           # tag = 0 (None)
+        ins.extend(f"  {x}" for x in gc_shadow_push(out))
+        ins.append("end")
+
+        ins.append(f"local.get {out}")
+        return ins
+
+    def _translate_byte_to_int(
+        self, arg: ast.Expr, env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """Translate byte_to_int(@Byte) → @Int.  WASM: i64.extend_i32_u."""
+        arg_instrs = self.translate_expr(arg, env)
+        if arg_instrs is None:
+            return None
+        instructions: list[str] = []
+        instructions.extend(arg_instrs)
+        instructions.append("i64.extend_i32_u")
+        return instructions
+
+    def _translate_int_to_byte(
+        self, arg: ast.Expr, env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """Translate int_to_byte(@Int) → @Option<Byte> (i32 heap pointer).
+
+        Option<Byte> layout (8 bytes, uniform for both variants):
+          None:       [tag=0 : i32] [pad 4]
+          Some(Byte): [tag=1 : i32] [value : i32]
+        """
+        arg_instrs = self.translate_expr(arg, env)
+        if arg_instrs is None:
+            return None
+
+        self.needs_alloc = True
+        val = self.alloc_local("i64")
+        out = self.alloc_local("i32")
+
+        ins: list[str] = []
+        ins.extend(arg_instrs)
+        ins.append(f"local.set {val}")
+
+        # Allocate 8 bytes (both variants fit in 8)
+        ins.append("i32.const 8")
+        ins.append("call $alloc")
+        ins.append(f"local.set {out}")
+
+        # Check: 0 <= val <= 255
+        ins.append(f"local.get {val}")
+        ins.append("i64.const 0")
+        ins.append("i64.ge_s")
+        ins.append(f"local.get {val}")
+        ins.append("i64.const 255")
+        ins.append("i64.le_s")
+        ins.append("i32.and")
+        ins.append("if")
+        # -- Some path: tag=1, i32.wrap_i64(val) at offset 4
+        ins.append(f"  local.get {out}")
+        ins.append("  i32.const 1")
+        ins.append("  i32.store")            # tag = 1 (Some)
+        ins.extend(f"  {x}" for x in gc_shadow_push(out))
+        ins.append(f"  local.get {out}")
+        ins.append(f"  local.get {val}")
+        ins.append("  i32.wrap_i64")
+        ins.append("  i32.store offset=4")   # Byte value
+        ins.append("else")
+        # -- None path: tag=0
+        ins.append(f"  local.get {out}")
+        ins.append("  i32.const 0")
+        ins.append("  i32.store")            # tag = 0 (None)
+        ins.extend(f"  {x}" for x in gc_shadow_push(out))
+        ins.append("end")
+
+        ins.append(f"local.get {out}")
+        return ins
 
     def _translate_handle_expr(
         self, expr: ast.HandleExpr, env: WasmSlotEnv,

--- a/vera/wasm/inference.py
+++ b/vera/wasm/inference.py
@@ -211,6 +211,13 @@ class InferenceMixin:
             return "i64"
         if expr.name in ("sqrt", "pow"):
             return "f64"
+        # Numeric type conversions
+        if expr.name == "to_float":
+            return "f64"
+        if expr.name in ("float_to_int", "nat_to_int", "byte_to_int"):
+            return "i64"
+        if expr.name in ("int_to_nat", "int_to_byte"):
+            return "i32"
         # apply_fn(closure, args...) — infer from closure type
         if expr.name == "apply_fn" and len(expr.args) >= 1:
             return self._infer_apply_fn_return_type(expr.args[0])
@@ -356,6 +363,13 @@ class InferenceMixin:
             return "Int"
         if call.name in ("sqrt", "pow"):
             return "Float64"
+        # Numeric type conversions
+        if call.name == "to_float":
+            return "Float64"
+        if call.name in ("float_to_int", "nat_to_int", "byte_to_int"):
+            return "Int"
+        if call.name in ("int_to_nat", "int_to_byte"):
+            return "Option"
         if call.name in self._generic_fn_info:
             forall_vars, param_types = self._generic_fn_info[call.name]
             mapping: dict[str, str] = {}


### PR DESCRIPTION
## Summary

- Add 6 builtin type conversion functions: `to_float`, `float_to_int`, `nat_to_int`, `int_to_nat`, `byte_to_int`, `int_to_byte`
- Partial conversions (`int_to_nat`, `int_to_byte`) return `Option<T>` with runtime range checks
- `nat_to_int` and `byte_to_int` verified at Tier 1 via Z3 identity translations
- Release v0.0.71: version bump, CHANGELOG, README roadmap strikethrough

## Implementation

Full pipeline: `environment.py` (6 FunctionInfo) → `modules.py` (guard rail) → `inference.py` (WASM type inference) → `calls.py` (6 WASM translation methods) → `smt.py` (Z3 for identity conversions)

## Test plan

- [x] 12 type checker tests (6 ok + 6 err)
- [x] 26 codegen end-to-end tests (basic + edge cases + roundtrips)
- [x] 1 conformance program (`ch09_type_conversions.vera`) — passes check, verify, run
- [x] Full suite: 1,766 passed, 6 skipped
- [x] mypy clean, all validators green (conformance, examples, spec, SKILL, README, version sync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)