### PR TITLE
Add Float64 special value operations (closes #212)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Read `SKILL.md` for the full language reference. It covers syntax, slot referenc
 
 ### Conformance programs as reference
 
-The conformance suite in `tests/conformance/` contains 41 small, self-contained programs — one per language feature — that all parse, type-check, verify, and (mostly) run correctly. These are the best minimal working examples of each feature. When you need to see how a specific construct works (e.g. effect handlers, match expressions, closures), check the corresponding conformance program before reading the spec. The `manifest.json` file maps features to programs.
+The conformance suite in `tests/conformance/` contains 42 small, self-contained programs — one per language feature — that all parse, type-check, verify, and (mostly) run correctly. These are the best minimal working examples of each feature. When you need to see how a specific construct works (e.g. effect handlers, match expressions, closures), check the corresponding conformance program before reading the spec. The `manifest.json` file maps features to programs.
 
 ### Workflow
 
@@ -140,7 +140,7 @@ Each stage is a module with a single public API function (`parse_file`, `transfo
 pytest tests/ -v                       # Run all tests (see TESTING.md)
 pytest tests/test_conformance.py -v    # Conformance suite only
 mypy vera/                             # Type-check the compiler
-python scripts/check_conformance.py    # All 41 conformance programs must pass
+python scripts/check_conformance.py    # All 42 conformance programs must pass
 python scripts/check_examples.py       # All 18 examples must pass
 ```
 
@@ -150,7 +150,7 @@ When implementing a new language feature, write the conformance program *first* 
 
 ### Invariants
 
-- All 41 conformance programs in `tests/conformance/` must pass their declared level
+- All 42 conformance programs in `tests/conformance/` must pass their declared level
 - All 18 examples in `examples/` must pass `vera check` and `vera verify`
 - `mypy vera/` must be clean
 - `pytest tests/ -v` must pass

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.72] - 2026-03-09
+
+### Added
+- **Close #212: Float64 special value operations** ([#212](https://github.com/aallan/vera/issues/212)):
+  Four new built-in functions for detecting and constructing IEEE 754 special
+  Float64 values: `is_nan` (Float64→Bool), `is_infinite` (Float64→Bool),
+  `nan` (→Float64), and `infinity` (→Float64). All are Tier 3 (runtime-tested).
+- New conformance test `ch10_float_predicates` (conformance suite: 41→42 programs)
+- 25 new tests (8 type checker + 17 codegen end-to-end)
+- Spec Section 9.6.5 "Float64 Predicates" with full signatures and contracts
+
 ## [0.0.71] - 2026-03-09
 
 ### Added
@@ -1109,7 +1120,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Grammar: handler body simplified to avoid LALR reduce/reduce conflict
 - `pyproject.toml`: corrected build backend, package discovery, PEP 639 compliance
 
-[Unreleased]: https://github.com/aallan/vera/compare/v0.0.71...HEAD
+[Unreleased]: https://github.com/aallan/vera/compare/v0.0.72...HEAD
+[0.0.72]: https://github.com/aallan/vera/compare/v0.0.71...v0.0.72
 [0.0.71]: https://github.com/aallan/vera/compare/v0.0.70...v0.0.71
 [0.0.70]: https://github.com/aallan/vera/compare/v0.0.69...v0.0.70
 [0.0.69]: https://github.com/aallan/vera/compare/v0.0.68...v0.0.69

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ vera fmt --check file.vera        # Check if already canonical
 pytest tests/ -v                  # Run the test suite (see TESTING.md)
 mypy vera/                        # Type-check the compiler itself
 
-python scripts/check_conformance.py    # Verify all 41 conformance programs pass their declared level
+python scripts/check_conformance.py    # Verify all 42 conformance programs pass their declared level
 python scripts/check_examples.py      # Verify all 18 examples parse + check + verify
 python scripts/check_spec_examples.py # Verify spec code blocks parse
 python scripts/check_readme_examples.py # Verify README code blocks parse
@@ -56,7 +56,7 @@ python scripts/fix_allowlists.py --fix # Auto-fix stale allowlist line numbers
 - `vera/` — Reference compiler: grammar, parser, AST, transformer, type checker, verifier, codegen, CLI
 - `examples/` — 18 example Vera programs (all must pass `vera check` and `vera verify`)
 - `tests/` — Test suite (unit tests + conformance suite)
-- `tests/conformance/` — 41 conformance programs validating every language feature against the spec
+- `tests/conformance/` — 42 conformance programs validating every language feature against the spec
 - `scripts/` — CI and validation scripts
 
 ## Writing Vera code
@@ -74,7 +74,7 @@ Each stage is a module with a public API function and is independently testable.
 ## What not to break
 
 - Pre-commit hooks run mypy + pytest + conformance suite + example validation on every commit
-- All 41 conformance programs in `tests/conformance/` must pass their declared level
+- All 42 conformance programs in `tests/conformance/` must pass their declared level
 - All 18 examples in `examples/` must pass `vera check` and `vera verify`
 - Version must stay in sync across `vera/__init__.py`, `pyproject.toml`, and `CHANGELOG.md`
 - All tests must pass: `pytest tests/ -v`

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ The language specification is in draft across 13 chapters:
 
 ### Testing
 
-Testing is organized in three layers: **unit tests** (1,766 tests across 20 files, testing compiler internals), a **conformance suite** (41 programs across 8 spec chapters, systematically validating every language feature against the spec), and **example programs** (18 end-to-end demos). The compiler has 90% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations. Every commit validates all conformance programs, example programs, and 95 specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference -- coverage tables, conformance suite details, CI pipeline, and infrastructure.
+Testing is organized in three layers: **unit tests** (1,796 tests across 20 files, testing compiler internals), a **conformance suite** (42 programs across 8 spec chapters, systematically validating every language feature against the spec), and **example programs** (18 end-to-end demos). The compiler has 90% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations. Every commit validates all conformance programs, example programs, and 95 specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference -- coverage tables, conformance suite details, CI pipeline, and infrastructure.
 
 ## Roadmap
 
@@ -319,7 +319,7 @@ Module refinements, lexical extensions, and IO runtime — completing the existi
 - <del>[#208](https://github.com/aallan/vera/issues/208) numeric type conversions</del> ([v0.0.71](https://github.com/aallan/vera/releases/tag/v0.0.71))
 - [#209](https://github.com/aallan/vera/issues/209) array construction builtins (range, append, concat)
 - [#210](https://github.com/aallan/vera/issues/210) from_char_code builtin
-- [#212](https://github.com/aallan/vera/issues/212) Float64 special value operations (is_nan, is_infinite)
+- <del>[#212](https://github.com/aallan/vera/issues/212) Float64 special value operations (is_nan, is_infinite)</del> ([v0.0.72](https://github.com/aallan/vera/releases/tag/v0.0.72))
 - [#213](https://github.com/aallan/vera/issues/213) string_repeat builtin
 - [#230](https://github.com/aallan/vera/issues/230) string interpolation
 - [#231](https://github.com/aallan/vera/issues/231) regex support

--- a/SKILL.md
+++ b/SKILL.md
@@ -445,6 +445,17 @@ int_to_byte(@Int.0)               -- returns Option<Byte> (None if out of 0..255
 
 Vera has no implicit numeric conversions — use these functions to convert between numeric types. `to_float`, `nat_to_int`, and `byte_to_int` are widening conversions that always succeed. `float_to_int` truncates toward zero and traps on NaN/Infinity. `int_to_nat` and `int_to_byte` are checked narrowing conversions that return `Option` — pattern match on the result to handle the failure case. `nat_to_int` and `byte_to_int` are SMT-verifiable (Tier 1); the rest are Tier 3 (runtime).
 
+### Float64 predicates
+
+```vera
+is_nan(@Float64.0)                 -- returns Bool (true if NaN)
+is_infinite(@Float64.0)            -- returns Bool (true if ±infinity)
+nan()                              -- returns Float64 (quiet NaN)
+infinity()                         -- returns Float64 (positive infinity)
+```
+
+`is_nan` and `is_infinite` test for IEEE 754 special values. `nan()` and `infinity()` construct them — use `0.0 - infinity()` for negative infinity. All four are Tier 3 (runtime-tested, not SMT-verifiable).
+
 **Shadowing**: If you define a function with the same name as a built-in (e.g. `length` for a custom list type), your definition takes priority. The built-in is only used when no user-defined function with that name exists.
 
 Example:

--- a/TESTING.md
+++ b/TESTING.md
@@ -8,7 +8,7 @@ This is the single source of truth for Vera's testing infrastructure, coverage d
 |--------|-------|
 | **Tests** | 1,673 across 20 files (~19,800 lines of test code) |
 | **Compiler code coverage** | 90% of 8,999 statements (CI minimum: 80%) |
-| **Conformance programs** | 41 programs across 8 spec chapters, validating every language feature |
+| **Conformance programs** | 42 programs across 8 spec chapters, validating every language feature |
 | **Example programs** | 18, all validated through `vera check` + `vera verify` |
 | **Spec code blocks** | 95 parseable blocks from 13 spec chapters: 71 parse, 59 type-check, 58 verify |
 | **README code blocks** | 7 Vera blocks (6 validated, 1 allowlisted future syntax) |
@@ -31,7 +31,7 @@ pytest tests/ --cov=vera --cov-report=term-missing   # with coverage
 mypy vera/                                           # strict mode
 
 # Validation scripts
-python scripts/check_conformance.py                  # conformance suite (41 programs)
+python scripts/check_conformance.py                  # conformance suite (42 programs)
 python scripts/check_examples.py                     # 18 example programs
 python scripts/check_spec_examples.py                # spec code blocks
 python scripts/check_readme_examples.py              # README code blocks
@@ -62,7 +62,7 @@ python scripts/fix_allowlists.py --fix               # auto-fix stale allowlists
 | `test_wasm.py` | 22 | 255 | WASM internals: StringPool, WasmSlotEnv, translation edge cases via full pipeline |
 | `test_wasm_coverage.py` | 113 | 1,738 | WASM coverage gaps: helpers unit tests, inference branches, closure free-var walking, operator/data/context edge cases |
 | `test_tester.py` | 13 | 345 | Contract-driven testing: tier classification, input generation, test execution |
-| `test_conformance.py` | 195 | ~250 | Parametrized conformance suite: parse, check, verify, run, format idempotency across 41 programs |
+| `test_conformance.py` | 195 | ~250 | Parametrized conformance suite: parse, check, verify, run, format idempotency across 42 programs |
 | `test_readme.py` | 2 | 78 | README code sample parsing |
 
 ## Conformance Suite
@@ -104,11 +104,12 @@ tests/conformance/
 ├── ch01_int_literals.vera     # Chapter 1: Integer literals
 ├── ch01_float_literals.vera   # Chapter 1: Float64 literals
 ├── ch01_string_escapes.vera   # Chapter 1: String escape sequences
-├── ...                        # 41 programs total, organized by spec chapter
+├── ...                        # 42 programs total, organized by spec chapter
 ├── ch07_state_handler.vera    # Chapter 7: State<T> effect handler
 ├── ch07_exn_handler.vera      # Chapter 7: Exn<E> effect handler
 ├── ch09_numeric_builtins.vera # Chapter 9: Numeric built-in functions
-└── ch09_type_conversions.vera # Chapter 9: Numeric type conversions
+├── ch09_type_conversions.vera # Chapter 9: Numeric type conversions
+└── ch10_float_predicates.vera # Chapter 9: Float64 predicates and constants
 ```
 
 ### Manifest
@@ -229,6 +230,7 @@ How Vera language features (by spec chapter) map to test files and example progr
 | Ch 7: Effects | Effect handlers (State\<T\>, Exn\<E\>) | test_codegen, test_checker | ch07_state_handler, ch07_exn_handler | effect_handler |
 | Ch 9: Stdlib | Numeric builtins (abs, min, max, floor, ceil, round, sqrt, pow) | test_codegen, test_checker | ch09_numeric_builtins | — |
 | Ch 9: Stdlib | Type conversions (to_float, float_to_int, nat_to_int, int_to_nat, byte_to_int, int_to_byte) | test_codegen, test_checker | ch09_type_conversions | — |
+| Ch 9: Stdlib | Float64 predicates (is_nan, is_infinite, nan, infinity) | test_codegen, test_checker | ch10_float_predicates | — |
 | Ch 7: Effects | Effect subtyping (§7.8), call-site checking | test_types, test_checker | — | — |
 | Ch 2: Types | Bidirectional type checking (local inference) | test_checker | — | — |
 | Ch 4: Expressions | Nested constructor patterns in match | test_codegen | ch04_match_nested | pattern_matching |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.71"
+version = "0.0.72"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/scripts/check_skill_examples.py
+++ b/scripts/check_skill_examples.py
@@ -43,52 +43,55 @@ ALLOWLIST: dict[int, tuple[str, str]] = {
     422: ("FRAGMENT", "Numeric built-in examples, bare calls"),
 
     # Contracts section — requires/ensures fragments
-    468: ("FRAGMENT", "Requires clause example, not full function"),
-    477: ("FRAGMENT", "Ensures clause example, not full function"),
-    504: ("FRAGMENT", "Quantified requires clause, not full function"),
+    479: ("FRAGMENT", "Requires clause example, not full function"),
+    488: ("FRAGMENT", "Ensures clause example, not full function"),
+    515: ("FRAGMENT", "Quantified requires clause, not full function"),
 
     # Effects section — bare effect rows
-    522: ("FRAGMENT", "Effect row examples, bare annotations"),
+    533: ("FRAGMENT", "Effect row examples, bare annotations"),
 
     # Effect handler syntax template
-    659: ("FRAGMENT", "Handler syntax template, not real code"),
+    670: ("FRAGMENT", "Handler syntax template, not real code"),
 
     # Qualified calls and handler fragments — bare expressions
-    671: ("FRAGMENT", "Handler with clause, bare expression"),
-    681: ("FRAGMENT", "Qualified call examples, bare expressions"),
+    682: ("FRAGMENT", "Handler with clause, bare expression"),
+    692: ("FRAGMENT", "Qualified call examples, bare expressions"),
 
     # Module declaration and import syntax
-    731: ("FRAGMENT", "Module declaration and import example"),
+    742: ("FRAGMENT", "Module declaration and import example"),
 
     # Line comments — bare comments
-    770: ("FRAGMENT", "Comment syntax example"),
+    781: ("FRAGMENT", "Comment syntax example"),
 
     # Type conversions — bare function calls
     437: ("FRAGMENT", "Type conversion examples, bare calls"),
 
+    # Float64 predicates — bare function calls
+    450: ("FRAGMENT", "Float64 predicate examples, bare calls"),
+
     # Common mistakes section — intentionally wrong code
-    798: ("FRAGMENT", "Wrong: missing contracts"),
-    805: ("FRAGMENT", "Wrong: incorrect contract syntax"),
-    818: ("FRAGMENT", "Wrong: missing requires"),
-    828: ("FRAGMENT", "Wrong: missing effects clause"),
-    841: ("FRAGMENT", "Wrong: wrong effect declared"),
-    852: ("FRAGMENT", "Wrong: bare expression without indices"),
-    865: ("FRAGMENT", "Wrong: bare expression no indices"),
-    870: ("FRAGMENT", "Correct: expression with indices (not full fn)"),
+    809: ("FRAGMENT", "Wrong: missing contracts"),
+    816: ("FRAGMENT", "Wrong: incorrect contract syntax"),
+    829: ("FRAGMENT", "Wrong: missing requires"),
+    839: ("FRAGMENT", "Wrong: missing effects clause"),
+    852: ("FRAGMENT", "Wrong: wrong effect declared"),
+    863: ("FRAGMENT", "Wrong: bare expression without indices"),
+    876: ("FRAGMENT", "Wrong: bare expression no indices"),
+    881: ("FRAGMENT", "Correct: expression with indices (not full fn)"),
     947: ("FRAGMENT", "Wrong: match arm with incorrect return"),
-    960: ("FRAGMENT", "Wrong: non-exhaustive match"),
-    967: ("FRAGMENT", "Correct: match arm example"),
-    977: ("FRAGMENT", "Wrong: if/else without braces (bare expression)"),
-    982: ("FRAGMENT", "Correct: if/else with braces"),
+    971: ("FRAGMENT", "Wrong: non-exhaustive match"),
+    978: ("FRAGMENT", "Correct: match arm example"),
+    988: ("FRAGMENT", "Wrong: if/else without braces (bare expression)"),
+    993: ("FRAGMENT", "Correct: if/else with braces"),
 
     # Import syntax — intentionally unsupported
-    993: ("FRAGMENT", "Wrong: import aliasing not supported"),
-    998: ("FRAGMENT", "Correct: import syntax example"),
-    1008: ("FRAGMENT", "Wrong: import hiding not supported"),
-    1013: ("FRAGMENT", "Correct: multi-import syntax"),
+    1004: ("FRAGMENT", "Wrong: import aliasing not supported"),
+    1009: ("FRAGMENT", "Correct: import syntax example"),
+    1019: ("FRAGMENT", "Wrong: import hiding not supported"),
+    1024: ("FRAGMENT", "Correct: multi-import syntax"),
 
     # String escapes — bare expression
-    1027: ("FRAGMENT", "String escape example"),
+    1038: ("FRAGMENT", "String escape example"),
 
     # =================================================================
     # MISMATCH — uses syntax the parser doesn't handle in isolation.

--- a/scripts/check_spec_examples.py
+++ b/scripts/check_spec_examples.py
@@ -60,7 +60,7 @@ ALLOWLIST: dict[tuple[str, int], str] = {
     ("09-standard-library.md", 290): "FUTURE",   # fn classify — uses ++ (string concat)
     ("09-standard-library.md", 304): "FRAGMENT",  # length signature (no body)
     ("09-standard-library.md", 324): "FRAGMENT",  # array_push signature (no body)
-    ("09-standard-library.md", 586): "FRAGMENT",  # similarity signature (no body)
+    ("09-standard-library.md", 658): "FRAGMENT",  # similarity signature (no body)
 
     # =================================================================
     # FRAGMENT — heuristic false positives (look like declarations but
@@ -127,13 +127,19 @@ ALLOWLIST: dict[tuple[str, int], str] = {
     ("09-standard-library.md", 546): "FRAGMENT",  # int_to_nat signature (no body)
     ("09-standard-library.md", 564): "FRAGMENT",  # int_to_byte signature (no body)
 
+    # Chapter 9 — Float64 predicates (signatures, no body)
+    ("09-standard-library.md", 588): "FRAGMENT",  # is_nan signature (no body)
+    ("09-standard-library.md", 605): "FRAGMENT",  # is_infinite signature (no body)
+    ("09-standard-library.md", 624): "FRAGMENT",  # nan signature (no body)
+    ("09-standard-library.md", 639): "FRAGMENT",  # infinity signature (no body)
+
     # Chapter 9 — Markdown stdlib type (future, uses MdBlock/MdInline types)
-    ("09-standard-library.md", 690): "FUTURE",   # md_parse(@String -> @Result<MdBlock, String>)
-    ("09-standard-library.md", 699): "FUTURE",   # md_render(@MdBlock -> @String)
-    ("09-standard-library.md", 710): "FUTURE",   # md_has_heading(@MdBlock, @Nat -> @Bool)
-    ("09-standard-library.md", 719): "FUTURE",   # md_has_code_block(@MdBlock, @String -> @Bool)
-    ("09-standard-library.md", 728): "FUTURE",   # md_extract_code_blocks(@MdBlock, @String -> @Array<String>)
-    ("09-standard-library.md", 752): "FUTURE",   # convert_to_markdown(@String -> @Result<MdBlock, String>)
+    ("09-standard-library.md", 762): "FUTURE",   # md_parse(@String -> @Result<MdBlock, String>)
+    ("09-standard-library.md", 771): "FUTURE",   # md_render(@MdBlock -> @String)
+    ("09-standard-library.md", 782): "FUTURE",   # md_has_heading(@MdBlock, @Nat -> @Bool)
+    ("09-standard-library.md", 791): "FUTURE",   # md_has_code_block(@MdBlock, @String -> @Bool)
+    ("09-standard-library.md", 800): "FUTURE",   # md_extract_code_blocks(@MdBlock, @String -> @Array<String>)
+    ("09-standard-library.md", 824): "FUTURE",   # convert_to_markdown(@String -> @Result<MdBlock, String>)
 }
 
 

--- a/spec/09-standard-library.md
+++ b/spec/09-standard-library.md
@@ -9,7 +9,7 @@ The standard library comprises:
 - **Built-in ADTs**: `Option<T>` and `Result<T, E>` for representing partiality and fallibility.
 - **Built-in collections**: `Array<T>` for fixed-size homogeneous sequences, plus future collections (`Set<T>`, `Map<K, V>`).
 - **Built-in effects**: `IO` for output, `State<T>` for mutable state, plus future effects for networking, concurrency, and LLM inference.
-- **Built-in functions**: `length` for arrays, numeric operations (`abs`, `min`, `max`, `floor`, `ceil`, `round`, `sqrt`, `pow`), type conversions (`to_float`, `float_to_int`, `nat_to_int`, `int_to_nat`, `byte_to_int`, `int_to_byte`), plus future functions for vector similarity.
+- **Built-in functions**: `length` for arrays, numeric operations (`abs`, `min`, `max`, `floor`, `ceil`, `round`, `sqrt`, `pow`), type conversions (`to_float`, `float_to_int`, `nat_to_int`, `int_to_nat`, `byte_to_int`, `int_to_byte`), Float64 predicates (`is_nan`, `is_infinite`, `nan`, `infinity`), plus future functions for vector similarity.
 - **Future types**: `Json` for structured data interchange, `Markdown` for agent-oriented document structure, `Decimal` for exact arithmetic.
 - **Future abilities**: Type constraints for generic programming (post-v0.1).
 
@@ -579,7 +579,79 @@ match int_to_byte(65) {
 
 This expression evaluates to `65`.
 
-### 9.6.5 similarity (Future)
+### 9.6.5 Float64 Predicates
+
+Vera provides built-in functions for testing and constructing IEEE 754 special float values (NaN and infinity).
+
+#### Predicates
+
+```
+public fn is_nan(@Float64 -> @Bool)
+  requires(true)
+  ensures(true)
+  effects(pure)
+```
+
+Tests whether a Float64 value is NaN (not a number). NaN is the only value that is not equal to itself. Compiled to `f64.ne(x, x)`.
+
+```vera
+public fn test_is_nan(@Unit -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ if is_nan(nan()) then { 1 } else { 0 } }
+```
+
+This expression evaluates to `1`.
+
+```
+public fn is_infinite(@Float64 -> @Bool)
+  requires(true)
+  ensures(true)
+  effects(pure)
+```
+
+Tests whether a Float64 value is positive or negative infinity. Compiled to `f64.eq(f64.abs(x), inf)`. Returns `false` for NaN.
+
+```vera
+public fn test_is_infinite(@Unit -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ if is_infinite(infinity()) then { 1 } else { 0 } }
+```
+
+This expression evaluates to `1`.
+
+#### Constants
+
+```
+public fn nan(-> @Float64)
+  requires(true)
+  ensures(true)
+  effects(pure)
+```
+
+Returns a quiet NaN value. Compiled to `f64.const nan`.
+
+```vera
+public fn test_nan(@Unit -> @Float64)
+  requires(true) ensures(true) effects(pure)
+{ nan() }
+```
+
+```
+public fn infinity(-> @Float64)
+  requires(true)
+  ensures(true)
+  effects(pure)
+```
+
+Returns positive infinity. Negative infinity can be obtained via `0.0 - infinity()`. Compiled to `f64.const inf`.
+
+```vera
+public fn test_infinity(@Unit -> @Float64)
+  requires(true) ensures(true) effects(pure)
+{ infinity() }
+```
+
+### 9.6.6 similarity (Future)
 
 > **Status: Not yet implemented.** Will be introduced alongside the `Inference` effect ([#61](https://github.com/aallan/vera/issues/61)).
 

--- a/tests/conformance/ch10_float_predicates.vera
+++ b/tests/conformance/ch10_float_predicates.vera
@@ -1,0 +1,113 @@
+-- Conformance: Float64 special value operations (Chapter 9)
+-- Tests: is_nan, is_infinite, nan, infinity
+public fn test_nan_constant(@Unit -> @Float64)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  nan()
+}
+
+public fn test_infinity_constant(@Unit -> @Float64)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  infinity()
+}
+
+public fn test_is_nan_true(@Unit -> @Int)
+  requires(true)
+  ensures(@Int.result == 1)
+  effects(pure)
+{
+  if is_nan(nan()) then {
+    1
+  } else {
+    0
+  }
+}
+
+public fn test_is_nan_false(@Unit -> @Int)
+  requires(true)
+  ensures(@Int.result == 0)
+  effects(pure)
+{
+  if is_nan(1.5) then {
+    1
+  } else {
+    0
+  }
+}
+
+public fn test_is_nan_infinity(@Unit -> @Int)
+  requires(true)
+  ensures(@Int.result == 0)
+  effects(pure)
+{
+  if is_nan(infinity()) then {
+    1
+  } else {
+    0
+  }
+}
+
+public fn test_is_infinite_true(@Unit -> @Int)
+  requires(true)
+  ensures(@Int.result == 1)
+  effects(pure)
+{
+  if is_infinite(infinity()) then {
+    1
+  } else {
+    0
+  }
+}
+
+public fn test_is_infinite_negative(@Unit -> @Int)
+  requires(true)
+  ensures(@Int.result == 1)
+  effects(pure)
+{
+  if is_infinite(0.0 - infinity()) then {
+    1
+  } else {
+    0
+  }
+}
+
+public fn test_is_infinite_false(@Unit -> @Int)
+  requires(true)
+  ensures(@Int.result == 0)
+  effects(pure)
+{
+  if is_infinite(2.5) then {
+    1
+  } else {
+    0
+  }
+}
+
+public fn test_is_infinite_nan(@Unit -> @Int)
+  requires(true)
+  ensures(@Int.result == 0)
+  effects(pure)
+{
+  if is_infinite(nan()) then {
+    1
+  } else {
+    0
+  }
+}
+
+public fn main(@Unit -> @Int)
+  requires(true)
+  ensures(@Int.result == 1)
+  effects(pure)
+{
+  if is_nan(nan()) then {
+    1
+  } else {
+    0
+  }
+}

--- a/tests/conformance/manifest.json
+++ b/tests/conformance/manifest.json
@@ -367,5 +367,14 @@
     "level": "run",
     "spec_ref": "Section 9.6.4",
     "features": ["to_float", "float_to_int", "nat_to_int", "int_to_nat", "byte_to_int", "int_to_byte"]
+  },
+  {
+    "id": "ch10_float_predicates",
+    "file": "ch10_float_predicates.vera",
+    "chapter": 9,
+    "title": "Float64 predicate and constant functions",
+    "level": "run",
+    "spec_ref": "Section 9.6.5",
+    "features": ["is_nan", "is_infinite", "nan", "infinity"]
   }
 ]

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -2821,6 +2821,70 @@ private fn f(@Float64 -> @Option<Byte>)
 
 
 # =====================================================================
+# Float64 predicate builtins (issue #212)
+# =====================================================================
+
+class TestFloatPredicateBuiltins:
+    """Type-checking for Float64 predicate and constant builtins."""
+
+    def test_is_nan_ok(self) -> None:
+        _check_ok("""
+private fn f(@Float64 -> @Bool)
+  requires(true) ensures(true) effects(pure)
+{ is_nan(@Float64.0) }
+""")
+
+    def test_is_nan_wrong_arg(self) -> None:
+        _check_err("""
+private fn f(@Int -> @Bool)
+  requires(true) ensures(true) effects(pure)
+{ is_nan(@Int.0) }
+""", "type")
+
+    def test_is_infinite_ok(self) -> None:
+        _check_ok("""
+private fn f(@Float64 -> @Bool)
+  requires(true) ensures(true) effects(pure)
+{ is_infinite(@Float64.0) }
+""")
+
+    def test_is_infinite_wrong_arg(self) -> None:
+        _check_err("""
+private fn f(@String -> @Bool)
+  requires(true) ensures(true) effects(pure)
+{ is_infinite(@String.0) }
+""", "type")
+
+    def test_nan_ok(self) -> None:
+        _check_ok("""
+private fn f(-> @Float64)
+  requires(true) ensures(true) effects(pure)
+{ nan() }
+""")
+
+    def test_nan_wrong_arity(self) -> None:
+        _check_err("""
+private fn f(@Float64 -> @Float64)
+  requires(true) ensures(true) effects(pure)
+{ nan(@Float64.0) }
+""", "argument")
+
+    def test_infinity_ok(self) -> None:
+        _check_ok("""
+private fn f(-> @Float64)
+  requires(true) ensures(true) effects(pure)
+{ infinity() }
+""")
+
+    def test_infinity_wrong_arity(self) -> None:
+        _check_err("""
+private fn f(@Float64 -> @Float64)
+  requires(true) ensures(true) effects(pure)
+{ infinity(@Float64.0) }
+""", "argument")
+
+
+# =====================================================================
 # Bidirectional type inference (issue #55)
 # =====================================================================
 

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -5056,6 +5056,177 @@ public fn f(-> @Float64) requires(true) ensures(true) effects(pure) {
 
 
 # =====================================================================
+# Float64 predicates and constants (#212)
+# =====================================================================
+
+
+class TestIsNan:
+    """End-to-end tests for is_nan builtin."""
+
+    def test_regular_float_not_nan(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  if is_nan(1.5) then { 1 } else { 0 }
+}
+"""
+        assert _run(src) == 0
+
+    def test_nan_is_nan(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  if is_nan(nan()) then { 1 } else { 0 }
+}
+"""
+        assert _run(src) == 1
+
+    def test_infinity_not_nan(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  if is_nan(infinity()) then { 1 } else { 0 }
+}
+"""
+        assert _run(src) == 0
+
+    def test_zero_not_nan(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  if is_nan(0.0) then { 1 } else { 0 }
+}
+"""
+        assert _run(src) == 0
+
+
+class TestIsInfinite:
+    """End-to-end tests for is_infinite builtin."""
+
+    def test_regular_float_not_infinite(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  if is_infinite(1.5) then { 1 } else { 0 }
+}
+"""
+        assert _run(src) == 0
+
+    def test_positive_infinity(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  if is_infinite(infinity()) then { 1 } else { 0 }
+}
+"""
+        assert _run(src) == 1
+
+    def test_negative_infinity(self) -> None:
+        """Negate infinity to get -inf, still infinite."""
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  if is_infinite(0.0 - infinity()) then { 1 } else { 0 }
+}
+"""
+        assert _run(src) == 1
+
+    def test_nan_not_infinite(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  if is_infinite(nan()) then { 1 } else { 0 }
+}
+"""
+        assert _run(src) == 0
+
+    def test_zero_not_infinite(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  if is_infinite(0.0) then { 1 } else { 0 }
+}
+"""
+        assert _run(src) == 0
+
+
+class TestNanConstant:
+    """End-to-end tests for nan() builtin."""
+
+    def test_nan_returns_float(self) -> None:
+        import math
+        src = """
+public fn f(-> @Float64) requires(true) ensures(true) effects(pure) {
+  nan()
+}
+"""
+        result = _run_float(src)
+        assert math.isnan(result)
+
+    def test_nan_not_equal_to_itself(self) -> None:
+        """NaN != NaN is the defining property of NaN."""
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  if nan() == nan() then { 1 } else { 0 }
+}
+"""
+        assert _run(src) == 0
+
+
+class TestInfinityConstant:
+    """End-to-end tests for infinity() builtin."""
+
+    def test_infinity_returns_float(self) -> None:
+        import math
+        src = """
+public fn f(-> @Float64) requires(true) ensures(true) effects(pure) {
+  infinity()
+}
+"""
+        result = _run_float(src)
+        assert math.isinf(result) and result > 0
+
+    def test_negative_infinity(self) -> None:
+        import math
+        src = """
+public fn f(-> @Float64) requires(true) ensures(true) effects(pure) {
+  0.0 - infinity()
+}
+"""
+        result = _run_float(src)
+        assert math.isinf(result) and result < 0
+
+
+class TestFloatPredicateRoundTrips:
+    """Composition and round-trip tests for float predicates."""
+
+    def test_is_nan_of_nan(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  if is_nan(nan()) then { 1 } else { 0 }
+}
+"""
+        assert _run(src) == 1
+
+    def test_is_infinite_of_infinity(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  if is_infinite(infinity()) then { 1 } else { 0 }
+}
+"""
+        assert _run(src) == 1
+
+    def test_is_nan_after_arithmetic(self) -> None:
+        """nan + anything = nan."""
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  if is_nan(nan() + 1.0) then { 1 } else { 0 }
+}
+"""
+        assert _run(src) == 1
+
+    def test_is_infinite_after_arithmetic(self) -> None:
+        """infinity + 1 = infinity."""
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  if is_infinite(infinity() + 1.0) then { 1 } else { 0 }
+}
+"""
+        assert _run(src) == 1
+
+
+# =====================================================================
 # C8e: Arrays of compound types (#132)
 # =====================================================================
 

--- a/vera/README.md
+++ b/vera/README.md
@@ -320,6 +320,10 @@ Context flags (`in_ensures`, `in_contract`, `current_return_type`, `current_effe
 | `int_to_nat` | Function | `Int → Option<Nat>`, pure |
 | `byte_to_int` | Function | `Byte → Int`, pure |
 | `int_to_byte` | Function | `Int → Option<Byte>`, pure |
+| `is_nan` | Function | `Float64 → Bool`, pure |
+| `is_infinite` | Function | `Float64 → Bool`, pure |
+| `nan` | Function | `→ Float64`, pure |
+| `infinity` | Function | `→ Float64`, pure |
 
 Additionally, `resume` is bound as a temporary function inside handler clause bodies (in `_check_handle()`). Its type is derived from the operation: for `op(params) → ReturnType`, `resume` has type `fn(ReturnType) → Unit effects(pure)`. The binding is added to `env.functions` before checking the clause body and removed afterward.
 
@@ -567,7 +571,7 @@ The `ERROR_CODES` dict in `errors.py` maps every code to a short description (80
 
 ## Test Suite
 
-Testing is organized in three layers: **unit tests** (1,673 tests testing compiler internals), a **conformance suite** (41 programs in `tests/conformance/` validating every language feature against the spec), and **example programs** (18 end-to-end demos). The conformance suite is the definitive specification artifact — each program tests one feature and serves as a minimal working example.
+Testing is organized in three layers: **unit tests** (1,673 tests testing compiler internals), a **conformance suite** (42 programs in `tests/conformance/` validating every language feature against the spec), and **example programs** (18 end-to-end demos). The conformance suite is the definitive specification artifact — each program tests one feature and serves as a minimal working example.
 
 See **[TESTING.md](../TESTING.md)** for the comprehensive testing reference -- test file table, conformance suite details, compiler code coverage, language feature coverage, helper conventions, validation scripts, CI pipeline, and guidelines for adding tests.
 

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.71"
+__version__ = "0.0.72"

--- a/vera/codegen/modules.py
+++ b/vera/codegen/modules.py
@@ -246,6 +246,7 @@ class CrossModuleMixin:
             "abs", "min", "max", "floor", "ceil", "round", "sqrt", "pow",
             "to_float", "float_to_int", "nat_to_int", "int_to_nat",
             "byte_to_int", "int_to_byte",
+            "is_nan", "is_infinite", "nan", "infinity",
         })
 
         seen: set[str] = set()  # deduplicate by function name

--- a/vera/environment.py
+++ b/vera/environment.py
@@ -437,6 +437,36 @@ class TypeEnv:
             effect=PureEffectRow(),
         )
 
+        # Float64 special value operations
+        self.functions["is_nan"] = FunctionInfo(
+            name="is_nan",
+            forall_vars=None,
+            param_types=(FLOAT64,),
+            return_type=BOOL,
+            effect=PureEffectRow(),
+        )
+        self.functions["is_infinite"] = FunctionInfo(
+            name="is_infinite",
+            forall_vars=None,
+            param_types=(FLOAT64,),
+            return_type=BOOL,
+            effect=PureEffectRow(),
+        )
+        self.functions["nan"] = FunctionInfo(
+            name="nan",
+            forall_vars=None,
+            param_types=(),
+            return_type=FLOAT64,
+            effect=PureEffectRow(),
+        )
+        self.functions["infinity"] = FunctionInfo(
+            name="infinity",
+            forall_vars=None,
+            param_types=(),
+            return_type=FLOAT64,
+            effect=PureEffectRow(),
+        )
+
     # -----------------------------------------------------------------
     # Scope management
     # -----------------------------------------------------------------

--- a/vera/wasm/calls.py
+++ b/vera/wasm/calls.py
@@ -102,6 +102,15 @@ class CallsMixin:
                 return self._translate_byte_to_int(call.args[0], env)
             if call.name == "int_to_byte" and len(call.args) == 1:
                 return self._translate_int_to_byte(call.args[0], env)
+            # Float64 predicates and constants
+            if call.name == "is_nan" and len(call.args) == 1:
+                return self._translate_is_nan(call.args[0], env)
+            if call.name == "is_infinite" and len(call.args) == 1:
+                return self._translate_is_infinite(call.args[0], env)
+            if call.name == "nan" and len(call.args) == 0:
+                return self._translate_nan()
+            if call.name == "infinity" and len(call.args) == 0:
+                return self._translate_infinity()
 
         # Check if this is a closure application: apply_fn(closure, args...)
         if call.name == "apply_fn" and len(call.args) >= 2:
@@ -2083,6 +2092,59 @@ class CallsMixin:
 
         ins.append(f"local.get {out}")
         return ins
+
+    # -- Float64 predicates and constants ----------------------------
+
+    def _translate_is_nan(
+        self, arg: ast.Expr, env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """Translate is_nan(@Float64) → @Bool.
+
+        WASM: NaN is the only float value not equal to itself.
+        ``f64.ne(x, x)`` returns i32(1) for NaN, i32(0) otherwise.
+        """
+        arg_instrs = self.translate_expr(arg, env)
+        if arg_instrs is None:
+            return None
+        tmp = self.alloc_local("f64")
+        instructions: list[str] = []
+        instructions.extend(arg_instrs)
+        instructions.append(f"local.tee {tmp}")
+        instructions.append(f"local.get {tmp}")
+        instructions.append("f64.ne")
+        return instructions
+
+    def _translate_is_infinite(
+        self, arg: ast.Expr, env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """Translate is_infinite(@Float64) → @Bool.
+
+        WASM: ``f64.abs(x) == inf`` returns i32(1) for ±∞, i32(0) otherwise.
+        This correctly returns false for NaN since NaN comparisons are false.
+        """
+        arg_instrs = self.translate_expr(arg, env)
+        if arg_instrs is None:
+            return None
+        instructions: list[str] = []
+        instructions.extend(arg_instrs)
+        instructions.append("f64.abs")
+        instructions.append("f64.const inf")
+        instructions.append("f64.eq")
+        return instructions
+
+    def _translate_nan(self) -> list[str]:
+        """Translate nan() → @Float64.
+
+        WASM: ``f64.const nan`` pushes a quiet NaN onto the stack.
+        """
+        return ["f64.const nan"]
+
+    def _translate_infinity(self) -> list[str]:
+        """Translate infinity() → @Float64.
+
+        WASM: ``f64.const inf`` pushes positive infinity onto the stack.
+        """
+        return ["f64.const inf"]
 
     def _translate_handle_expr(
         self, expr: ast.HandleExpr, env: WasmSlotEnv,

--- a/vera/wasm/inference.py
+++ b/vera/wasm/inference.py
@@ -218,6 +218,11 @@ class InferenceMixin:
             return "i64"
         if expr.name in ("int_to_nat", "int_to_byte"):
             return "i32"
+        # Float64 predicates and constants
+        if expr.name in ("is_nan", "is_infinite"):
+            return "i32"
+        if expr.name in ("nan", "infinity"):
+            return "f64"
         # apply_fn(closure, args...) — infer from closure type
         if expr.name == "apply_fn" and len(expr.args) >= 1:
             return self._infer_apply_fn_return_type(expr.args[0])
@@ -370,6 +375,11 @@ class InferenceMixin:
             return "Int"
         if call.name in ("int_to_nat", "int_to_byte"):
             return "Option"
+        # Float64 predicates and constants
+        if call.name in ("is_nan", "is_infinite"):
+            return "Bool"
+        if call.name in ("nan", "infinity"):
+            return "Float64"
         if call.name in self._generic_fn_info:
             forall_vars, param_types = self._generic_fn_info[call.name]
             mapping: dict[str, str] = {}


### PR DESCRIPTION
## Summary

- Add 4 builtin functions: `is_nan`, `is_infinite`, `nan`, `infinity`
- `is_nan` uses NaN != NaN property (`f64.ne` with itself); `is_infinite` compares `f64.abs` with inf
- `nan()` and `infinity()` are nullary builtins (first zero-arg builtins in Vera)
- All four are Tier 3 (runtime-tested, Float64 not modeled in Z3)
- Release v0.0.72: version bump, CHANGELOG, README roadmap strikethrough

## Test plan

- [x] 8 type checker tests (4 ok + 4 err)
- [x] 17 codegen end-to-end tests (4 classes + roundtrips)
- [x] 1 conformance program (`ch10_float_predicates.vera`) -- passes check, verify, run
- [x] Full suite: 1,796 passed, 6 skipped
- [x] mypy clean, all validators green (conformance, examples, spec, SKILL, README, version sync)

Generated with [Claude Code](https://claude.com/claude-code)