### PR TITLE
Add string interpolation (\(expr) syntax)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.76] - 2026-03-10
+
+### Added
+- **Close #230: String interpolation** ([#230](https://github.com/aallan/vera/issues/230)):
+  New `\(expr)` syntax inside double-quoted strings for ergonomic string building.
+  Non-String expressions of type Int, Nat, Bool, Byte, and Float64 are automatically
+  converted using the appropriate `*_to_string` built-in. `InterpolatedString` is a
+  first-class AST node (canonical form, survives formatting). Touches every compiler
+  stage: grammar, transformer, type checker, formatter, and WASM codegen.
+- New conformance test `ch04_string_interpolation` (conformance suite: 43→44 programs)
+- 18 new tests (9 type checker + 9 codegen end-to-end)
+- Spec Sections 1.4 "String Interpolation" and 4.13.1 "String Interpolation"
+
 ## [0.0.75] - 2026-03-10
 
 ### Added
@@ -1152,7 +1165,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Grammar: handler body simplified to avoid LALR reduce/reduce conflict
 - `pyproject.toml`: corrected build backend, package discovery, PEP 639 compliance
 
-[Unreleased]: https://github.com/aallan/vera/compare/v0.0.75...HEAD
+[Unreleased]: https://github.com/aallan/vera/compare/v0.0.76...HEAD
+[0.0.76]: https://github.com/aallan/vera/compare/v0.0.75...v0.0.76
 [0.0.75]: https://github.com/aallan/vera/compare/v0.0.74...v0.0.75
 [0.0.74]: https://github.com/aallan/vera/compare/v0.0.73...v0.0.74
 [0.0.73]: https://github.com/aallan/vera/compare/v0.0.72...v0.0.73

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ The language specification is in draft across 13 chapters:
 
 ### Testing
 
-Testing is organized in three layers: **unit tests** (1,865 tests across 20 files, testing compiler internals), a **conformance suite** (43 programs across 8 spec chapters, systematically validating every language feature against the spec), and **example programs** (18 end-to-end demos). The compiler has 90% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations. Every commit validates all conformance programs, example programs, and 95 specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference -- coverage tables, conformance suite details, CI pipeline, and infrastructure.
+Testing is organized in three layers: **unit tests** (1,899 tests across 20 files, testing compiler internals), a **conformance suite** (44 programs across 8 spec chapters, systematically validating every language feature against the spec), and **example programs** (18 end-to-end demos). The compiler has 90% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations. Every commit validates all conformance programs, example programs, and 95 specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference -- coverage tables, conformance suite details, CI pipeline, and infrastructure.
 
 ## Roadmap
 
