### PR TITLE
Add string search and transformation builtins (close #198)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Read `SKILL.md` for the full language reference. It covers syntax, slot referenc
 
 ### Conformance programs as reference
 
-The conformance suite in `tests/conformance/` contains 42 small, self-contained programs — one per language feature — that all parse, type-check, verify, and (mostly) run correctly. These are the best minimal working examples of each feature. When you need to see how a specific construct works (e.g. effect handlers, match expressions, closures), check the corresponding conformance program before reading the spec. The `manifest.json` file maps features to programs.
+The conformance suite in `tests/conformance/` contains 43 small, self-contained programs — one per language feature — that all parse, type-check, verify, and (mostly) run correctly. These are the best minimal working examples of each feature. When you need to see how a specific construct works (e.g. effect handlers, match expressions, closures), check the corresponding conformance program before reading the spec. The `manifest.json` file maps features to programs.
 
 ### Workflow
 
@@ -140,7 +140,7 @@ Each stage is a module with a single public API function (`parse_file`, `transfo
 pytest tests/ -v                       # Run all tests (see TESTING.md)
 pytest tests/test_conformance.py -v    # Conformance suite only
 mypy vera/                             # Type-check the compiler
-python scripts/check_conformance.py    # All 42 conformance programs must pass
+python scripts/check_conformance.py    # All 43 conformance programs must pass
 python scripts/check_examples.py       # All 18 examples must pass
 ```
 
@@ -150,7 +150,7 @@ When implementing a new language feature, write the conformance program *first* 
 
 ### Invariants
 
-- All 42 conformance programs in `tests/conformance/` must pass their declared level
+- All 43 conformance programs in `tests/conformance/` must pass their declared level
 - All 18 examples in `examples/` must pass `vera check` and `vera verify`
 - `mypy vera/` must be clean
 - `pytest tests/ -v` must pass

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.73] - 2026-03-09
+
+### Added
+- **Close #198: String search and transformation builtins** ([#198](https://github.com/aallan/vera/issues/198)):
+  Nine new built-in functions for string search and transformation:
+  `string_contains` (String,String→Bool), `starts_with` (String,String→Bool),
+  `ends_with` (String,String→Bool), `index_of` (String,String→Option\<Nat\>),
+  `to_upper` (String→String), `to_lower` (String→String),
+  `replace` (String,String,String→String), `split` (String,String→Array\<String\>),
+  `join` (Array\<String\>,String→String). All are pure and Tier 3 (runtime-tested).
+- New conformance test `ch09_string_search` (conformance suite: 42→43 programs)
+- 55 new tests (18 type checker + 37 codegen end-to-end)
+- Spec Sections 9.6.6 "String Search" and 9.6.7 "String Transformation"
+
 ## [0.0.72] - 2026-03-09
 
 ### Added
@@ -1120,7 +1134,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Grammar: handler body simplified to avoid LALR reduce/reduce conflict
 - `pyproject.toml`: corrected build backend, package discovery, PEP 639 compliance
 
-[Unreleased]: https://github.com/aallan/vera/compare/v0.0.72...HEAD
+[Unreleased]: https://github.com/aallan/vera/compare/v0.0.73...HEAD
+[0.0.73]: https://github.com/aallan/vera/compare/v0.0.72...v0.0.73
 [0.0.72]: https://github.com/aallan/vera/compare/v0.0.71...v0.0.72
 [0.0.71]: https://github.com/aallan/vera/compare/v0.0.70...v0.0.71
 [0.0.70]: https://github.com/aallan/vera/compare/v0.0.69...v0.0.70

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ vera fmt --check file.vera        # Check if already canonical
 pytest tests/ -v                  # Run the test suite (see TESTING.md)
 mypy vera/                        # Type-check the compiler itself
 
-python scripts/check_conformance.py    # Verify all 42 conformance programs pass their declared level
+python scripts/check_conformance.py    # Verify all 43 conformance programs pass their declared level
 python scripts/check_examples.py      # Verify all 18 examples parse + check + verify
 python scripts/check_spec_examples.py # Verify spec code blocks parse
 python scripts/check_readme_examples.py # Verify README code blocks parse
@@ -56,7 +56,7 @@ python scripts/fix_allowlists.py --fix # Auto-fix stale allowlist line numbers
 - `vera/` — Reference compiler: grammar, parser, AST, transformer, type checker, verifier, codegen, CLI
 - `examples/` — 18 example Vera programs (all must pass `vera check` and `vera verify`)
 - `tests/` — Test suite (unit tests + conformance suite)
-- `tests/conformance/` — 42 conformance programs validating every language feature against the spec
+- `tests/conformance/` — 43 conformance programs validating every language feature against the spec
 - `scripts/` — CI and validation scripts
 
 ## Writing Vera code
@@ -74,7 +74,7 @@ Each stage is a module with a public API function and is independently testable.
 ## What not to break
 
 - Pre-commit hooks run mypy + pytest + conformance suite + example validation on every commit
-- All 42 conformance programs in `tests/conformance/` must pass their declared level
+- All 43 conformance programs in `tests/conformance/` must pass their declared level
 - All 18 examples in `examples/` must pass `vera check` and `vera verify`
 - Version must stay in sync across `vera/__init__.py`, `pyproject.toml`, and `CHANGELOG.md`
 - All tests must pass: `pytest tests/ -v`

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ The language specification is in draft across 13 chapters:
 
 ### Testing
 
-Testing is organized in three layers: **unit tests** (1,796 tests across 20 files, testing compiler internals), a **conformance suite** (42 programs across 8 spec chapters, systematically validating every language feature against the spec), and **example programs** (18 end-to-end demos). The compiler has 90% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations. Every commit validates all conformance programs, example programs, and 95 specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference -- coverage tables, conformance suite details, CI pipeline, and infrastructure.
+Testing is organized in three layers: **unit tests** (1,851 tests across 20 files, testing compiler internals), a **conformance suite** (43 programs across 8 spec chapters, systematically validating every language feature against the spec), and **example programs** (18 end-to-end demos). The compiler has 90% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations. Every commit validates all conformance programs, example programs, and 95 specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference -- coverage tables, conformance suite details, CI pipeline, and infrastructure.
 
 ## Roadmap
 
@@ -315,7 +315,7 @@ Module refinements, lexical extensions, and IO runtime — completing the existi
 
 - <del>[#199](https://github.com/aallan/vera/issues/199) numeric math builtins</del> ([v0.0.70](https://github.com/aallan/vera/releases/tag/v0.0.70))
 - [#200](https://github.com/aallan/vera/issues/200) parsing completeness (parse_int, parse_bool, safe parse_float64)
-- [#198](https://github.com/aallan/vera/issues/198) string search and transformation builtins
+- <del>[#198](https://github.com/aallan/vera/issues/198) string search and transformation builtins</del> ([v0.0.73](https://github.com/aallan/vera/releases/tag/v0.0.73))
 - <del>[#208](https://github.com/aallan/vera/issues/208) numeric type conversions</del> ([v0.0.71](https://github.com/aallan/vera/releases/tag/v0.0.71))
 - [#209](https://github.com/aallan/vera/issues/209) array construction builtins (range, append, concat)
 - [#210](https://github.com/aallan/vera/issues/210) from_char_code builtin

--- a/SKILL.md
+++ b/SKILL.md
@@ -415,6 +415,29 @@ float_to_string(@Float64.0)             -- returns String (decimal representatio
 strip(@String.0)                        -- returns String (trim whitespace)
 ```
 
+#### String search
+
+```vera
+string_contains(@String.0, @String.1)  -- returns Bool (substring test)
+starts_with(@String.0, @String.1)      -- returns Bool (prefix test)
+ends_with(@String.0, @String.1)        -- returns Bool (suffix test)
+index_of(@String.0, @String.1)         -- returns Option<Nat> (first occurrence)
+```
+
+`string_contains` checks whether the needle appears anywhere in the haystack. `starts_with` and `ends_with` test prefix and suffix matches. `index_of` returns `Some(i)` with the byte offset of the first match, or `None` if not found. An empty needle always matches (returns `true` or `Some(0)`).
+
+#### String transformation
+
+```vera
+to_upper(@String.0)                             -- returns String (ASCII uppercase)
+to_lower(@String.0)                             -- returns String (ASCII lowercase)
+replace(@String.0, @String.1, @String.2)        -- returns String (replace all)
+split(@String.0, @String.1)                     -- returns Array<String> (split by delimiter)
+join(@Array<String>.0, @String.0)               -- returns String (join with separator)
+```
+
+`to_upper` and `to_lower` convert ASCII letters only (a-z ↔ A-Z). `replace` substitutes all non-overlapping occurrences; an empty needle returns the original string unchanged. `split` returns an array of segments; an empty delimiter returns a single-element array. `join` concatenates array elements with the separator between each pair.
+
 String functions use the heap allocator (`$alloc`). Memory is managed automatically by a conservative mark-sweep garbage collector — there is no manual allocation or deallocation. `parse_nat` returns `Ok(n)` on valid decimal input and `Err(msg)` on empty or invalid input; leading and trailing spaces are tolerated.
 
 ### Numeric operations

--- a/TESTING.md
+++ b/TESTING.md
@@ -31,7 +31,7 @@ pytest tests/ --cov=vera --cov-report=term-missing   # with coverage
 mypy vera/                                           # strict mode
 
 # Validation scripts
-python scripts/check_conformance.py                  # conformance suite (42 programs)
+python scripts/check_conformance.py                  # conformance suite (43 programs)
 python scripts/check_examples.py                     # 18 example programs
 python scripts/check_spec_examples.py                # spec code blocks
 python scripts/check_readme_examples.py              # README code blocks
@@ -62,7 +62,7 @@ python scripts/fix_allowlists.py --fix               # auto-fix stale allowlists
 | `test_wasm.py` | 22 | 255 | WASM internals: StringPool, WasmSlotEnv, translation edge cases via full pipeline |
 | `test_wasm_coverage.py` | 113 | 1,738 | WASM coverage gaps: helpers unit tests, inference branches, closure free-var walking, operator/data/context edge cases |
 | `test_tester.py` | 13 | 345 | Contract-driven testing: tier classification, input generation, test execution |
-| `test_conformance.py` | 195 | ~250 | Parametrized conformance suite: parse, check, verify, run, format idempotency across 42 programs |
+| `test_conformance.py` | 195 | ~250 | Parametrized conformance suite: parse, check, verify, run, format idempotency across 43 programs |
 | `test_readme.py` | 2 | 78 | README code sample parsing |
 
 ## Conformance Suite

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.72"
+version = "0.0.73"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/scripts/check_skill_examples.py
+++ b/scripts/check_skill_examples.py
@@ -39,59 +39,65 @@ ALLOWLIST: dict[int, tuple[str, str]] = {
     # String operations — bare function calls
     402: ("FRAGMENT", "String built-in examples, bare calls"),
 
+    # String search — bare function calls
+    420: ("FRAGMENT", "String search built-in examples, bare calls"),
+
+    # String transformation — bare function calls
+    431: ("FRAGMENT", "String transformation built-in examples, bare calls"),
+
     # Numeric operations — bare function calls
-    422: ("FRAGMENT", "Numeric built-in examples, bare calls"),
+    445: ("FRAGMENT", "Numeric built-in examples, bare calls"),
 
     # Contracts section — requires/ensures fragments
-    479: ("FRAGMENT", "Requires clause example, not full function"),
-    488: ("FRAGMENT", "Ensures clause example, not full function"),
-    515: ("FRAGMENT", "Quantified requires clause, not full function"),
+    502: ("FRAGMENT", "Requires clause example, not full function"),
+    511: ("FRAGMENT", "Ensures clause example, not full function"),
+    538: ("FRAGMENT", "Quantified requires clause, not full function"),
 
     # Effects section — bare effect rows
-    533: ("FRAGMENT", "Effect row examples, bare annotations"),
+    556: ("FRAGMENT", "Effect row examples, bare annotations"),
 
     # Effect handler syntax template
-    670: ("FRAGMENT", "Handler syntax template, not real code"),
+    693: ("FRAGMENT", "Handler syntax template, not real code"),
 
     # Qualified calls and handler fragments — bare expressions
-    682: ("FRAGMENT", "Handler with clause, bare expression"),
-    692: ("FRAGMENT", "Qualified call examples, bare expressions"),
+    705: ("FRAGMENT", "Handler with clause, bare expression"),
+    715: ("FRAGMENT", "Qualified call examples, bare expressions"),
 
     # Module declaration and import syntax
-    742: ("FRAGMENT", "Module declaration and import example"),
+    765: ("FRAGMENT", "Module declaration and import example"),
 
     # Line comments — bare comments
-    781: ("FRAGMENT", "Comment syntax example"),
+    804: ("FRAGMENT", "Comment syntax example"),
 
     # Type conversions — bare function calls
-    437: ("FRAGMENT", "Type conversion examples, bare calls"),
+    460: ("FRAGMENT", "Type conversion examples, bare calls"),
 
     # Float64 predicates — bare function calls
-    450: ("FRAGMENT", "Float64 predicate examples, bare calls"),
+    473: ("FRAGMENT", "Float64 predicate examples, bare calls"),
 
     # Common mistakes section — intentionally wrong code
-    809: ("FRAGMENT", "Wrong: missing contracts"),
-    816: ("FRAGMENT", "Wrong: incorrect contract syntax"),
-    829: ("FRAGMENT", "Wrong: missing requires"),
+    832: ("FRAGMENT", "Wrong: missing contracts"),
+    839: ("FRAGMENT", "Wrong: incorrect contract syntax"),
+    852: ("FRAGMENT", "Wrong: missing requires"),
     839: ("FRAGMENT", "Wrong: missing effects clause"),
     852: ("FRAGMENT", "Wrong: wrong effect declared"),
-    863: ("FRAGMENT", "Wrong: bare expression without indices"),
-    876: ("FRAGMENT", "Wrong: bare expression no indices"),
-    881: ("FRAGMENT", "Correct: expression with indices (not full fn)"),
-    947: ("FRAGMENT", "Wrong: match arm with incorrect return"),
-    971: ("FRAGMENT", "Wrong: non-exhaustive match"),
-    978: ("FRAGMENT", "Correct: match arm example"),
-    988: ("FRAGMENT", "Wrong: if/else without braces (bare expression)"),
-    993: ("FRAGMENT", "Correct: if/else with braces"),
+    886: ("FRAGMENT", "Wrong: bare expression without indices"),
+    899: ("FRAGMENT", "Wrong: bare expression no indices"),
+    904: ("FRAGMENT", "Correct: expression with indices (not full fn)"),
+    970: ("FRAGMENT", "Wrong: match arm with incorrect return"),
+    994: ("FRAGMENT", "Wrong: non-exhaustive match"),
+    1001: ("FRAGMENT", "Correct: match arm example"),
+    1011: ("FRAGMENT", "Wrong: if/else without braces (bare expression)"),
+    1016: ("FRAGMENT", "Correct: if/else with braces"),
 
     # Import syntax — intentionally unsupported
-    1004: ("FRAGMENT", "Wrong: import aliasing not supported"),
-    1009: ("FRAGMENT", "Correct: import syntax example"),
-    1019: ("FRAGMENT", "Wrong: import hiding not supported"),
-    1024: ("FRAGMENT", "Correct: multi-import syntax"),
+    1027: ("FRAGMENT", "Wrong: import aliasing not supported"),
+    1032: ("FRAGMENT", "Correct: import syntax example"),
+    1042: ("FRAGMENT", "Wrong: import hiding not supported"),
+    1047: ("FRAGMENT", "Correct: multi-import syntax"),
 
     # String escapes — bare expression
-    1038: ("FRAGMENT", "String escape example"),
+    1061: ("FRAGMENT", "String escape example"),
 
     # =================================================================
     # MISMATCH — uses syntax the parser doesn't handle in isolation.

--- a/scripts/check_spec_examples.py
+++ b/scripts/check_spec_examples.py
@@ -60,7 +60,7 @@ ALLOWLIST: dict[tuple[str, int], str] = {
     ("09-standard-library.md", 290): "FUTURE",   # fn classify — uses ++ (string concat)
     ("09-standard-library.md", 304): "FRAGMENT",  # length signature (no body)
     ("09-standard-library.md", 324): "FRAGMENT",  # array_push signature (no body)
-    ("09-standard-library.md", 658): "FRAGMENT",  # similarity signature (no body)
+    ("09-standard-library.md", 803): "FRAGMENT",  # similarity signature (no body)
 
     # =================================================================
     # FRAGMENT — heuristic false positives (look like declarations but
@@ -133,13 +133,26 @@ ALLOWLIST: dict[tuple[str, int], str] = {
     ("09-standard-library.md", 624): "FRAGMENT",  # nan signature (no body)
     ("09-standard-library.md", 639): "FRAGMENT",  # infinity signature (no body)
 
+    # Chapter 9 — String search signatures (no body)
+    ("09-standard-library.md", 660): "FRAGMENT",  # string_contains signature (no body)
+    ("09-standard-library.md", 675): "FRAGMENT",  # starts_with signature (no body)
+    ("09-standard-library.md", 690): "FRAGMENT",  # ends_with signature (no body)
+    ("09-standard-library.md", 705): "FRAGMENT",  # index_of signature (no body)
+
+    # Chapter 9 — String transformation signatures (no body)
+    ("09-standard-library.md", 726): "FRAGMENT",  # to_upper signature (no body)
+    ("09-standard-library.md", 741): "FRAGMENT",  # to_lower signature (no body)
+    ("09-standard-library.md", 756): "FRAGMENT",  # replace signature (no body)
+    ("09-standard-library.md", 772): "FRAGMENT",  # split signature (no body)
+    ("09-standard-library.md", 787): "FRAGMENT",  # join signature (no body)
+
     # Chapter 9 — Markdown stdlib type (future, uses MdBlock/MdInline types)
-    ("09-standard-library.md", 762): "FUTURE",   # md_parse(@String -> @Result<MdBlock, String>)
-    ("09-standard-library.md", 771): "FUTURE",   # md_render(@MdBlock -> @String)
-    ("09-standard-library.md", 782): "FUTURE",   # md_has_heading(@MdBlock, @Nat -> @Bool)
-    ("09-standard-library.md", 791): "FUTURE",   # md_has_code_block(@MdBlock, @String -> @Bool)
-    ("09-standard-library.md", 800): "FUTURE",   # md_extract_code_blocks(@MdBlock, @String -> @Array<String>)
-    ("09-standard-library.md", 824): "FUTURE",   # convert_to_markdown(@String -> @Result<MdBlock, String>)
+    ("09-standard-library.md", 907): "FUTURE",   # md_parse(@String -> @Result<MdBlock, String>)
+    ("09-standard-library.md", 916): "FUTURE",   # md_render(@MdBlock -> @String)
+    ("09-standard-library.md", 927): "FUTURE",   # md_has_heading(@MdBlock, @Nat -> @Bool)
+    ("09-standard-library.md", 936): "FUTURE",   # md_has_code_block(@MdBlock, @String -> @Bool)
+    ("09-standard-library.md", 945): "FUTURE",   # md_extract_code_blocks(@MdBlock, @String -> @Array<String>)
+    ("09-standard-library.md", 969): "FUTURE",   # convert_to_markdown(@String -> @Result<MdBlock, String>)
 }
 
 

--- a/spec/09-standard-library.md
+++ b/spec/09-standard-library.md
@@ -9,7 +9,7 @@ The standard library comprises:
 - **Built-in ADTs**: `Option<T>` and `Result<T, E>` for representing partiality and fallibility.
 - **Built-in collections**: `Array<T>` for fixed-size homogeneous sequences, plus future collections (`Set<T>`, `Map<K, V>`).
 - **Built-in effects**: `IO` for output, `State<T>` for mutable state, plus future effects for networking, concurrency, and LLM inference.
-- **Built-in functions**: `length` for arrays, numeric operations (`abs`, `min`, `max`, `floor`, `ceil`, `round`, `sqrt`, `pow`), type conversions (`to_float`, `float_to_int`, `nat_to_int`, `int_to_nat`, `byte_to_int`, `int_to_byte`), Float64 predicates (`is_nan`, `is_infinite`, `nan`, `infinity`), plus future functions for vector similarity.
+- **Built-in functions**: `length` for arrays, numeric operations (`abs`, `min`, `max`, `floor`, `ceil`, `round`, `sqrt`, `pow`), type conversions (`to_float`, `float_to_int`, `nat_to_int`, `int_to_nat`, `byte_to_int`, `int_to_byte`), Float64 predicates (`is_nan`, `is_infinite`, `nan`, `infinity`), string search (`string_contains`, `starts_with`, `ends_with`, `index_of`), string transformation (`to_upper`, `to_lower`, `replace`, `split`, `join`), plus future functions for vector similarity.
 - **Future types**: `Json` for structured data interchange, `Markdown` for agent-oriented document structure, `Decimal` for exact arithmetic.
 - **Future abilities**: Type constraints for generic programming (post-v0.1).
 
@@ -651,7 +651,152 @@ public fn test_infinity(@Unit -> @Float64)
 { infinity() }
 ```
 
-### 9.6.6 similarity (Future)
+### 9.6.6 String Search
+
+String search functions test for the presence or position of substrings. All are pure, take `String` arguments, and operate on raw bytes (ASCII). All are Tier 3 for verification (String is not modeled in Z3).
+
+#### string_contains
+
+```vera
+public fn string_contains(@String, @String -> @Bool)
+  requires(true) ensures(true) effects(pure)
+```
+
+Returns `true` if the second argument (needle) appears as a contiguous substring of the first (haystack). An empty needle always matches. Uses a naive O(n×m) byte comparison.
+
+```vera
+string_contains("hello world", "world")  -- true
+string_contains("hello", "xyz")          -- false
+string_contains("hello", "")             -- true
+```
+
+#### starts_with
+
+```vera
+public fn starts_with(@String, @String -> @Bool)
+  requires(true) ensures(true) effects(pure)
+```
+
+Returns `true` if the haystack begins with the given prefix. An empty prefix always matches. If the prefix is longer than the haystack, returns `false`.
+
+```vera
+starts_with("hello world", "hello")  -- true
+starts_with("hello", "world")        -- false
+starts_with("hello", "")             -- true
+```
+
+#### ends_with
+
+```vera
+public fn ends_with(@String, @String -> @Bool)
+  requires(true) ensures(true) effects(pure)
+```
+
+Returns `true` if the haystack ends with the given suffix. An empty suffix always matches. If the suffix is longer than the haystack, returns `false`.
+
+```vera
+ends_with("hello world", "world")  -- true
+ends_with("hello", "world")        -- false
+ends_with("hello", "")             -- true
+```
+
+#### index_of
+
+```vera
+public fn index_of(@String, @String -> @Option<Nat>)
+  requires(true) ensures(true) effects(pure)
+```
+
+Returns `Some(i)` where `i` is the byte offset of the first occurrence of the needle in the haystack, or `None` if not found. An empty needle matches at position 0. The returned index is a `Nat` (natural number).
+
+```vera
+match index_of("hello world", "world") {
+  Some(@Nat) -> nat_to_int(@Nat.0),
+  None -> 0 - 1
+}
+-- evaluates to 6
+```
+
+### 9.6.7 String Transformation
+
+String transformation functions produce new strings by modifying characters or structure. All allocate heap memory for the result and register it with the GC shadow stack. All are pure and Tier 3.
+
+#### to_upper
+
+```vera
+public fn to_upper(@String -> @String)
+  requires(true) ensures(true) effects(pure)
+```
+
+Returns a new string with all ASCII lowercase letters (a–z, bytes 97–122) converted to uppercase (A–Z, bytes 65–90). Non-ASCII bytes and non-letter bytes are unchanged.
+
+```vera
+to_upper("hello")   -- "HELLO"
+to_upper("Hello!")   -- "HELLO!"
+to_upper("123")      -- "123"
+```
+
+#### to_lower
+
+```vera
+public fn to_lower(@String -> @String)
+  requires(true) ensures(true) effects(pure)
+```
+
+Returns a new string with all ASCII uppercase letters (A–Z, bytes 65–90) converted to lowercase (a–z, bytes 97–122). Non-ASCII bytes and non-letter bytes are unchanged.
+
+```vera
+to_lower("HELLO")   -- "hello"
+to_lower("Hello!")   -- "hello!"
+to_lower("123")      -- "123"
+```
+
+#### replace
+
+```vera
+public fn replace(@String, @String, @String -> @String)
+  requires(true) ensures(true) effects(pure)
+```
+
+Replaces all non-overlapping occurrences of the needle (second argument) in the haystack (first argument) with the replacement (third argument). If the needle is empty, returns a copy of the haystack. Uses a two-pass algorithm: pass 1 counts occurrences, then allocates the output buffer; pass 2 copies bytes with substitutions.
+
+```vera
+replace("hello world", "world", "vera")  -- "hello vera"
+replace("aaa", "a", "bb")                -- "bbbbbb"
+replace("hello", "xyz", "abc")           -- "hello"
+replace("hello", "", "x")                -- "hello"
+```
+
+#### split
+
+```vera
+public fn split(@String, @String -> @Array<String>)
+  requires(true) ensures(true) effects(pure)
+```
+
+Splits the string at each non-overlapping occurrence of the delimiter, returning an `Array<String>`. If the delimiter is empty, returns a single-element array containing the original string. Consecutive delimiters produce empty string segments. Uses a two-pass algorithm: pass 1 counts delimiters, then allocates the array and segment buffers in pass 2.
+
+```vera
+split("a,b,c", ",")     -- Array with 3 elements: "a", "b", "c"
+split("hello", ",")     -- Array with 1 element: "hello"
+split("a,,b", ",")      -- Array with 3 elements: "a", "", "b"
+```
+
+#### join
+
+```vera
+public fn join(@Array<String>, @String -> @String)
+  requires(true) ensures(true) effects(pure)
+```
+
+Joins an array of strings with the given separator between each pair of elements. An empty array produces an empty string. Uses a two-pass algorithm: pass 1 sums the total length, pass 2 copies bytes.
+
+```vera
+join(split("a,b,c", ","), "-")  -- "a-b-c"
+join(split("hello", ","), "-")  -- "hello"
+```
+
+### 9.6.8 similarity (Future)
 
 > **Status: Not yet implemented.** Will be introduced alongside the `Inference` effect ([#61](https://github.com/aallan/vera/issues/61)).
 

--- a/tests/conformance/ch09_string_search.vera
+++ b/tests/conformance/ch09_string_search.vera
@@ -1,0 +1,81 @@
+-- Conformance: string search and transformation builtins (Chapter 9)
+-- Tests: string_contains, starts_with, ends_with, index_of,
+--        to_upper, to_lower, replace, split, join
+public fn test_string_contains(@Unit -> @Bool)
+  requires(true)
+  ensures(@Bool.result == true)
+  effects(pure)
+{
+  string_contains("hello world", "world")
+}
+
+public fn test_starts_with(@Unit -> @Bool)
+  requires(true)
+  ensures(@Bool.result == true)
+  effects(pure)
+{
+  starts_with("hello world", "hello")
+}
+
+public fn test_ends_with(@Unit -> @Bool)
+  requires(true)
+  ensures(@Bool.result == true)
+  effects(pure)
+{
+  ends_with("hello world", "world")
+}
+
+public fn test_index_of(@Unit -> @Int)
+  requires(true)
+  ensures(@Int.result == 6)
+  effects(pure)
+{
+  match index_of("hello world", "world") {
+    Some(@Nat) -> nat_to_int(@Nat.0),
+    None -> 0 - 1
+  }
+}
+
+public fn test_to_upper(@Unit -> @String)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  to_upper("hello")
+}
+
+public fn test_to_lower(@Unit -> @String)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  to_lower("HELLO")
+}
+
+public fn test_replace(@Unit -> @String)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  replace("hello world", "world", "vera")
+}
+
+public fn test_split_join(@Unit -> @String)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  join(split("a,b,c", ","), "-")
+}
+
+public fn main(@Unit -> @Int)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  if string_contains("vera", "er") then {
+    1
+  } else {
+    0
+  }
+}

--- a/tests/conformance/manifest.json
+++ b/tests/conformance/manifest.json
@@ -369,6 +369,15 @@
     "features": ["to_float", "float_to_int", "nat_to_int", "int_to_nat", "byte_to_int", "int_to_byte"]
   },
   {
+    "id": "ch09_string_search",
+    "file": "ch09_string_search.vera",
+    "chapter": 9,
+    "title": "String search and transformation functions",
+    "level": "run",
+    "spec_ref": "Section 9.6.6-9.6.7",
+    "features": ["string_contains", "starts_with", "ends_with", "index_of", "to_upper", "to_lower", "replace", "split", "join"]
+  },
+  {
     "id": "ch10_float_predicates",
     "file": "ch10_float_predicates.vera",
     "chapter": 9,

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -2885,6 +2885,159 @@ private fn f(@Float64 -> @Float64)
 
 
 # =====================================================================
+# String search and transformation builtins
+# =====================================================================
+
+class TestStringSearchBuiltins:
+    """Type-checking for string search and transformation builtins."""
+
+    # -- string_contains --
+
+    def test_string_contains_ok(self) -> None:
+        _check_ok("""
+private fn f(@String, @String -> @Bool)
+  requires(true) ensures(true) effects(pure)
+{ string_contains(@String.0, @String.1) }
+""")
+
+    def test_string_contains_wrong_arg(self) -> None:
+        _check_err("""
+private fn f(@Int, @String -> @Bool)
+  requires(true) ensures(true) effects(pure)
+{ string_contains(@Int.0, @String.0) }
+""", "type")
+
+    # -- starts_with --
+
+    def test_starts_with_ok(self) -> None:
+        _check_ok("""
+private fn f(@String, @String -> @Bool)
+  requires(true) ensures(true) effects(pure)
+{ starts_with(@String.0, @String.1) }
+""")
+
+    def test_starts_with_wrong_arg(self) -> None:
+        _check_err("""
+private fn f(@Int, @String -> @Bool)
+  requires(true) ensures(true) effects(pure)
+{ starts_with(@Int.0, @String.0) }
+""", "type")
+
+    # -- ends_with --
+
+    def test_ends_with_ok(self) -> None:
+        _check_ok("""
+private fn f(@String, @String -> @Bool)
+  requires(true) ensures(true) effects(pure)
+{ ends_with(@String.0, @String.1) }
+""")
+
+    def test_ends_with_wrong_arg(self) -> None:
+        _check_err("""
+private fn f(@Int, @String -> @Bool)
+  requires(true) ensures(true) effects(pure)
+{ ends_with(@Int.0, @String.0) }
+""", "type")
+
+    # -- index_of --
+
+    def test_index_of_ok(self) -> None:
+        _check_ok("""
+private data Option<T> { Some(T), None }
+private fn f(@String, @String -> @Option<Nat>)
+  requires(true) ensures(true) effects(pure)
+{ index_of(@String.0, @String.1) }
+""")
+
+    def test_index_of_wrong_arg(self) -> None:
+        _check_err("""
+private fn f(@Int, @String -> @Bool)
+  requires(true) ensures(true) effects(pure)
+{ index_of(@Int.0, @String.0) }
+""", "type")
+
+    # -- to_upper --
+
+    def test_to_upper_ok(self) -> None:
+        _check_ok("""
+private fn f(@String -> @String)
+  requires(true) ensures(true) effects(pure)
+{ to_upper(@String.0) }
+""")
+
+    def test_to_upper_wrong_arg(self) -> None:
+        _check_err("""
+private fn f(@Int -> @String)
+  requires(true) ensures(true) effects(pure)
+{ to_upper(@Int.0) }
+""", "type")
+
+    # -- to_lower --
+
+    def test_to_lower_ok(self) -> None:
+        _check_ok("""
+private fn f(@String -> @String)
+  requires(true) ensures(true) effects(pure)
+{ to_lower(@String.0) }
+""")
+
+    def test_to_lower_wrong_arg(self) -> None:
+        _check_err("""
+private fn f(@Int -> @String)
+  requires(true) ensures(true) effects(pure)
+{ to_lower(@Int.0) }
+""", "type")
+
+    # -- replace --
+
+    def test_replace_ok(self) -> None:
+        _check_ok("""
+private fn f(@String, @String, @String -> @String)
+  requires(true) ensures(true) effects(pure)
+{ replace(@String.0, @String.1, @String.2) }
+""")
+
+    def test_replace_wrong_arg(self) -> None:
+        _check_err("""
+private fn f(@Int, @String, @String -> @String)
+  requires(true) ensures(true) effects(pure)
+{ replace(@Int.0, @String.0, @String.1) }
+""", "type")
+
+    # -- split --
+
+    def test_split_ok(self) -> None:
+        _check_ok("""
+private fn f(@String, @String -> @Array<String>)
+  requires(true) ensures(true) effects(pure)
+{ split(@String.0, @String.1) }
+""")
+
+    def test_split_wrong_arg(self) -> None:
+        _check_err("""
+private fn f(@Int, @String -> @Array<String>)
+  requires(true) ensures(true) effects(pure)
+{ split(@Int.0, @String.0) }
+""", "type")
+
+    # -- join --
+
+    def test_join_ok(self) -> None:
+        _check_ok("""
+private fn f(@Array<String>, @String -> @String)
+  requires(true) ensures(true) effects(pure)
+{ join(@Array<String>.0, @String.0) }
+""")
+
+    def test_join_wrong_arg(self) -> None:
+        _check_err("""
+private fn f(@Array<Int>, @String -> @String)
+  requires(true) ensures(true) effects(pure)
+{ join(@Array<Int>.0, @String.0) }
+""", "type")
+
+
+# =====================================================================
 # Bidirectional type inference (issue #55)
 # =====================================================================
 

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -4380,6 +4380,385 @@ public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
 
 
 # =====================================================================
+# C8f: String search and transformation builtins (#198)
+# =====================================================================
+
+
+class TestStringContains:
+    def test_basic_true(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  if string_contains("hello world", "world") then { 1 } else { 0 }
+}
+"""
+        assert _run(src) == 1
+
+    def test_basic_false(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  if string_contains("hello", "xyz") then { 1 } else { 0 }
+}
+"""
+        assert _run(src) == 0
+
+    def test_empty_needle(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  if string_contains("hello", "") then { 1 } else { 0 }
+}
+"""
+        assert _run(src) == 1
+
+    def test_empty_haystack(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  if string_contains("", "a") then { 1 } else { 0 }
+}
+"""
+        assert _run(src) == 0
+
+    def test_same_string(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  if string_contains("abc", "abc") then { 1 } else { 0 }
+}
+"""
+        assert _run(src) == 1
+
+
+class TestStartsWith:
+    def test_basic_true(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  if starts_with("hello", "hel") then { 1 } else { 0 }
+}
+"""
+        assert _run(src) == 1
+
+    def test_basic_false(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  if starts_with("hello", "xyz") then { 1 } else { 0 }
+}
+"""
+        assert _run(src) == 0
+
+    def test_empty_prefix(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  if starts_with("hello", "") then { 1 } else { 0 }
+}
+"""
+        assert _run(src) == 1
+
+    def test_longer_needle(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  if starts_with("hi", "hello") then { 1 } else { 0 }
+}
+"""
+        assert _run(src) == 0
+
+
+class TestEndsWith:
+    def test_basic_true(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  if ends_with("hello", "llo") then { 1 } else { 0 }
+}
+"""
+        assert _run(src) == 1
+
+    def test_basic_false(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  if ends_with("hello", "xyz") then { 1 } else { 0 }
+}
+"""
+        assert _run(src) == 0
+
+    def test_empty_suffix(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  if ends_with("hello", "") then { 1 } else { 0 }
+}
+"""
+        assert _run(src) == 1
+
+    def test_longer_needle(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  if ends_with("hi", "hello") then { 1 } else { 0 }
+}
+"""
+        assert _run(src) == 0
+
+
+class TestIndexOf:
+    def test_found(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  match index_of("hello world", "world") {
+    Some(@Nat) -> nat_to_int(@Nat.0),
+    None -> 0 - 1
+  }
+}
+"""
+        assert _run(src) == 6
+
+    def test_not_found(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  match index_of("hello", "xyz") {
+    Some(@Nat) -> nat_to_int(@Nat.0),
+    None -> 0 - 1
+  }
+}
+"""
+        assert _run(src) == -1
+
+    def test_at_start(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  match index_of("hello", "hel") {
+    Some(@Nat) -> nat_to_int(@Nat.0),
+    None -> 0 - 1
+  }
+}
+"""
+        assert _run(src) == 0
+
+    def test_empty_needle(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  match index_of("hello", "") {
+    Some(@Nat) -> nat_to_int(@Nat.0),
+    None -> 0 - 1
+  }
+}
+"""
+        assert _run(src) == 0
+
+
+class TestToUpper:
+    def test_basic(self) -> None:
+        src = """
+effect IO { op print(String -> Unit); }
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  IO.print(to_upper("hello"))
+}
+"""
+        assert _run_io(src) == "HELLO"
+
+    def test_mixed(self) -> None:
+        src = """
+effect IO { op print(String -> Unit); }
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  IO.print(to_upper("Hello World"))
+}
+"""
+        assert _run_io(src) == "HELLO WORLD"
+
+    def test_no_letters(self) -> None:
+        src = """
+effect IO { op print(String -> Unit); }
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  IO.print(to_upper("123"))
+}
+"""
+        assert _run_io(src) == "123"
+
+    def test_empty(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  string_length(to_upper(""))
+}
+"""
+        assert _run(src) == 0
+
+
+class TestToLower:
+    def test_basic(self) -> None:
+        src = """
+effect IO { op print(String -> Unit); }
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  IO.print(to_lower("HELLO"))
+}
+"""
+        assert _run_io(src) == "hello"
+
+    def test_mixed(self) -> None:
+        src = """
+effect IO { op print(String -> Unit); }
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  IO.print(to_lower("Hello World"))
+}
+"""
+        assert _run_io(src) == "hello world"
+
+    def test_no_letters(self) -> None:
+        src = """
+effect IO { op print(String -> Unit); }
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  IO.print(to_lower("123"))
+}
+"""
+        assert _run_io(src) == "123"
+
+    def test_empty(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  string_length(to_lower(""))
+}
+"""
+        assert _run(src) == 0
+
+
+class TestReplace:
+    def test_basic(self) -> None:
+        src = """
+effect IO { op print(String -> Unit); }
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  IO.print(replace("hello world", "world", "vera"))
+}
+"""
+        assert _run_io(src) == "hello vera"
+
+    def test_not_found(self) -> None:
+        src = """
+effect IO { op print(String -> Unit); }
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  IO.print(replace("hello", "xyz", "abc"))
+}
+"""
+        assert _run_io(src) == "hello"
+
+    def test_empty_needle(self) -> None:
+        src = """
+effect IO { op print(String -> Unit); }
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  IO.print(replace("hello", "", "x"))
+}
+"""
+        assert _run_io(src) == "hello"
+
+    def test_multiple(self) -> None:
+        src = """
+effect IO { op print(String -> Unit); }
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  IO.print(replace("aabaa", "a", "x"))
+}
+"""
+        assert _run_io(src) == "xxbxx"
+
+
+class TestSplit:
+    def test_basic(self) -> None:
+        src = """
+effect IO { op print(String -> Unit); }
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  IO.print(join(split("a,b,c", ","), "-"))
+}
+"""
+        assert _run_io(src) == "a-b-c"
+
+    def test_no_delimiter(self) -> None:
+        src = """
+effect IO { op print(String -> Unit); }
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  IO.print(join(split("hello", ","), "-"))
+}
+"""
+        assert _run_io(src) == "hello"
+
+    def test_count(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  length(split("a,b,c", ","))
+}
+"""
+        assert _run(src) == 3
+
+    def test_consecutive_delimiters(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  length(split("a,,b", ","))
+}
+"""
+        assert _run(src) == 3
+
+
+class TestJoin:
+    def test_basic(self) -> None:
+        src = """
+effect IO { op print(String -> Unit); }
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  IO.print(join(split("a,b,c", ","), "-"))
+}
+"""
+        assert _run_io(src) == "a-b-c"
+
+    def test_single_element(self) -> None:
+        src = """
+effect IO { op print(String -> Unit); }
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  IO.print(join(split("hello", ","), "-"))
+}
+"""
+        assert _run_io(src) == "hello"
+
+    def test_empty_separator(self) -> None:
+        src = """
+effect IO { op print(String -> Unit); }
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  IO.print(join(split("a,b", ","), ""))
+}
+"""
+        assert _run_io(src) == "ab"
+
+    def test_roundtrip(self) -> None:
+        src = """
+effect IO { op print(String -> Unit); }
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  IO.print(join(split("hello world", " "), " "))
+}
+"""
+        assert _run_io(src) == "hello world"
+
+
+# =====================================================================
 # C8e: Universal to-string conversion (#106)
 # =====================================================================
 

--- a/vera/README.md
+++ b/vera/README.md
@@ -324,6 +324,15 @@ Context flags (`in_ensures`, `in_contract`, `current_return_type`, `current_effe
 | `is_infinite` | Function | `Float64 → Bool`, pure |
 | `nan` | Function | `→ Float64`, pure |
 | `infinity` | Function | `→ Float64`, pure |
+| `string_contains` | Function | `String, String → Bool`, pure |
+| `starts_with` | Function | `String, String → Bool`, pure |
+| `ends_with` | Function | `String, String → Bool`, pure |
+| `index_of` | Function | `String, String → Option<Nat>`, pure |
+| `to_upper` | Function | `String → String`, pure |
+| `to_lower` | Function | `String → String`, pure |
+| `replace` | Function | `String, String, String → String`, pure |
+| `split` | Function | `String, String → Array<String>`, pure |
+| `join` | Function | `Array<String>, String → String`, pure |
 
 Additionally, `resume` is bound as a temporary function inside handler clause bodies (in `_check_handle()`). Its type is derived from the operation: for `op(params) → ReturnType`, `resume` has type `fn(ReturnType) → Unit effects(pure)`. The binding is added to `env.functions` before checking the clause body and removed afterward.
 
@@ -571,7 +580,7 @@ The `ERROR_CODES` dict in `errors.py` maps every code to a short description (80
 
 ## Test Suite
 
-Testing is organized in three layers: **unit tests** (1,673 tests testing compiler internals), a **conformance suite** (42 programs in `tests/conformance/` validating every language feature against the spec), and **example programs** (18 end-to-end demos). The conformance suite is the definitive specification artifact — each program tests one feature and serves as a minimal working example.
+Testing is organized in three layers: **unit tests** (1,673 tests testing compiler internals), a **conformance suite** (43 programs in `tests/conformance/` validating every language feature against the spec), and **example programs** (18 end-to-end demos). The conformance suite is the definitive specification artifact — each program tests one feature and serves as a minimal working example.
 
 See **[TESTING.md](../TESTING.md)** for the comprehensive testing reference -- test file table, conformance suite details, compiler code coverage, language feature coverage, helper conventions, validation scripts, CI pipeline, and guidelines for adding tests.
 

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.72"
+__version__ = "0.0.73"

--- a/vera/codegen/modules.py
+++ b/vera/codegen/modules.py
@@ -243,6 +243,8 @@ class CrossModuleMixin:
             "to_string", "int_to_string", "bool_to_string",
             "nat_to_string", "byte_to_string", "float_to_string",
             "strip",
+            "string_contains", "starts_with", "ends_with", "index_of",
+            "to_upper", "to_lower", "replace", "split", "join",
             "abs", "min", "max", "floor", "ceil", "round", "sqrt", "pow",
             "to_float", "float_to_int", "nat_to_int", "int_to_nat",
             "byte_to_int", "int_to_byte",

--- a/vera/environment.py
+++ b/vera/environment.py
@@ -335,6 +335,71 @@ class TypeEnv:
             effect=PureEffectRow(),
         )
 
+        # String search and transformation builtins
+        self.functions["string_contains"] = FunctionInfo(
+            name="string_contains",
+            forall_vars=None,
+            param_types=(STRING, STRING),
+            return_type=BOOL,
+            effect=PureEffectRow(),
+        )
+        self.functions["starts_with"] = FunctionInfo(
+            name="starts_with",
+            forall_vars=None,
+            param_types=(STRING, STRING),
+            return_type=BOOL,
+            effect=PureEffectRow(),
+        )
+        self.functions["ends_with"] = FunctionInfo(
+            name="ends_with",
+            forall_vars=None,
+            param_types=(STRING, STRING),
+            return_type=BOOL,
+            effect=PureEffectRow(),
+        )
+        self.functions["index_of"] = FunctionInfo(
+            name="index_of",
+            forall_vars=None,
+            param_types=(STRING, STRING),
+            return_type=AdtType("Option", (NAT,)),
+            effect=PureEffectRow(),
+        )
+        self.functions["to_upper"] = FunctionInfo(
+            name="to_upper",
+            forall_vars=None,
+            param_types=(STRING,),
+            return_type=STRING,
+            effect=PureEffectRow(),
+        )
+        self.functions["to_lower"] = FunctionInfo(
+            name="to_lower",
+            forall_vars=None,
+            param_types=(STRING,),
+            return_type=STRING,
+            effect=PureEffectRow(),
+        )
+        self.functions["replace"] = FunctionInfo(
+            name="replace",
+            forall_vars=None,
+            param_types=(STRING, STRING, STRING),
+            return_type=STRING,
+            effect=PureEffectRow(),
+        )
+        self.functions["split"] = FunctionInfo(
+            name="split",
+            forall_vars=None,
+            param_types=(STRING, STRING),
+            return_type=AdtType("Array", (STRING,)),
+            effect=PureEffectRow(),
+        )
+        self.functions["join"] = FunctionInfo(
+            name="join",
+            forall_vars=None,
+            param_types=(AdtType("Array", (STRING,)), STRING),
+            return_type=STRING,
+            effect=PureEffectRow(),
+        )
+
         # Numeric math builtins
         self.functions["abs"] = FunctionInfo(
             name="abs",

--- a/vera/wasm/calls.py
+++ b/vera/wasm/calls.py
@@ -62,6 +62,40 @@ class CallsMixin:
                 return self._translate_float_to_string(call.args[0], env)
             if call.name == "strip" and len(call.args) == 1:
                 return self._translate_strip(call.args[0], env)
+            # String search builtins
+            if call.name == "string_contains" and len(call.args) == 2:
+                return self._translate_string_contains(
+                    call.args[0], call.args[1], env,
+                )
+            if call.name == "starts_with" and len(call.args) == 2:
+                return self._translate_starts_with(
+                    call.args[0], call.args[1], env,
+                )
+            if call.name == "ends_with" and len(call.args) == 2:
+                return self._translate_ends_with(
+                    call.args[0], call.args[1], env,
+                )
+            if call.name == "index_of" and len(call.args) == 2:
+                return self._translate_index_of(
+                    call.args[0], call.args[1], env,
+                )
+            # String transformation builtins
+            if call.name == "to_upper" and len(call.args) == 1:
+                return self._translate_to_upper(call.args[0], env)
+            if call.name == "to_lower" and len(call.args) == 1:
+                return self._translate_to_lower(call.args[0], env)
+            if call.name == "replace" and len(call.args) == 3:
+                return self._translate_replace(
+                    call.args[0], call.args[1], call.args[2], env,
+                )
+            if call.name == "split" and len(call.args) == 2:
+                return self._translate_split(
+                    call.args[0], call.args[1], env,
+                )
+            if call.name == "join" and len(call.args) == 2:
+                return self._translate_join(
+                    call.args[0], call.args[1], env,
+                )
             if call.name == "array_push" and len(call.args) == 2:
                 return self._translate_array_push(
                     call.args[0], call.args[1], env,
@@ -1703,6 +1737,1510 @@ class CallsMixin:
         instructions.append(f"local.get {dst}")
         instructions.append(f"local.get {new_len}")
         return instructions
+
+    # -----------------------------------------------------------------
+    # String search builtins
+    # -----------------------------------------------------------------
+
+    def _translate_starts_with(
+        self,
+        arg_h: ast.Expr,
+        arg_n: ast.Expr,
+        env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """Translate starts_with(haystack, needle) → Bool (i32).
+
+        Returns 1 if haystack starts with needle, 0 otherwise.
+        Compares prefix bytes; empty needle always matches.
+        """
+        h_instrs = self.translate_expr(arg_h, env)
+        n_instrs = self.translate_expr(arg_n, env)
+        if h_instrs is None or n_instrs is None:
+            return None
+
+        ptr_h = self.alloc_local("i32")
+        len_h = self.alloc_local("i32")
+        ptr_n = self.alloc_local("i32")
+        len_n = self.alloc_local("i32")
+        idx = self.alloc_local("i32")
+
+        ins: list[str] = []
+
+        # Evaluate haystack → (ptr, len)
+        ins.extend(h_instrs)
+        ins.append(f"local.set {len_h}")
+        ins.append(f"local.set {ptr_h}")
+
+        # Evaluate needle → (ptr, len)
+        ins.extend(n_instrs)
+        ins.append(f"local.set {len_n}")
+        ins.append(f"local.set {ptr_n}")
+
+        # block $done_sw produces i32 result
+        ins.append("block $done_sw (result i32)")
+
+        # If needle longer than haystack → false
+        ins.append(f"  local.get {len_n}")
+        ins.append(f"  local.get {len_h}")
+        ins.append("  i32.gt_u")
+        ins.append("  if")
+        ins.append("    i32.const 0")
+        ins.append("    br $done_sw")
+        ins.append("  end")
+
+        # Compare loop
+        ins.append("  i32.const 0")
+        ins.append(f"  local.set {idx}")
+        ins.append("  block $brk_sw")
+        ins.append("    loop $lp_sw")
+        ins.append(f"      local.get {idx}")
+        ins.append(f"      local.get {len_n}")
+        ins.append("      i32.ge_u")
+        ins.append("      br_if $brk_sw")
+        # Compare bytes
+        ins.append(f"      local.get {ptr_h}")
+        ins.append(f"      local.get {idx}")
+        ins.append("      i32.add")
+        ins.append("      i32.load8_u offset=0")
+        ins.append(f"      local.get {ptr_n}")
+        ins.append(f"      local.get {idx}")
+        ins.append("      i32.add")
+        ins.append("      i32.load8_u offset=0")
+        ins.append("      i32.ne")
+        ins.append("      if")
+        ins.append("        i32.const 0")
+        ins.append("        br $done_sw")
+        ins.append("      end")
+        # idx++
+        ins.append(f"      local.get {idx}")
+        ins.append("      i32.const 1")
+        ins.append("      i32.add")
+        ins.append(f"      local.set {idx}")
+        ins.append("      br $lp_sw")
+        ins.append("    end")
+        ins.append("  end")
+
+        # All bytes matched
+        ins.append("  i32.const 1")
+        ins.append("end")  # $done_sw
+
+        return ins
+
+    def _translate_ends_with(
+        self,
+        arg_h: ast.Expr,
+        arg_n: ast.Expr,
+        env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """Translate ends_with(haystack, needle) → Bool (i32).
+
+        Returns 1 if haystack ends with needle, 0 otherwise.
+        Compares suffix bytes at offset (len_h - len_n).
+        """
+        h_instrs = self.translate_expr(arg_h, env)
+        n_instrs = self.translate_expr(arg_n, env)
+        if h_instrs is None or n_instrs is None:
+            return None
+
+        ptr_h = self.alloc_local("i32")
+        len_h = self.alloc_local("i32")
+        ptr_n = self.alloc_local("i32")
+        len_n = self.alloc_local("i32")
+        idx = self.alloc_local("i32")
+        offset = self.alloc_local("i32")
+
+        ins: list[str] = []
+
+        ins.extend(h_instrs)
+        ins.append(f"local.set {len_h}")
+        ins.append(f"local.set {ptr_h}")
+
+        ins.extend(n_instrs)
+        ins.append(f"local.set {len_n}")
+        ins.append(f"local.set {ptr_n}")
+
+        ins.append("block $done_ew (result i32)")
+
+        # If needle longer than haystack → false
+        ins.append(f"  local.get {len_n}")
+        ins.append(f"  local.get {len_h}")
+        ins.append("  i32.gt_u")
+        ins.append("  if")
+        ins.append("    i32.const 0")
+        ins.append("    br $done_ew")
+        ins.append("  end")
+
+        # offset = len_h - len_n
+        ins.append(f"  local.get {len_h}")
+        ins.append(f"  local.get {len_n}")
+        ins.append("  i32.sub")
+        ins.append(f"  local.set {offset}")
+
+        # Compare loop
+        ins.append("  i32.const 0")
+        ins.append(f"  local.set {idx}")
+        ins.append("  block $brk_ew")
+        ins.append("    loop $lp_ew")
+        ins.append(f"      local.get {idx}")
+        ins.append(f"      local.get {len_n}")
+        ins.append("      i32.ge_u")
+        ins.append("      br_if $brk_ew")
+        # Compare haystack[offset + idx] vs needle[idx]
+        ins.append(f"      local.get {ptr_h}")
+        ins.append(f"      local.get {offset}")
+        ins.append("      i32.add")
+        ins.append(f"      local.get {idx}")
+        ins.append("      i32.add")
+        ins.append("      i32.load8_u offset=0")
+        ins.append(f"      local.get {ptr_n}")
+        ins.append(f"      local.get {idx}")
+        ins.append("      i32.add")
+        ins.append("      i32.load8_u offset=0")
+        ins.append("      i32.ne")
+        ins.append("      if")
+        ins.append("        i32.const 0")
+        ins.append("        br $done_ew")
+        ins.append("      end")
+        ins.append(f"      local.get {idx}")
+        ins.append("      i32.const 1")
+        ins.append("      i32.add")
+        ins.append(f"      local.set {idx}")
+        ins.append("      br $lp_ew")
+        ins.append("    end")
+        ins.append("  end")
+
+        ins.append("  i32.const 1")
+        ins.append("end")
+
+        return ins
+
+    def _translate_string_contains(
+        self,
+        arg_h: ast.Expr,
+        arg_n: ast.Expr,
+        env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """Translate string_contains(haystack, needle) → Bool (i32).
+
+        Naive O(n*m) substring search.  Returns 1 if needle is found
+        anywhere in haystack, 0 otherwise.  Empty needle always matches.
+        """
+        h_instrs = self.translate_expr(arg_h, env)
+        n_instrs = self.translate_expr(arg_n, env)
+        if h_instrs is None or n_instrs is None:
+            return None
+
+        ptr_h = self.alloc_local("i32")
+        len_h = self.alloc_local("i32")
+        ptr_n = self.alloc_local("i32")
+        len_n = self.alloc_local("i32")
+        i = self.alloc_local("i32")
+        j = self.alloc_local("i32")
+        limit = self.alloc_local("i32")
+        matched = self.alloc_local("i32")
+
+        ins: list[str] = []
+
+        ins.extend(h_instrs)
+        ins.append(f"local.set {len_h}")
+        ins.append(f"local.set {ptr_h}")
+
+        ins.extend(n_instrs)
+        ins.append(f"local.set {len_n}")
+        ins.append(f"local.set {ptr_n}")
+
+        ins.append("block $done_sc (result i32)")
+
+        # Empty needle → true
+        ins.append(f"  local.get {len_n}")
+        ins.append("  i32.eqz")
+        ins.append("  if")
+        ins.append("    i32.const 1")
+        ins.append("    br $done_sc")
+        ins.append("  end")
+
+        # Needle longer than haystack → false
+        ins.append(f"  local.get {len_n}")
+        ins.append(f"  local.get {len_h}")
+        ins.append("  i32.gt_u")
+        ins.append("  if")
+        ins.append("    i32.const 0")
+        ins.append("    br $done_sc")
+        ins.append("  end")
+
+        # limit = len_h - len_n + 1
+        ins.append(f"  local.get {len_h}")
+        ins.append(f"  local.get {len_n}")
+        ins.append("  i32.sub")
+        ins.append("  i32.const 1")
+        ins.append("  i32.add")
+        ins.append(f"  local.set {limit}")
+
+        # Outer loop: try each starting position
+        ins.append("  i32.const 0")
+        ins.append(f"  local.set {i}")
+        ins.append("  block $brk_sco")
+        ins.append("    loop $lp_sco")
+        ins.append(f"      local.get {i}")
+        ins.append(f"      local.get {limit}")
+        ins.append("      i32.ge_u")
+        ins.append("      br_if $brk_sco")
+
+        # Inner loop: compare needle bytes
+        ins.append("      i32.const 0")
+        ins.append(f"      local.set {j}")
+        ins.append("      i32.const 1")
+        ins.append(f"      local.set {matched}")
+        ins.append("      block $brk_sci")
+        ins.append("        loop $lp_sci")
+        ins.append(f"          local.get {j}")
+        ins.append(f"          local.get {len_n}")
+        ins.append("          i32.ge_u")
+        ins.append("          br_if $brk_sci")
+        # Compare haystack[i+j] vs needle[j]
+        ins.append(f"          local.get {ptr_h}")
+        ins.append(f"          local.get {i}")
+        ins.append("          i32.add")
+        ins.append(f"          local.get {j}")
+        ins.append("          i32.add")
+        ins.append("          i32.load8_u offset=0")
+        ins.append(f"          local.get {ptr_n}")
+        ins.append(f"          local.get {j}")
+        ins.append("          i32.add")
+        ins.append("          i32.load8_u offset=0")
+        ins.append("          i32.ne")
+        ins.append("          if")
+        ins.append("            i32.const 0")
+        ins.append(f"            local.set {matched}")
+        ins.append("            br $brk_sci")
+        ins.append("          end")
+        ins.append(f"          local.get {j}")
+        ins.append("          i32.const 1")
+        ins.append("          i32.add")
+        ins.append(f"          local.set {j}")
+        ins.append("          br $lp_sci")
+        ins.append("        end")
+        ins.append("      end")
+
+        # If matched, return true
+        ins.append(f"      local.get {matched}")
+        ins.append("      if")
+        ins.append("        i32.const 1")
+        ins.append("        br $done_sc")
+        ins.append("      end")
+
+        # i++
+        ins.append(f"      local.get {i}")
+        ins.append("      i32.const 1")
+        ins.append("      i32.add")
+        ins.append(f"      local.set {i}")
+        ins.append("      br $lp_sco")
+        ins.append("    end")
+        ins.append("  end")
+
+        # No match found
+        ins.append("  i32.const 0")
+        ins.append("end")
+
+        return ins
+
+    # -----------------------------------------------------------------
+    # String transformation builtins
+    # -----------------------------------------------------------------
+
+    def _translate_to_upper(
+        self, arg: ast.Expr, env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """Translate to_upper(s) → String (i32_pair).
+
+        Allocates a new buffer of the same size and converts ASCII
+        lowercase letters (97–122) to uppercase by subtracting 32.
+        """
+        arg_instrs = self.translate_expr(arg, env)
+        if arg_instrs is None:
+            return None
+
+        self.needs_alloc = True
+
+        ptr = self.alloc_local("i32")
+        slen = self.alloc_local("i32")
+        dst = self.alloc_local("i32")
+        idx = self.alloc_local("i32")
+        byte = self.alloc_local("i32")
+
+        ins: list[str] = []
+
+        ins.extend(arg_instrs)
+        ins.append(f"local.set {slen}")
+        ins.append(f"local.set {ptr}")
+
+        # Allocate same-size buffer
+        ins.append(f"local.get {slen}")
+        ins.append("call $alloc")
+        ins.append(f"local.set {dst}")
+        ins.extend(gc_shadow_push(dst))
+
+        # Transform loop
+        ins.append("i32.const 0")
+        ins.append(f"local.set {idx}")
+        ins.append("block $brk_tu")
+        ins.append("  loop $lp_tu")
+        ins.append(f"    local.get {idx}")
+        ins.append(f"    local.get {slen}")
+        ins.append("    i32.ge_u")
+        ins.append("    br_if $brk_tu")
+        # Load byte
+        ins.append(f"    local.get {ptr}")
+        ins.append(f"    local.get {idx}")
+        ins.append("    i32.add")
+        ins.append("    i32.load8_u offset=0")
+        ins.append(f"    local.set {byte}")
+        # Check: 97 <= byte <= 122 (lowercase ASCII)
+        ins.append(f"    local.get {byte}")
+        ins.append("    i32.const 97")
+        ins.append("    i32.ge_u")
+        ins.append(f"    local.get {byte}")
+        ins.append("    i32.const 122")
+        ins.append("    i32.le_u")
+        ins.append("    i32.and")
+        ins.append("    if")
+        # Store byte - 32
+        ins.append(f"      local.get {dst}")
+        ins.append(f"      local.get {idx}")
+        ins.append("      i32.add")
+        ins.append(f"      local.get {byte}")
+        ins.append("      i32.const 32")
+        ins.append("      i32.sub")
+        ins.append("      i32.store8 offset=0")
+        ins.append("    else")
+        # Store byte as-is
+        ins.append(f"      local.get {dst}")
+        ins.append(f"      local.get {idx}")
+        ins.append("      i32.add")
+        ins.append(f"      local.get {byte}")
+        ins.append("      i32.store8 offset=0")
+        ins.append("    end")
+        # idx++
+        ins.append(f"    local.get {idx}")
+        ins.append("    i32.const 1")
+        ins.append("    i32.add")
+        ins.append(f"    local.set {idx}")
+        ins.append("    br $lp_tu")
+        ins.append("  end")
+        ins.append("end")
+
+        # Result: (dst, slen)
+        ins.append(f"local.get {dst}")
+        ins.append(f"local.get {slen}")
+        return ins
+
+    def _translate_to_lower(
+        self, arg: ast.Expr, env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """Translate to_lower(s) → String (i32_pair).
+
+        Allocates a new buffer of the same size and converts ASCII
+        uppercase letters (65–90) to lowercase by adding 32.
+        """
+        arg_instrs = self.translate_expr(arg, env)
+        if arg_instrs is None:
+            return None
+
+        self.needs_alloc = True
+
+        ptr = self.alloc_local("i32")
+        slen = self.alloc_local("i32")
+        dst = self.alloc_local("i32")
+        idx = self.alloc_local("i32")
+        byte = self.alloc_local("i32")
+
+        ins: list[str] = []
+
+        ins.extend(arg_instrs)
+        ins.append(f"local.set {slen}")
+        ins.append(f"local.set {ptr}")
+
+        ins.append(f"local.get {slen}")
+        ins.append("call $alloc")
+        ins.append(f"local.set {dst}")
+        ins.extend(gc_shadow_push(dst))
+
+        ins.append("i32.const 0")
+        ins.append(f"local.set {idx}")
+        ins.append("block $brk_tl")
+        ins.append("  loop $lp_tl")
+        ins.append(f"    local.get {idx}")
+        ins.append(f"    local.get {slen}")
+        ins.append("    i32.ge_u")
+        ins.append("    br_if $brk_tl")
+        ins.append(f"    local.get {ptr}")
+        ins.append(f"    local.get {idx}")
+        ins.append("    i32.add")
+        ins.append("    i32.load8_u offset=0")
+        ins.append(f"    local.set {byte}")
+        # Check: 65 <= byte <= 90 (uppercase ASCII)
+        ins.append(f"    local.get {byte}")
+        ins.append("    i32.const 65")
+        ins.append("    i32.ge_u")
+        ins.append(f"    local.get {byte}")
+        ins.append("    i32.const 90")
+        ins.append("    i32.le_u")
+        ins.append("    i32.and")
+        ins.append("    if")
+        ins.append(f"      local.get {dst}")
+        ins.append(f"      local.get {idx}")
+        ins.append("      i32.add")
+        ins.append(f"      local.get {byte}")
+        ins.append("      i32.const 32")
+        ins.append("      i32.add")
+        ins.append("      i32.store8 offset=0")
+        ins.append("    else")
+        ins.append(f"      local.get {dst}")
+        ins.append(f"      local.get {idx}")
+        ins.append("      i32.add")
+        ins.append(f"      local.get {byte}")
+        ins.append("      i32.store8 offset=0")
+        ins.append("    end")
+        ins.append(f"    local.get {idx}")
+        ins.append("    i32.const 1")
+        ins.append("    i32.add")
+        ins.append(f"    local.set {idx}")
+        ins.append("    br $lp_tl")
+        ins.append("  end")
+        ins.append("end")
+
+        ins.append(f"local.get {dst}")
+        ins.append(f"local.get {slen}")
+        return ins
+
+    def _translate_index_of(
+        self,
+        arg_h: ast.Expr,
+        arg_n: ast.Expr,
+        env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """Translate index_of(haystack, needle) → Option<Nat> (i32 ptr).
+
+        Returns a heap-allocated Option<Nat>:
+          Some(Nat): [tag=1 : i32] [pad 4] [value : i64]  (16 bytes)
+          None:      [tag=0 : i32] [pad 12]                (16 bytes)
+        """
+        h_instrs = self.translate_expr(arg_h, env)
+        n_instrs = self.translate_expr(arg_n, env)
+        if h_instrs is None or n_instrs is None:
+            return None
+
+        self.needs_alloc = True
+
+        ptr_h = self.alloc_local("i32")
+        len_h = self.alloc_local("i32")
+        ptr_n = self.alloc_local("i32")
+        len_n = self.alloc_local("i32")
+        i = self.alloc_local("i32")
+        j = self.alloc_local("i32")
+        limit = self.alloc_local("i32")
+        matched = self.alloc_local("i32")
+        out = self.alloc_local("i32")
+
+        ins: list[str] = []
+
+        ins.extend(h_instrs)
+        ins.append(f"local.set {len_h}")
+        ins.append(f"local.set {ptr_h}")
+
+        ins.extend(n_instrs)
+        ins.append(f"local.set {len_n}")
+        ins.append(f"local.set {ptr_n}")
+
+        # Allocate Option<Nat> (16 bytes)
+        ins.append("i32.const 16")
+        ins.append("call $alloc")
+        ins.append(f"local.set {out}")
+
+        ins.append("block $done_io")
+
+        # Empty needle → Some(0)
+        ins.append(f"  local.get {len_n}")
+        ins.append("  i32.eqz")
+        ins.append("  if")
+        ins.append(f"    local.get {out}")
+        ins.append("    i32.const 1")
+        ins.append("    i32.store")              # tag = 1 (Some)
+        ins.extend(f"    {x}" for x in gc_shadow_push(out))
+        ins.append(f"    local.get {out}")
+        ins.append("    i64.const 0")
+        ins.append("    i64.store offset=8")     # value = 0
+        ins.append("    br $done_io")
+        ins.append("  end")
+
+        # Needle longer than haystack → None
+        ins.append(f"  local.get {len_n}")
+        ins.append(f"  local.get {len_h}")
+        ins.append("  i32.gt_u")
+        ins.append("  if")
+        ins.append(f"    local.get {out}")
+        ins.append("    i32.const 0")
+        ins.append("    i32.store")              # tag = 0 (None)
+        ins.extend(f"    {x}" for x in gc_shadow_push(out))
+        ins.append("    br $done_io")
+        ins.append("  end")
+
+        # limit = len_h - len_n + 1
+        ins.append(f"  local.get {len_h}")
+        ins.append(f"  local.get {len_n}")
+        ins.append("  i32.sub")
+        ins.append("  i32.const 1")
+        ins.append("  i32.add")
+        ins.append(f"  local.set {limit}")
+
+        # Outer loop
+        ins.append("  i32.const 0")
+        ins.append(f"  local.set {i}")
+        ins.append("  block $brk_ioo")
+        ins.append("    loop $lp_ioo")
+        ins.append(f"      local.get {i}")
+        ins.append(f"      local.get {limit}")
+        ins.append("      i32.ge_u")
+        ins.append("      br_if $brk_ioo")
+
+        # Inner loop
+        ins.append("      i32.const 0")
+        ins.append(f"      local.set {j}")
+        ins.append("      i32.const 1")
+        ins.append(f"      local.set {matched}")
+        ins.append("      block $brk_ioi")
+        ins.append("        loop $lp_ioi")
+        ins.append(f"          local.get {j}")
+        ins.append(f"          local.get {len_n}")
+        ins.append("          i32.ge_u")
+        ins.append("          br_if $brk_ioi")
+        ins.append(f"          local.get {ptr_h}")
+        ins.append(f"          local.get {i}")
+        ins.append("          i32.add")
+        ins.append(f"          local.get {j}")
+        ins.append("          i32.add")
+        ins.append("          i32.load8_u offset=0")
+        ins.append(f"          local.get {ptr_n}")
+        ins.append(f"          local.get {j}")
+        ins.append("          i32.add")
+        ins.append("          i32.load8_u offset=0")
+        ins.append("          i32.ne")
+        ins.append("          if")
+        ins.append("            i32.const 0")
+        ins.append(f"            local.set {matched}")
+        ins.append("            br $brk_ioi")
+        ins.append("          end")
+        ins.append(f"          local.get {j}")
+        ins.append("          i32.const 1")
+        ins.append("          i32.add")
+        ins.append(f"          local.set {j}")
+        ins.append("          br $lp_ioi")
+        ins.append("        end")
+        ins.append("      end")
+
+        # If matched → Some(i)
+        ins.append(f"      local.get {matched}")
+        ins.append("      if")
+        ins.append(f"        local.get {out}")
+        ins.append("        i32.const 1")
+        ins.append("        i32.store")          # tag = 1 (Some)
+        ins.extend(f"        {x}" for x in gc_shadow_push(out))
+        ins.append(f"        local.get {out}")
+        ins.append(f"        local.get {i}")
+        ins.append("        i64.extend_i32_u")
+        ins.append("        i64.store offset=8") # value = i
+        ins.append("        br $done_io")
+        ins.append("      end")
+
+        ins.append(f"      local.get {i}")
+        ins.append("      i32.const 1")
+        ins.append("      i32.add")
+        ins.append(f"      local.set {i}")
+        ins.append("      br $lp_ioo")
+        ins.append("    end")
+        ins.append("  end")
+
+        # No match → None
+        ins.append(f"  local.get {out}")
+        ins.append("  i32.const 0")
+        ins.append("  i32.store")                # tag = 0 (None)
+        ins.extend(f"  {x}" for x in gc_shadow_push(out))
+
+        ins.append("end")  # $done_io
+
+        ins.append(f"local.get {out}")
+        return ins
+
+    def _translate_replace(
+        self,
+        arg_h: ast.Expr,
+        arg_n: ast.Expr,
+        arg_r: ast.Expr,
+        env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """Translate replace(haystack, needle, replacement) → String.
+
+        Two-pass algorithm:
+        1. Count non-overlapping occurrences of needle.
+        2. Allocate result buffer and copy with replacements.
+        Empty needle returns a copy of the haystack unchanged.
+        """
+        h_instrs = self.translate_expr(arg_h, env)
+        n_instrs = self.translate_expr(arg_n, env)
+        r_instrs = self.translate_expr(arg_r, env)
+        if h_instrs is None or n_instrs is None or r_instrs is None:
+            return None
+
+        self.needs_alloc = True
+
+        ptr_h = self.alloc_local("i32")
+        len_h = self.alloc_local("i32")
+        ptr_n = self.alloc_local("i32")
+        len_n = self.alloc_local("i32")
+        ptr_r = self.alloc_local("i32")
+        len_r = self.alloc_local("i32")
+        count = self.alloc_local("i32")
+        i = self.alloc_local("i32")
+        j = self.alloc_local("i32")
+        matched = self.alloc_local("i32")
+        new_len = self.alloc_local("i32")
+        dst = self.alloc_local("i32")
+        out_idx = self.alloc_local("i32")
+        copy_idx = self.alloc_local("i32")
+
+        ins: list[str] = []
+
+        # Evaluate all three strings
+        ins.extend(h_instrs)
+        ins.append(f"local.set {len_h}")
+        ins.append(f"local.set {ptr_h}")
+        ins.extend(n_instrs)
+        ins.append(f"local.set {len_n}")
+        ins.append(f"local.set {ptr_n}")
+        ins.extend(r_instrs)
+        ins.append(f"local.set {len_r}")
+        ins.append(f"local.set {ptr_r}")
+
+        # Wrap main computation in a block so the empty-needle edge case
+        # can skip it with br instead of return (return would exit the
+        # enclosing function, breaking subexpressions like length(replace(...))).
+        ins.append("block $rp_main")
+
+        # Edge case: empty needle → copy haystack
+        ins.append(f"local.get {len_n}")
+        ins.append("i32.eqz")
+        ins.append("if")
+        # Allocate and copy haystack as-is
+        ins.append(f"  local.get {len_h}")
+        ins.append("  call $alloc")
+        ins.append(f"  local.set {dst}")
+        ins.extend(f"  {x}" for x in gc_shadow_push(dst))
+        ins.append("  i32.const 0")
+        ins.append(f"  local.set {i}")
+        ins.append("  block $brk_rce")
+        ins.append("    loop $lp_rce")
+        ins.append(f"      local.get {i}")
+        ins.append(f"      local.get {len_h}")
+        ins.append("      i32.ge_u")
+        ins.append("      br_if $brk_rce")
+        ins.append(f"      local.get {dst}")
+        ins.append(f"      local.get {i}")
+        ins.append("      i32.add")
+        ins.append(f"      local.get {ptr_h}")
+        ins.append(f"      local.get {i}")
+        ins.append("      i32.add")
+        ins.append("      i32.load8_u offset=0")
+        ins.append("      i32.store8 offset=0")
+        ins.append(f"      local.get {i}")
+        ins.append("      i32.const 1")
+        ins.append("      i32.add")
+        ins.append(f"      local.set {i}")
+        ins.append("      br $lp_rce")
+        ins.append("    end")
+        ins.append("  end")
+        ins.append(f"  local.get {len_h}")
+        ins.append(f"  local.set {new_len}")
+        ins.append("  br $rp_main")
+        ins.append("end")
+
+        # ---- Pass 1: count occurrences ----
+        ins.append("i32.const 0")
+        ins.append(f"local.set {count}")
+        ins.append("i32.const 0")
+        ins.append(f"local.set {i}")
+
+        ins.append("block $brk_rp1")
+        ins.append("  loop $lp_rp1")
+        # i + len_n > len_h → break
+        ins.append(f"    local.get {i}")
+        ins.append(f"    local.get {len_n}")
+        ins.append("    i32.add")
+        ins.append(f"    local.get {len_h}")
+        ins.append("    i32.gt_u")
+        ins.append("    br_if $brk_rp1")
+        # Inner: compare needle
+        ins.append("    i32.const 0")
+        ins.append(f"    local.set {j}")
+        ins.append("    i32.const 1")
+        ins.append(f"    local.set {matched}")
+        ins.append("    block $brk_rp1i")
+        ins.append("      loop $lp_rp1i")
+        ins.append(f"        local.get {j}")
+        ins.append(f"        local.get {len_n}")
+        ins.append("        i32.ge_u")
+        ins.append("        br_if $brk_rp1i")
+        ins.append(f"        local.get {ptr_h}")
+        ins.append(f"        local.get {i}")
+        ins.append("        i32.add")
+        ins.append(f"        local.get {j}")
+        ins.append("        i32.add")
+        ins.append("        i32.load8_u offset=0")
+        ins.append(f"        local.get {ptr_n}")
+        ins.append(f"        local.get {j}")
+        ins.append("        i32.add")
+        ins.append("        i32.load8_u offset=0")
+        ins.append("        i32.ne")
+        ins.append("        if")
+        ins.append("          i32.const 0")
+        ins.append(f"          local.set {matched}")
+        ins.append("          br $brk_rp1i")
+        ins.append("        end")
+        ins.append(f"        local.get {j}")
+        ins.append("        i32.const 1")
+        ins.append("        i32.add")
+        ins.append(f"        local.set {j}")
+        ins.append("        br $lp_rp1i")
+        ins.append("      end")
+        ins.append("    end")
+        # If matched: count++, i += len_n; else i++
+        ins.append(f"    local.get {matched}")
+        ins.append("    if")
+        ins.append(f"      local.get {count}")
+        ins.append("      i32.const 1")
+        ins.append("      i32.add")
+        ins.append(f"      local.set {count}")
+        ins.append(f"      local.get {i}")
+        ins.append(f"      local.get {len_n}")
+        ins.append("      i32.add")
+        ins.append(f"      local.set {i}")
+        ins.append("    else")
+        ins.append(f"      local.get {i}")
+        ins.append("      i32.const 1")
+        ins.append("      i32.add")
+        ins.append(f"      local.set {i}")
+        ins.append("    end")
+        ins.append("    br $lp_rp1")
+        ins.append("  end")
+        ins.append("end")
+
+        # Compute new_len = len_h - count * len_n + count * len_r
+        ins.append(f"local.get {len_h}")
+        ins.append(f"local.get {count}")
+        ins.append(f"local.get {len_n}")
+        ins.append("i32.mul")
+        ins.append("i32.sub")
+        ins.append(f"local.get {count}")
+        ins.append(f"local.get {len_r}")
+        ins.append("i32.mul")
+        ins.append("i32.add")
+        ins.append(f"local.set {new_len}")
+
+        # Allocate result
+        ins.append(f"local.get {new_len}")
+        ins.append("call $alloc")
+        ins.append(f"local.set {dst}")
+        ins.extend(gc_shadow_push(dst))
+
+        # ---- Pass 2: copy with replacements ----
+        ins.append("i32.const 0")
+        ins.append(f"local.set {i}")
+        ins.append("i32.const 0")
+        ins.append(f"local.set {out_idx}")
+
+        ins.append("block $brk_rp2")
+        ins.append("  loop $lp_rp2")
+        # i >= len_h → break
+        ins.append(f"    local.get {i}")
+        ins.append(f"    local.get {len_h}")
+        ins.append("    i32.ge_u")
+        ins.append("    br_if $brk_rp2")
+
+        # Check if needle matches at position i (only if i+len_n <= len_h)
+        ins.append("    i32.const 0")
+        ins.append(f"    local.set {matched}")
+        ins.append(f"    local.get {i}")
+        ins.append(f"    local.get {len_n}")
+        ins.append("    i32.add")
+        ins.append(f"    local.get {len_h}")
+        ins.append("    i32.le_u")
+        ins.append("    if")
+        ins.append("      i32.const 0")
+        ins.append(f"      local.set {j}")
+        ins.append("      i32.const 1")
+        ins.append(f"      local.set {matched}")
+        ins.append("      block $brk_rp2i")
+        ins.append("        loop $lp_rp2i")
+        ins.append(f"          local.get {j}")
+        ins.append(f"          local.get {len_n}")
+        ins.append("          i32.ge_u")
+        ins.append("          br_if $brk_rp2i")
+        ins.append(f"          local.get {ptr_h}")
+        ins.append(f"          local.get {i}")
+        ins.append("          i32.add")
+        ins.append(f"          local.get {j}")
+        ins.append("          i32.add")
+        ins.append("          i32.load8_u offset=0")
+        ins.append(f"          local.get {ptr_n}")
+        ins.append(f"          local.get {j}")
+        ins.append("          i32.add")
+        ins.append("          i32.load8_u offset=0")
+        ins.append("          i32.ne")
+        ins.append("          if")
+        ins.append("            i32.const 0")
+        ins.append(f"            local.set {matched}")
+        ins.append("            br $brk_rp2i")
+        ins.append("          end")
+        ins.append(f"          local.get {j}")
+        ins.append("          i32.const 1")
+        ins.append("          i32.add")
+        ins.append(f"          local.set {j}")
+        ins.append("          br $lp_rp2i")
+        ins.append("        end")
+        ins.append("      end")
+        ins.append("    end")
+
+        # If matched: copy replacement, advance i by len_n
+        ins.append(f"    local.get {matched}")
+        ins.append("    if")
+        # Copy replacement bytes
+        ins.append("      i32.const 0")
+        ins.append(f"      local.set {copy_idx}")
+        ins.append("      block $brk_rpc")
+        ins.append("        loop $lp_rpc")
+        ins.append(f"          local.get {copy_idx}")
+        ins.append(f"          local.get {len_r}")
+        ins.append("          i32.ge_u")
+        ins.append("          br_if $brk_rpc")
+        ins.append(f"          local.get {dst}")
+        ins.append(f"          local.get {out_idx}")
+        ins.append("          i32.add")
+        ins.append(f"          local.get {ptr_r}")
+        ins.append(f"          local.get {copy_idx}")
+        ins.append("          i32.add")
+        ins.append("          i32.load8_u offset=0")
+        ins.append("          i32.store8 offset=0")
+        ins.append(f"          local.get {copy_idx}")
+        ins.append("          i32.const 1")
+        ins.append("          i32.add")
+        ins.append(f"          local.set {copy_idx}")
+        ins.append(f"          local.get {out_idx}")
+        ins.append("          i32.const 1")
+        ins.append("          i32.add")
+        ins.append(f"          local.set {out_idx}")
+        ins.append("          br $lp_rpc")
+        ins.append("        end")
+        ins.append("      end")
+        # Advance i by len_n
+        ins.append(f"      local.get {i}")
+        ins.append(f"      local.get {len_n}")
+        ins.append("      i32.add")
+        ins.append(f"      local.set {i}")
+        ins.append("    else")
+        # Copy one byte from haystack
+        ins.append(f"      local.get {dst}")
+        ins.append(f"      local.get {out_idx}")
+        ins.append("      i32.add")
+        ins.append(f"      local.get {ptr_h}")
+        ins.append(f"      local.get {i}")
+        ins.append("      i32.add")
+        ins.append("      i32.load8_u offset=0")
+        ins.append("      i32.store8 offset=0")
+        ins.append(f"      local.get {out_idx}")
+        ins.append("      i32.const 1")
+        ins.append("      i32.add")
+        ins.append(f"      local.set {out_idx}")
+        ins.append(f"      local.get {i}")
+        ins.append("      i32.const 1")
+        ins.append("      i32.add")
+        ins.append(f"      local.set {i}")
+        ins.append("    end")
+        ins.append("    br $lp_rp2")
+        ins.append("  end")
+        ins.append("end")
+
+        ins.append("end")  # end $rp_main
+
+        # Result: (dst, new_len)
+        ins.append(f"local.get {dst}")
+        ins.append(f"local.get {new_len}")
+        return ins
+
+    def _translate_split(
+        self,
+        arg_s: ast.Expr,
+        arg_d: ast.Expr,
+        env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """Translate split(string, delimiter) → Array<String> (i32_pair).
+
+        Two-pass algorithm:
+        1. Count delimiter occurrences to determine segment count.
+        2. Allocate array buffer (seg_count * 8 bytes), then for each
+           segment allocate a string buffer and copy bytes.
+        Returns (arr_ptr, seg_count).
+        """
+        s_instrs = self.translate_expr(arg_s, env)
+        d_instrs = self.translate_expr(arg_d, env)
+        if s_instrs is None or d_instrs is None:
+            return None
+
+        self.needs_alloc = True
+
+        ptr_s = self.alloc_local("i32")
+        len_s = self.alloc_local("i32")
+        ptr_d = self.alloc_local("i32")
+        len_d = self.alloc_local("i32")
+        count = self.alloc_local("i32")
+        seg_count = self.alloc_local("i32")
+        arr = self.alloc_local("i32")
+        seg_idx = self.alloc_local("i32")
+        seg_start = self.alloc_local("i32")
+        i = self.alloc_local("i32")
+        j = self.alloc_local("i32")
+        matched = self.alloc_local("i32")
+        seg_len = self.alloc_local("i32")
+        seg_ptr = self.alloc_local("i32")
+        copy_idx = self.alloc_local("i32")
+
+        ins: list[str] = []
+
+        ins.extend(s_instrs)
+        ins.append(f"local.set {len_s}")
+        ins.append(f"local.set {ptr_s}")
+        ins.extend(d_instrs)
+        ins.append(f"local.set {len_d}")
+        ins.append(f"local.set {ptr_d}")
+
+        # Wrap main computation in a block so the empty-delimiter edge case
+        # can skip it with br instead of return (return would exit the
+        # enclosing function, breaking subexpressions like length(split(...))).
+        ins.append("block $sp_main")
+
+        # Edge case: empty delimiter → single-element array
+        ins.append(f"local.get {len_d}")
+        ins.append("i32.eqz")
+        ins.append("if")
+        # Allocate array of 1 element (8 bytes)
+        ins.append("  i32.const 8")
+        ins.append("  call $alloc")
+        ins.append(f"  local.set {arr}")
+        ins.extend(f"  {x}" for x in gc_shadow_push(arr))
+        # Allocate copy of the string
+        ins.append(f"  local.get {len_s}")
+        ins.append("  call $alloc")
+        ins.append(f"  local.set {seg_ptr}")
+        ins.extend(f"  {x}" for x in gc_shadow_push(seg_ptr))
+        # Copy string bytes
+        ins.append("  i32.const 0")
+        ins.append(f"  local.set {i}")
+        ins.append("  block $brk_spe")
+        ins.append("    loop $lp_spe")
+        ins.append(f"      local.get {i}")
+        ins.append(f"      local.get {len_s}")
+        ins.append("      i32.ge_u")
+        ins.append("      br_if $brk_spe")
+        ins.append(f"      local.get {seg_ptr}")
+        ins.append(f"      local.get {i}")
+        ins.append("      i32.add")
+        ins.append(f"      local.get {ptr_s}")
+        ins.append(f"      local.get {i}")
+        ins.append("      i32.add")
+        ins.append("      i32.load8_u offset=0")
+        ins.append("      i32.store8 offset=0")
+        ins.append(f"      local.get {i}")
+        ins.append("      i32.const 1")
+        ins.append("      i32.add")
+        ins.append(f"      local.set {i}")
+        ins.append("      br $lp_spe")
+        ins.append("    end")
+        ins.append("  end")
+        # Store (seg_ptr, len_s) at arr[0]
+        ins.append(f"  local.get {arr}")
+        ins.append(f"  local.get {seg_ptr}")
+        ins.append("  i32.store offset=0")
+        ins.append(f"  local.get {arr}")
+        ins.append(f"  local.get {len_s}")
+        ins.append("  i32.store offset=4")
+        # Set seg_count = 1, skip main computation
+        ins.append("  i32.const 1")
+        ins.append(f"  local.set {seg_count}")
+        ins.append("  br $sp_main")
+        ins.append("end")
+
+        # ---- Pass 1: count delimiter occurrences ----
+        ins.append("i32.const 0")
+        ins.append(f"local.set {count}")
+        ins.append("i32.const 0")
+        ins.append(f"local.set {i}")
+        ins.append("block $brk_sp1")
+        ins.append("  loop $lp_sp1")
+        ins.append(f"    local.get {i}")
+        ins.append(f"    local.get {len_d}")
+        ins.append("    i32.add")
+        ins.append(f"    local.get {len_s}")
+        ins.append("    i32.gt_u")
+        ins.append("    br_if $brk_sp1")
+        # Inner: compare delimiter
+        ins.append("    i32.const 0")
+        ins.append(f"    local.set {j}")
+        ins.append("    i32.const 1")
+        ins.append(f"    local.set {matched}")
+        ins.append("    block $brk_sp1i")
+        ins.append("      loop $lp_sp1i")
+        ins.append(f"        local.get {j}")
+        ins.append(f"        local.get {len_d}")
+        ins.append("        i32.ge_u")
+        ins.append("        br_if $brk_sp1i")
+        ins.append(f"        local.get {ptr_s}")
+        ins.append(f"        local.get {i}")
+        ins.append("        i32.add")
+        ins.append(f"        local.get {j}")
+        ins.append("        i32.add")
+        ins.append("        i32.load8_u offset=0")
+        ins.append(f"        local.get {ptr_d}")
+        ins.append(f"        local.get {j}")
+        ins.append("        i32.add")
+        ins.append("        i32.load8_u offset=0")
+        ins.append("        i32.ne")
+        ins.append("        if")
+        ins.append("          i32.const 0")
+        ins.append(f"          local.set {matched}")
+        ins.append("          br $brk_sp1i")
+        ins.append("        end")
+        ins.append(f"        local.get {j}")
+        ins.append("        i32.const 1")
+        ins.append("        i32.add")
+        ins.append(f"        local.set {j}")
+        ins.append("        br $lp_sp1i")
+        ins.append("      end")
+        ins.append("    end")
+        ins.append(f"    local.get {matched}")
+        ins.append("    if")
+        ins.append(f"      local.get {count}")
+        ins.append("      i32.const 1")
+        ins.append("      i32.add")
+        ins.append(f"      local.set {count}")
+        ins.append(f"      local.get {i}")
+        ins.append(f"      local.get {len_d}")
+        ins.append("      i32.add")
+        ins.append(f"      local.set {i}")
+        ins.append("    else")
+        ins.append(f"      local.get {i}")
+        ins.append("      i32.const 1")
+        ins.append("      i32.add")
+        ins.append(f"      local.set {i}")
+        ins.append("    end")
+        ins.append("    br $lp_sp1")
+        ins.append("  end")
+        ins.append("end")
+
+        # seg_count = count + 1
+        ins.append(f"local.get {count}")
+        ins.append("i32.const 1")
+        ins.append("i32.add")
+        ins.append(f"local.set {seg_count}")
+
+        # Allocate array: seg_count * 8 bytes
+        ins.append(f"local.get {seg_count}")
+        ins.append("i32.const 8")
+        ins.append("i32.mul")
+        ins.append("call $alloc")
+        ins.append(f"local.set {arr}")
+        ins.extend(gc_shadow_push(arr))
+
+        # ---- Pass 2: fill segments ----
+        ins.append("i32.const 0")
+        ins.append(f"local.set {i}")
+        ins.append("i32.const 0")
+        ins.append(f"local.set {seg_idx}")
+        ins.append("i32.const 0")
+        ins.append(f"local.set {seg_start}")
+
+        ins.append("block $brk_sp2")
+        ins.append("  loop $lp_sp2")
+        # Check if i + len_d > len_s → break
+        ins.append(f"    local.get {i}")
+        ins.append(f"    local.get {len_d}")
+        ins.append("    i32.add")
+        ins.append(f"    local.get {len_s}")
+        ins.append("    i32.gt_u")
+        ins.append("    br_if $brk_sp2")
+        # Inner: compare delimiter
+        ins.append("    i32.const 0")
+        ins.append(f"    local.set {j}")
+        ins.append("    i32.const 1")
+        ins.append(f"    local.set {matched}")
+        ins.append("    block $brk_sp2i")
+        ins.append("      loop $lp_sp2i")
+        ins.append(f"        local.get {j}")
+        ins.append(f"        local.get {len_d}")
+        ins.append("        i32.ge_u")
+        ins.append("        br_if $brk_sp2i")
+        ins.append(f"        local.get {ptr_s}")
+        ins.append(f"        local.get {i}")
+        ins.append("        i32.add")
+        ins.append(f"        local.get {j}")
+        ins.append("        i32.add")
+        ins.append("        i32.load8_u offset=0")
+        ins.append(f"        local.get {ptr_d}")
+        ins.append(f"        local.get {j}")
+        ins.append("        i32.add")
+        ins.append("        i32.load8_u offset=0")
+        ins.append("        i32.ne")
+        ins.append("        if")
+        ins.append("          i32.const 0")
+        ins.append(f"          local.set {matched}")
+        ins.append("          br $brk_sp2i")
+        ins.append("        end")
+        ins.append(f"        local.get {j}")
+        ins.append("        i32.const 1")
+        ins.append("        i32.add")
+        ins.append(f"        local.set {j}")
+        ins.append("        br $lp_sp2i")
+        ins.append("      end")
+        ins.append("    end")
+        ins.append(f"    local.get {matched}")
+        ins.append("    if")
+        # Found delimiter: emit segment [seg_start, i)
+        ins.append(f"      local.get {i}")
+        ins.append(f"      local.get {seg_start}")
+        ins.append("      i32.sub")
+        ins.append(f"      local.set {seg_len}")
+        # Allocate segment string
+        ins.append(f"      local.get {seg_len}")
+        ins.append("      call $alloc")
+        ins.append(f"      local.set {seg_ptr}")
+        ins.extend(f"      {x}" for x in gc_shadow_push(seg_ptr))
+        # Copy segment bytes
+        ins.append("      i32.const 0")
+        ins.append(f"      local.set {copy_idx}")
+        ins.append("      block $brk_spc")
+        ins.append("        loop $lp_spc")
+        ins.append(f"          local.get {copy_idx}")
+        ins.append(f"          local.get {seg_len}")
+        ins.append("          i32.ge_u")
+        ins.append("          br_if $brk_spc")
+        ins.append(f"          local.get {seg_ptr}")
+        ins.append(f"          local.get {copy_idx}")
+        ins.append("          i32.add")
+        ins.append(f"          local.get {ptr_s}")
+        ins.append(f"          local.get {seg_start}")
+        ins.append("          i32.add")
+        ins.append(f"          local.get {copy_idx}")
+        ins.append("          i32.add")
+        ins.append("          i32.load8_u offset=0")
+        ins.append("          i32.store8 offset=0")
+        ins.append(f"          local.get {copy_idx}")
+        ins.append("          i32.const 1")
+        ins.append("          i32.add")
+        ins.append(f"          local.set {copy_idx}")
+        ins.append("          br $lp_spc")
+        ins.append("        end")
+        ins.append("      end")
+        # Store (seg_ptr, seg_len) in array
+        ins.append(f"      local.get {arr}")
+        ins.append(f"      local.get {seg_idx}")
+        ins.append("      i32.const 8")
+        ins.append("      i32.mul")
+        ins.append("      i32.add")
+        ins.append(f"      local.get {seg_ptr}")
+        ins.append("      i32.store offset=0")
+        ins.append(f"      local.get {arr}")
+        ins.append(f"      local.get {seg_idx}")
+        ins.append("      i32.const 8")
+        ins.append("      i32.mul")
+        ins.append("      i32.add")
+        ins.append(f"      local.get {seg_len}")
+        ins.append("      i32.store offset=4")
+        # Advance
+        ins.append(f"      local.get {seg_idx}")
+        ins.append("      i32.const 1")
+        ins.append("      i32.add")
+        ins.append(f"      local.set {seg_idx}")
+        ins.append(f"      local.get {i}")
+        ins.append(f"      local.get {len_d}")
+        ins.append("      i32.add")
+        ins.append(f"      local.set {i}")
+        ins.append(f"      local.get {i}")
+        ins.append(f"      local.set {seg_start}")
+        ins.append("    else")
+        ins.append(f"      local.get {i}")
+        ins.append("      i32.const 1")
+        ins.append("      i32.add")
+        ins.append(f"      local.set {i}")
+        ins.append("    end")
+        ins.append("    br $lp_sp2")
+        ins.append("  end")
+        ins.append("end")
+
+        # Handle last segment: [seg_start, len_s)
+        ins.append(f"local.get {len_s}")
+        ins.append(f"local.get {seg_start}")
+        ins.append("i32.sub")
+        ins.append(f"local.set {seg_len}")
+        ins.append(f"local.get {seg_len}")
+        ins.append("call $alloc")
+        ins.append(f"local.set {seg_ptr}")
+        ins.extend(gc_shadow_push(seg_ptr))
+        # Copy last segment
+        ins.append("i32.const 0")
+        ins.append(f"local.set {copy_idx}")
+        ins.append("block $brk_spl")
+        ins.append("  loop $lp_spl")
+        ins.append(f"    local.get {copy_idx}")
+        ins.append(f"    local.get {seg_len}")
+        ins.append("    i32.ge_u")
+        ins.append("    br_if $brk_spl")
+        ins.append(f"    local.get {seg_ptr}")
+        ins.append(f"    local.get {copy_idx}")
+        ins.append("    i32.add")
+        ins.append(f"    local.get {ptr_s}")
+        ins.append(f"    local.get {seg_start}")
+        ins.append("    i32.add")
+        ins.append(f"    local.get {copy_idx}")
+        ins.append("    i32.add")
+        ins.append("    i32.load8_u offset=0")
+        ins.append("    i32.store8 offset=0")
+        ins.append(f"    local.get {copy_idx}")
+        ins.append("    i32.const 1")
+        ins.append("    i32.add")
+        ins.append(f"    local.set {copy_idx}")
+        ins.append("    br $lp_spl")
+        ins.append("  end")
+        ins.append("end")
+        # Store last segment in array
+        ins.append(f"local.get {arr}")
+        ins.append(f"local.get {seg_idx}")
+        ins.append("i32.const 8")
+        ins.append("i32.mul")
+        ins.append("i32.add")
+        ins.append(f"local.get {seg_ptr}")
+        ins.append("i32.store offset=0")
+        ins.append(f"local.get {arr}")
+        ins.append(f"local.get {seg_idx}")
+        ins.append("i32.const 8")
+        ins.append("i32.mul")
+        ins.append("i32.add")
+        ins.append(f"local.get {seg_len}")
+        ins.append("i32.store offset=4")
+
+        ins.append("end")  # end $sp_main
+
+        # Return (arr, seg_count)
+        ins.append(f"local.get {arr}")
+        ins.append(f"local.get {seg_count}")
+        return ins
+
+    def _translate_join(
+        self,
+        arg_a: ast.Expr,
+        arg_s: ast.Expr,
+        env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """Translate join(array, separator) → String (i32_pair).
+
+        Two-pass algorithm:
+        1. Sum all string lengths plus separators.
+        2. Allocate result buffer and copy strings with separator
+           between them.
+        Array<String> is (arr_ptr, count).  Each element is 8 bytes:
+        (str_ptr: i32, str_len: i32) at arr_ptr + i*8.
+        """
+        a_instrs = self.translate_expr(arg_a, env)
+        s_instrs = self.translate_expr(arg_s, env)
+        if a_instrs is None or s_instrs is None:
+            return None
+
+        self.needs_alloc = True
+
+        arr_ptr = self.alloc_local("i32")
+        arr_count = self.alloc_local("i32")
+        ptr_sep = self.alloc_local("i32")
+        len_sep = self.alloc_local("i32")
+        total_len = self.alloc_local("i32")
+        dst = self.alloc_local("i32")
+        i = self.alloc_local("i32")
+        out_idx = self.alloc_local("i32")
+        str_ptr = self.alloc_local("i32")
+        str_len = self.alloc_local("i32")
+        copy_idx = self.alloc_local("i32")
+
+        ins: list[str] = []
+
+        # Evaluate array → (ptr, count)
+        ins.extend(a_instrs)
+        ins.append(f"local.set {arr_count}")
+        ins.append(f"local.set {arr_ptr}")
+        # Evaluate separator → (ptr, len)
+        ins.extend(s_instrs)
+        ins.append(f"local.set {len_sep}")
+        ins.append(f"local.set {ptr_sep}")
+
+        # ---- Pass 1: compute total length ----
+        ins.append("i32.const 0")
+        ins.append(f"local.set {total_len}")
+        ins.append("i32.const 0")
+        ins.append(f"local.set {i}")
+        ins.append("block $brk_j1")
+        ins.append("  loop $lp_j1")
+        ins.append(f"    local.get {i}")
+        ins.append(f"    local.get {arr_count}")
+        ins.append("    i32.ge_u")
+        ins.append("    br_if $brk_j1")
+        # Load str_len at arr_ptr + i*8 + 4
+        ins.append(f"    local.get {arr_ptr}")
+        ins.append(f"    local.get {i}")
+        ins.append("    i32.const 8")
+        ins.append("    i32.mul")
+        ins.append("    i32.add")
+        ins.append("    i32.load offset=4")
+        ins.append(f"    local.set {str_len}")
+        ins.append(f"    local.get {total_len}")
+        ins.append(f"    local.get {str_len}")
+        ins.append("    i32.add")
+        ins.append(f"    local.set {total_len}")
+        ins.append(f"    local.get {i}")
+        ins.append("    i32.const 1")
+        ins.append("    i32.add")
+        ins.append(f"    local.set {i}")
+        ins.append("    br $lp_j1")
+        ins.append("  end")
+        ins.append("end")
+
+        # Add separator lengths: (count - 1) * len_sep (if count > 0)
+        ins.append(f"local.get {arr_count}")
+        ins.append("i32.const 1")
+        ins.append("i32.gt_u")
+        ins.append("if")
+        ins.append(f"  local.get {total_len}")
+        ins.append(f"  local.get {arr_count}")
+        ins.append("  i32.const 1")
+        ins.append("  i32.sub")
+        ins.append(f"  local.get {len_sep}")
+        ins.append("  i32.mul")
+        ins.append("  i32.add")
+        ins.append(f"  local.set {total_len}")
+        ins.append("end")
+
+        # Allocate result
+        ins.append(f"local.get {total_len}")
+        ins.append("call $alloc")
+        ins.append(f"local.set {dst}")
+        ins.extend(gc_shadow_push(dst))
+
+        # ---- Pass 2: copy strings with separators ----
+        ins.append("i32.const 0")
+        ins.append(f"local.set {i}")
+        ins.append("i32.const 0")
+        ins.append(f"local.set {out_idx}")
+
+        ins.append("block $brk_j2")
+        ins.append("  loop $lp_j2")
+        ins.append(f"    local.get {i}")
+        ins.append(f"    local.get {arr_count}")
+        ins.append("    i32.ge_u")
+        ins.append("    br_if $brk_j2")
+        # Load (str_ptr, str_len) from array
+        ins.append(f"    local.get {arr_ptr}")
+        ins.append(f"    local.get {i}")
+        ins.append("    i32.const 8")
+        ins.append("    i32.mul")
+        ins.append("    i32.add")
+        ins.append("    i32.load offset=0")
+        ins.append(f"    local.set {str_ptr}")
+        ins.append(f"    local.get {arr_ptr}")
+        ins.append(f"    local.get {i}")
+        ins.append("    i32.const 8")
+        ins.append("    i32.mul")
+        ins.append("    i32.add")
+        ins.append("    i32.load offset=4")
+        ins.append(f"    local.set {str_len}")
+        # Copy string bytes
+        ins.append("    i32.const 0")
+        ins.append(f"    local.set {copy_idx}")
+        ins.append("    block $brk_jc")
+        ins.append("      loop $lp_jc")
+        ins.append(f"        local.get {copy_idx}")
+        ins.append(f"        local.get {str_len}")
+        ins.append("        i32.ge_u")
+        ins.append("        br_if $brk_jc")
+        ins.append(f"        local.get {dst}")
+        ins.append(f"        local.get {out_idx}")
+        ins.append("        i32.add")
+        ins.append(f"        local.get {str_ptr}")
+        ins.append(f"        local.get {copy_idx}")
+        ins.append("        i32.add")
+        ins.append("        i32.load8_u offset=0")
+        ins.append("        i32.store8 offset=0")
+        ins.append(f"        local.get {out_idx}")
+        ins.append("        i32.const 1")
+        ins.append("        i32.add")
+        ins.append(f"        local.set {out_idx}")
+        ins.append(f"        local.get {copy_idx}")
+        ins.append("        i32.const 1")
+        ins.append("        i32.add")
+        ins.append(f"        local.set {copy_idx}")
+        ins.append("        br $lp_jc")
+        ins.append("      end")
+        ins.append("    end")
+        # If not last element, copy separator
+        ins.append(f"    local.get {i}")
+        ins.append(f"    local.get {arr_count}")
+        ins.append("    i32.const 1")
+        ins.append("    i32.sub")
+        ins.append("    i32.lt_u")
+        ins.append("    if")
+        ins.append("      i32.const 0")
+        ins.append(f"      local.set {copy_idx}")
+        ins.append("      block $brk_js")
+        ins.append("        loop $lp_js")
+        ins.append(f"          local.get {copy_idx}")
+        ins.append(f"          local.get {len_sep}")
+        ins.append("          i32.ge_u")
+        ins.append("          br_if $brk_js")
+        ins.append(f"          local.get {dst}")
+        ins.append(f"          local.get {out_idx}")
+        ins.append("          i32.add")
+        ins.append(f"          local.get {ptr_sep}")
+        ins.append(f"          local.get {copy_idx}")
+        ins.append("          i32.add")
+        ins.append("          i32.load8_u offset=0")
+        ins.append("          i32.store8 offset=0")
+        ins.append(f"          local.get {out_idx}")
+        ins.append("          i32.const 1")
+        ins.append("          i32.add")
+        ins.append(f"          local.set {out_idx}")
+        ins.append(f"          local.get {copy_idx}")
+        ins.append("          i32.const 1")
+        ins.append("          i32.add")
+        ins.append(f"          local.set {copy_idx}")
+        ins.append("          br $lp_js")
+        ins.append("        end")
+        ins.append("      end")
+        ins.append("    end")
+        # i++
+        ins.append(f"    local.get {i}")
+        ins.append("    i32.const 1")
+        ins.append("    i32.add")
+        ins.append(f"    local.set {i}")
+        ins.append("    br $lp_j2")
+        ins.append("  end")
+        ins.append("end")
+
+        # Result: (dst, total_len)
+        ins.append(f"local.get {dst}")
+        ins.append(f"local.get {total_len}")
+        return ins
 
     # -----------------------------------------------------------------
     # Numeric math builtins

--- a/vera/wasm/inference.py
+++ b/vera/wasm/inference.py
@@ -200,6 +200,16 @@ class InferenceMixin:
         # char_code → Nat (i64)
         if expr.name == "char_code":
             return "i64"
+        # String search builtins
+        if expr.name in ("string_contains", "starts_with", "ends_with"):
+            return "i32"
+        if expr.name == "index_of":
+            return "i32"
+        # String transformation builtins
+        if expr.name in ("to_upper", "to_lower", "replace", "join"):
+            return "i32_pair"
+        if expr.name == "split":
+            return "i32_pair"
         # parse_nat → Result<Nat, String> (i32 heap pointer)
         if expr.name == "parse_nat":
             return "i32"
@@ -357,6 +367,16 @@ class InferenceMixin:
             return "String"
         if call.name == "char_code":
             return "Nat"
+        # String search builtins
+        if call.name in ("string_contains", "starts_with", "ends_with"):
+            return "Bool"
+        if call.name == "index_of":
+            return "Option"
+        # String transformation builtins
+        if call.name in ("to_upper", "to_lower", "replace", "join"):
+            return "String"
+        if call.name == "split":
+            return "Array"
         if call.name == "parse_nat":
             return "Result"
         if call.name == "parse_float64":


### PR DESCRIPTION
## Summary
- Nine new built-in functions: `string_contains`, `starts_with`, `ends_with`, `index_of`, `to_upper`, `to_lower`, `replace`, `split`, `join`
- Complete WASM codegen for all 9 functions (~1,500 lines), including two-pass algorithms for `replace`, `split`, and `join`
- 55 new tests (18 type checker + 37 codegen end-to-end), all passing
- New conformance test `ch09_string_search` (42→43 programs)
- Spec Sections 9.6.6 "String Search" and 9.6.7 "String Transformation"
- Version bump to v0.0.73

## Test plan
- [x] All 1,856 tests pass (`pytest tests/ -v`)
- [x] mypy clean (`mypy vera/`)
- [x] All 43 conformance programs pass (`python scripts/check_conformance.py`)
- [x] All 18 examples pass (`python scripts/check_examples.py`)
- [x] Spec code blocks pass (`python scripts/check_spec_examples.py`)
- [x] SKILL.md code blocks pass (`python scripts/check_skill_examples.py`)
- [x] Version sync pass (`python scripts/check_version_sync.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)