### PR TITLE
Add from_char_code builtin (close #210)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.74] - 2026-03-09
+
+### Added
+- **Close #210: from_char_code builtin** ([#210](https://github.com/aallan/vera/issues/210)):
+  New `from_char_code` function (`Nat → String`) that creates a single-character
+  string from an ASCII code point. Inverse of the existing `char_code`. Pure,
+  Tier 3 (runtime-tested).
+- 7 new tests (2 type checker + 5 codegen end-to-end)
+
 ## [0.0.73] - 2026-03-09
 
 ### Added
@@ -1134,7 +1143,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Grammar: handler body simplified to avoid LALR reduce/reduce conflict
 - `pyproject.toml`: corrected build backend, package discovery, PEP 639 compliance
 
-[Unreleased]: https://github.com/aallan/vera/compare/v0.0.73...HEAD
+[Unreleased]: https://github.com/aallan/vera/compare/v0.0.74...HEAD
+[0.0.74]: https://github.com/aallan/vera/compare/v0.0.73...v0.0.74
 [0.0.73]: https://github.com/aallan/vera/compare/v0.0.72...v0.0.73
 [0.0.72]: https://github.com/aallan/vera/compare/v0.0.71...v0.0.72
 [0.0.71]: https://github.com/aallan/vera/compare/v0.0.70...v0.0.71

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ The language specification is in draft across 13 chapters:
 
 ### Testing
 
-Testing is organized in three layers: **unit tests** (1,851 tests across 20 files, testing compiler internals), a **conformance suite** (43 programs across 8 spec chapters, systematically validating every language feature against the spec), and **example programs** (18 end-to-end demos). The compiler has 90% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations. Every commit validates all conformance programs, example programs, and 95 specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference -- coverage tables, conformance suite details, CI pipeline, and infrastructure.
+Testing is organized in three layers: **unit tests** (1,858 tests across 20 files, testing compiler internals), a **conformance suite** (43 programs across 8 spec chapters, systematically validating every language feature against the spec), and **example programs** (18 end-to-end demos). The compiler has 90% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations. Every commit validates all conformance programs, example programs, and 95 specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference -- coverage tables, conformance suite details, CI pipeline, and infrastructure.
 
 ## Roadmap
 
@@ -318,7 +318,7 @@ Module refinements, lexical extensions, and IO runtime — completing the existi
 - <del>[#198](https://github.com/aallan/vera/issues/198) string search and transformation builtins</del> ([v0.0.73](https://github.com/aallan/vera/releases/tag/v0.0.73))
 - <del>[#208](https://github.com/aallan/vera/issues/208) numeric type conversions</del> ([v0.0.71](https://github.com/aallan/vera/releases/tag/v0.0.71))
 - [#209](https://github.com/aallan/vera/issues/209) array construction builtins (range, append, concat)
-- [#210](https://github.com/aallan/vera/issues/210) from_char_code builtin
+- <del>[#210](https://github.com/aallan/vera/issues/210) from_char_code builtin</del> ([v0.0.74](https://github.com/aallan/vera/releases/tag/v0.0.74))
 - <del>[#212](https://github.com/aallan/vera/issues/212) Float64 special value operations (is_nan, is_infinite)</del> ([v0.0.72](https://github.com/aallan/vera/releases/tag/v0.0.72))
 - [#213](https://github.com/aallan/vera/issues/213) string_repeat builtin
 - [#230](https://github.com/aallan/vera/issues/230) string interpolation

--- a/SKILL.md
+++ b/SKILL.md
@@ -404,6 +404,7 @@ string_length(@String.0)                -- returns Nat
 string_concat(@String.0, @String.1)     -- returns String
 string_slice(@String.0, @Nat.0, @Nat.1) -- returns String (start, end)
 char_code(@String.0, @Int.0)            -- returns Nat (ASCII code at index)
+from_char_code(@Nat.0)                  -- returns String (single char from code point)
 parse_nat(@String.0)                    -- returns Result<Nat, String>
 parse_float64(@String.0)                -- returns Float64
 to_string(@Int.0)                       -- returns String (integer to decimal)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.73"
+version = "0.0.74"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/scripts/check_skill_examples.py
+++ b/scripts/check_skill_examples.py
@@ -40,64 +40,64 @@ ALLOWLIST: dict[int, tuple[str, str]] = {
     402: ("FRAGMENT", "String built-in examples, bare calls"),
 
     # String search — bare function calls
-    420: ("FRAGMENT", "String search built-in examples, bare calls"),
+    421: ("FRAGMENT", "String search built-in examples, bare calls"),
 
     # String transformation — bare function calls
-    431: ("FRAGMENT", "String transformation built-in examples, bare calls"),
+    432: ("FRAGMENT", "String transformation built-in examples, bare calls"),
 
     # Numeric operations — bare function calls
-    445: ("FRAGMENT", "Numeric built-in examples, bare calls"),
+    446: ("FRAGMENT", "Numeric built-in examples, bare calls"),
 
     # Contracts section — requires/ensures fragments
-    502: ("FRAGMENT", "Requires clause example, not full function"),
-    511: ("FRAGMENT", "Ensures clause example, not full function"),
-    538: ("FRAGMENT", "Quantified requires clause, not full function"),
+    503: ("FRAGMENT", "Requires clause example, not full function"),
+    512: ("FRAGMENT", "Ensures clause example, not full function"),
+    539: ("FRAGMENT", "Quantified requires clause, not full function"),
 
     # Effects section — bare effect rows
-    556: ("FRAGMENT", "Effect row examples, bare annotations"),
+    557: ("FRAGMENT", "Effect row examples, bare annotations"),
 
     # Effect handler syntax template
-    693: ("FRAGMENT", "Handler syntax template, not real code"),
+    694: ("FRAGMENT", "Handler syntax template, not real code"),
 
     # Qualified calls and handler fragments — bare expressions
-    705: ("FRAGMENT", "Handler with clause, bare expression"),
-    715: ("FRAGMENT", "Qualified call examples, bare expressions"),
+    706: ("FRAGMENT", "Handler with clause, bare expression"),
+    716: ("FRAGMENT", "Qualified call examples, bare expressions"),
 
     # Module declaration and import syntax
-    765: ("FRAGMENT", "Module declaration and import example"),
+    766: ("FRAGMENT", "Module declaration and import example"),
 
     # Line comments — bare comments
-    804: ("FRAGMENT", "Comment syntax example"),
+    805: ("FRAGMENT", "Comment syntax example"),
 
     # Type conversions — bare function calls
-    460: ("FRAGMENT", "Type conversion examples, bare calls"),
+    461: ("FRAGMENT", "Type conversion examples, bare calls"),
 
     # Float64 predicates — bare function calls
-    473: ("FRAGMENT", "Float64 predicate examples, bare calls"),
+    474: ("FRAGMENT", "Float64 predicate examples, bare calls"),
 
     # Common mistakes section — intentionally wrong code
-    832: ("FRAGMENT", "Wrong: missing contracts"),
-    839: ("FRAGMENT", "Wrong: incorrect contract syntax"),
-    852: ("FRAGMENT", "Wrong: missing requires"),
-    839: ("FRAGMENT", "Wrong: missing effects clause"),
-    852: ("FRAGMENT", "Wrong: wrong effect declared"),
-    886: ("FRAGMENT", "Wrong: bare expression without indices"),
-    899: ("FRAGMENT", "Wrong: bare expression no indices"),
-    904: ("FRAGMENT", "Correct: expression with indices (not full fn)"),
-    970: ("FRAGMENT", "Wrong: match arm with incorrect return"),
-    994: ("FRAGMENT", "Wrong: non-exhaustive match"),
-    1001: ("FRAGMENT", "Correct: match arm example"),
-    1011: ("FRAGMENT", "Wrong: if/else without braces (bare expression)"),
-    1016: ("FRAGMENT", "Correct: if/else with braces"),
+    833: ("FRAGMENT", "Wrong: missing contracts"),
+    840: ("FRAGMENT", "Wrong: incorrect contract syntax"),
+    853: ("FRAGMENT", "Wrong: missing requires"),
+    840: ("FRAGMENT", "Wrong: missing effects clause"),
+    853: ("FRAGMENT", "Wrong: wrong effect declared"),
+    887: ("FRAGMENT", "Wrong: bare expression without indices"),
+    900: ("FRAGMENT", "Wrong: bare expression no indices"),
+    905: ("FRAGMENT", "Correct: expression with indices (not full fn)"),
+    971: ("FRAGMENT", "Wrong: match arm with incorrect return"),
+    995: ("FRAGMENT", "Wrong: non-exhaustive match"),
+    1002: ("FRAGMENT", "Correct: match arm example"),
+    1012: ("FRAGMENT", "Wrong: if/else without braces (bare expression)"),
+    1017: ("FRAGMENT", "Correct: if/else with braces"),
 
     # Import syntax — intentionally unsupported
-    1027: ("FRAGMENT", "Wrong: import aliasing not supported"),
-    1032: ("FRAGMENT", "Correct: import syntax example"),
-    1042: ("FRAGMENT", "Wrong: import hiding not supported"),
-    1047: ("FRAGMENT", "Correct: multi-import syntax"),
+    1028: ("FRAGMENT", "Wrong: import aliasing not supported"),
+    1033: ("FRAGMENT", "Correct: import syntax example"),
+    1043: ("FRAGMENT", "Wrong: import hiding not supported"),
+    1048: ("FRAGMENT", "Correct: multi-import syntax"),
 
     # String escapes — bare expression
-    1061: ("FRAGMENT", "String escape example"),
+    1062: ("FRAGMENT", "String escape example"),
 
     # =================================================================
     # MISMATCH — uses syntax the parser doesn't handle in isolation.

--- a/scripts/check_spec_examples.py
+++ b/scripts/check_spec_examples.py
@@ -60,7 +60,7 @@ ALLOWLIST: dict[tuple[str, int], str] = {
     ("09-standard-library.md", 290): "FUTURE",   # fn classify — uses ++ (string concat)
     ("09-standard-library.md", 304): "FRAGMENT",  # length signature (no body)
     ("09-standard-library.md", 324): "FRAGMENT",  # array_push signature (no body)
-    ("09-standard-library.md", 803): "FRAGMENT",  # similarity signature (no body)
+    ("09-standard-library.md", 818): "FRAGMENT",  # similarity signature (no body)
 
     # =================================================================
     # FRAGMENT — heuristic false positives (look like declarations but
@@ -145,14 +145,15 @@ ALLOWLIST: dict[tuple[str, int], str] = {
     ("09-standard-library.md", 756): "FRAGMENT",  # replace signature (no body)
     ("09-standard-library.md", 772): "FRAGMENT",  # split signature (no body)
     ("09-standard-library.md", 787): "FRAGMENT",  # join signature (no body)
+    ("09-standard-library.md", 801): "FRAGMENT",  # from_char_code signature (no body)
 
     # Chapter 9 — Markdown stdlib type (future, uses MdBlock/MdInline types)
-    ("09-standard-library.md", 907): "FUTURE",   # md_parse(@String -> @Result<MdBlock, String>)
-    ("09-standard-library.md", 916): "FUTURE",   # md_render(@MdBlock -> @String)
-    ("09-standard-library.md", 927): "FUTURE",   # md_has_heading(@MdBlock, @Nat -> @Bool)
-    ("09-standard-library.md", 936): "FUTURE",   # md_has_code_block(@MdBlock, @String -> @Bool)
-    ("09-standard-library.md", 945): "FUTURE",   # md_extract_code_blocks(@MdBlock, @String -> @Array<String>)
-    ("09-standard-library.md", 969): "FUTURE",   # convert_to_markdown(@String -> @Result<MdBlock, String>)
+    ("09-standard-library.md", 922): "FUTURE",   # md_parse(@String -> @Result<MdBlock, String>)
+    ("09-standard-library.md", 931): "FUTURE",   # md_render(@MdBlock -> @String)
+    ("09-standard-library.md", 942): "FUTURE",   # md_has_heading(@MdBlock, @Nat -> @Bool)
+    ("09-standard-library.md", 951): "FUTURE",   # md_has_code_block(@MdBlock, @String -> @Bool)
+    ("09-standard-library.md", 960): "FUTURE",   # md_extract_code_blocks(@MdBlock, @String -> @Array<String>)
+    ("09-standard-library.md", 984): "FUTURE",   # convert_to_markdown(@String -> @Result<MdBlock, String>)
 }
 
 

--- a/spec/09-standard-library.md
+++ b/spec/09-standard-library.md
@@ -9,7 +9,7 @@ The standard library comprises:
 - **Built-in ADTs**: `Option<T>` and `Result<T, E>` for representing partiality and fallibility.
 - **Built-in collections**: `Array<T>` for fixed-size homogeneous sequences, plus future collections (`Set<T>`, `Map<K, V>`).
 - **Built-in effects**: `IO` for output, `State<T>` for mutable state, plus future effects for networking, concurrency, and LLM inference.
-- **Built-in functions**: `length` for arrays, numeric operations (`abs`, `min`, `max`, `floor`, `ceil`, `round`, `sqrt`, `pow`), type conversions (`to_float`, `float_to_int`, `nat_to_int`, `int_to_nat`, `byte_to_int`, `int_to_byte`), Float64 predicates (`is_nan`, `is_infinite`, `nan`, `infinity`), string search (`string_contains`, `starts_with`, `ends_with`, `index_of`), string transformation (`to_upper`, `to_lower`, `replace`, `split`, `join`), plus future functions for vector similarity.
+- **Built-in functions**: `length` for arrays, numeric operations (`abs`, `min`, `max`, `floor`, `ceil`, `round`, `sqrt`, `pow`), type conversions (`to_float`, `float_to_int`, `nat_to_int`, `int_to_nat`, `byte_to_int`, `int_to_byte`), Float64 predicates (`is_nan`, `is_infinite`, `nan`, `infinity`), string search (`string_contains`, `starts_with`, `ends_with`, `index_of`), string transformation (`to_upper`, `to_lower`, `replace`, `split`, `join`, `from_char_code`), plus future functions for vector similarity.
 - **Future types**: `Json` for structured data interchange, `Markdown` for agent-oriented document structure, `Decimal` for exact arithmetic.
 - **Future abilities**: Type constraints for generic programming (post-v0.1).
 
@@ -794,6 +794,21 @@ Joins an array of strings with the given separator between each pair of elements
 ```vera
 join(split("a,b,c", ","), "-")  -- "a-b-c"
 join(split("hello", ","), "-")  -- "hello"
+```
+
+#### from_char_code
+
+```vera
+public fn from_char_code(@Nat -> @String)
+  requires(true) ensures(true) effects(pure)
+```
+
+Creates a single-character (1-byte) string from an ASCII code point. Inverse of `char_code`. Allocates 1 byte of heap memory for the result.
+
+```vera
+from_char_code(65)                        -- "A"
+char_code(from_char_code(65), 0)          -- 65 (roundtrip)
+string_concat(from_char_code(72), from_char_code(105))  -- "Hi"
 ```
 
 ### 9.6.8 similarity (Future)

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -3036,6 +3036,22 @@ private fn f(@Array<Int>, @String -> @String)
 { join(@Array<Int>.0, @String.0) }
 """, "type")
 
+    # -- from_char_code --
+
+    def test_from_char_code_ok(self) -> None:
+        _check_ok("""
+private fn f(@Nat -> @String)
+  requires(true) ensures(true) effects(pure)
+{ from_char_code(@Nat.0) }
+""")
+
+    def test_from_char_code_wrong_arg(self) -> None:
+        _check_err("""
+private fn f(@String -> @String)
+  requires(true) ensures(true) effects(pure)
+{ from_char_code(@String.0) }
+""", "type")
+
 
 # =====================================================================
 # Bidirectional type inference (issue #55)

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -4146,6 +4146,55 @@ public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
         assert _run(src) == 32
 
 
+class TestFromCharCode:
+    """from_char_code creates a single-character string from a code point."""
+
+    def test_uppercase_a(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  let @Nat = char_code(from_char_code(65), 0);
+  @Nat.0
+}
+"""
+        assert _run(src) == 65
+
+    def test_digit(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  let @Nat = char_code(from_char_code(48), 0);
+  @Nat.0
+}
+"""
+        assert _run(src) == 48
+
+    def test_space(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  let @Nat = char_code(from_char_code(32), 0);
+  @Nat.0
+}
+"""
+        assert _run(src) == 32
+
+    def test_length_is_one(self) -> None:
+        src = """
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
+  let @Nat = string_length(from_char_code(65));
+  @Nat.0
+}
+"""
+        assert _run(src) == 1
+
+    def test_concat_builds_string(self) -> None:
+        src = """
+public fn f(-> @Bool) requires(true) ensures(true) effects(pure) {
+  let @String = string_concat(from_char_code(65), from_char_code(66));
+  starts_with(@String.0, "AB")
+}
+"""
+        assert _run(src) == 1
+
+
 class TestParseNat:
     """parse_nat returns Result<Nat, String>."""
 

--- a/vera/README.md
+++ b/vera/README.md
@@ -297,6 +297,7 @@ Context flags (`in_ensures`, `in_contract`, `current_return_type`, `current_effe
 | `string_concat` | Function | `String, String → String`, pure |
 | `string_slice` | Function | `String, Nat, Nat → String`, pure |
 | `char_code` | Function | `String, Int → Nat`, pure |
+| `from_char_code` | Function | `Nat → String`, pure |
 | `parse_nat` | Function | `String → Result<Nat, String>`, pure |
 | `parse_float64` | Function | `String → Float64`, pure |
 | `to_string` | Function | `Int → String`, pure |

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.73"
+__version__ = "0.0.74"

--- a/vera/codegen/modules.py
+++ b/vera/codegen/modules.py
@@ -239,7 +239,7 @@ class CrossModuleMixin:
             "length", "array_push",
             "apply_fn", "get", "put", "throw", "resume",
             "string_length", "string_concat", "string_slice",
-            "char_code", "parse_nat", "parse_float64",
+            "char_code", "from_char_code", "parse_nat", "parse_float64",
             "to_string", "int_to_string", "bool_to_string",
             "nat_to_string", "byte_to_string", "float_to_string",
             "strip",

--- a/vera/environment.py
+++ b/vera/environment.py
@@ -271,6 +271,13 @@ class TypeEnv:
             return_type=NAT,
             effect=PureEffectRow(),
         )
+        self.functions["from_char_code"] = FunctionInfo(
+            name="from_char_code",
+            forall_vars=None,
+            param_types=(NAT,),
+            return_type=STRING,
+            effect=PureEffectRow(),
+        )
         self.functions["parse_nat"] = FunctionInfo(
             name="parse_nat",
             forall_vars=None,

--- a/vera/wasm/calls.py
+++ b/vera/wasm/calls.py
@@ -44,6 +44,8 @@ class CallsMixin:
                 return self._translate_char_code(
                     call.args[0], call.args[1], env,
                 )
+            if call.name == "from_char_code" and len(call.args) == 1:
+                return self._translate_from_char_code(call.args[0], env)
             if call.name == "parse_nat" and len(call.args) == 1:
                 return self._translate_parse_nat(call.args[0], env)
             if call.name == "parse_float64" and len(call.args) == 1:
@@ -670,6 +672,46 @@ class CallsMixin:
         instructions.append("i32.load8_u offset=0")
         instructions.append("i64.extend_i32_u")
         return instructions
+
+    def _translate_from_char_code(
+        self, arg: ast.Expr, env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """Translate from_char_code(n) → String (i32_pair).
+
+        Allocates a 1-byte string and stores the byte value.
+        Inverse of char_code.
+        """
+        n_instrs = self.translate_expr(arg, env)
+        if n_instrs is None:
+            return None
+
+        self.needs_alloc = True
+
+        byte_val = self.alloc_local("i32")
+        ptr = self.alloc_local("i32")
+
+        ins: list[str] = []
+
+        # Evaluate arg (Nat = i64) → i32
+        ins.extend(n_instrs)
+        ins.append("i32.wrap_i64")
+        ins.append(f"local.set {byte_val}")
+
+        # Allocate 1-byte buffer
+        ins.append("i32.const 1")
+        ins.append("call $alloc")
+        ins.append(f"local.set {ptr}")
+        ins.extend(gc_shadow_push(ptr))
+
+        # Store the byte
+        ins.append(f"local.get {ptr}")
+        ins.append(f"local.get {byte_val}")
+        ins.append("i32.store8 offset=0")
+
+        # Result: (ptr, 1)
+        ins.append(f"local.get {ptr}")
+        ins.append("i32.const 1")
+        return ins
 
     def _translate_parse_nat(
         self, arg: ast.Expr, env: WasmSlotEnv,

--- a/vera/wasm/inference.py
+++ b/vera/wasm/inference.py
@@ -200,6 +200,9 @@ class InferenceMixin:
         # char_code → Nat (i64)
         if expr.name == "char_code":
             return "i64"
+        # from_char_code → String (i32_pair)
+        if expr.name == "from_char_code":
+            return "i32_pair"
         # String search builtins
         if expr.name in ("string_contains", "starts_with", "ends_with"):
             return "i32"
@@ -367,6 +370,8 @@ class InferenceMixin:
             return "String"
         if call.name == "char_code":
             return "Nat"
+        if call.name == "from_char_code":
+            return "String"
         # String search builtins
         if call.name in ("string_contains", "starts_with", "ends_with"):
             return "Bool"


### PR DESCRIPTION
## Summary
- New `from_char_code` function (`Nat → String`): creates a single-character string from an ASCII code point
- Inverse of the existing `char_code` function — enables character-level string construction
- 7 new tests (2 type checker + 5 codegen end-to-end)
- Version bump to v0.0.74

## Test plan
- [x] All 1,863 tests pass (`pytest tests/ -v`)
- [x] mypy clean
- [x] All 43 conformance programs pass
- [x] All 18 examples pass
- [x] Spec, SKILL.md, README code blocks pass
- [x] Version sync pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)