@@ -321,7 +321,7 @@ Module refinements, lexical extensions, and IO runtime — completing the existi
 - <del>[#210](https://github.com/aallan/vera/issues/210) from_char_code builtin</del> ([v0.0.74](https://github.com/aallan/vera/releases/tag/v0.0.74))
 - <del>[#212](https://github.com/aallan/vera/issues/212) Float64 special value operations (is_nan, is_infinite)</del> ([v0.0.72](https://github.com/aallan/vera/releases/tag/v0.0.72))
 - <del>[#213](https://github.com/aallan/vera/issues/213) string_repeat builtin</del> ([v0.0.75](https://github.com/aallan/vera/releases/tag/v0.0.75))
-- [#230](https://github.com/aallan/vera/issues/230) string interpolation
+- <del>[#230](https://github.com/aallan/vera/issues/230) string interpolation</del> ([v0.0.76](https://github.com/aallan/vera/releases/tag/v0.0.76))
 - [#231](https://github.com/aallan/vera/issues/231) regex support
 - [#232](https://github.com/aallan/vera/issues/232) URL parsing and construction builtins
 - [#234](https://github.com/aallan/vera/issues/234) base64 encoding and decoding

--- a/SKILL.md
+++ b/SKILL.md
@@ -417,6 +417,18 @@ float_to_string(@Float64.0)             -- returns String (decimal representatio
 strip(@String.0)                        -- returns String (trim whitespace)
 ```
 
+#### String interpolation
+
+```vera
+"hello \(@String.0)"               -- embeds a String value
+"x = \(@Int.0)"                    -- auto-converts Int to String
+"a=\(@Int.1), b=\(@Int.0)"        -- multiple interpolations
+"\(@String.0)"                     -- interpolation-only (no literal text)
+"len=\(string_length(@String.0))"  -- function call inside interpolation
+```
+
+Expressions inside `\(...)` are auto-converted to String for types: Int, Nat, Bool, Byte, Float64. Other types produce error E148. Expressions cannot contain string literals (use `let` bindings instead).
+
 #### String search
 
 ```vera

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.75"
+version = "0.0.76"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/scripts/check_skill_examples.py
+++ b/scripts/check_skill_examples.py
@@ -39,65 +39,68 @@ ALLOWLIST: dict[int, tuple[str, str]] = {
     # String operations — bare function calls
     402: ("FRAGMENT", "String built-in examples, bare calls"),
 
+    # String interpolation — bare expressions
+    422: ("FRAGMENT", "String interpolation examples, bare expressions"),
+
     # String search — bare function calls
-    422: ("FRAGMENT", "String search built-in examples, bare calls"),
+    434: ("FRAGMENT", "String search built-in examples, bare calls"),
 
     # String transformation — bare function calls
-    433: ("FRAGMENT", "String transformation built-in examples, bare calls"),
+    445: ("FRAGMENT", "String transformation built-in examples, bare calls"),
 
     # Numeric operations — bare function calls
-    447: ("FRAGMENT", "Numeric built-in examples, bare calls"),
+    459: ("FRAGMENT", "Numeric built-in examples, bare calls"),
 
     # Contracts section — requires/ensures fragments
-    504: ("FRAGMENT", "Requires clause example, not full function"),
-    513: ("FRAGMENT", "Ensures clause example, not full function"),
-    540: ("FRAGMENT", "Quantified requires clause, not full function"),
+    516: ("FRAGMENT", "Requires clause example, not full function"),
+    525: ("FRAGMENT", "Ensures clause example, not full function"),
+    552: ("FRAGMENT", "Quantified requires clause, not full function"),
 
     # Effects section — bare effect rows
-    558: ("FRAGMENT", "Effect row examples, bare annotations"),
+    570: ("FRAGMENT", "Effect row examples, bare annotations"),
 
     # Effect handler syntax template
-    695: ("FRAGMENT", "Handler syntax template, not real code"),
+    707: ("FRAGMENT", "Handler syntax template, not real code"),
 
     # Qualified calls and handler fragments — bare expressions
-    707: ("FRAGMENT", "Handler with clause, bare expression"),
-    717: ("FRAGMENT", "Qualified call examples, bare expressions"),
+    719: ("FRAGMENT", "Handler with clause, bare expression"),
+    729: ("FRAGMENT", "Qualified call examples, bare expressions"),
 
     # Module declaration and import syntax
     767: ("FRAGMENT", "Module declaration and import example"),
 
     # Line comments — bare comments
-    806: ("FRAGMENT", "Comment syntax example"),
+    818: ("FRAGMENT", "Comment syntax example"),
 
     # Type conversions — bare function calls
-    462: ("FRAGMENT", "Type conversion examples, bare calls"),
+    474: ("FRAGMENT", "Type conversion examples, bare calls"),
 
     # Float64 predicates — bare function calls
-    475: ("FRAGMENT", "Float64 predicate examples, bare calls"),
+    487: ("FRAGMENT", "Float64 predicate examples, bare calls"),
 
     # Common mistakes section — intentionally wrong code
-    834: ("FRAGMENT", "Wrong: missing contracts"),
-    841: ("FRAGMENT", "Wrong: incorrect contract syntax"),
-    854: ("FRAGMENT", "Wrong: missing requires"),
-    841: ("FRAGMENT", "Wrong: missing effects clause"),
-    854: ("FRAGMENT", "Wrong: wrong effect declared"),
-    888: ("FRAGMENT", "Wrong: bare expression without indices"),
-    901: ("FRAGMENT", "Wrong: bare expression no indices"),
-    906: ("FRAGMENT", "Correct: expression with indices (not full fn)"),
-    972: ("FRAGMENT", "Wrong: match arm with incorrect return"),
-    996: ("FRAGMENT", "Wrong: non-exhaustive match"),
-    1003: ("FRAGMENT", "Correct: match arm example"),
-    1013: ("FRAGMENT", "Wrong: if/else without braces (bare expression)"),
-    1018: ("FRAGMENT", "Correct: if/else with braces"),
+    846: ("FRAGMENT", "Wrong: missing contracts"),
+    853: ("FRAGMENT", "Wrong: incorrect contract syntax"),
+    866: ("FRAGMENT", "Wrong: missing requires"),
+    853: ("FRAGMENT", "Wrong: missing effects clause"),
+    866: ("FRAGMENT", "Wrong: wrong effect declared"),
+    900: ("FRAGMENT", "Wrong: bare expression without indices"),
+    913: ("FRAGMENT", "Wrong: bare expression no indices"),
+    918: ("FRAGMENT", "Correct: expression with indices (not full fn)"),
+    984: ("FRAGMENT", "Wrong: match arm with incorrect return"),
+    1008: ("FRAGMENT", "Wrong: non-exhaustive match"),
+    1015: ("FRAGMENT", "Correct: match arm example"),
+    1025: ("FRAGMENT", "Wrong: if/else without braces (bare expression)"),
+    1030: ("FRAGMENT", "Correct: if/else with braces"),
 
     # Import syntax — intentionally unsupported
-    1029: ("FRAGMENT", "Wrong: import aliasing not supported"),
-    1034: ("FRAGMENT", "Correct: import syntax example"),
-    1044: ("FRAGMENT", "Wrong: import hiding not supported"),
-    1049: ("FRAGMENT", "Correct: multi-import syntax"),
+    1041: ("FRAGMENT", "Wrong: import aliasing not supported"),
+    1046: ("FRAGMENT", "Correct: import syntax example"),
+    1056: ("FRAGMENT", "Wrong: import hiding not supported"),
+    1061: ("FRAGMENT", "Correct: multi-import syntax"),
 
     # String escapes — bare expression
-    1063: ("FRAGMENT", "String escape example"),
+    1075: ("FRAGMENT", "String escape example"),
 
     # =================================================================
     # MISMATCH — uses syntax the parser doesn't handle in isolation.

--- a/spec/01-lexical-structure.md
+++ b/spec/01-lexical-structure.md
@@ -171,8 +171,25 @@ Escape sequences:
 | `\r`     | Carriage return |
 | `\0`     | Null |
 | `\u{XXXX}` | Unicode code point (1-6 hex digits) |
+| `\(`...`)` | String interpolation (see §4.6) |
 
-No other escape sequences are valid.
+No other escape sequences are valid (except `\(` which begins interpolation).
+
+#### String Interpolation
+
+String interpolation embeds expressions inside string literals using `\(expr)` syntax:
+
+```
+"hello \(@String.0)"
+"x = \(@Int.0)"
+"a=\(@Int.1), b=\(@Int.0)"
+```
+
+The `\(` sequence opens an interpolation hole. The expression inside is parsed and type-checked normally. The matching `)` closes the hole (parentheses nest correctly). Non-String expressions of type Int, Nat, Bool, Byte, or Float64 are automatically converted to String using the appropriate `*_to_string` built-in. Other types produce a type error (E148).
+
+An `InterpolatedString` is a first-class expression that returns String. It is the canonical form for strings with embedded expressions — there is no equivalent `string_concat`/`to_string` desugaring at the source level.
+
+**Limitation.** Expressions inside `\(...)` cannot contain string literals, because the lexer's regex-based string matching would terminate at the inner `"`. Use `let` bindings for expressions requiring string arguments.
 
 **Design note.** Vera does not support raw string syntax or multi-line string literals. A raw string (`r"..."`) would be an alternative representation for any string containing backslash characters, and a multi-line literal would be an alternative representation for any string containing newline characters. Both would violate the one-canonical-form principle (§0.2.3): the same string value would be expressible in two syntactically distinct ways. Since Vera targets LLM emission rather than human authoring (§0.3.1), the readability benefit of alternative string syntaxes does not justify the representational ambiguity. The escape sequence table above is the canonical and only mechanism for embedding special characters in strings.
 

--- a/spec/04-expressions.md
+++ b/spec/04-expressions.md
@@ -328,6 +328,35 @@ String concatenation uses a function, not an operator. There is no `+` on string
 
 String memory is allocated via the bump allocator and is not freed. Garbage collection for WASM linear memory is tracked in [#51](https://github.com/aallan/vera/issues/51). See Chapter 11, Section 11.5 for the string pool implementation.
 
+### 4.13.1 String Interpolation
+
+String interpolation provides ergonomic syntax for building strings from mixed types. The syntax uses `\(expr)` inside double-quoted strings:
+
+```
+"hello \(@String.0)"               -- embeds a String value
+"x = \(@Int.0)"                    -- auto-converts Int to String
+"a=\(@Int.1), b=\(@Int.0)"        -- multiple interpolations
+"\(@String.0)"                     -- interpolation-only (no literal text)
+"len=\(string_length(@String.0))"  -- function call inside interpolation
+```
+
+**Type rules.** An interpolated string is an expression of type String. Each interpolated expression is type-checked independently:
+
+- If the expression has type String, it is used directly.
+- If the expression has type Int, Nat, Bool, Byte, or Float64, it is automatically converted using the appropriate built-in (`to_string`, `nat_to_string`, `bool_to_string`, `byte_to_string`, `float_to_string`).
+- All other types produce error E148.
+
+**Canonical form.** `InterpolatedString` is a first-class AST node and the canonical representation for strings with embedded expressions. The formatter preserves interpolation syntax — it does not desugar to `string_concat`/`to_string` chains.
+
+**Compilation.** At the WASM level, interpolation desugars to a chain of `string_concat` and `*_to_string` calls. For example, `"a=\(@Int.0), b=\(@Bool.0)"` becomes `string_concat(string_concat(string_concat("a=", to_string(@Int.0)), ", b="), bool_to_string(@Bool.0))`.
+
+**Limitation.** Expressions inside `\(...)` cannot contain string literals (nested `"` terminates the outer string in the regex lexer). Use `let` bindings for expressions that require string arguments:
+
+```
+let @String = string_concat("a", "b");
+"result: \(@String.0)"
+```
+
 ## 4.14 Expression Precedence (Complete)
 
 From highest to lowest precedence:

--- a/tests/conformance/ch04_string_interpolation.vera
+++ b/tests/conformance/ch04_string_interpolation.vera
@@ -1,0 +1,79 @@
+-- Conformance: string interpolation (Chapter 4)
+-- Tests: interpolated strings, auto-conversion (Int, Bool, Nat, Float64)
+effect IO {
+  op print(String -> Unit);
+}
+
+public fn test_basic(@Unit -> @String)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  let @String = "world";
+  "hello \(@String.0)"
+}
+
+public fn test_int_convert(@Unit -> @String)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  let @Int = 42;
+  "x = \(@Int.0)"
+}
+
+public fn test_bool_convert(@Unit -> @String)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  let @Bool = true;
+  "flag: \(@Bool.0)"
+}
+
+public fn test_nat_convert(@Unit -> @String)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  let @Nat = string_length("abc");
+  "len=\(@Nat.0)"
+}
+
+public fn test_multiple(@Unit -> @String)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  let @Int = 1;
+  let @Int = 2;
+  "a=\(@Int.1), b=\(@Int.0)"
+}
+
+public fn test_only_expr(@Unit -> @String)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  let @String = "hello";
+  "\(@String.0)"
+}
+
+public fn test_nested_call(@Unit -> @String)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  let @String = "hello";
+  "len=\(string_length(@String.0))"
+}
+
+public fn main(@Unit -> @Unit)
+  requires(true)
+  ensures(true)
+  effects(<IO>)
+{
+  let @Int = 42;
+  IO.print("value = \(@Int.0)");
+  ()
+}

--- a/tests/conformance/manifest.json
+++ b/tests/conformance/manifest.json
@@ -216,6 +216,15 @@
     "features": ["string_length", "string_concat", "string_slice", "char_code", "to_string"]
   },
   {
+    "id": "ch04_string_interpolation",
+    "file": "ch04_string_interpolation.vera",
+    "chapter": 4,
+    "title": "String interpolation",
+    "level": "run",
+    "spec_ref": "Section 4.6",
+    "features": ["string_interpolation", "auto_to_string"]
+  },
+  {
     "id": "ch04_array_ops",
     "file": "ch04_array_ops.vera",
     "chapter": 4,

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -3399,3 +3399,86 @@ public fn main(-> @Unit)
         assert any("read_line" in w.description for w in warnings), \
             f"Expected warning about read_line, got: " \
             f"{[w.description for w in warnings]}"
+
+
+# =====================================================================
+# String interpolation
+# =====================================================================
+
+
+class TestStringInterpolation:
+    """String interpolation type checking."""
+
+    def test_interp_string_ok(self) -> None:
+        """Interpolating a String expression is allowed."""
+        _check_ok("""
+private fn f(@String -> @String)
+  requires(true) ensures(true) effects(pure)
+{ "hello \\(@String.0)" }
+""")
+
+    def test_interp_int_auto_convert(self) -> None:
+        """Int expressions are auto-converted to String."""
+        _check_ok("""
+private fn f(@Int -> @String)
+  requires(true) ensures(true) effects(pure)
+{ "x = \\(@Int.0)" }
+""")
+
+    def test_interp_bool_auto_convert(self) -> None:
+        """Bool expressions are auto-converted to String."""
+        _check_ok("""
+private fn f(@Bool -> @String)
+  requires(true) ensures(true) effects(pure)
+{ "flag: \\(@Bool.0)" }
+""")
+
+    def test_interp_nat_auto_convert(self) -> None:
+        """Nat expressions are auto-converted to String."""
+        _check_ok("""
+private fn f(@Nat -> @String)
+  requires(true) ensures(true) effects(pure)
+{ "n = \\(@Nat.0)" }
+""")
+
+    def test_interp_float_auto_convert(self) -> None:
+        """Float64 expressions are auto-converted to String."""
+        _check_ok("""
+private fn f(@Float64 -> @String)
+  requires(true) ensures(true) effects(pure)
+{ "f = \\(@Float64.0)" }
+""")
+
+    def test_interp_byte_auto_convert(self) -> None:
+        """Byte expressions are auto-converted to String."""
+        _check_ok("""
+private fn f(@Byte -> @String)
+  requires(true) ensures(true) effects(pure)
+{ "b = \\(@Byte.0)" }
+""")
+
+    def test_interp_multiple_exprs(self) -> None:
+        """Multiple interpolated expressions in one string."""
+        _check_ok("""
+private fn f(@Int, @Bool -> @String)
+  requires(true) ensures(true) effects(pure)
+{ "a=\\(@Int.0) b=\\(@Bool.0)" }
+""")
+
+    def test_interp_no_interp_still_works(self) -> None:
+        """A plain string without interpolation still works as StringLit."""
+        _check_ok("""
+private fn f(-> @String)
+  requires(true) ensures(true) effects(pure)
+{ "plain string" }
+""")
+
+    def test_interp_unsupported_type(self) -> None:
+        """ADT types without to_string produce E148."""
+        _check_err("""
+private data Color { Red, Green, Blue }
+
+private fn f(-> @String)
+  requires(true) ensures(true) effects(pure)
+{ "color: \\(Red)" }
+""", "cannot be automatically converted to String")

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -6106,3 +6106,130 @@ public fn main(-> @Unit)
 """
         result = _compile_ok(source)
         assert '(export "alloc"' not in result.wat
+
+
+# =====================================================================
+# String interpolation
+# =====================================================================
+
+
+class TestStringInterpolation:
+    """String interpolation compiles and executes correctly."""
+
+    def test_basic_string(self) -> None:
+        """Interpolating a String value into a literal."""
+        source = _IO_PRELUDE + """\
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{ IO.print("hello \\(@String.0)") }
+"""
+        # Pass a string via string_concat workaround — use a known string
+        # Instead, use a function that builds the interpolated string
+        source2 = _IO_PRELUDE + """\
+public fn main(-> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  let @String = "world";
+  IO.print("hello \\(@String.0)")
+}
+"""
+        assert _run_io(source2, fn="main") == "hello world"
+
+    def test_int_convert(self) -> None:
+        """Int expressions are auto-converted to String."""
+        source = _IO_PRELUDE + """\
+public fn main(-> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  let @Int = 42;
+  IO.print("x = \\(@Int.0)")
+}
+"""
+        assert _run_io(source, fn="main") == "x = 42"
+
+    def test_bool_convert(self) -> None:
+        """Bool expressions are auto-converted to String."""
+        source = _IO_PRELUDE + """\
+public fn main(-> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  let @Bool = true;
+  IO.print("flag: \\(@Bool.0)")
+}
+"""
+        assert _run_io(source, fn="main") == "flag: true"
+
+    def test_multiple_parts(self) -> None:
+        """Multiple interpolated expressions."""
+        source = _IO_PRELUDE + """\
+public fn main(-> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  let @Int = 1;
+  let @Int = 2;
+  IO.print("a=\\(@Int.1), b=\\(@Int.0)")
+}
+"""
+        assert _run_io(source, fn="main") == "a=1, b=2"
+
+    def test_only_expr(self) -> None:
+        """Interpolation with only an expression, no literal text."""
+        source = _IO_PRELUDE + """\
+public fn main(-> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  let @String = "hello";
+  IO.print("\\(@String.0)")
+}
+"""
+        assert _run_io(source, fn="main") == "hello"
+
+    def test_empty_fragments(self) -> None:
+        """Adjacent interpolations with no text between them."""
+        source = _IO_PRELUDE + """\
+public fn main(-> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  let @Int = 1;
+  let @Int = 2;
+  IO.print("\\(@Int.1)\\(@Int.0)")
+}
+"""
+        assert _run_io(source, fn="main") == "12"
+
+    def test_nat_convert(self) -> None:
+        """Nat auto-conversion works."""
+        source = _IO_PRELUDE + """\
+public fn main(-> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  let @Nat = string_length("abc");
+  IO.print("len=\\(@Nat.0)")
+}
+"""
+        assert _run_io(source, fn="main") == "len=3"
+
+    def test_float_convert(self) -> None:
+        """Float64 auto-conversion works."""
+        source = _IO_PRELUDE + """\
+public fn main(-> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  let @Float64 = 3.14;
+  IO.print("pi=\\(@Float64.0)")
+}
+"""
+        out = _run_io(source, fn="main")
+        assert out.startswith("pi=3.14")
+
+    def test_nested_fn_call(self) -> None:
+        """Function call inside interpolation."""
+        source = _IO_PRELUDE + """\
+public fn main(-> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  let @String = "hello";
+  IO.print("len=\\(string_length(@String.0))")
+}
+"""
+        assert _run_io(source, fn="main") == "len=5"

--- a/vera/README.md
+++ b/vera/README.md
@@ -145,7 +145,7 @@ The AST is a shallow class hierarchy. Every node is a frozen dataclass carrying 
 Node
 ├── Expr                                    Expressions
 │   ├── IntLit, FloatLit, StringLit         Literals
-│   ├── BoolLit, UnitLit, ArrayLit
+│   ├── BoolLit, UnitLit, ArrayLit, InterpolatedString
 │   ├── SlotRef(@Type.n)                    Typed De Bruijn reference
 │   ├── ResultRef(@Type.result)             Return value reference
 │   ├── BinaryExpr, UnaryExpr              Operators

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.75"
+__version__ = "0.0.76"

--- a/vera/ast.py
+++ b/vera/ast.py
@@ -332,6 +332,16 @@ class StringLit(Expr):
 
 
 @dataclass(frozen=True)
+class InterpolatedString(Expr):
+    """String with interpolated expressions: "text \\(expr) more".
+
+    Parts alternate: str, Expr, str, Expr, ..., str.
+    Always starts and ends with a string fragment (may be empty ``""``).
+    """
+    parts: tuple[str | Expr, ...]
+
+
+@dataclass(frozen=True)
 class BoolLit(Expr):
     """Boolean literal."""
     value: bool
@@ -720,6 +730,14 @@ def format_expr(expr: Expr) -> str:
         return "true" if expr.value else "false"
     if isinstance(expr, StringLit):
         return f'"{expr.value}"'
+    if isinstance(expr, InterpolatedString):
+        parts = []
+        for p in expr.parts:
+            if isinstance(p, str):
+                parts.append(p)
+            else:
+                parts.append(f"\\({format_expr(p)})")
+        return '"' + "".join(parts) + '"'
     if isinstance(expr, SlotRef):
         base = expr.type_name
         if expr.type_args:

--- a/vera/checker/expressions.py
+++ b/vera/checker/expressions.py
@@ -63,6 +63,8 @@ class ExpressionsMixin:
             return FLOAT64
         if isinstance(expr, ast.StringLit):
             return STRING
+        if isinstance(expr, ast.InterpolatedString):
+            return self._check_interpolated_string(expr)
         if isinstance(expr, ast.BoolLit):
             return BOOL
         if isinstance(expr, ast.UnitLit):
@@ -113,6 +115,49 @@ class ExpressionsMixin:
             return self._check_new_expr(expr)
         self._error(expr, f"Unknown expression type: {type(expr).__name__}", error_code="E176")
         return None
+
+    # -----------------------------------------------------------------
+    # String interpolation
+    # -----------------------------------------------------------------
+
+    # Types that have a corresponding *_to_string builtin.
+    _TO_STRING_TYPES: dict[str, str] = {
+        "Int": "to_string",
+        "Nat": "nat_to_string",
+        "Bool": "bool_to_string",
+        "Byte": "byte_to_string",
+        "Float64": "float_to_string",
+    }
+
+    def _check_interpolated_string(
+        self, expr: ast.InterpolatedString,
+    ) -> Type:
+        """Type-check an interpolated string expression."""
+        for part in expr.parts:
+            if isinstance(part, str):
+                continue
+            part_ty = self._synth_expr(part)
+            if part_ty is None:
+                continue  # error already emitted
+            # String expressions are fine as-is
+            if is_subtype(part_ty, STRING):
+                continue
+            # Check for auto-convertible primitive types
+            type_name = (
+                part_ty.name
+                if isinstance(part_ty, PrimitiveType)
+                else None
+            )
+            if type_name not in self._TO_STRING_TYPES:
+                self._error(
+                    part,
+                    f"Type '{pretty_type(part_ty)}' cannot be "
+                    f"automatically converted to String in string "
+                    f"interpolation. Only String, Int, Nat, Bool, "
+                    f"Byte, and Float64 are supported.",
+                    error_code="E148",
+                )
+        return STRING
 
     # -----------------------------------------------------------------
     # Slot references

--- a/vera/codegen/modules.py
+++ b/vera/codegen/modules.py
@@ -316,6 +316,10 @@ class CrossModuleMixin:
             self._scan_body_for_unknown_calls(node.scrutinee, known, seen)
             for arm in node.arms:
                 self._scan_body_for_unknown_calls(arm.body, known, seen)
+        elif isinstance(node, ast.InterpolatedString):
+            for part in node.parts:
+                if not isinstance(part, str):
+                    self._scan_body_for_unknown_calls(part, known, seen)
 
     def _emit_cross_module_error(
         self,

--- a/vera/errors.py
+++ b/vera/errors.py
@@ -436,6 +436,7 @@ ERROR_CODES: dict[str, str] = {
     "E145": "Logical operand not Bool (right)",
     "E146": "Unary not requires Bool",
     "E147": "Unary negate requires numeric",
+    "E148": "Non-convertible type in string interpolation",
     "E160": "Array index must be Int or Nat",
     "E161": "Cannot index non-array type",
     "E170": "Let binding type mismatch",

--- a/vera/formatter.py
+++ b/vera/formatter.py
@@ -68,6 +68,7 @@ from vera.ast import (
     IfExpr,
     ImportDecl,
     IndexExpr,
+    InterpolatedString,
     IntLit,
     IntPattern,
     Invariant,
@@ -807,6 +808,14 @@ class Formatter:
             return "true" if expr.value else "false"
         if isinstance(expr, StringLit):
             return f'"{_encode_string_escapes(expr.value)}"'
+        if isinstance(expr, InterpolatedString):
+            chunks: list[str] = []
+            for part in expr.parts:
+                if isinstance(part, str):
+                    chunks.append(_encode_string_escapes(part))
+                else:
+                    chunks.append(f"\\({self._fmt_expr(part)})")
+            return '"' + "".join(chunks) + '"'
         if isinstance(expr, UnitLit):
             return "()"
         if isinstance(expr, ArrayLit):

--- a/vera/transform.py
+++ b/vera/transform.py
@@ -49,6 +49,7 @@ from vera.ast import (
     IfExpr,
     ImportDecl,
     IndexExpr,
+    InterpolatedString,
     IntLit,
     IntPattern,
     Invariant,
@@ -189,6 +190,98 @@ def _decode_string_escapes(s: str, meta: Any = None) -> str:
     return "".join(result)
 
 
+# ---------------------------------------------------------------------------
+# String interpolation helpers (spec §4)
+# ---------------------------------------------------------------------------
+
+def _has_interpolation(raw: str) -> bool:
+    """Check whether a raw (between-quotes) string contains ``\\(``."""
+    i = 0
+    while i < len(raw) - 1:
+        if raw[i] == "\\" and raw[i + 1] == "(":
+            return True
+        if raw[i] == "\\":
+            i += 2  # skip escaped char
+        else:
+            i += 1
+    return False
+
+
+def _split_interpolation(raw: str, meta: Any = None) -> list[str]:
+    r"""Split a raw string on ``\(`` and matching ``)`` markers.
+
+    Returns an alternating list ``[literal, expr, literal, expr, ..., literal]``
+    where even-indexed elements are literal text and odd-indexed elements are
+    expression source strings.
+    """
+    parts: list[str] = []
+    buf: list[str] = []
+    i = 0
+    while i < len(raw):
+        if raw[i] == "\\" and i + 1 < len(raw) and raw[i + 1] == "(":
+            # Flush literal buffer
+            parts.append("".join(buf))
+            buf = []
+            # Find matching ')' tracking paren depth
+            depth = 1
+            j = i + 2
+            while j < len(raw) and depth > 0:
+                if raw[j] == "(":
+                    depth += 1
+                elif raw[j] == ")":
+                    depth -= 1
+                j += 1
+            if depth != 0:
+                raise _transform_error(
+                    "Unmatched '\\(' in string interpolation — "
+                    "missing closing ')'.",
+                    meta, error_code="E009",
+                )
+            expr_text = raw[i + 2:j - 1]
+            if not expr_text.strip():
+                raise _transform_error(
+                    "Empty expression in string interpolation '\\()'.",
+                    meta, error_code="E009",
+                )
+            parts.append(expr_text)
+            i = j
+        else:
+            buf.append(raw[i])
+            i += 1
+    parts.append("".join(buf))
+    return parts
+
+
+def _parse_interp_expr(source: str, meta: Any = None) -> Expr:
+    """Parse an interpolated expression by wrapping in a dummy function."""
+    from vera.parser import parse as _parse
+
+    wrapper = (
+        "private fn interpExpr(@Unit -> @Unit)\n"
+        "  requires(true) ensures(true) effects(pure)\n"
+        f"{{ {source} }}\n"
+    )
+    try:
+        tree = _parse(wrapper)
+    except Exception:
+        raise _transform_error(
+            f"Invalid expression in string interpolation: "
+            f"\\({source})",
+            meta, error_code="E009",
+        )
+    # Transform the parse tree and extract the body expression
+    program = VeraTransformer().transform(tree)
+    fn_decl = program.declarations[0].decl
+    body = fn_decl.body
+    if body.statements:
+        raise _transform_error(
+            "Statements are not allowed inside string interpolation. "
+            "Only expressions may appear inside '\\(...)'.",
+            meta, error_code="E009",
+        )
+    return body.expr
+
+
 class VeraTransformer(Transformer):
     """Transforms a Lark parse tree into Vera AST nodes."""
 
@@ -219,8 +312,10 @@ class VeraTransformer(Transformer):
     def FLOAT_LIT(self, token: Token) -> float:
         return float(token)
 
-    def STRING_LIT(self, token: Token) -> str:
+    def STRING_LIT(self, token: Token) -> str | list[str]:
         raw = str(token)[1:-1]  # Strip surrounding quotes
+        if _has_interpolation(raw):
+            return _split_interpolation(raw, token)
         return _decode_string_escapes(raw, token)
 
     # =================================================================
@@ -696,7 +791,24 @@ class VeraTransformer(Transformer):
 
     @v_args(meta=True)
     def string_lit(self, meta, children):
-        return StringLit(value=children[0], span=_span_from_meta(meta))
+        child = children[0]
+        if isinstance(child, list):
+            # Interpolated string — child is alternating [lit, expr, lit, ...]
+            span = _span_from_meta(meta)
+            resolved: list[str | Expr] = []
+            for i, segment in enumerate(child):
+                if i % 2 == 0:
+                    # Literal fragment — decode escapes
+                    resolved.append(
+                        _decode_string_escapes(segment, meta)
+                    )
+                else:
+                    # Expression — recursively parse
+                    resolved.append(_parse_interp_expr(segment, meta))
+            return InterpolatedString(
+                parts=tuple(resolved), span=span,
+            )
+        return StringLit(value=child, span=_span_from_meta(meta))
 
     @v_args(meta=True)
     def true_lit(self, meta, children):

--- a/vera/wasm/context.py
+++ b/vera/wasm/context.py
@@ -226,6 +226,9 @@ class WasmContext(
         if isinstance(expr, ast.StringLit):
             return self._translate_string_lit(expr)
 
+        if isinstance(expr, ast.InterpolatedString):
+            return self._translate_interpolated_string(expr, env)
+
         if isinstance(expr, ast.ResultRef):
             return self._translate_result_ref()
 
@@ -373,6 +376,8 @@ class WasmContext(
         calls returning i32_pair all produce two values.
         """
         if isinstance(expr, ast.StringLit):
+            return True
+        if isinstance(expr, ast.InterpolatedString):
             return True
         if isinstance(expr, ast.ArrayLit):
             return True

--- a/vera/wasm/inference.py
+++ b/vera/wasm/inference.py
@@ -151,6 +151,8 @@ class InferenceMixin:
             return "i32_pair"
         if isinstance(expr, ast.StringLit):
             return "i32_pair"
+        if isinstance(expr, ast.InterpolatedString):
+            return "i32_pair"
         if isinstance(expr, ast.QualifiedCall):
             return self._infer_qualified_call_wasm_type(expr)
         if isinstance(expr, (ast.ForallExpr, ast.ExistsExpr)):
@@ -300,6 +302,8 @@ class InferenceMixin:
             return self._infer_qualified_call_wasm_type(expr)
         if isinstance(expr, ast.StringLit):
             return "i32_pair"
+        if isinstance(expr, ast.InterpolatedString):
+            return "i32_pair"
         if isinstance(expr, ast.Block):
             return self._infer_block_result_type(expr)
         if isinstance(expr, ast.ConstructorCall):
@@ -350,6 +354,8 @@ class InferenceMixin:
         if isinstance(expr, ast.FnCall):
             return self._infer_fncall_vera_type(expr)
         if isinstance(expr, ast.StringLit):
+            return "String"
+        if isinstance(expr, ast.InterpolatedString):
             return "String"
         if isinstance(expr, ast.ArrayLit):
             return "Array"

--- a/vera/wasm/operators.py
+++ b/vera/wasm/operators.py
@@ -218,6 +218,75 @@ class OperatorsMixin:
         return [f"i32.const {offset}", f"i32.const {length}"]
 
     # -----------------------------------------------------------------
+    # String interpolation
+    # -----------------------------------------------------------------
+
+    # Type -> to_string builtin dispatch (must match checker's map)
+    _INTERP_TO_STRING: dict[str, str] = {
+        "Int": "to_string",
+        "Nat": "nat_to_string",
+        "Bool": "bool_to_string",
+        "Byte": "byte_to_string",
+        "Float64": "float_to_string",
+    }
+
+    def _translate_interpolated_string(
+        self, expr: ast.InterpolatedString, env: "WasmSlotEnv",
+    ) -> list[str] | None:
+        """Translate an interpolated string to a chain of string_concat calls.
+
+        Desugars at the WASM level: ``"a\\(x)b"`` becomes
+        ``string_concat(string_concat("a", to_string(x)), "b")``.
+        Each part is translated to ``(ptr, len)`` on the stack, then
+        folded left with ``string_concat``.
+        """
+        # Collect non-empty parts as AST nodes ready for translation
+        parts: list[ast.Expr] = []
+        for p in expr.parts:
+            if isinstance(p, str):
+                if p:  # skip empty string fragments
+                    parts.append(ast.StringLit(value=p, span=expr.span))
+            else:
+                # Determine Vera type for auto-conversion
+                vera_type = self._infer_vera_type(p)
+                if vera_type == "String":
+                    parts.append(p)
+                elif vera_type in self._INTERP_TO_STRING:
+                    # Wrap with the appropriate to_string call
+                    fn_name = self._INTERP_TO_STRING[vera_type]
+                    parts.append(ast.FnCall(
+                        name=fn_name, args=(p,), span=expr.span,
+                    ))
+                else:
+                    # Fallback: try to_string (Int-compatible types)
+                    parts.append(ast.FnCall(
+                        name="to_string", args=(p,), span=expr.span,
+                    ))
+
+        if not parts:
+            # All fragments were empty -> empty string
+            offset, length = self.string_pool.intern("")
+            return [f"i32.const {offset}", f"i32.const {length}"]
+
+        if len(parts) == 1:
+            # Single part -- translate directly
+            return self.translate_expr(parts[0], env)
+
+        # Left-fold with string_concat: concat(concat(a, b), c) ...
+        result = ast.FnCall(
+            name="string_concat",
+            args=(parts[0], parts[1]),
+            span=expr.span,
+        )
+        for part in parts[2:]:
+            result = ast.FnCall(
+                name="string_concat",
+                args=(result, part),
+                span=expr.span,
+            )
+        return self.translate_expr(result, env)
+
+    # -----------------------------------------------------------------
     # Result references (postconditions)
     # -----------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Closes #230. Adds Swift-style `\(expr)` string interpolation — the fourth and final item in the string builtins roadmap (#198 → #210 → #213 → **#230**).

- **Syntax**: `"hello \(@String.0)"`, `"x = \(@Int.0)"`, `"a=\(@Int.1), b=\(@Int.0)"`
- **Auto-conversion**: Non-String expressions of type Int, Nat, Bool, Byte, Float64 are auto-wrapped with the appropriate `*_to_string` built-in
- **Canonical form**: `InterpolatedString` is a first-class AST node that survives formatting (no desugaring to `string_concat` chains at source level)
- **Full pipeline**: Touches every compiler stage — transformer, type checker (E148 for unsupported types), formatter, WASM codegen
- **Limitation**: Expressions inside `\(...)` cannot contain string literals (regex lexer limitation; use `let` bindings)

### Files changed (21 files, +682/-40)

**Compiler core** (9 files):
- `vera/ast.py` — `InterpolatedString` dataclass + `format_expr` update
- `vera/transform.py` — `_split_interpolation`, `_parse_interp_expr`, `STRING_LIT`/`string_lit` handlers
- `vera/checker/expressions.py` — type synthesis with `_TO_STRING_TYPES` auto-conversion map
- `vera/errors.py` — E148 error code
- `vera/formatter.py` — round-trip `\(expr)` rendering
- `vera/wasm/inference.py` — `InterpolatedString` → `i32_pair` in 3 dispatchers
- `vera/wasm/context.py` — expression dispatcher + `_is_pair_expr`
- `vera/wasm/operators.py` — `_translate_interpolated_string` (desugars to synthetic FnCall nodes)
- `vera/codegen/modules.py` — guard rail recurse into interpolation parts

**Tests** (18 new tests):
- 9 type checker tests (auto-conversion for all types, unsupported type error, multiple exprs)
- 9 codegen end-to-end tests (basic string, int/bool/nat/float conversion, multiple parts, nested fn calls)
- New conformance test `ch04_string_interpolation` (conformance suite: 43→44 programs)

**Documentation**:
- Spec §1.4 "String Interpolation" and §4.13.1 "String Interpolation"
- SKILL.md interpolation examples
- CHANGELOG v0.0.76

## Test plan

- [x] `mypy vera/` — clean (41 source files)
- [x] `pytest tests/ -v` — 1,899 tests collected, 1,893 passed, 6 skipped, 0 failed
- [x] `python scripts/check_conformance.py` — all 44 conformance programs pass
- [x] `python scripts/check_examples.py` — all 18 examples pass
- [x] `python scripts/check_spec_examples.py` — all spec code blocks pass
- [x] `python scripts/check_skill_examples.py` — all SKILL.md code blocks pass
- [x] `python scripts/check_version_sync.py` — version 0.0.76 consistent
- [x] Pre-commit hooks pass (mypy, pytest, conformance, examples, allowlists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)