### PR TITLE
Add base64 encoding and decoding builtins (close #234)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.79] - 2026-03-10
+
+### Added
+- **Close #234: Base64 encoding and decoding** ([#234](https://github.com/aallan/vera/issues/234)):
+  New `base64_encode(@String -> @String)` — standard Base64 (RFC 4648) encoding.
+  New `base64_decode(@String -> @Result<String, String>)` — Base64 decoding with
+  error handling for invalid length or characters.
+- New conformance test `ch09_base64` (conformance suite: 46→47 programs)
+- New example `examples/base64.vera` — encode, decode, and round-trip demo
+- 20 new tests (4 type checker + 16 codegen)
+
 ## [0.0.78] - 2026-03-10
 
 ### Added
@@ -1200,7 +1211,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Grammar: handler body simplified to avoid LALR reduce/reduce conflict
 - `pyproject.toml`: corrected build backend, package discovery, PEP 639 compliance
 
-[Unreleased]: https://github.com/aallan/vera/compare/v0.0.78...HEAD
+[Unreleased]: https://github.com/aallan/vera/compare/v0.0.79...HEAD
+[0.0.79]: https://github.com/aallan/vera/compare/v0.0.78...v0.0.79
 [0.0.78]: https://github.com/aallan/vera/compare/v0.0.77...v0.0.78
 [0.0.77]: https://github.com/aallan/vera/compare/v0.0.76...v0.0.77
 [0.0.76]: https://github.com/aallan/vera/compare/v0.0.75...v0.0.76

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ The language specification is in draft across 13 chapters:
 
 ### Testing
 
-Testing is organized in three layers: **unit tests** (1,943 tests across 20 files, testing compiler internals), a **conformance suite** (46 programs across 8 spec chapters, systematically validating every language feature against the spec), and **example programs** (18 end-to-end demos). The compiler has 90% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations. Every commit validates all conformance programs, example programs, and 95 specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference -- coverage tables, conformance suite details, CI pipeline, and infrastructure.
+Testing is organized in three layers: **unit tests** (1,978 tests across 20 files, testing compiler internals), a **conformance suite** (47 programs across 9 spec chapters, systematically validating every language feature against the spec), and **example programs** (19 end-to-end demos). The compiler has 90% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations. Every commit validates all conformance programs, example programs, and 95 specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference -- coverage tables, conformance suite details, CI pipeline, and infrastructure.
 
 ## Roadmap
 
@@ -324,7 +324,7 @@ Module refinements, lexical extensions, and IO runtime — completing the existi
 - <del>[#230](https://github.com/aallan/vera/issues/230) string interpolation</del> ([v0.0.76](https://github.com/aallan/vera/releases/tag/v0.0.76))
 - [#231](https://github.com/aallan/vera/issues/231) regex support
 - [#232](https://github.com/aallan/vera/issues/232) URL parsing and construction builtins
-- [#234](https://github.com/aallan/vera/issues/234) base64 encoding and decoding
+- <del>[#234](https://github.com/aallan/vera/issues/234) base64 encoding and decoding</del>
 
 **Module system** — sequential dependency (#187 before #127)
 
@@ -453,7 +453,7 @@ OK: examples/safe_divide.vera
 Verification: 4 verified (Tier 1)
 ```
 
-`vera verify` runs the type checker and then verifies contracts using Z3. Tier 1 contracts (decidable arithmetic, comparisons, Boolean logic, match expressions, ADT constructors, and decreases clauses) are proved automatically. Contracts that Z3 cannot decide are reported as Tier 3 (runtime checks) with a warning. Across all 18 examples, 118 of 122 contracts (96.7%) are verified statically.
+`vera verify` runs the type checker and then verifies contracts using Z3. Tier 1 contracts (decidable arithmetic, comparisons, Boolean logic, match expressions, ADT constructors, and decreases clauses) are proved automatically. Contracts that Z3 cannot decide are reported as Tier 3 (runtime checks) with a warning. Across all 19 examples, 120 of 124 contracts (96.8%) are verified statically.
 
 ### Format a program
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -412,6 +412,8 @@ parse_nat(@String.0)                    -- returns Result<Nat, String>
 parse_int(@String.0)                    -- returns Result<Int, String>
 parse_float64(@String.0)                -- returns Result<Float64, String>
 parse_bool(@String.0)                   -- returns Result<Bool, String>
+base64_encode(@String.0)                -- returns String (RFC 4648)
+base64_decode(@String.0)                -- returns Result<String, String>
 to_string(@Int.0)                       -- returns String (integer to decimal)
 int_to_string(@Int.0)                   -- returns String (alias for to_string)
 bool_to_string(@Bool.0)                 -- returns String ("true" or "false")
@@ -456,7 +458,7 @@ join(@Array<String>.0, @String.0)               -- returns String (join with sep
 
 `to_upper` and `to_lower` convert ASCII letters only (a-z ↔ A-Z). `replace` substitutes all non-overlapping occurrences; an empty needle returns the original string unchanged. `split` returns an array of segments; an empty delimiter returns a single-element array. `join` concatenates array elements with the separator between each pair.
 
-String functions use the heap allocator (`$alloc`). Memory is managed automatically by a conservative mark-sweep garbage collector — there is no manual allocation or deallocation. All four parse functions return `Result<T, String>`: `parse_nat`, `parse_int`, `parse_float64`, and `parse_bool`. They return `Ok(value)` on valid input and `Err(msg)` on empty or invalid input; leading and trailing spaces are tolerated. `parse_int` accepts an optional `+` or `-` sign. `parse_bool` is strict: only `"true"` and `"false"` (lowercase) are valid.
+String functions use the heap allocator (`$alloc`). Memory is managed automatically by a conservative mark-sweep garbage collector — there is no manual allocation or deallocation. All four parse functions return `Result<T, String>`: `parse_nat`, `parse_int`, `parse_float64`, and `parse_bool`. They return `Ok(value)` on valid input and `Err(msg)` on empty or invalid input; leading and trailing spaces are tolerated. `parse_int` accepts an optional `+` or `-` sign. `parse_bool` is strict: only `"true"` and `"false"` (lowercase) are valid. `base64_encode` encodes a string to standard Base64 (RFC 4648); `base64_decode` returns `Result<String, String>`, failing on invalid length or characters.
 
 ### Numeric operations
 

--- a/examples/base64.vera
+++ b/examples/base64.vera
@@ -1,0 +1,22 @@
+-- Base64 encoding and decoding
+effect IO {
+  op print(String -> Unit);
+}
+
+private data Result<T, E> {
+  Ok(T),
+  Err(E)
+}
+
+public fn main(@Unit -> @Unit)
+  requires(true)
+  ensures(true)
+  effects(<IO>)
+{
+  IO.print(base64_encode("Hello, World!"));
+  match base64_decode("SGVsbG8sIFdvcmxkIQ==") { Ok(@String) -> IO.print(@String.0), Err(@String) -> IO.print(@String.0) };
+  match base64_decode(base64_encode("Hello, World!")) {
+    Ok(@String) -> IO.print(@String.0),
+    Err(@String) -> IO.print(@String.0)
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.78"
+version = "0.0.79"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/scripts/check_skill_examples.py
+++ b/scripts/check_skill_examples.py
@@ -40,67 +40,64 @@ ALLOWLIST: dict[int, tuple[str, str]] = {
     404: ("FRAGMENT", "String built-in examples, bare calls"),
 
     # String interpolation — bare expressions
-    426: ("FRAGMENT", "String interpolation examples, bare expressions"),
+    428: ("FRAGMENT", "String interpolation examples, bare expressions"),
 
     # String search — bare function calls
-    438: ("FRAGMENT", "String search built-in examples, bare calls"),
+    440: ("FRAGMENT", "String search built-in examples, bare calls"),
 
     # String transformation — bare function calls
-    449: ("FRAGMENT", "String transformation built-in examples, bare calls"),
+    451: ("FRAGMENT", "String transformation built-in examples, bare calls"),
 
     # Numeric operations — bare function calls
-    463: ("FRAGMENT", "Numeric built-in examples, bare calls"),
+    465: ("FRAGMENT", "Numeric built-in examples, bare calls"),
 
     # Contracts section — requires/ensures fragments
-    520: ("FRAGMENT", "Requires clause example, not full function"),
-    529: ("FRAGMENT", "Ensures clause example, not full function"),
-    556: ("FRAGMENT", "Quantified requires clause, not full function"),
+    522: ("FRAGMENT", "Requires clause example, not full function"),
+    531: ("FRAGMENT", "Ensures clause example, not full function"),
+    558: ("FRAGMENT", "Quantified requires clause, not full function"),
 
     # Effects section — bare effect rows
-    574: ("FRAGMENT", "Effect row examples, bare annotations"),
+    576: ("FRAGMENT", "Effect row examples, bare annotations"),
 
     # Effect handler syntax template
-    711: ("FRAGMENT", "Handler syntax template, not real code"),
+    713: ("FRAGMENT", "Handler syntax template, not real code"),
 
     # Qualified calls and handler fragments — bare expressions
-    723: ("FRAGMENT", "Handler with clause, bare expression"),
-    733: ("FRAGMENT", "Qualified call examples, bare expressions"),
+    725: ("FRAGMENT", "Handler with clause, bare expression"),
+    735: ("FRAGMENT", "Qualified call examples, bare expressions"),
 
     # Module declaration and import syntax
-    771: ("FRAGMENT", "Module declaration and import example"),
+    773: ("FRAGMENT", "Module declaration and import example"),
 
     # Line comments — bare comments
-    822: ("FRAGMENT", "Comment syntax example"),
+    824: ("FRAGMENT", "Comment syntax example"),
 
     # Type conversions — bare function calls
-    478: ("FRAGMENT", "Type conversion examples, bare calls"),
+    480: ("FRAGMENT", "Type conversion examples, bare calls"),
 
     # Float64 predicates — bare function calls
-    491: ("FRAGMENT", "Float64 predicate examples, bare calls"),
+    493: ("FRAGMENT", "Float64 predicate examples, bare calls"),
 
     # Common mistakes section — intentionally wrong code
-    850: ("FRAGMENT", "Wrong: missing contracts"),
-    857: ("FRAGMENT", "Wrong: incorrect contract syntax"),
-    870: ("FRAGMENT", "Wrong: missing requires"),
-    857: ("FRAGMENT", "Wrong: missing effects clause"),
-    870: ("FRAGMENT", "Wrong: wrong effect declared"),
-    904: ("FRAGMENT", "Wrong: bare expression without indices"),
-    917: ("FRAGMENT", "Wrong: bare expression no indices"),
-    922: ("FRAGMENT", "Correct: expression with indices (not full fn)"),
-    988: ("FRAGMENT", "Wrong: match arm with incorrect return"),
-    1012: ("FRAGMENT", "Wrong: non-exhaustive match"),
-    1019: ("FRAGMENT", "Correct: match arm example"),
-    1029: ("FRAGMENT", "Wrong: if/else without braces (bare expression)"),
-    1034: ("FRAGMENT", "Correct: if/else with braces"),
+    852: ("FRAGMENT", "Wrong: missing contracts"),
+    872: ("FRAGMENT", "Wrong: missing effects clause"),
+    906: ("FRAGMENT", "Wrong: bare expression without indices"),
+    919: ("FRAGMENT", "Wrong: bare expression no indices"),
+    924: ("FRAGMENT", "Correct: expression with indices (not full fn)"),
+    990: ("FRAGMENT", "Wrong: match arm with incorrect return"),
+    1014: ("FRAGMENT", "Wrong: non-exhaustive match"),
+    1021: ("FRAGMENT", "Correct: match arm example"),
+    1031: ("FRAGMENT", "Wrong: if/else without braces (bare expression)"),
+    1036: ("FRAGMENT", "Correct: if/else with braces"),
 
     # Import syntax — intentionally unsupported
-    1045: ("FRAGMENT", "Wrong: import aliasing not supported"),
-    1050: ("FRAGMENT", "Correct: import syntax example"),
-    1060: ("FRAGMENT", "Wrong: import hiding not supported"),
-    1065: ("FRAGMENT", "Correct: multi-import syntax"),
+    1047: ("FRAGMENT", "Wrong: import aliasing not supported"),
+    1052: ("FRAGMENT", "Correct: import syntax example"),
+    1062: ("FRAGMENT", "Wrong: import hiding not supported"),
+    1067: ("FRAGMENT", "Correct: multi-import syntax"),
 
     # String escapes — bare expression
-    1079: ("FRAGMENT", "String escape example"),
+    1081: ("FRAGMENT", "String escape example"),
 
     # =================================================================
     # MISMATCH — uses syntax the parser doesn't handle in isolation.

--- a/scripts/check_spec_examples.py
+++ b/scripts/check_spec_examples.py
@@ -157,16 +157,20 @@ ALLOWLIST: dict[tuple[str, int], str] = {
     ("09-standard-library.md", 925): "FRAGMENT",  # parse_float64 signature (no body)
     ("09-standard-library.md", 947): "FRAGMENT",  # parse_bool signature (no body)
 
+    # Chapter 9 — Base64 builtin signatures (no body)
+    ("09-standard-library.md", 970): "FRAGMENT",  # base64_encode signature (no body)
+    ("09-standard-library.md", 989): "FRAGMENT",  # base64_decode signature (no body)
+
     # Chapter 9 — ML/vector builtin signatures (no body)
-    ("09-standard-library.md", 970): "FRAGMENT",  # similarity signature (no body)
+    ("09-standard-library.md", 1016): "FRAGMENT",  # similarity signature (no body)
 
     # Chapter 9 — Markdown stdlib type (future, uses MdBlock/MdInline types)
-    ("09-standard-library.md", 1074): "FUTURE",   # md_parse(@String -> @Result<MdBlock, String>)
-    ("09-standard-library.md", 1083): "FUTURE",   # md_render(@MdBlock -> @String)
-    ("09-standard-library.md", 1094): "FUTURE",   # md_has_heading(@MdBlock, @Nat -> @Bool)
-    ("09-standard-library.md", 1103): "FUTURE",   # md_has_code_block(@MdBlock, @String -> @Bool)
-    ("09-standard-library.md", 1112): "FUTURE",   # md_extract_code_blocks(@MdBlock, @String -> @Array<String>)
-    ("09-standard-library.md", 1136): "FUTURE",   # convert_to_markdown(@String -> @Result<MdBlock, String>)
+    ("09-standard-library.md", 1120): "FUTURE",   # md_parse(@String -> @Result<MdBlock, String>)
+    ("09-standard-library.md", 1129): "FUTURE",   # md_render(@MdBlock -> @String)
+    ("09-standard-library.md", 1140): "FUTURE",   # md_has_heading(@MdBlock, @Nat -> @Bool)
+    ("09-standard-library.md", 1149): "FUTURE",   # md_has_code_block(@MdBlock, @String -> @Bool)
+    ("09-standard-library.md", 1158): "FUTURE",   # md_extract_code_blocks(@MdBlock, @String -> @Array<String>)
+    ("09-standard-library.md", 1182): "FUTURE",   # convert_to_markdown(@String -> @Result<MdBlock, String>)
 }
 
 

--- a/spec/04-expressions.md
+++ b/spec/04-expressions.md
@@ -330,6 +330,8 @@ parse_int(@String.0)                    -- returns Result<Int, String>
 parse_float64(@String.0)                -- returns Result<Float64, String>
 parse_bool(@String.0)                   -- returns Result<Bool, String>
                                         -- strict: only "true" and "false" are valid
+base64_encode(@String.0)                -- returns String (RFC 4648)
+base64_decode(@String.0)                -- returns Result<String, String>
 to_string(@Int.0)                       -- returns String
 int_to_string(@Int.0)                   -- returns String (alias for to_string)
 bool_to_string(@Bool.0)                 -- returns String ("true" or "false")

--- a/spec/09-standard-library.md
+++ b/spec/09-standard-library.md
@@ -963,7 +963,53 @@ parse_bool("yes")          -- Err("expected true or false")
 parse_bool("")             -- Err("expected true or false")
 ```
 
-### 9.6.11 similarity (Future)
+### 9.6.11 Base64
+
+#### base64\_encode
+
+```
+public fn base64_encode(@String -> @String)
+  requires(true)
+  ensures(string_length(@String.result) == ((string_length(@String.0) + 2) / 3) * 4
+          || string_length(@String.0) == 0 && string_length(@String.result) == 0)
+  effects(pure)
+```
+
+Encodes a UTF-8 string to standard Base64 (RFC 4648). Every 3 input bytes produce 4 output characters from the alphabet `A`–`Z`, `a`–`z`, `0`–`9`, `+`, `/`. Remaining 1–2 bytes are padded with `=`. An empty input produces an empty string.
+
+```vera
+base64_encode("Hello, World!")   -- "SGVsbG8sIFdvcmxkIQ=="
+base64_encode("ABC")             -- "QUJD"
+base64_encode("A")               -- "QQ=="
+base64_encode("")                 -- ""
+```
+
+#### base64\_decode
+
+```
+public fn base64_decode(@String -> @Result<String, String>)
+  requires(true)
+  ensures(true)
+  effects(pure)
+```
+
+Decodes a standard Base64 string (RFC 4648) to its original UTF-8 bytes. Returns `Ok(String)` on success or `Err(String)` with an error message on failure.
+
+**Error conditions:**
+
+- `"invalid base64 length"` — the input length is not a multiple of 4
+- `"invalid base64"` — the input contains characters outside the Base64 alphabet
+
+```vera
+base64_decode("QUJD")                  -- Ok("ABC")
+base64_decode("SGVsbG8sIFdvcmxkIQ==")  -- Ok("Hello, World!")
+base64_decode("QQ==")                  -- Ok("A")
+base64_decode("")                      -- Ok("")
+base64_decode("ABC")                   -- Err("invalid base64 length")
+base64_decode("QQ!!")                  -- Err("invalid base64")
+```
+
+### 9.6.12 similarity (Future)
 
 > **Status: Not yet implemented.** Will be introduced alongside the `Inference` effect ([#61](https://github.com/aallan/vera/issues/61)).
 

--- a/tests/conformance/ch09_base64.vera
+++ b/tests/conformance/ch09_base64.vera
@@ -1,0 +1,72 @@
+-- Conformance: base64_encode, base64_decode (Chapter 9)
+-- Tests: base64_encode, base64_decode returning Result<String, String>
+effect IO {
+  op print(String -> Unit);
+}
+
+private data Result<T, E> {
+  Ok(T),
+  Err(E)
+}
+
+public fn test_encode_empty(@Unit -> @Int)
+  requires(true)
+  ensures(@Int.result == 0)
+  effects(pure)
+{
+  string_length(base64_encode(""))
+}
+
+public fn test_encode_hello(@Unit -> @Int)
+  requires(true)
+  ensures(@Int.result == 8)
+  effects(pure)
+{
+  string_length(base64_encode("Hello"))
+}
+
+public fn test_decode_ok(@Unit -> @Int)
+  requires(true)
+  ensures(@Int.result == 3)
+  effects(pure)
+{
+  match base64_decode("QUJD") {
+    Ok(@String) -> string_length(@String.0),
+    Err(_) -> 0 - 1
+  }
+}
+
+public fn test_decode_err(@Unit -> @Int)
+  requires(true)
+  ensures(@Int.result == 1)
+  effects(pure)
+{
+  match base64_decode("ABC") {
+    Ok(_) -> 0,
+    Err(_) -> 1
+  }
+}
+
+public fn test_roundtrip(@Unit -> @Int)
+  requires(true)
+  ensures(@Int.result == 13)
+  effects(pure)
+{
+  match base64_decode(base64_encode("Hello, World!")) {
+    Ok(@String) -> string_length(@String.0),
+    Err(_) -> 0 - 1
+  }
+}
+
+public fn main(@Unit -> @Unit)
+  requires(true)
+  ensures(true)
+  effects(<IO>)
+{
+  IO.print(to_string(test_encode_empty(())));
+  IO.print(to_string(test_encode_hello(())));
+  IO.print(to_string(test_decode_ok(())));
+  IO.print(to_string(test_decode_err(())));
+  IO.print(to_string(test_roundtrip(())));
+  ()
+}

--- a/tests/conformance/manifest.json
+++ b/tests/conformance/manifest.json
@@ -412,5 +412,14 @@
     "level": "run",
     "spec_ref": "Section 4.6",
     "features": ["parse_int", "parse_bool", "parse_float64", "result_type"]
+  },
+  {
+    "id": "ch09_base64",
+    "file": "ch09_base64.vera",
+    "chapter": 9,
+    "title": "Base64 encoding and decoding",
+    "level": "run",
+    "spec_ref": "Section 9.6.5",
+    "features": ["base64_encode", "base64_decode", "result_type"]
   }
 ]

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -2614,6 +2614,35 @@ private fn f(@String -> @Bool)
 { parse_bool(@String.0) }
 """, "expected Bool")
 
+    def test_base64_encode_ok(self) -> None:
+        _check_ok("""
+private fn f(@String -> @String)
+  requires(true) ensures(true) effects(pure)
+{ base64_encode(@String.0) }
+""")
+
+    def test_base64_encode_wrong_type(self) -> None:
+        _check_err("""
+private fn f(@Int -> @String)
+  requires(true) ensures(true) effects(pure)
+{ base64_encode(@Int.0) }
+""", "expected String")
+
+    def test_base64_decode_ok(self) -> None:
+        _check_ok("""
+private data Result<T, E> { Ok(T), Err(E) }
+private fn f(@String -> @Result<String, String>)
+  requires(true) ensures(true) effects(pure)
+{ base64_decode(@String.0) }
+""")
+
+    def test_base64_decode_wrong_type(self) -> None:
+        _check_err("""
+private fn f(@Int -> @String)
+  requires(true) ensures(true) effects(pure)
+{ base64_decode(@Int.0) }
+""", "expected String")
+
     def test_to_string_ok(self) -> None:
         _check_ok("""
 private fn f(@Int -> @String)

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -4631,6 +4631,133 @@ public fn f(-> @Int) requires(true) ensures(true) effects(pure) {
         assert _run(src) == 22
 
 
+class TestBase64Encode:
+    """base64_encode returns String."""
+
+    def _prog(self, literal: str) -> str:
+        return f"""
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {{
+  string_length(base64_encode("{literal}"))
+}}
+"""
+
+    def _io_prog(self, literal: str) -> str:
+        return f"""
+effect IO {{ op print(String -> Unit); }}
+public fn f(@Unit -> @Unit) requires(true) ensures(true) effects(<IO>) {{
+  IO.print(base64_encode("{literal}"));
+  ()
+}}
+"""
+
+    def test_empty(self) -> None:
+        assert _run(self._prog("")) == 0
+
+    def test_one_byte(self) -> None:
+        # "A" -> "QQ==" (length 4)
+        assert _run_io(self._io_prog("A")) == "QQ=="
+
+    def test_two_bytes(self) -> None:
+        # "AB" -> "QUI=" (length 4)
+        assert _run_io(self._io_prog("AB")) == "QUI="
+
+    def test_three_bytes(self) -> None:
+        # "ABC" -> "QUJD" (length 4)
+        assert _run_io(self._io_prog("ABC")) == "QUJD"
+
+    def test_hello(self) -> None:
+        assert _run_io(self._io_prog("Hello")) == "SGVsbG8="
+
+    def test_hello_world(self) -> None:
+        assert _run_io(self._io_prog("Hello, World!")) == "SGVsbG8sIFdvcmxkIQ=="
+
+    def test_length_multiple_of_three(self) -> None:
+        # "abcdef" (6 bytes) -> "YWJjZGVm" (8 chars, no padding)
+        assert _run_io(self._io_prog("abcdef")) == "YWJjZGVm"
+
+
+class TestBase64Decode:
+    """base64_decode returns Result<String, String>."""
+
+    _PREAMBLE = """
+private data Result<T, E> { Ok(T), Err(E) }
+"""
+
+    def _ok_prog(self, literal: str) -> str:
+        return self._PREAMBLE + f"""
+effect IO {{ op print(String -> Unit); }}
+public fn f(@Unit -> @Unit) requires(true) ensures(true) effects(<IO>) {{
+  match base64_decode("{literal}") {{
+    Ok(@String) -> IO.print(@String.0),
+    Err(@String) -> IO.print(@String.0)
+  }}
+}}
+"""
+
+    def _ok_len_prog(self, literal: str) -> str:
+        return self._PREAMBLE + f"""
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {{
+  match base64_decode("{literal}") {{
+    Ok(@String) -> string_length(@String.0),
+    Err(_) -> 0 - 1
+  }}
+}}
+"""
+
+    def _err_prog(self, literal: str) -> str:
+        return self._PREAMBLE + f"""
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {{
+  match base64_decode("{literal}") {{
+    Ok(_) -> 0,
+    Err(_) -> 1
+  }}
+}}
+"""
+
+    def test_empty(self) -> None:
+        assert _run(self._ok_len_prog("")) == 0
+
+    def test_no_padding(self) -> None:
+        # "QUJD" -> "ABC"
+        assert _run_io(self._ok_prog("QUJD")) == "ABC"
+
+    def test_one_pad(self) -> None:
+        # "QUI=" -> "AB"
+        assert _run_io(self._ok_prog("QUI=")) == "AB"
+
+    def test_two_pad(self) -> None:
+        # "QQ==" -> "A"
+        assert _run_io(self._ok_prog("QQ==")) == "A"
+
+    def test_hello(self) -> None:
+        assert _run_io(self._ok_prog("SGVsbG8=")) == "Hello"
+
+    def test_hello_world(self) -> None:
+        assert _run_io(self._ok_prog("SGVsbG8sIFdvcmxkIQ==")) == "Hello, World!"
+
+    def test_invalid_length(self) -> None:
+        # "ABC" is not a multiple of 4
+        assert _run(self._err_prog("ABC")) == 1
+
+    def test_invalid_char(self) -> None:
+        # "QQ!!" contains invalid char '!'
+        assert _run(self._err_prog("QQ!!")) == 1
+
+    def test_roundtrip(self) -> None:
+        """Encode then decode round-trips correctly."""
+        src = self._PREAMBLE + """
+effect IO { op print(String -> Unit); }
+public fn f(@Unit -> @Unit) requires(true) ensures(true) effects(<IO>) {
+  let @String = base64_encode("Hello, World!");
+  match base64_decode(@String.0) {
+    Ok(@String) -> IO.print(@String.0),
+    Err(@String) -> IO.print(@String.0)
+  }
+}
+"""
+        assert _run_io(src) == "Hello, World!"
+
+
 class TestToString:
     def test_positive(self) -> None:
         src = """

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -1480,9 +1480,9 @@ private fn sum(@List<Int> -> @Int)
             t1 += result.summary.tier1_verified
             t3 += result.summary.tier3_runtime
             total += result.summary.total
-        assert t1 == 117, f"Expected 117 T1, got {t1}"
+        assert t1 == 119, f"Expected 119 T1, got {t1}"
         assert t3 == 5, f"Expected 5 T3, got {t3}"
-        assert total == 122, f"Expected 122 total, got {total}"
+        assert total == 124, f"Expected 124 total, got {total}"
 
 
 # =====================================================================

--- a/vera/README.md
+++ b/vera/README.md
@@ -306,6 +306,8 @@ Context flags (`in_ensures`, `in_contract`, `current_return_type`, `current_effe
 | `parse_int` | Function | `String → Result<Int, String>`, pure |
 | `parse_float64` | Function | `String → Result<Float64, String>`, pure |
 | `parse_bool` | Function | `String → Result<Bool, String>`, pure |
+| `base64_encode` | Function | `String → String`, pure (RFC 4648) |
+| `base64_decode` | Function | `String → Result<String, String>`, pure |
 | `to_string` | Function | `Int → String`, pure |
 | `int_to_string` | Function | `Int → String`, pure (alias for `to_string`) |
 | `bool_to_string` | Function | `Bool → String`, pure |

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.78"
+__version__ = "0.0.79"

--- a/vera/codegen/modules.py
+++ b/vera/codegen/modules.py
@@ -241,6 +241,7 @@ class CrossModuleMixin:
             "string_length", "string_concat", "string_slice",
             "char_code", "from_char_code", "string_repeat",
             "parse_nat", "parse_int", "parse_float64", "parse_bool",
+            "base64_encode", "base64_decode",
             "to_string", "int_to_string", "bool_to_string",
             "nat_to_string", "byte_to_string", "float_to_string",
             "strip",

--- a/vera/environment.py
+++ b/vera/environment.py
@@ -328,6 +328,20 @@ class TypeEnv:
             return_type=AdtType("Result", (BOOL, STRING)),
             effect=PureEffectRow(),
         )
+        self.functions["base64_encode"] = FunctionInfo(
+            name="base64_encode",
+            forall_vars=None,
+            param_types=(STRING,),
+            return_type=STRING,
+            effect=PureEffectRow(),
+        )
+        self.functions["base64_decode"] = FunctionInfo(
+            name="base64_decode",
+            forall_vars=None,
+            param_types=(STRING,),
+            return_type=AdtType("Result", (STRING, STRING)),
+            effect=PureEffectRow(),
+        )
         self.functions["to_string"] = FunctionInfo(
             name="to_string",
             forall_vars=None,

--- a/vera/wasm/calls.py
+++ b/vera/wasm/calls.py
@@ -58,6 +58,10 @@ class CallsMixin:
                 return self._translate_parse_float64(call.args[0], env)
             if call.name == "parse_bool" and len(call.args) == 1:
                 return self._translate_parse_bool(call.args[0], env)
+            if call.name == "base64_encode" and len(call.args) == 1:
+                return self._translate_base64_encode(call.args[0], env)
+            if call.name == "base64_decode" and len(call.args) == 1:
+                return self._translate_base64_decode(call.args[0], env)
             if call.name == "to_string" and len(call.args) == 1:
                 return self._translate_to_string(call.args[0], env)
             if call.name == "int_to_string" and len(call.args) == 1:
@@ -2025,6 +2029,696 @@ class CallsMixin:
         ins.append("i32.store offset=8")    # string len
 
         ins.append("end")  # block $done_pf
+
+        ins.append(f"local.get {out}")
+        return ins
+
+    # -----------------------------------------------------------------
+    # Base64 encoding / decoding (RFC 4648)
+    # -----------------------------------------------------------------
+
+    def _translate_base64_encode(
+        self, arg: ast.Expr, env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """Translate base64_encode(s) → String (i32_pair).
+
+        Every 3 input bytes produce 4 output chars from the standard
+        Base64 alphabet.  Remaining 1 or 2 bytes are padded with '='.
+        """
+        arg_instrs = self.translate_expr(arg, env)
+        if arg_instrs is None:
+            return None
+
+        self.needs_alloc = True
+
+        # Intern the Base64 alphabet in the string pool so we can
+        # look up output characters by 6-bit index.
+        alpha_off, _ = self.string_pool.intern(
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+        )
+        empty_off, empty_len = self.string_pool.intern("")
+
+        ptr = self.alloc_local("i32")
+        slen = self.alloc_local("i32")
+        dst = self.alloc_local("i32")
+        out_len = self.alloc_local("i32")
+        i = self.alloc_local("i32")   # input index
+        j = self.alloc_local("i32")   # output index
+        b0 = self.alloc_local("i32")
+        b1 = self.alloc_local("i32")
+        b2 = self.alloc_local("i32")
+        rem = self.alloc_local("i32")
+        full = self.alloc_local("i32")  # slen - remainder
+
+        ins: list[str] = []
+
+        # Evaluate string arg → (ptr, len)
+        ins.extend(arg_instrs)
+        ins.append(f"local.set {slen}")
+        ins.append(f"local.set {ptr}")
+
+        # Empty input → empty output
+        ins.append(f"local.get {slen}")
+        ins.append("i32.eqz")
+        ins.append("if (result i32 i32)")
+        ins.append(f"  i32.const {empty_off}")
+        ins.append(f"  i32.const {empty_len}")
+        ins.append("else")
+
+        # out_len = ((slen + 2) / 3) * 4
+        ins.append(f"local.get {slen}")
+        ins.append("i32.const 2")
+        ins.append("i32.add")
+        ins.append("i32.const 3")
+        ins.append("i32.div_u")
+        ins.append("i32.const 4")
+        ins.append("i32.mul")
+        ins.append(f"local.set {out_len}")
+
+        # Allocate output buffer
+        ins.append(f"local.get {out_len}")
+        ins.append("call $alloc")
+        ins.append(f"local.set {dst}")
+        ins.extend(gc_shadow_push(dst))
+
+        # rem = slen % 3; full = slen - rem
+        ins.append(f"local.get {slen}")
+        ins.append("i32.const 3")
+        ins.append("i32.rem_u")
+        ins.append(f"local.set {rem}")
+        ins.append(f"local.get {slen}")
+        ins.append(f"local.get {rem}")
+        ins.append("i32.sub")
+        ins.append(f"local.set {full}")
+
+        # --- Main loop: process complete 3-byte groups ----------------
+        ins.append("i32.const 0")
+        ins.append(f"local.set {i}")
+        ins.append("i32.const 0")
+        ins.append(f"local.set {j}")
+        ins.append("block $brk_e3")
+        ins.append("  loop $lp_e3")
+        ins.append(f"    local.get {i}")
+        ins.append(f"    local.get {full}")
+        ins.append("    i32.ge_u")
+        ins.append("    br_if $brk_e3")
+
+        # Load b0, b1, b2
+        ins.append(f"    local.get {ptr}")
+        ins.append(f"    local.get {i}")
+        ins.append("    i32.add")
+        ins.append("    i32.load8_u offset=0")
+        ins.append(f"    local.set {b0}")
+        ins.append(f"    local.get {ptr}")
+        ins.append(f"    local.get {i}")
+        ins.append("    i32.add")
+        ins.append("    i32.load8_u offset=1")
+        ins.append(f"    local.set {b1}")
+        ins.append(f"    local.get {ptr}")
+        ins.append(f"    local.get {i}")
+        ins.append("    i32.add")
+        ins.append("    i32.load8_u offset=2")
+        ins.append(f"    local.set {b2}")
+
+        # Output char 0: alphabet[b0 >> 2]
+        ins.append(f"    local.get {dst}")
+        ins.append(f"    local.get {j}")
+        ins.append("    i32.add")
+        ins.append(f"    i32.const {alpha_off}")
+        ins.append(f"    local.get {b0}")
+        ins.append("    i32.const 2")
+        ins.append("    i32.shr_u")
+        ins.append("    i32.add")
+        ins.append("    i32.load8_u offset=0")
+        ins.append("    i32.store8 offset=0")
+
+        # Output char 1: alphabet[((b0 & 3) << 4) | (b1 >> 4)]
+        ins.append(f"    local.get {dst}")
+        ins.append(f"    local.get {j}")
+        ins.append("    i32.add")
+        ins.append(f"    i32.const {alpha_off}")
+        ins.append(f"    local.get {b0}")
+        ins.append("    i32.const 3")
+        ins.append("    i32.and")
+        ins.append("    i32.const 4")
+        ins.append("    i32.shl")
+        ins.append(f"    local.get {b1}")
+        ins.append("    i32.const 4")
+        ins.append("    i32.shr_u")
+        ins.append("    i32.or")
+        ins.append("    i32.add")
+        ins.append("    i32.load8_u offset=0")
+        ins.append("    i32.store8 offset=1")
+
+        # Output char 2: alphabet[((b1 & 0xF) << 2) | (b2 >> 6)]
+        ins.append(f"    local.get {dst}")
+        ins.append(f"    local.get {j}")
+        ins.append("    i32.add")
+        ins.append(f"    i32.const {alpha_off}")
+        ins.append(f"    local.get {b1}")
+        ins.append("    i32.const 15")
+        ins.append("    i32.and")
+        ins.append("    i32.const 2")
+        ins.append("    i32.shl")
+        ins.append(f"    local.get {b2}")
+        ins.append("    i32.const 6")
+        ins.append("    i32.shr_u")
+        ins.append("    i32.or")
+        ins.append("    i32.add")
+        ins.append("    i32.load8_u offset=0")
+        ins.append("    i32.store8 offset=2")
+
+        # Output char 3: alphabet[b2 & 0x3F]
+        ins.append(f"    local.get {dst}")
+        ins.append(f"    local.get {j}")
+        ins.append("    i32.add")
+        ins.append(f"    i32.const {alpha_off}")
+        ins.append(f"    local.get {b2}")
+        ins.append("    i32.const 63")
+        ins.append("    i32.and")
+        ins.append("    i32.add")
+        ins.append("    i32.load8_u offset=0")
+        ins.append("    i32.store8 offset=3")
+
+        # i += 3; j += 4
+        ins.append(f"    local.get {i}")
+        ins.append("    i32.const 3")
+        ins.append("    i32.add")
+        ins.append(f"    local.set {i}")
+        ins.append(f"    local.get {j}")
+        ins.append("    i32.const 4")
+        ins.append("    i32.add")
+        ins.append(f"    local.set {j}")
+        ins.append("    br $lp_e3")
+        ins.append("  end")
+        ins.append("end")
+
+        # --- Handle remainder (1 or 2 bytes) --------------------------
+        # rem == 1: 2 base64 chars + "=="
+        ins.append(f"local.get {rem}")
+        ins.append("i32.const 1")
+        ins.append("i32.eq")
+        ins.append("if")
+        ins.append(f"  local.get {ptr}")
+        ins.append(f"  local.get {i}")
+        ins.append("  i32.add")
+        ins.append("  i32.load8_u offset=0")
+        ins.append(f"  local.set {b0}")
+        # char 0: alphabet[b0 >> 2]
+        ins.append(f"  local.get {dst}")
+        ins.append(f"  local.get {j}")
+        ins.append("  i32.add")
+        ins.append(f"  i32.const {alpha_off}")
+        ins.append(f"  local.get {b0}")
+        ins.append("  i32.const 2")
+        ins.append("  i32.shr_u")
+        ins.append("  i32.add")
+        ins.append("  i32.load8_u offset=0")
+        ins.append("  i32.store8 offset=0")
+        # char 1: alphabet[(b0 & 3) << 4]
+        ins.append(f"  local.get {dst}")
+        ins.append(f"  local.get {j}")
+        ins.append("  i32.add")
+        ins.append(f"  i32.const {alpha_off}")
+        ins.append(f"  local.get {b0}")
+        ins.append("  i32.const 3")
+        ins.append("  i32.and")
+        ins.append("  i32.const 4")
+        ins.append("  i32.shl")
+        ins.append("  i32.add")
+        ins.append("  i32.load8_u offset=0")
+        ins.append("  i32.store8 offset=1")
+        # char 2-3: '=' (61)
+        ins.append(f"  local.get {dst}")
+        ins.append(f"  local.get {j}")
+        ins.append("  i32.add")
+        ins.append("  i32.const 61")
+        ins.append("  i32.store8 offset=2")
+        ins.append(f"  local.get {dst}")
+        ins.append(f"  local.get {j}")
+        ins.append("  i32.add")
+        ins.append("  i32.const 61")
+        ins.append("  i32.store8 offset=3")
+        ins.append("end")
+
+        # rem == 2: 3 base64 chars + "="
+        ins.append(f"local.get {rem}")
+        ins.append("i32.const 2")
+        ins.append("i32.eq")
+        ins.append("if")
+        ins.append(f"  local.get {ptr}")
+        ins.append(f"  local.get {i}")
+        ins.append("  i32.add")
+        ins.append("  i32.load8_u offset=0")
+        ins.append(f"  local.set {b0}")
+        ins.append(f"  local.get {ptr}")
+        ins.append(f"  local.get {i}")
+        ins.append("  i32.add")
+        ins.append("  i32.load8_u offset=1")
+        ins.append(f"  local.set {b1}")
+        # char 0: alphabet[b0 >> 2]
+        ins.append(f"  local.get {dst}")
+        ins.append(f"  local.get {j}")
+        ins.append("  i32.add")
+        ins.append(f"  i32.const {alpha_off}")
+        ins.append(f"  local.get {b0}")
+        ins.append("  i32.const 2")
+        ins.append("  i32.shr_u")
+        ins.append("  i32.add")
+        ins.append("  i32.load8_u offset=0")
+        ins.append("  i32.store8 offset=0")
+        # char 1: alphabet[((b0 & 3) << 4) | (b1 >> 4)]
+        ins.append(f"  local.get {dst}")
+        ins.append(f"  local.get {j}")
+        ins.append("  i32.add")
+        ins.append(f"  i32.const {alpha_off}")
+        ins.append(f"  local.get {b0}")
+        ins.append("  i32.const 3")
+        ins.append("  i32.and")
+        ins.append("  i32.const 4")
+        ins.append("  i32.shl")
+        ins.append(f"  local.get {b1}")
+        ins.append("  i32.const 4")
+        ins.append("  i32.shr_u")
+        ins.append("  i32.or")
+        ins.append("  i32.add")
+        ins.append("  i32.load8_u offset=0")
+        ins.append("  i32.store8 offset=1")
+        # char 2: alphabet[(b1 & 0xF) << 2]
+        ins.append(f"  local.get {dst}")
+        ins.append(f"  local.get {j}")
+        ins.append("  i32.add")
+        ins.append(f"  i32.const {alpha_off}")
+        ins.append(f"  local.get {b1}")
+        ins.append("  i32.const 15")
+        ins.append("  i32.and")
+        ins.append("  i32.const 2")
+        ins.append("  i32.shl")
+        ins.append("  i32.add")
+        ins.append("  i32.load8_u offset=0")
+        ins.append("  i32.store8 offset=2")
+        # char 3: '='
+        ins.append(f"  local.get {dst}")
+        ins.append(f"  local.get {j}")
+        ins.append("  i32.add")
+        ins.append("  i32.const 61")
+        ins.append("  i32.store8 offset=3")
+        ins.append("end")
+
+        # Leave (dst, out_len) on the stack
+        ins.append(f"local.get {dst}")
+        ins.append(f"local.get {out_len}")
+
+        ins.append("end")  # else branch of empty check
+
+        return ins
+
+    def _translate_base64_decode(
+        self, arg: ast.Expr, env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """Translate base64_decode(s) → Result<String, String> (i32 ptr).
+
+        Decodes a standard Base64 string (RFC 4648).  Returns Err on
+        invalid length (not a multiple of 4) or invalid characters.
+
+        ADT layout (16 bytes):
+          Ok(String):  [tag=0 : i32] [ptr : i32] [len : i32] [pad 4]
+          Err(String): [tag=1 : i32] [ptr : i32] [len : i32] [pad 4]
+        """
+        arg_instrs = self.translate_expr(arg, env)
+        if arg_instrs is None:
+            return None
+
+        self.needs_alloc = True
+
+        err_len_off, err_len_ln = self.string_pool.intern(
+            "invalid base64 length"
+        )
+        err_chr_off, err_chr_ln = self.string_pool.intern("invalid base64")
+        empty_off, empty_len = self.string_pool.intern("")
+
+        ptr = self.alloc_local("i32")
+        slen = self.alloc_local("i32")
+        out = self.alloc_local("i32")    # Result ADT pointer
+        dst = self.alloc_local("i32")    # decoded bytes pointer
+        out_len = self.alloc_local("i32")
+        pad = self.alloc_local("i32")    # padding count (0-2)
+        i = self.alloc_local("i32")      # input index
+        k = self.alloc_local("i32")      # output index
+        ch = self.alloc_local("i32")     # current input byte
+        val = self.alloc_local("i32")    # decoded 6-bit value
+        acc = self.alloc_local("i32")    # accumulated 24-bit value
+        gi = self.alloc_local("i32")     # group-internal index (0-3)
+
+        ins: list[str] = []
+
+        # Evaluate string arg → (ptr, len)
+        ins.extend(arg_instrs)
+        ins.append(f"local.set {slen}")
+        ins.append(f"local.set {ptr}")
+
+        ins.append("block $done_bd")
+        ins.append("block $err_chr_bd")
+        ins.append("block $err_len_bd")
+
+        # Validate: slen % 4 must be 0
+        ins.append(f"local.get {slen}")
+        ins.append("i32.const 3")
+        ins.append("i32.and")        # slen & 3 (faster than rem_u)
+        ins.append("i32.const 0")
+        ins.append("i32.ne")
+        ins.append("br_if $err_len_bd")
+
+        # Empty input → Ok("")
+        ins.append(f"local.get {slen}")
+        ins.append("i32.eqz")
+        ins.append("if")
+        ins.append("  i32.const 16")
+        ins.append("  call $alloc")
+        ins.append(f"  local.tee {out}")
+        ins.append("  i32.const 0")
+        ins.append("  i32.store")          # tag = 0 (Ok)
+        ins.extend(["  " + x for x in gc_shadow_push(out)])
+        ins.append(f"  local.get {out}")
+        ins.append(f"  i32.const {empty_off}")
+        ins.append("  i32.store offset=4") # ptr
+        ins.append(f"  local.get {out}")
+        ins.append(f"  i32.const {empty_len}")
+        ins.append("  i32.store offset=8") # len
+        ins.append("  br $done_bd")
+        ins.append("end")
+
+        # Count trailing '=' padding
+        ins.append("i32.const 0")
+        ins.append(f"local.set {pad}")
+        # Check last byte: ptr + slen - 1
+        ins.append(f"local.get {ptr}")
+        ins.append(f"local.get {slen}")
+        ins.append("i32.add")
+        ins.append("i32.const 1")
+        ins.append("i32.sub")
+        ins.append("i32.load8_u offset=0")
+        ins.append("i32.const 61")         # '='
+        ins.append("i32.eq")
+        ins.append("if")
+        ins.append(f"  local.get {pad}")
+        ins.append("  i32.const 1")
+        ins.append("  i32.add")
+        ins.append(f"  local.set {pad}")
+        # Check second-to-last byte: ptr + slen - 2
+        ins.append(f"  local.get {ptr}")
+        ins.append(f"  local.get {slen}")
+        ins.append("  i32.add")
+        ins.append("  i32.const 2")
+        ins.append("  i32.sub")
+        ins.append("  i32.load8_u offset=0")
+        ins.append("  i32.const 61")
+        ins.append("  i32.eq")
+        ins.append("  if")
+        ins.append(f"    local.get {pad}")
+        ins.append("    i32.const 1")
+        ins.append("    i32.add")
+        ins.append(f"    local.set {pad}")
+        ins.append("  end")
+        ins.append("end")
+
+        # out_len = (slen / 4) * 3 - pad
+        ins.append(f"local.get {slen}")
+        ins.append("i32.const 2")
+        ins.append("i32.shr_u")           # slen / 4
+        ins.append("i32.const 3")
+        ins.append("i32.mul")
+        ins.append(f"local.get {pad}")
+        ins.append("i32.sub")
+        ins.append(f"local.set {out_len}")
+
+        # Allocate decoded buffer
+        ins.append(f"local.get {out_len}")
+        ins.append("i32.const 1")
+        ins.append("i32.or")              # at least 1 byte for alloc
+        ins.append("call $alloc")
+        ins.append(f"local.set {dst}")
+        ins.extend(gc_shadow_push(dst))
+
+        # --- Decode loop: 4 input chars → 3 output bytes -------------
+        ins.append("i32.const 0")
+        ins.append(f"local.set {i}")
+        ins.append("i32.const 0")
+        ins.append(f"local.set {k}")
+
+        ins.append("block $brk_dl")
+        ins.append("  loop $lp_dl")
+        ins.append(f"    local.get {i}")
+        ins.append(f"    local.get {slen}")
+        ins.append("    i32.ge_u")
+        ins.append("    br_if $brk_dl")
+
+        # Decode 4 chars into acc (24 bits)
+        ins.append("    i32.const 0")
+        ins.append(f"    local.set {acc}")
+        ins.append("    i32.const 0")
+        ins.append(f"    local.set {gi}")
+        ins.append("    block $brk_g")
+        ins.append("      loop $lp_g")
+        ins.append(f"        local.get {gi}")
+        ins.append("        i32.const 4")
+        ins.append("        i32.ge_u")
+        ins.append("        br_if $brk_g")
+
+        # Load input char
+        ins.append(f"        local.get {ptr}")
+        ins.append(f"        local.get {i}")
+        ins.append(f"        local.get {gi}")
+        ins.append("        i32.add")
+        ins.append("        i32.add")
+        ins.append("        i32.load8_u offset=0")
+        ins.append(f"        local.set {ch}")
+
+        # Decode char → 6-bit value via branching
+        ins.append("        block $valid_d")
+        ins.append("        block $invalid_d")
+
+        # A-Z (65-90) → 0-25
+        ins.append(f"        local.get {ch}")
+        ins.append("        i32.const 65")
+        ins.append("        i32.ge_u")
+        ins.append(f"        local.get {ch}")
+        ins.append("        i32.const 90")
+        ins.append("        i32.le_u")
+        ins.append("        i32.and")
+        ins.append("        if")
+        ins.append(f"          local.get {ch}")
+        ins.append("          i32.const 65")
+        ins.append("          i32.sub")
+        ins.append(f"          local.set {val}")
+        ins.append("          br $valid_d")
+        ins.append("        end")
+
+        # a-z (97-122) → 26-51
+        ins.append(f"        local.get {ch}")
+        ins.append("        i32.const 97")
+        ins.append("        i32.ge_u")
+        ins.append(f"        local.get {ch}")
+        ins.append("        i32.const 122")
+        ins.append("        i32.le_u")
+        ins.append("        i32.and")
+        ins.append("        if")
+        ins.append(f"          local.get {ch}")
+        ins.append("          i32.const 97")
+        ins.append("          i32.sub")
+        ins.append("          i32.const 26")
+        ins.append("          i32.add")
+        ins.append(f"          local.set {val}")
+        ins.append("          br $valid_d")
+        ins.append("        end")
+
+        # 0-9 (48-57) → 52-61
+        ins.append(f"        local.get {ch}")
+        ins.append("        i32.const 48")
+        ins.append("        i32.ge_u")
+        ins.append(f"        local.get {ch}")
+        ins.append("        i32.const 57")
+        ins.append("        i32.le_u")
+        ins.append("        i32.and")
+        ins.append("        if")
+        ins.append(f"          local.get {ch}")
+        ins.append("          i32.const 48")
+        ins.append("          i32.sub")
+        ins.append("          i32.const 52")
+        ins.append("          i32.add")
+        ins.append(f"          local.set {val}")
+        ins.append("          br $valid_d")
+        ins.append("        end")
+
+        # '+' (43) → 62
+        ins.append(f"        local.get {ch}")
+        ins.append("        i32.const 43")
+        ins.append("        i32.eq")
+        ins.append("        if")
+        ins.append("          i32.const 62")
+        ins.append(f"          local.set {val}")
+        ins.append("          br $valid_d")
+        ins.append("        end")
+
+        # '/' (47) → 63
+        ins.append(f"        local.get {ch}")
+        ins.append("        i32.const 47")
+        ins.append("        i32.eq")
+        ins.append("        if")
+        ins.append("          i32.const 63")
+        ins.append(f"          local.set {val}")
+        ins.append("          br $valid_d")
+        ins.append("        end")
+
+        # '=' (61) → 0 (padding)
+        ins.append(f"        local.get {ch}")
+        ins.append("        i32.const 61")
+        ins.append("        i32.eq")
+        ins.append("        if")
+        ins.append("          i32.const 0")
+        ins.append(f"          local.set {val}")
+        ins.append("          br $valid_d")
+        ins.append("        end")
+
+        # Invalid character
+        ins.append("        br $invalid_d")
+        ins.append("        end")  # block $invalid_d
+        ins.append("        br $err_chr_bd")
+
+        ins.append("        end")  # block $valid_d
+
+        # acc = (acc << 6) | val
+        ins.append(f"        local.get {acc}")
+        ins.append("        i32.const 6")
+        ins.append("        i32.shl")
+        ins.append(f"        local.get {val}")
+        ins.append("        i32.or")
+        ins.append(f"        local.set {acc}")
+
+        # gi++
+        ins.append(f"        local.get {gi}")
+        ins.append("        i32.const 1")
+        ins.append("        i32.add")
+        ins.append(f"        local.set {gi}")
+        ins.append("        br $lp_g")
+        ins.append("      end")  # loop $lp_g
+        ins.append("    end")    # block $brk_g
+
+        # Extract up to 3 bytes from acc and store if within out_len
+        # Byte 0: (acc >> 16) & 0xFF
+        ins.append(f"    local.get {k}")
+        ins.append(f"    local.get {out_len}")
+        ins.append("    i32.lt_u")
+        ins.append("    if")
+        ins.append(f"      local.get {dst}")
+        ins.append(f"      local.get {k}")
+        ins.append("      i32.add")
+        ins.append(f"      local.get {acc}")
+        ins.append("      i32.const 16")
+        ins.append("      i32.shr_u")
+        ins.append("      i32.const 255")
+        ins.append("      i32.and")
+        ins.append("      i32.store8 offset=0")
+        ins.append(f"      local.get {k}")
+        ins.append("      i32.const 1")
+        ins.append("      i32.add")
+        ins.append(f"      local.set {k}")
+        ins.append("    end")
+
+        # Byte 1: (acc >> 8) & 0xFF
+        ins.append(f"    local.get {k}")
+        ins.append(f"    local.get {out_len}")
+        ins.append("    i32.lt_u")
+        ins.append("    if")
+        ins.append(f"      local.get {dst}")
+        ins.append(f"      local.get {k}")
+        ins.append("      i32.add")
+        ins.append(f"      local.get {acc}")
+        ins.append("      i32.const 8")
+        ins.append("      i32.shr_u")
+        ins.append("      i32.const 255")
+        ins.append("      i32.and")
+        ins.append("      i32.store8 offset=0")
+        ins.append(f"      local.get {k}")
+        ins.append("      i32.const 1")
+        ins.append("      i32.add")
+        ins.append(f"      local.set {k}")
+        ins.append("    end")
+
+        # Byte 2: acc & 0xFF
+        ins.append(f"    local.get {k}")
+        ins.append(f"    local.get {out_len}")
+        ins.append("    i32.lt_u")
+        ins.append("    if")
+        ins.append(f"      local.get {dst}")
+        ins.append(f"      local.get {k}")
+        ins.append("      i32.add")
+        ins.append(f"      local.get {acc}")
+        ins.append("      i32.const 255")
+        ins.append("      i32.and")
+        ins.append("      i32.store8 offset=0")
+        ins.append(f"      local.get {k}")
+        ins.append("      i32.const 1")
+        ins.append("      i32.add")
+        ins.append(f"      local.set {k}")
+        ins.append("    end")
+
+        # i += 4
+        ins.append(f"    local.get {i}")
+        ins.append("    i32.const 4")
+        ins.append("    i32.add")
+        ins.append(f"    local.set {i}")
+        ins.append("    br $lp_dl")
+        ins.append("  end")  # loop $lp_dl
+        ins.append("end")    # block $brk_dl
+
+        # --- Ok path: wrap (dst, out_len) in Result -------------------
+        ins.append("i32.const 16")
+        ins.append("call $alloc")
+        ins.append(f"local.tee {out}")
+        ins.append("i32.const 0")
+        ins.append("i32.store")            # tag = 0 (Ok)
+        ins.extend(gc_shadow_push(out))
+        ins.append(f"local.get {out}")
+        ins.append(f"local.get {dst}")
+        ins.append("i32.store offset=4")   # string ptr
+        ins.append(f"local.get {out}")
+        ins.append(f"local.get {out_len}")
+        ins.append("i32.store offset=8")   # string len
+        ins.append("br $done_bd")
+
+        # --- Err path: invalid length ---------------------------------
+        ins.append("end")  # block $err_len_bd
+        ins.append("i32.const 16")
+        ins.append("call $alloc")
+        ins.append(f"local.tee {out}")
+        ins.append("i32.const 1")
+        ins.append("i32.store")            # tag = 1 (Err)
+        ins.extend(gc_shadow_push(out))
+        ins.append(f"local.get {out}")
+        ins.append(f"i32.const {err_len_off}")
+        ins.append("i32.store offset=4")
+        ins.append(f"local.get {out}")
+        ins.append(f"i32.const {err_len_ln}")
+        ins.append("i32.store offset=8")
+        ins.append("br $done_bd")
+
+        # --- Err path: invalid character ------------------------------
+        ins.append("end")  # block $err_chr_bd
+        ins.append("i32.const 16")
+        ins.append("call $alloc")
+        ins.append(f"local.tee {out}")
+        ins.append("i32.const 1")
+        ins.append("i32.store")            # tag = 1 (Err)
+        ins.extend(gc_shadow_push(out))
+        ins.append(f"local.get {out}")
+        ins.append(f"i32.const {err_chr_off}")
+        ins.append("i32.store offset=4")
+        ins.append(f"local.get {out}")
+        ins.append(f"i32.const {err_chr_ln}")
+        ins.append("i32.store offset=8")
+
+        ins.append("end")  # block $done_bd
 
         ins.append(f"local.get {out}")
         return ins

--- a/vera/wasm/inference.py
+++ b/vera/wasm/inference.py
@@ -221,9 +221,14 @@ class InferenceMixin:
             return "i32_pair"
         if expr.name == "split":
             return "i32_pair"
-        # parse builtins → Result<T, String> (i32 heap pointer)
-        if expr.name in ("parse_nat", "parse_int", "parse_float64", "parse_bool"):
+        # parse/decode builtins → Result<T, String> (i32 heap pointer)
+        if expr.name in (
+            "parse_nat", "parse_int", "parse_float64", "parse_bool",
+            "base64_decode",
+        ):
             return "i32"
+        if expr.name == "base64_encode":
+            return "i32_pair"
         # Numeric math builtins
         if expr.name in ("abs", "min", "max", "floor", "ceil", "round"):
             return "i64"
@@ -395,8 +400,13 @@ class InferenceMixin:
             return "String"
         if call.name == "split":
             return "Array"
-        if call.name in ("parse_nat", "parse_int", "parse_float64", "parse_bool"):
+        if call.name in (
+            "parse_nat", "parse_int", "parse_float64", "parse_bool",
+            "base64_decode",
+        ):
             return "Result"
+        if call.name == "base64_encode":
+            return "String"
         # Numeric math builtins
         if call.name == "abs":
             return "Nat"


### PR DESCRIPTION
## Summary
- New `base64_encode(@String -> @String)` — standard Base64 (RFC 4648) encoding
- New `base64_decode(@String -> @Result<String, String>)` — Base64 decoding with error handling
- Both are pure WASM implementations (no host imports): encode uses string-pool lookup table, decode uses range-based branching
- New `examples/base64.vera` end-to-end demo (encode, decode, round-trip)
- New conformance test `ch09_base64` (conformance suite: 46 -> 47 programs)
- 20 new tests (4 checker + 16 codegen including round-trip)
- Version bump 0.0.78 -> 0.0.79

## Test plan
- [x] `pytest tests/ -v` — 1,978 tests pass (1,972 passed, 6 skipped)
- [x] `mypy vera/` — 0 errors
- [x] `python scripts/check_conformance.py` — 47 conformance programs pass
- [x] `python scripts/check_examples.py` — 19 examples pass
- [x] `python scripts/check_spec_examples.py` — all spec blocks pass
- [x] `python scripts/check_skill_examples.py` — all SKILL.md blocks pass
- [x] `python scripts/check_version_sync.py` — version 0.0.79 consistent
- [x] Smoke test: `vera run examples/base64.vera` prints encoded, decoded, and round-tripped strings

Generated with [Claude Code](https://claude.com/claude-code)