### PR TITLE
Update docs: technical decisions, one-pager, parsing spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -770,6 +770,10 @@ For compiler architecture, pipeline internals, design patterns, and how to exten
 | Diagnostics | Structured JSON with `--json` flag | Machine-readable errors with locations, fix suggestions, and spec references |
 | Testing | Contract-driven via Z3 + WASM (`vera test`) | Generate test inputs from contracts, no manual test cases |
 | Formatting | Canonical formatter (`vera fmt`) | One canonical form, enforced by tooling |
+| Error handling | `Result<T, E>` ADTs, no exceptions | Errors are values; models handle every case via `match` |
+| Type annotations | Mandatory on all parameters and returns | No type inference across boundaries — explicitness over convenience |
+| Verification tiers | Proven (Tier 1) or runtime-checked (Tier 3) | Every contract is checked; unproven ones become runtime assertions, never silently dropped |
+| Naming | No user-chosen variable names | `@T.n` indices are the only binding mechanism — no naming decisions to hallucinate |
 
 ## Prior Art
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -576,6 +576,20 @@
             <div class="feature-desc">Cross-file imports with public/private visibility, verified contracts across module boundaries</div>
           </div>
         </div>
+        <div class="feature">
+          <div class="feature-marker"></div>
+          <div>
+            <div class="feature-title">Contract-driven testing</div>
+            <div class="feature-desc">Generate test inputs from contracts via <a href="https://www.microsoft.com/en-us/research/project/z3-3/">Z3</a>, compile and run through WASM &mdash; no manual test cases</div>
+          </div>
+        </div>
+        <div class="feature">
+          <div class="feature-marker"></div>
+          <div>
+            <div class="feature-title">Canonical formatter</div>
+            <div class="feature-desc">One canonical textual form, enforced by <code>vera fmt</code> &mdash; no style choices</div>
+          </div>
+        </div>
       </div>
     </div>
   </section>

--- a/scripts/check_spec_examples.py
+++ b/scripts/check_spec_examples.py
@@ -60,7 +60,7 @@ ALLOWLIST: dict[tuple[str, int], str] = {
     ("09-standard-library.md", 290): "FUTURE",   # fn classify — uses ++ (string concat)
     ("09-standard-library.md", 304): "FRAGMENT",  # length signature (no body)
     ("09-standard-library.md", 324): "FRAGMENT",  # array_push signature (no body)
-    ("09-standard-library.md", 834): "FRAGMENT",  # similarity signature (no body)
+    ("09-standard-library.md", 934): "FRAGMENT",  # similarity signature (no body)
 
     # =================================================================
     # FRAGMENT — heuristic false positives (look like declarations but
@@ -148,13 +148,19 @@ ALLOWLIST: dict[tuple[str, int], str] = {
     ("09-standard-library.md", 801): "FRAGMENT",  # from_char_code signature (no body)
     ("09-standard-library.md", 816): "FRAGMENT",  # string_repeat signature (no body)
 
+    # Chapter 9 — Parsing function signatures (no body)
+    ("09-standard-library.md", 844): "FRAGMENT",  # parse_nat signature (no body)
+    ("09-standard-library.md", 866): "FRAGMENT",  # parse_int signature (no body)
+    ("09-standard-library.md", 889): "FRAGMENT",  # parse_float64 signature (no body)
+    ("09-standard-library.md", 911): "FRAGMENT",  # parse_bool signature (no body)
+
     # Chapter 9 — Markdown stdlib type (future, uses MdBlock/MdInline types)
-    ("09-standard-library.md", 938): "FUTURE",   # md_parse(@String -> @Result<MdBlock, String>)
-    ("09-standard-library.md", 947): "FUTURE",   # md_render(@MdBlock -> @String)
-    ("09-standard-library.md", 958): "FUTURE",   # md_has_heading(@MdBlock, @Nat -> @Bool)
-    ("09-standard-library.md", 967): "FUTURE",   # md_has_code_block(@MdBlock, @String -> @Bool)
-    ("09-standard-library.md", 976): "FUTURE",   # md_extract_code_blocks(@MdBlock, @String -> @Array<String>)
-    ("09-standard-library.md", 1000): "FUTURE",   # convert_to_markdown(@String -> @Result<MdBlock, String>)
+    ("09-standard-library.md", 1038): "FUTURE",   # md_parse(@String -> @Result<MdBlock, String>)
+    ("09-standard-library.md", 1047): "FUTURE",   # md_render(@MdBlock -> @String)
+    ("09-standard-library.md", 1058): "FUTURE",   # md_has_heading(@MdBlock, @Nat -> @Bool)
+    ("09-standard-library.md", 1067): "FUTURE",   # md_has_code_block(@MdBlock, @String -> @Bool)
+    ("09-standard-library.md", 1076): "FUTURE",   # md_extract_code_blocks(@MdBlock, @String -> @Array<String>)
+    ("09-standard-library.md", 1100): "FUTURE",   # convert_to_markdown(@String -> @Result<MdBlock, String>)
 }
 
 

--- a/spec/09-standard-library.md
+++ b/spec/09-standard-library.md
@@ -827,7 +827,107 @@ string_repeat("hello", 0)                -- "" (empty)
 string_repeat("", 100)                   -- "" (empty)
 ```
 
-### 9.6.8 similarity (Future)
+### 9.6.8 Parsing Functions
+
+Parsing functions convert strings to typed values, returning `Result<T, String>` to represent success or failure. All strip leading and trailing ASCII whitespace (spaces, tabs, `\r`, `\n`) before parsing. All are pure and Tier 3 for verification.
+
+The `Result` type used by parsing functions is the standard ADT:
+
+```vera
+private data Result<T, E> { Ok(T), Err(E) }
+```
+
+On success, the `Ok` variant contains the parsed value. On failure, the `Err` variant contains a descriptive error message string.
+
+#### parse_nat
+
+```vera
+public fn parse_nat(@String -> @Result<Nat, String>)
+  requires(true) ensures(true) effects(pure)
+```
+
+Parses a non-negative integer from a string. After stripping whitespace, the remaining characters must all be ASCII digits (`0`–`9`). Leading zeros are permitted (e.g., `"007"` parses as `7`).
+
+Error messages:
+- `"empty string"` — the input is empty or contains only whitespace
+- `"invalid digit"` — a non-digit character was encountered
+
+```vera
+parse_nat("42")        -- Ok(42)
+parse_nat("  7  ")     -- Ok(7)   (whitespace stripped)
+parse_nat("007")       -- Ok(7)   (leading zeros allowed)
+parse_nat("abc")       -- Err("invalid digit")
+parse_nat("")          -- Err("empty string")
+parse_nat("  ")        -- Err("empty string")
+```
+
+#### parse_int
+
+```vera
+public fn parse_int(@String -> @Result<Int, String>)
+  requires(true) ensures(true) effects(pure)
+```
+
+Parses a signed integer from a string. After stripping whitespace, an optional leading `+` or `-` sign is consumed. The remaining characters must all be ASCII digits (`0`–`9`). A bare sign with no digits (e.g., `"-"`) is an error.
+
+Error messages:
+- `"empty string"` — the input is empty or contains only whitespace
+- `"invalid character"` — a non-digit character was encountered (after any sign)
+
+```vera
+parse_int("42")        -- Ok(42)
+parse_int("-7")        -- Ok(-7)
+parse_int("+3")        -- Ok(3)
+parse_int("  -42  ")   -- Ok(-42) (whitespace stripped)
+parse_int("abc")       -- Err("invalid character")
+parse_int("-")         -- Err("invalid character")
+parse_int("")          -- Err("empty string")
+```
+
+#### parse_float64
+
+```vera
+public fn parse_float64(@String -> @Result<Float64, String>)
+  requires(true) ensures(true) effects(pure)
+```
+
+Parses a 64-bit floating-point number from a string. After stripping whitespace, an optional leading `-` sign is consumed, followed by one or more digits, an optional decimal point with additional digits, and an optional exponent (`e` or `E` followed by an optional sign and digits). At least one digit must appear in the integer part.
+
+Error messages:
+- `"empty string"` — the input is empty or contains only whitespace
+- `"invalid character"` — a non-digit, non-`.`, non-`e`/`E` character was encountered
+
+```vera
+parse_float64("3.14")      -- Ok(3.14)
+parse_float64("-2.5")      -- Ok(-2.5)
+parse_float64("42")        -- Ok(42.0)
+parse_float64("  1.0  ")   -- Ok(1.0) (whitespace stripped)
+parse_float64("abc")       -- Err("invalid character")
+parse_float64("")          -- Err("empty string")
+```
+
+#### parse_bool
+
+```vera
+public fn parse_bool(@String -> @Result<Bool, String>)
+  requires(true) ensures(true) effects(pure)
+```
+
+Parses a boolean from a string. After stripping whitespace, the remaining content must be exactly `"true"` or `"false"` (strict lowercase). No other forms are accepted — `"True"`, `"TRUE"`, `"yes"`, `"1"`, etc. all produce errors. This strictness prevents ambiguity when models generate boolean values.
+
+Error messages:
+- `"expected true or false"` — the input does not match `"true"` or `"false"` after whitespace stripping
+
+```vera
+parse_bool("true")         -- Ok(true)
+parse_bool("false")        -- Ok(false)
+parse_bool("  true  ")     -- Ok(true) (whitespace stripped)
+parse_bool("True")         -- Err("expected true or false")
+parse_bool("yes")          -- Err("expected true or false")
+parse_bool("")             -- Err("expected true or false")
+```
+
+### 9.6.9 similarity (Future)
 
 > **Status: Not yet implemented.** Will be introduced alongside the `Inference` effect ([#61](https://github.com/aallan/vera/issues/61)).
 


### PR DESCRIPTION
## Summary

- **README.md**: Add 4 rows to the Technical Decisions table — error handling (`Result<T, E>` ADTs), type annotations (mandatory on all params/returns), verification tiers (Tier 1 proven / Tier 3 runtime), and naming (no user-chosen variables)
- **docs/index.html**: Add 2 features to the Key Features grid — contract-driven testing (Z3 → WASM) and canonical formatter (`vera fmt`)
- **spec/09-standard-library.md**: Add §9.6.8 Parsing Functions documenting `parse_nat`, `parse_int`, `parse_float64`, and `parse_bool` with signatures, behavior descriptions, examples, and error messages. Shift existing §9.6.8 similarity → §9.6.9

## Test plan

- [x] `python scripts/check_spec_examples.py` — all 299 spec code blocks pass
- [x] `python scripts/check_conformance.py` — all 45 conformance programs pass
- [x] `python scripts/check_examples.py` — all 18 examples pass
- [x] `python scripts/check_readme_examples.py` — all README blocks pass
- [x] `mypy vera/` — clean
- [x] `pytest tests/ -v` — 1,920 passed, 6 skipped
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)