### PR TITLE
Add url_encode, url_decode builtins (Phase 1 of #232)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.80] - 2026-03-10
+
+### Added
+- **URL percent-encoding and decoding** ([#232](https://github.com/aallan/vera/issues/232)):
+  New `url_encode(@String -> @String)` — RFC 3986 percent-encoding, leaving
+  unreserved characters unchanged.
+  New `url_decode(@String -> @Result<String, String>)` — percent-decoding with
+  error handling for invalid `%XX` sequences.
+- New conformance test `ch09_url_encoding` (conformance suite: 47→48 programs)
+- New example `examples/url_encoding.vera` — encode, decode, and round-trip demo
+- 21 new tests (4 type checker + 17 codegen)
+
 ## [0.0.79] - 2026-03-10
 
 ### Added
@@ -1211,7 +1223,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Grammar: handler body simplified to avoid LALR reduce/reduce conflict
 - `pyproject.toml`: corrected build backend, package discovery, PEP 639 compliance
 
-[Unreleased]: https://github.com/aallan/vera/compare/v0.0.79...HEAD
+[Unreleased]: https://github.com/aallan/vera/compare/v0.0.80...HEAD
+[0.0.80]: https://github.com/aallan/vera/compare/v0.0.79...v0.0.80
 [0.0.79]: https://github.com/aallan/vera/compare/v0.0.78...v0.0.79
 [0.0.78]: https://github.com/aallan/vera/compare/v0.0.77...v0.0.78
 [0.0.77]: https://github.com/aallan/vera/compare/v0.0.76...v0.0.77

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,8 +40,8 @@ vera fmt --check file.vera        # Check if already canonical
 pytest tests/ -v                  # Run the test suite (see TESTING.md)
 mypy vera/                        # Type-check the compiler itself
 
-python scripts/check_conformance.py    # Verify all 43 conformance programs pass their declared level
-python scripts/check_examples.py      # Verify all 18 examples parse + check + verify
+python scripts/check_conformance.py    # Verify all 48 conformance programs pass their declared level
+python scripts/check_examples.py      # Verify all 20 examples parse + check + verify
 python scripts/check_spec_examples.py # Verify spec code blocks parse
 python scripts/check_readme_examples.py # Verify README code blocks parse
 python scripts/check_skill_examples.py # Verify SKILL.md code blocks parse
@@ -54,9 +54,9 @@ python scripts/fix_allowlists.py --fix # Auto-fix stale allowlist line numbers
 
 - `spec/` — Language specification (Chapters 0-12)
 - `vera/` — Reference compiler: grammar, parser, AST, transformer, type checker, verifier, codegen, CLI
-- `examples/` — 18 example Vera programs (all must pass `vera check` and `vera verify`)
+- `examples/` — 20 example Vera programs (all must pass `vera check` and `vera verify`)
 - `tests/` — Test suite (unit tests + conformance suite)
-- `tests/conformance/` — 43 conformance programs validating every language feature against the spec
+- `tests/conformance/` — 48 conformance programs validating every language feature against the spec
 - `scripts/` — CI and validation scripts
 
 ## Writing Vera code
@@ -74,8 +74,8 @@ Each stage is a module with a public API function and is independently testable.
 ## What not to break
 
 - Pre-commit hooks run mypy + pytest + conformance suite + example validation on every commit
-- All 43 conformance programs in `tests/conformance/` must pass their declared level
-- All 18 examples in `examples/` must pass `vera check` and `vera verify`
+- All 48 conformance programs in `tests/conformance/` must pass their declared level
+- All 20 examples in `examples/` must pass `vera check` and `vera verify`
 - Version must stay in sync across `vera/__init__.py`, `pyproject.toml`, and `CHANGELOG.md`
 - All tests must pass: `pytest tests/ -v`
 - Type checking must be clean: `mypy vera/`

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ The language specification is in draft across 13 chapters:
 
 ### Testing
 
-Testing is organized in three layers: **unit tests** (1,978 tests across 20 files, testing compiler internals), a **conformance suite** (47 programs across 9 spec chapters, systematically validating every language feature against the spec), and **example programs** (19 end-to-end demos). The compiler has 90% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations. Every commit validates all conformance programs, example programs, and 95 specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference -- coverage tables, conformance suite details, CI pipeline, and infrastructure.
+Testing is organized in three layers: **unit tests** (2,003 tests across 20 files, testing compiler internals), a **conformance suite** (48 programs across 9 spec chapters, systematically validating every language feature against the spec), and **example programs** (20 end-to-end demos). The compiler has 90% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations. Every commit validates all conformance programs, example programs, and 95 specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference -- coverage tables, conformance suite details, CI pipeline, and infrastructure.
 
 ## Roadmap
 
@@ -454,7 +454,7 @@ OK: examples/safe_divide.vera
 Verification: 4 verified (Tier 1)
 ```
 
-`vera verify` runs the type checker and then verifies contracts using Z3. Tier 1 contracts (decidable arithmetic, comparisons, Boolean logic, match expressions, ADT constructors, and decreases clauses) are proved automatically. Contracts that Z3 cannot decide are reported as Tier 3 (runtime checks) with a warning. Across all 19 examples, 120 of 124 contracts (96.8%) are verified statically.
+`vera verify` runs the type checker and then verifies contracts using Z3. Tier 1 contracts (decidable arithmetic, comparisons, Boolean logic, match expressions, ADT constructors, and decreases clauses) are proved automatically. Contracts that Z3 cannot decide are reported as Tier 3 (runtime checks) with a warning. Across all 20 examples, 122 of 126 contracts (96.8%) are verified statically.
 
 ### Format a program
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -414,6 +414,8 @@ parse_float64(@String.0)                -- returns Result<Float64, String>
 parse_bool(@String.0)                   -- returns Result<Bool, String>
 base64_encode(@String.0)                -- returns String (RFC 4648)
 base64_decode(@String.0)                -- returns Result<String, String>
+url_encode(@String.0)                   -- returns String (RFC 3986 percent-encoding)
+url_decode(@String.0)                   -- returns Result<String, String>
 to_string(@Int.0)                       -- returns String (integer to decimal)
 int_to_string(@Int.0)                   -- returns String (alias for to_string)
 bool_to_string(@Bool.0)                 -- returns String ("true" or "false")
@@ -458,7 +460,7 @@ join(@Array<String>.0, @String.0)               -- returns String (join with sep
 
 `to_upper` and `to_lower` convert ASCII letters only (a-z ↔ A-Z). `replace` substitutes all non-overlapping occurrences; an empty needle returns the original string unchanged. `split` returns an array of segments; an empty delimiter returns a single-element array. `join` concatenates array elements with the separator between each pair.
 
-String functions use the heap allocator (`$alloc`). Memory is managed automatically by a conservative mark-sweep garbage collector — there is no manual allocation or deallocation. All four parse functions return `Result<T, String>`: `parse_nat`, `parse_int`, `parse_float64`, and `parse_bool`. They return `Ok(value)` on valid input and `Err(msg)` on empty or invalid input; leading and trailing spaces are tolerated. `parse_int` accepts an optional `+` or `-` sign. `parse_bool` is strict: only `"true"` and `"false"` (lowercase) are valid. `base64_encode` encodes a string to standard Base64 (RFC 4648); `base64_decode` returns `Result<String, String>`, failing on invalid length or characters.
+String functions use the heap allocator (`$alloc`). Memory is managed automatically by a conservative mark-sweep garbage collector — there is no manual allocation or deallocation. All four parse functions return `Result<T, String>`: `parse_nat`, `parse_int`, `parse_float64`, and `parse_bool`. They return `Ok(value)` on valid input and `Err(msg)` on empty or invalid input; leading and trailing spaces are tolerated. `parse_int` accepts an optional `+` or `-` sign. `parse_bool` is strict: only `"true"` and `"false"` (lowercase) are valid. `base64_encode` encodes a string to standard Base64 (RFC 4648); `base64_decode` returns `Result<String, String>`, failing on invalid length or characters. `url_encode` percent-encodes a string for use in URLs (RFC 3986), leaving unreserved characters (`A-Z`, `a-z`, `0-9`, `-`, `_`, `.`, `~`) unchanged; `url_decode` returns `Result<String, String>`, failing on invalid `%XX` sequences.
 
 ### Numeric operations
 

--- a/examples/url_encoding.vera
+++ b/examples/url_encoding.vera
@@ -1,0 +1,23 @@
+-- URL percent-encoding and decoding
+effect IO {
+  op print(String -> Unit);
+}
+
+private data Result<T, E> {
+  Ok(T),
+  Err(E)
+}
+
+public fn main(@Unit -> @Unit)
+  requires(true)
+  ensures(true)
+  effects(<IO>)
+{
+  IO.print(url_encode("Hello, World!"));
+  IO.print(url_encode("key=value&foo=bar"));
+  match url_decode("Hello%2C%20World%21") { Ok(@String) -> IO.print(@String.0), Err(@String) -> IO.print(@String.0) };
+  match url_decode(url_encode("round-trip test!")) {
+    Ok(@String) -> IO.print(@String.0),
+    Err(@String) -> IO.print(@String.0)
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.79"
+version = "0.0.80"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/scripts/check_skill_examples.py
+++ b/scripts/check_skill_examples.py
@@ -40,64 +40,64 @@ ALLOWLIST: dict[int, tuple[str, str]] = {
     404: ("FRAGMENT", "String built-in examples, bare calls"),
 
     # String interpolation — bare expressions
-    428: ("FRAGMENT", "String interpolation examples, bare expressions"),
+    430: ("FRAGMENT", "String interpolation examples, bare expressions"),
 
     # String search — bare function calls
-    440: ("FRAGMENT", "String search built-in examples, bare calls"),
+    442: ("FRAGMENT", "String search built-in examples, bare calls"),
 
     # String transformation — bare function calls
-    451: ("FRAGMENT", "String transformation built-in examples, bare calls"),
+    453: ("FRAGMENT", "String transformation built-in examples, bare calls"),
 
     # Numeric operations — bare function calls
-    465: ("FRAGMENT", "Numeric built-in examples, bare calls"),
+    467: ("FRAGMENT", "Numeric built-in examples, bare calls"),
 
     # Contracts section — requires/ensures fragments
-    522: ("FRAGMENT", "Requires clause example, not full function"),
-    531: ("FRAGMENT", "Ensures clause example, not full function"),
-    558: ("FRAGMENT", "Quantified requires clause, not full function"),
+    524: ("FRAGMENT", "Requires clause example, not full function"),
+    533: ("FRAGMENT", "Ensures clause example, not full function"),
+    560: ("FRAGMENT", "Quantified requires clause, not full function"),
 
     # Effects section — bare effect rows
-    576: ("FRAGMENT", "Effect row examples, bare annotations"),
+    578: ("FRAGMENT", "Effect row examples, bare annotations"),
 
     # Effect handler syntax template
-    713: ("FRAGMENT", "Handler syntax template, not real code"),
+    715: ("FRAGMENT", "Handler syntax template, not real code"),
 
     # Qualified calls and handler fragments — bare expressions
-    725: ("FRAGMENT", "Handler with clause, bare expression"),
-    735: ("FRAGMENT", "Qualified call examples, bare expressions"),
+    727: ("FRAGMENT", "Handler with clause, bare expression"),
+    737: ("FRAGMENT", "Qualified call examples, bare expressions"),
 
     # Module declaration and import syntax
-    773: ("FRAGMENT", "Module declaration and import example"),
+    775: ("FRAGMENT", "Module declaration and import example"),
 
     # Line comments — bare comments
-    824: ("FRAGMENT", "Comment syntax example"),
+    826: ("FRAGMENT", "Comment syntax example"),
 
     # Type conversions — bare function calls
-    480: ("FRAGMENT", "Type conversion examples, bare calls"),
+    482: ("FRAGMENT", "Type conversion examples, bare calls"),
 
     # Float64 predicates — bare function calls
-    493: ("FRAGMENT", "Float64 predicate examples, bare calls"),
+    495: ("FRAGMENT", "Float64 predicate examples, bare calls"),
 
     # Common mistakes section — intentionally wrong code
-    852: ("FRAGMENT", "Wrong: missing contracts"),
-    872: ("FRAGMENT", "Wrong: missing effects clause"),
-    906: ("FRAGMENT", "Wrong: bare expression without indices"),
-    919: ("FRAGMENT", "Wrong: bare expression no indices"),
-    924: ("FRAGMENT", "Correct: expression with indices (not full fn)"),
-    990: ("FRAGMENT", "Wrong: match arm with incorrect return"),
-    1014: ("FRAGMENT", "Wrong: non-exhaustive match"),
-    1021: ("FRAGMENT", "Correct: match arm example"),
-    1031: ("FRAGMENT", "Wrong: if/else without braces (bare expression)"),
-    1036: ("FRAGMENT", "Correct: if/else with braces"),
+    854: ("FRAGMENT", "Wrong: missing contracts"),
+    874: ("FRAGMENT", "Wrong: missing effects clause"),
+    908: ("FRAGMENT", "Wrong: bare expression without indices"),
+    921: ("FRAGMENT", "Wrong: bare expression no indices"),
+    926: ("FRAGMENT", "Correct: expression with indices (not full fn)"),
+    992: ("FRAGMENT", "Wrong: match arm with incorrect return"),
+    1016: ("FRAGMENT", "Wrong: non-exhaustive match"),
+    1023: ("FRAGMENT", "Correct: match arm example"),
+    1033: ("FRAGMENT", "Wrong: if/else without braces (bare expression)"),
+    1038: ("FRAGMENT", "Correct: if/else with braces"),
 
     # Import syntax — intentionally unsupported
-    1047: ("FRAGMENT", "Wrong: import aliasing not supported"),
-    1052: ("FRAGMENT", "Correct: import syntax example"),
-    1062: ("FRAGMENT", "Wrong: import hiding not supported"),
-    1067: ("FRAGMENT", "Correct: multi-import syntax"),
+    1049: ("FRAGMENT", "Wrong: import aliasing not supported"),
+    1054: ("FRAGMENT", "Correct: import syntax example"),
+    1064: ("FRAGMENT", "Wrong: import hiding not supported"),
+    1069: ("FRAGMENT", "Correct: multi-import syntax"),
 
     # String escapes — bare expression
-    1081: ("FRAGMENT", "String escape example"),
+    1083: ("FRAGMENT", "String escape example"),
 
     # =================================================================
     # MISMATCH — uses syntax the parser doesn't handle in isolation.

--- a/scripts/check_spec_examples.py
+++ b/scripts/check_spec_examples.py
@@ -161,16 +161,20 @@ ALLOWLIST: dict[tuple[str, int], str] = {
     ("09-standard-library.md", 970): "FRAGMENT",  # base64_encode signature (no body)
     ("09-standard-library.md", 989): "FRAGMENT",  # base64_decode signature (no body)
 
+    # Chapter 9 — URL encoding builtin signatures (no body)
+    ("09-standard-library.md", 1016): "FRAGMENT",  # url_encode signature (no body)
+    ("09-standard-library.md", 1035): "FRAGMENT",  # url_decode signature (no body)
+
     # Chapter 9 — ML/vector builtin signatures (no body)
-    ("09-standard-library.md", 1016): "FRAGMENT",  # similarity signature (no body)
+    ("09-standard-library.md", 1061): "FRAGMENT",  # similarity signature (no body)
 
     # Chapter 9 — Markdown stdlib type (future, uses MdBlock/MdInline types)
-    ("09-standard-library.md", 1120): "FUTURE",   # md_parse(@String -> @Result<MdBlock, String>)
-    ("09-standard-library.md", 1129): "FUTURE",   # md_render(@MdBlock -> @String)
-    ("09-standard-library.md", 1140): "FUTURE",   # md_has_heading(@MdBlock, @Nat -> @Bool)
-    ("09-standard-library.md", 1149): "FUTURE",   # md_has_code_block(@MdBlock, @String -> @Bool)
-    ("09-standard-library.md", 1158): "FUTURE",   # md_extract_code_blocks(@MdBlock, @String -> @Array<String>)
-    ("09-standard-library.md", 1182): "FUTURE",   # convert_to_markdown(@String -> @Result<MdBlock, String>)
+    ("09-standard-library.md", 1165): "FUTURE",   # md_parse(@String -> @Result<MdBlock, String>)
+    ("09-standard-library.md", 1174): "FUTURE",   # md_render(@MdBlock -> @String)
+    ("09-standard-library.md", 1185): "FUTURE",   # md_has_heading(@MdBlock, @Nat -> @Bool)
+    ("09-standard-library.md", 1194): "FUTURE",   # md_has_code_block(@MdBlock, @String -> @Bool)
+    ("09-standard-library.md", 1203): "FUTURE",   # md_extract_code_blocks(@MdBlock, @String -> @Array<String>)
+    ("09-standard-library.md", 1227): "FUTURE",   # convert_to_markdown(@String -> @Result<MdBlock, String>)
 }
 
 

--- a/spec/04-expressions.md
+++ b/spec/04-expressions.md
@@ -332,6 +332,8 @@ parse_bool(@String.0)                   -- returns Result<Bool, String>
                                         -- strict: only "true" and "false" are valid
 base64_encode(@String.0)                -- returns String (RFC 4648)
 base64_decode(@String.0)                -- returns Result<String, String>
+url_encode(@String.0)                   -- returns String (RFC 3986 percent-encoding)
+url_decode(@String.0)                   -- returns Result<String, String>
 to_string(@Int.0)                       -- returns String
 int_to_string(@Int.0)                   -- returns String (alias for to_string)
 bool_to_string(@Bool.0)                 -- returns String ("true" or "false")

--- a/spec/09-standard-library.md
+++ b/spec/09-standard-library.md
@@ -1009,7 +1009,52 @@ base64_decode("ABC")                   -- Err("invalid base64 length")
 base64_decode("QQ!!")                  -- Err("invalid base64")
 ```
 
-### 9.6.12 similarity (Future)
+### 9.6.12 URL Encoding
+
+#### url\_encode
+
+```
+public fn url_encode(@String -> @String)
+  requires(true)
+  ensures(true)
+  effects(pure)
+```
+
+Percent-encodes a string for use in URLs (RFC 3986). Unreserved characters (`A`–`Z`, `a`–`z`, `0`–`9`, `-`, `_`, `.`, `~`) pass through unchanged. All other bytes are encoded as `%XX` where `XX` is the uppercase hexadecimal representation of the byte value.
+
+```vera
+url_encode("Hello, World!")     -- "Hello%2C%20World%21"
+url_encode("foo@bar.com")       -- "foo%40bar.com"
+url_encode("a b c")             -- "a%20b%20c"
+url_encode("safe-text_123.~")   -- "safe-text_123.~"
+url_encode("")                  -- ""
+```
+
+#### url\_decode
+
+```
+public fn url_decode(@String -> @Result<String, String>)
+  requires(true)
+  ensures(true)
+  effects(pure)
+```
+
+Decodes a percent-encoded string (RFC 3986). Each `%XX` sequence is converted to the byte with that hexadecimal value. Both uppercase and lowercase hex digits are accepted. Returns `Ok(String)` on success or `Err(String)` with an error message on failure.
+
+**Error conditions:**
+
+- `"invalid percent-encoding"` — truncated `%` sequence (fewer than 2 hex digits following `%`) or invalid hex digits
+
+```vera
+url_decode("Hello%2C%20World%21")  -- Ok("Hello, World!")
+url_decode("%41%42%43")            -- Ok("ABC")
+url_decode("hello")               -- Ok("hello")
+url_decode("")                     -- Ok("")
+url_decode("%ZZ")                  -- Err("invalid percent-encoding")
+url_decode("%4")                   -- Err("invalid percent-encoding")
+```
+
+### 9.6.13 similarity (Future)
 
 > **Status: Not yet implemented.** Will be introduced alongside the `Inference` effect ([#61](https://github.com/aallan/vera/issues/61)).
 

--- a/tests/conformance/ch09_url_encoding.vera
+++ b/tests/conformance/ch09_url_encoding.vera
@@ -1,0 +1,81 @@
+-- Conformance: url_encode, url_decode (Chapter 9)
+-- Tests: url_encode, url_decode returning Result<String, String>
+effect IO {
+  op print(String -> Unit);
+}
+
+private data Result<T, E> {
+  Ok(T),
+  Err(E)
+}
+
+public fn test_encode_empty(@Unit -> @Int)
+  requires(true)
+  ensures(@Int.result == 0)
+  effects(pure)
+{
+  string_length(url_encode(""))
+}
+
+public fn test_encode_unreserved(@Unit -> @Int)
+  requires(true)
+  ensures(@Int.result == 5)
+  effects(pure)
+{
+  string_length(url_encode("Hello"))
+}
+
+public fn test_encode_special(@Unit -> @Int)
+  requires(true)
+  ensures(@Int.result == 9)
+  effects(pure)
+{
+  string_length(url_encode("a b c"))
+}
+
+public fn test_decode_ok(@Unit -> @Int)
+  requires(true)
+  ensures(@Int.result == 3)
+  effects(pure)
+{
+  match url_decode("%41%42%43") {
+    Ok(@String) -> string_length(@String.0),
+    Err(_) -> 0 - 1
+  }
+}
+
+public fn test_decode_err(@Unit -> @Int)
+  requires(true)
+  ensures(@Int.result == 1)
+  effects(pure)
+{
+  match url_decode("%ZZ") {
+    Ok(_) -> 0,
+    Err(_) -> 1
+  }
+}
+
+public fn test_roundtrip(@Unit -> @Int)
+  requires(true)
+  ensures(@Int.result == 13)
+  effects(pure)
+{
+  match url_decode(url_encode("Hello, World!")) {
+    Ok(@String) -> string_length(@String.0),
+    Err(_) -> 0 - 1
+  }
+}
+
+public fn main(@Unit -> @Unit)
+  requires(true)
+  ensures(true)
+  effects(<IO>)
+{
+  IO.print(to_string(test_encode_empty(())));
+  IO.print(to_string(test_encode_unreserved(())));
+  IO.print(to_string(test_encode_special(())));
+  IO.print(to_string(test_decode_ok(())));
+  IO.print(to_string(test_decode_err(())));
+  IO.print(to_string(test_roundtrip(())));
+  ()
+}

--- a/tests/conformance/manifest.json
+++ b/tests/conformance/manifest.json
@@ -421,5 +421,14 @@
     "level": "run",
     "spec_ref": "Section 9.6.5",
     "features": ["base64_encode", "base64_decode", "result_type"]
+  },
+  {
+    "id": "ch09_url_encoding",
+    "file": "ch09_url_encoding.vera",
+    "chapter": 9,
+    "title": "URL percent-encoding and decoding",
+    "level": "run",
+    "spec_ref": "Section 9.6.5",
+    "features": ["url_encode", "url_decode", "result_type"]
   }
 ]

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -2643,6 +2643,35 @@ private fn f(@Int -> @String)
 { base64_decode(@Int.0) }
 """, "expected String")
 
+    def test_url_encode_ok(self) -> None:
+        _check_ok("""
+private fn f(@String -> @String)
+  requires(true) ensures(true) effects(pure)
+{ url_encode(@String.0) }
+""")
+
+    def test_url_encode_wrong_type(self) -> None:
+        _check_err("""
+private fn f(@Int -> @String)
+  requires(true) ensures(true) effects(pure)
+{ url_encode(@Int.0) }
+""", "expected String")
+
+    def test_url_decode_ok(self) -> None:
+        _check_ok("""
+private data Result<T, E> { Ok(T), Err(E) }
+private fn f(@String -> @Result<String, String>)
+  requires(true) ensures(true) effects(pure)
+{ url_decode(@String.0) }
+""")
+
+    def test_url_decode_wrong_type(self) -> None:
+        _check_err("""
+private fn f(@Int -> @String)
+  requires(true) ensures(true) effects(pure)
+{ url_decode(@Int.0) }
+""", "expected String")
+
     def test_to_string_ok(self) -> None:
         _check_ok("""
 private fn f(@Int -> @String)

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -4758,6 +4758,109 @@ public fn f(@Unit -> @Unit) requires(true) ensures(true) effects(<IO>) {
         assert _run_io(src) == "Hello, World!"
 
 
+class TestUrlEncode:
+    """url_encode returns String."""
+
+    def _io_prog(self, literal: str) -> str:
+        return f"""
+effect IO {{ op print(String -> Unit); }}
+public fn f(@Unit -> @Unit) requires(true) ensures(true) effects(<IO>) {{
+  IO.print(url_encode("{literal}"));
+  ()
+}}
+"""
+
+    def test_empty(self) -> None:
+        assert _run_io(self._io_prog("")) == ""
+
+    def test_unreserved_passthrough(self) -> None:
+        assert _run_io(self._io_prog("abc-XYZ_012.~")) == "abc-XYZ_012.~"
+
+    def test_space(self) -> None:
+        assert _run_io(self._io_prog("a b")) == "a%20b"
+
+    def test_special_chars(self) -> None:
+        assert _run_io(self._io_prog("foo@bar.com")) == "foo%40bar.com"
+
+    def test_query_string(self) -> None:
+        assert _run_io(self._io_prog("key=value&x=1")) == "key%3Dvalue%26x%3D1"
+
+    def test_slash_and_colon(self) -> None:
+        assert _run_io(self._io_prog("http://x.com")) == "http%3A%2F%2Fx.com"
+
+    def test_hello_world(self) -> None:
+        assert _run_io(self._io_prog("Hello, World!")) == "Hello%2C%20World%21"
+
+
+class TestUrlDecode:
+    """url_decode returns Result<String, String>."""
+
+    _PREAMBLE = """
+private data Result<T, E> { Ok(T), Err(E) }
+"""
+
+    def _ok_prog(self, literal: str) -> str:
+        return self._PREAMBLE + f"""
+effect IO {{ op print(String -> Unit); }}
+public fn f(@Unit -> @Unit) requires(true) ensures(true) effects(<IO>) {{
+  match url_decode("{literal}") {{
+    Ok(@String) -> IO.print(@String.0),
+    Err(@String) -> IO.print(@String.0)
+  }}
+}}
+"""
+
+    def _err_prog(self, literal: str) -> str:
+        return self._PREAMBLE + f"""
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {{
+  match url_decode("{literal}") {{
+    Ok(_) -> 0,
+    Err(_) -> 1
+  }}
+}}
+"""
+
+    def test_empty(self) -> None:
+        assert _run_io(self._ok_prog("")) == ""
+
+    def test_no_encoding(self) -> None:
+        assert _run_io(self._ok_prog("hello")) == "hello"
+
+    def test_space(self) -> None:
+        assert _run_io(self._ok_prog("a%20b")) == "a b"
+
+    def test_uppercase_hex(self) -> None:
+        assert _run_io(self._ok_prog("%41%42%43")) == "ABC"
+
+    def test_lowercase_hex(self) -> None:
+        assert _run_io(self._ok_prog("%61%62%63")) == "abc"
+
+    def test_mixed_case_hex(self) -> None:
+        assert _run_io(self._ok_prog("%2f%2F")) == "//"
+
+    def test_hello_world(self) -> None:
+        assert _run_io(self._ok_prog("Hello%2C%20World%21")) == "Hello, World!"
+
+    def test_invalid_truncated(self) -> None:
+        assert _run(self._err_prog("%4")) == 1
+
+    def test_invalid_hex(self) -> None:
+        assert _run(self._err_prog("%ZZ")) == 1
+
+    def test_roundtrip(self) -> None:
+        """Encode then decode round-trips correctly."""
+        src = self._PREAMBLE + """
+effect IO { op print(String -> Unit); }
+public fn f(@Unit -> @Unit) requires(true) ensures(true) effects(<IO>) {
+  match url_decode(url_encode("Hello, World!")) {
+    Ok(@String) -> IO.print(@String.0),
+    Err(@String) -> IO.print(@String.0)
+  }
+}
+"""
+        assert _run_io(src) == "Hello, World!"
+
+
 class TestToString:
     def test_positive(self) -> None:
         src = """

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -1480,9 +1480,9 @@ private fn sum(@List<Int> -> @Int)
             t1 += result.summary.tier1_verified
             t3 += result.summary.tier3_runtime
             total += result.summary.total
-        assert t1 == 119, f"Expected 119 T1, got {t1}"
+        assert t1 == 121, f"Expected 121 T1, got {t1}"
         assert t3 == 5, f"Expected 5 T3, got {t3}"
-        assert total == 124, f"Expected 124 total, got {total}"
+        assert total == 126, f"Expected 126 total, got {total}"
 
 
 # =====================================================================

--- a/vera/README.md
+++ b/vera/README.md
@@ -308,6 +308,8 @@ Context flags (`in_ensures`, `in_contract`, `current_return_type`, `current_effe
 | `parse_bool` | Function | `String → Result<Bool, String>`, pure |
 | `base64_encode` | Function | `String → String`, pure (RFC 4648) |
 | `base64_decode` | Function | `String → Result<String, String>`, pure |
+| `url_encode` | Function | `String → String`, pure (RFC 3986 percent-encoding) |
+| `url_decode` | Function | `String → Result<String, String>`, pure |
 | `to_string` | Function | `Int → String`, pure |
 | `int_to_string` | Function | `Int → String`, pure (alias for `to_string`) |
 | `bool_to_string` | Function | `Bool → String`, pure |

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.79"
+__version__ = "0.0.80"

--- a/vera/codegen/modules.py
+++ b/vera/codegen/modules.py
@@ -242,6 +242,7 @@ class CrossModuleMixin:
             "char_code", "from_char_code", "string_repeat",
             "parse_nat", "parse_int", "parse_float64", "parse_bool",
             "base64_encode", "base64_decode",
+            "url_encode", "url_decode",
             "to_string", "int_to_string", "bool_to_string",
             "nat_to_string", "byte_to_string", "float_to_string",
             "strip",

--- a/vera/environment.py
+++ b/vera/environment.py
@@ -342,6 +342,20 @@ class TypeEnv:
             return_type=AdtType("Result", (STRING, STRING)),
             effect=PureEffectRow(),
         )
+        self.functions["url_encode"] = FunctionInfo(
+            name="url_encode",
+            forall_vars=None,
+            param_types=(STRING,),
+            return_type=STRING,
+            effect=PureEffectRow(),
+        )
+        self.functions["url_decode"] = FunctionInfo(
+            name="url_decode",
+            forall_vars=None,
+            param_types=(STRING,),
+            return_type=AdtType("Result", (STRING, STRING)),
+            effect=PureEffectRow(),
+        )
         self.functions["to_string"] = FunctionInfo(
             name="to_string",
             forall_vars=None,

--- a/vera/wasm/calls.py
+++ b/vera/wasm/calls.py
@@ -62,6 +62,10 @@ class CallsMixin:
                 return self._translate_base64_encode(call.args[0], env)
             if call.name == "base64_decode" and len(call.args) == 1:
                 return self._translate_base64_decode(call.args[0], env)
+            if call.name == "url_encode" and len(call.args) == 1:
+                return self._translate_url_encode(call.args[0], env)
+            if call.name == "url_decode" and len(call.args) == 1:
+                return self._translate_url_decode(call.args[0], env)
             if call.name == "to_string" and len(call.args) == 1:
                 return self._translate_to_string(call.args[0], env)
             if call.name == "int_to_string" and len(call.args) == 1:
@@ -2719,6 +2723,581 @@ class CallsMixin:
         ins.append("i32.store offset=8")
 
         ins.append("end")  # block $done_bd
+
+        ins.append(f"local.get {out}")
+        return ins
+
+    def _translate_url_encode(
+        self, arg: ast.Expr, env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """Translate url_encode(s) → String (i32_pair).
+
+        Percent-encodes all bytes except RFC 3986 unreserved characters:
+        A-Z, a-z, 0-9, '-', '_', '.', '~'.
+        Each reserved byte becomes %XX (uppercase hex).
+        """
+        arg_instrs = self.translate_expr(arg, env)
+        if arg_instrs is None:
+            return None
+
+        self.needs_alloc = True
+
+        # Intern the hex digit alphabet for fast lookup
+        hex_off, _ = self.string_pool.intern("0123456789ABCDEF")
+        empty_off, empty_len = self.string_pool.intern("")
+
+        ptr = self.alloc_local("i32")
+        slen = self.alloc_local("i32")
+        dst = self.alloc_local("i32")
+        out_len = self.alloc_local("i32")
+        i = self.alloc_local("i32")    # input index
+        j = self.alloc_local("i32")    # output index
+        ch = self.alloc_local("i32")   # current byte
+
+        ins: list[str] = []
+
+        # Evaluate string arg → (ptr, len)
+        ins.extend(arg_instrs)
+        ins.append(f"local.set {slen}")
+        ins.append(f"local.set {ptr}")
+
+        # Empty input → empty output
+        ins.append(f"local.get {slen}")
+        ins.append("i32.eqz")
+        ins.append("if (result i32 i32)")
+        ins.append(f"  i32.const {empty_off}")
+        ins.append(f"  i32.const {empty_len}")
+        ins.append("else")
+
+        # First pass: count output length
+        # Each byte is either 1 (unreserved) or 3 (%XX)
+        ins.append("i32.const 0")
+        ins.append(f"local.set {out_len}")
+        ins.append("i32.const 0")
+        ins.append(f"local.set {i}")
+        ins.append("block $brk_cnt")
+        ins.append("  loop $lp_cnt")
+        ins.append(f"    local.get {i}")
+        ins.append(f"    local.get {slen}")
+        ins.append("    i32.ge_u")
+        ins.append("    br_if $brk_cnt")
+        ins.append(f"    local.get {ptr}")
+        ins.append(f"    local.get {i}")
+        ins.append("    i32.add")
+        ins.append("    i32.load8_u offset=0")
+        ins.append(f"    local.set {ch}")
+
+        # Check if unreserved: A-Z || a-z || 0-9 || '-' || '_' || '.' || '~'
+        ins.append("    block $unreserved_c")
+        # A-Z (65-90)
+        ins.append(f"    local.get {ch}")
+        ins.append("    i32.const 65")
+        ins.append("    i32.ge_u")
+        ins.append(f"    local.get {ch}")
+        ins.append("    i32.const 90")
+        ins.append("    i32.le_u")
+        ins.append("    i32.and")
+        ins.append("    br_if $unreserved_c")
+        # a-z (97-122)
+        ins.append(f"    local.get {ch}")
+        ins.append("    i32.const 97")
+        ins.append("    i32.ge_u")
+        ins.append(f"    local.get {ch}")
+        ins.append("    i32.const 122")
+        ins.append("    i32.le_u")
+        ins.append("    i32.and")
+        ins.append("    br_if $unreserved_c")
+        # 0-9 (48-57)
+        ins.append(f"    local.get {ch}")
+        ins.append("    i32.const 48")
+        ins.append("    i32.ge_u")
+        ins.append(f"    local.get {ch}")
+        ins.append("    i32.const 57")
+        ins.append("    i32.le_u")
+        ins.append("    i32.and")
+        ins.append("    br_if $unreserved_c")
+        # '-' (45)
+        ins.append(f"    local.get {ch}")
+        ins.append("    i32.const 45")
+        ins.append("    i32.eq")
+        ins.append("    br_if $unreserved_c")
+        # '_' (95)
+        ins.append(f"    local.get {ch}")
+        ins.append("    i32.const 95")
+        ins.append("    i32.eq")
+        ins.append("    br_if $unreserved_c")
+        # '.' (46)
+        ins.append(f"    local.get {ch}")
+        ins.append("    i32.const 46")
+        ins.append("    i32.eq")
+        ins.append("    br_if $unreserved_c")
+        # '~' (126)
+        ins.append(f"    local.get {ch}")
+        ins.append("    i32.const 126")
+        ins.append("    i32.eq")
+        ins.append("    br_if $unreserved_c")
+
+        # Reserved: out_len += 3
+        ins.append(f"    local.get {out_len}")
+        ins.append("    i32.const 3")
+        ins.append("    i32.add")
+        ins.append(f"    local.set {out_len}")
+        ins.append(f"    local.get {i}")
+        ins.append("    i32.const 1")
+        ins.append("    i32.add")
+        ins.append(f"    local.set {i}")
+        ins.append("    br $lp_cnt")
+        ins.append("    end")  # block $unreserved_c
+
+        # Unreserved: out_len += 1
+        ins.append(f"    local.get {out_len}")
+        ins.append("    i32.const 1")
+        ins.append("    i32.add")
+        ins.append(f"    local.set {out_len}")
+        ins.append(f"    local.get {i}")
+        ins.append("    i32.const 1")
+        ins.append("    i32.add")
+        ins.append(f"    local.set {i}")
+        ins.append("    br $lp_cnt")
+        ins.append("  end")  # loop
+        ins.append("end")    # block $brk_cnt
+
+        # Allocate output buffer
+        ins.append(f"local.get {out_len}")
+        ins.append("call $alloc")
+        ins.append(f"local.set {dst}")
+        ins.extend(gc_shadow_push(dst))
+
+        # Second pass: write encoded output
+        ins.append("i32.const 0")
+        ins.append(f"local.set {i}")
+        ins.append("i32.const 0")
+        ins.append(f"local.set {j}")
+        ins.append("block $brk_enc")
+        ins.append("  loop $lp_enc")
+        ins.append(f"    local.get {i}")
+        ins.append(f"    local.get {slen}")
+        ins.append("    i32.ge_u")
+        ins.append("    br_if $brk_enc")
+        ins.append(f"    local.get {ptr}")
+        ins.append(f"    local.get {i}")
+        ins.append("    i32.add")
+        ins.append("    i32.load8_u offset=0")
+        ins.append(f"    local.set {ch}")
+
+        # Check if unreserved (same logic as counting pass)
+        ins.append("    block $unreserved_e")
+        # A-Z
+        ins.append(f"    local.get {ch}")
+        ins.append("    i32.const 65")
+        ins.append("    i32.ge_u")
+        ins.append(f"    local.get {ch}")
+        ins.append("    i32.const 90")
+        ins.append("    i32.le_u")
+        ins.append("    i32.and")
+        ins.append("    br_if $unreserved_e")
+        # a-z
+        ins.append(f"    local.get {ch}")
+        ins.append("    i32.const 97")
+        ins.append("    i32.ge_u")
+        ins.append(f"    local.get {ch}")
+        ins.append("    i32.const 122")
+        ins.append("    i32.le_u")
+        ins.append("    i32.and")
+        ins.append("    br_if $unreserved_e")
+        # 0-9
+        ins.append(f"    local.get {ch}")
+        ins.append("    i32.const 48")
+        ins.append("    i32.ge_u")
+        ins.append(f"    local.get {ch}")
+        ins.append("    i32.const 57")
+        ins.append("    i32.le_u")
+        ins.append("    i32.and")
+        ins.append("    br_if $unreserved_e")
+        # '-'
+        ins.append(f"    local.get {ch}")
+        ins.append("    i32.const 45")
+        ins.append("    i32.eq")
+        ins.append("    br_if $unreserved_e")
+        # '_'
+        ins.append(f"    local.get {ch}")
+        ins.append("    i32.const 95")
+        ins.append("    i32.eq")
+        ins.append("    br_if $unreserved_e")
+        # '.'
+        ins.append(f"    local.get {ch}")
+        ins.append("    i32.const 46")
+        ins.append("    i32.eq")
+        ins.append("    br_if $unreserved_e")
+        # '~'
+        ins.append(f"    local.get {ch}")
+        ins.append("    i32.const 126")
+        ins.append("    i32.eq")
+        ins.append("    br_if $unreserved_e")
+
+        # Reserved: write '%', hex_hi, hex_lo
+        ins.append(f"    local.get {dst}")
+        ins.append(f"    local.get {j}")
+        ins.append("    i32.add")
+        ins.append("    i32.const 37")         # '%'
+        ins.append("    i32.store8 offset=0")
+        # High nibble: hex[ch >> 4]
+        ins.append(f"    local.get {dst}")
+        ins.append(f"    local.get {j}")
+        ins.append("    i32.add")
+        ins.append(f"    i32.const {hex_off}")
+        ins.append(f"    local.get {ch}")
+        ins.append("    i32.const 4")
+        ins.append("    i32.shr_u")
+        ins.append("    i32.add")
+        ins.append("    i32.load8_u offset=0")
+        ins.append("    i32.store8 offset=1")
+        # Low nibble: hex[ch & 0xF]
+        ins.append(f"    local.get {dst}")
+        ins.append(f"    local.get {j}")
+        ins.append("    i32.add")
+        ins.append(f"    i32.const {hex_off}")
+        ins.append(f"    local.get {ch}")
+        ins.append("    i32.const 15")
+        ins.append("    i32.and")
+        ins.append("    i32.add")
+        ins.append("    i32.load8_u offset=0")
+        ins.append("    i32.store8 offset=2")
+        # j += 3
+        ins.append(f"    local.get {j}")
+        ins.append("    i32.const 3")
+        ins.append("    i32.add")
+        ins.append(f"    local.set {j}")
+        ins.append(f"    local.get {i}")
+        ins.append("    i32.const 1")
+        ins.append("    i32.add")
+        ins.append(f"    local.set {i}")
+        ins.append("    br $lp_enc")
+        ins.append("    end")  # block $unreserved_e
+
+        # Unreserved: copy byte directly
+        ins.append(f"    local.get {dst}")
+        ins.append(f"    local.get {j}")
+        ins.append("    i32.add")
+        ins.append(f"    local.get {ch}")
+        ins.append("    i32.store8 offset=0")
+        # j += 1
+        ins.append(f"    local.get {j}")
+        ins.append("    i32.const 1")
+        ins.append("    i32.add")
+        ins.append(f"    local.set {j}")
+        ins.append(f"    local.get {i}")
+        ins.append("    i32.const 1")
+        ins.append("    i32.add")
+        ins.append(f"    local.set {i}")
+        ins.append("    br $lp_enc")
+        ins.append("  end")  # loop
+        ins.append("end")    # block $brk_enc
+
+        # Leave (dst, out_len) on the stack
+        ins.append(f"local.get {dst}")
+        ins.append(f"local.get {out_len}")
+
+        ins.append("end")  # else branch of empty check
+
+        return ins
+
+    def _translate_url_decode(
+        self, arg: ast.Expr, env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """Translate url_decode(s) → Result<String, String> (i32 ptr).
+
+        Decodes percent-encoded strings (RFC 3986).  Each %XX sequence
+        is converted to the byte with that hex value.  Returns Err on
+        invalid sequences (truncated %, invalid hex digits).
+
+        ADT layout (16 bytes):
+          Ok(String):  [tag=0 : i32] [ptr : i32] [len : i32] [pad 4]
+          Err(String): [tag=1 : i32] [ptr : i32] [len : i32] [pad 4]
+        """
+        arg_instrs = self.translate_expr(arg, env)
+        if arg_instrs is None:
+            return None
+
+        self.needs_alloc = True
+
+        err_off, err_ln = self.string_pool.intern("invalid percent-encoding")
+        empty_off, empty_len = self.string_pool.intern("")
+
+        ptr = self.alloc_local("i32")
+        slen = self.alloc_local("i32")
+        out = self.alloc_local("i32")    # Result ADT pointer
+        dst = self.alloc_local("i32")    # decoded bytes pointer
+        out_len = self.alloc_local("i32")
+        i = self.alloc_local("i32")      # input index
+        k = self.alloc_local("i32")      # output index
+        ch = self.alloc_local("i32")     # current byte
+        hi = self.alloc_local("i32")     # high hex nibble value
+        lo = self.alloc_local("i32")     # low hex nibble value
+
+        ins: list[str] = []
+
+        # Evaluate string arg → (ptr, len)
+        ins.extend(arg_instrs)
+        ins.append(f"local.set {slen}")
+        ins.append(f"local.set {ptr}")
+
+        ins.append("block $done_ud")
+        ins.append("block $err_ud")
+
+        # Empty input → Ok("")
+        ins.append(f"local.get {slen}")
+        ins.append("i32.eqz")
+        ins.append("if")
+        ins.append("  i32.const 16")
+        ins.append("  call $alloc")
+        ins.append(f"  local.tee {out}")
+        ins.append("  i32.const 0")
+        ins.append("  i32.store")              # tag = 0 (Ok)
+        ins.extend(["  " + x for x in gc_shadow_push(out)])
+        ins.append(f"  local.get {out}")
+        ins.append(f"  i32.const {empty_off}")
+        ins.append("  i32.store offset=4")
+        ins.append(f"  local.get {out}")
+        ins.append(f"  i32.const {empty_len}")
+        ins.append("  i32.store offset=8")
+        ins.append("  br $done_ud")
+        ins.append("end")
+
+        # Allocate output buffer (at most slen bytes — decoding shrinks)
+        ins.append(f"local.get {slen}")
+        ins.append("call $alloc")
+        ins.append(f"local.set {dst}")
+        ins.extend(gc_shadow_push(dst))
+
+        # Decode loop
+        ins.append("i32.const 0")
+        ins.append(f"local.set {i}")
+        ins.append("i32.const 0")
+        ins.append(f"local.set {k}")
+
+        ins.append("block $brk_dl")
+        ins.append("  loop $lp_dl")
+        ins.append(f"    local.get {i}")
+        ins.append(f"    local.get {slen}")
+        ins.append("    i32.ge_u")
+        ins.append("    br_if $brk_dl")
+
+        # Load current byte
+        ins.append(f"    local.get {ptr}")
+        ins.append(f"    local.get {i}")
+        ins.append("    i32.add")
+        ins.append("    i32.load8_u offset=0")
+        ins.append(f"    local.set {ch}")
+
+        # Check if '%' (37)
+        ins.append(f"    local.get {ch}")
+        ins.append("    i32.const 37")
+        ins.append("    i32.eq")
+        ins.append("    if")
+
+        # Need at least 2 more bytes
+        ins.append(f"      local.get {i}")
+        ins.append("      i32.const 2")
+        ins.append("      i32.add")
+        ins.append(f"      local.get {slen}")
+        ins.append("      i32.ge_u")
+        ins.append("      br_if $err_ud")
+
+        # Decode high nibble (i+1)
+        ins.append(f"      local.get {ptr}")
+        ins.append(f"      local.get {i}")
+        ins.append("      i32.add")
+        ins.append("      i32.load8_u offset=1")
+        ins.append(f"      local.set {ch}")
+
+        # Convert hex char to value (hi)
+        ins.append("      block $hi_ok")
+        ins.append("      block $hi_bad")
+        # 0-9 (48-57) → 0-9
+        ins.append(f"      local.get {ch}")
+        ins.append("      i32.const 48")
+        ins.append("      i32.ge_u")
+        ins.append(f"      local.get {ch}")
+        ins.append("      i32.const 57")
+        ins.append("      i32.le_u")
+        ins.append("      i32.and")
+        ins.append("      if")
+        ins.append(f"        local.get {ch}")
+        ins.append("        i32.const 48")
+        ins.append("        i32.sub")
+        ins.append(f"        local.set {hi}")
+        ins.append("        br $hi_ok")
+        ins.append("      end")
+        # A-F (65-70) → 10-15
+        ins.append(f"      local.get {ch}")
+        ins.append("      i32.const 65")
+        ins.append("      i32.ge_u")
+        ins.append(f"      local.get {ch}")
+        ins.append("      i32.const 70")
+        ins.append("      i32.le_u")
+        ins.append("      i32.and")
+        ins.append("      if")
+        ins.append(f"        local.get {ch}")
+        ins.append("        i32.const 55")
+        ins.append("        i32.sub")
+        ins.append(f"        local.set {hi}")
+        ins.append("        br $hi_ok")
+        ins.append("      end")
+        # a-f (97-102) → 10-15
+        ins.append(f"      local.get {ch}")
+        ins.append("      i32.const 97")
+        ins.append("      i32.ge_u")
+        ins.append(f"      local.get {ch}")
+        ins.append("      i32.const 102")
+        ins.append("      i32.le_u")
+        ins.append("      i32.and")
+        ins.append("      if")
+        ins.append(f"        local.get {ch}")
+        ins.append("        i32.const 87")
+        ins.append("        i32.sub")
+        ins.append(f"        local.set {hi}")
+        ins.append("        br $hi_ok")
+        ins.append("      end")
+        ins.append("      br $hi_bad")
+        ins.append("      end")  # block $hi_bad
+        ins.append("      br $err_ud")
+        ins.append("      end")  # block $hi_ok
+
+        # Decode low nibble (i+2)
+        ins.append(f"      local.get {ptr}")
+        ins.append(f"      local.get {i}")
+        ins.append("      i32.add")
+        ins.append("      i32.load8_u offset=2")
+        ins.append(f"      local.set {ch}")
+
+        # Convert hex char to value (lo)
+        ins.append("      block $lo_ok")
+        ins.append("      block $lo_bad")
+        # 0-9
+        ins.append(f"      local.get {ch}")
+        ins.append("      i32.const 48")
+        ins.append("      i32.ge_u")
+        ins.append(f"      local.get {ch}")
+        ins.append("      i32.const 57")
+        ins.append("      i32.le_u")
+        ins.append("      i32.and")
+        ins.append("      if")
+        ins.append(f"        local.get {ch}")
+        ins.append("        i32.const 48")
+        ins.append("        i32.sub")
+        ins.append(f"        local.set {lo}")
+        ins.append("        br $lo_ok")
+        ins.append("      end")
+        # A-F
+        ins.append(f"      local.get {ch}")
+        ins.append("      i32.const 65")
+        ins.append("      i32.ge_u")
+        ins.append(f"      local.get {ch}")
+        ins.append("      i32.const 70")
+        ins.append("      i32.le_u")
+        ins.append("      i32.and")
+        ins.append("      if")
+        ins.append(f"        local.get {ch}")
+        ins.append("        i32.const 55")
+        ins.append("        i32.sub")
+        ins.append(f"        local.set {lo}")
+        ins.append("        br $lo_ok")
+        ins.append("      end")
+        # a-f
+        ins.append(f"      local.get {ch}")
+        ins.append("      i32.const 97")
+        ins.append("      i32.ge_u")
+        ins.append(f"      local.get {ch}")
+        ins.append("      i32.const 102")
+        ins.append("      i32.le_u")
+        ins.append("      i32.and")
+        ins.append("      if")
+        ins.append(f"        local.get {ch}")
+        ins.append("        i32.const 87")
+        ins.append("        i32.sub")
+        ins.append(f"        local.set {lo}")
+        ins.append("        br $lo_ok")
+        ins.append("      end")
+        ins.append("      br $lo_bad")
+        ins.append("      end")  # block $lo_bad
+        ins.append("      br $err_ud")
+        ins.append("      end")  # block $lo_ok
+
+        # Store decoded byte: (hi << 4) | lo
+        ins.append(f"      local.get {dst}")
+        ins.append(f"      local.get {k}")
+        ins.append("      i32.add")
+        ins.append(f"      local.get {hi}")
+        ins.append("      i32.const 4")
+        ins.append("      i32.shl")
+        ins.append(f"      local.get {lo}")
+        ins.append("      i32.or")
+        ins.append("      i32.store8 offset=0")
+        ins.append(f"      local.get {k}")
+        ins.append("      i32.const 1")
+        ins.append("      i32.add")
+        ins.append(f"      local.set {k}")
+        # i += 3
+        ins.append(f"      local.get {i}")
+        ins.append("      i32.const 3")
+        ins.append("      i32.add")
+        ins.append(f"      local.set {i}")
+
+        ins.append("    else")
+
+        # Not '%': copy byte directly
+        ins.append(f"      local.get {dst}")
+        ins.append(f"      local.get {k}")
+        ins.append("      i32.add")
+        ins.append(f"      local.get {ch}")
+        ins.append("      i32.store8 offset=0")
+        ins.append(f"      local.get {k}")
+        ins.append("      i32.const 1")
+        ins.append("      i32.add")
+        ins.append(f"      local.set {k}")
+        ins.append(f"      local.get {i}")
+        ins.append("      i32.const 1")
+        ins.append("      i32.add")
+        ins.append(f"      local.set {i}")
+
+        ins.append("    end")  # if '%'
+
+        ins.append("    br $lp_dl")
+        ins.append("  end")  # loop
+        ins.append("end")    # block $brk_dl
+
+        # --- Ok path ---
+        ins.append("i32.const 16")
+        ins.append("call $alloc")
+        ins.append(f"local.tee {out}")
+        ins.append("i32.const 0")
+        ins.append("i32.store")                # tag = 0 (Ok)
+        ins.extend(gc_shadow_push(out))
+        ins.append(f"local.get {out}")
+        ins.append(f"local.get {dst}")
+        ins.append("i32.store offset=4")       # string ptr
+        ins.append(f"local.get {out}")
+        ins.append(f"local.get {k}")
+        ins.append("i32.store offset=8")       # string len
+        ins.append("br $done_ud")
+
+        # --- Err path ---
+        ins.append("end")  # block $err_ud
+        ins.append("i32.const 16")
+        ins.append("call $alloc")
+        ins.append(f"local.tee {out}")
+        ins.append("i32.const 1")
+        ins.append("i32.store")                # tag = 1 (Err)
+        ins.extend(gc_shadow_push(out))
+        ins.append(f"local.get {out}")
+        ins.append(f"i32.const {err_off}")
+        ins.append("i32.store offset=4")
+        ins.append(f"local.get {out}")
+        ins.append(f"i32.const {err_ln}")
+        ins.append("i32.store offset=8")
+
+        ins.append("end")  # block $done_ud
 
         ins.append(f"local.get {out}")
         return ins

--- a/vera/wasm/inference.py
+++ b/vera/wasm/inference.py
@@ -224,10 +224,10 @@ class InferenceMixin:
         # parse/decode builtins → Result<T, String> (i32 heap pointer)
         if expr.name in (
             "parse_nat", "parse_int", "parse_float64", "parse_bool",
-            "base64_decode",
+            "base64_decode", "url_decode",
         ):
             return "i32"
-        if expr.name == "base64_encode":
+        if expr.name in ("base64_encode", "url_encode"):
             return "i32_pair"
         # Numeric math builtins
         if expr.name in ("abs", "min", "max", "floor", "ceil", "round"):
@@ -402,10 +402,10 @@ class InferenceMixin:
             return "Array"
         if call.name in (
             "parse_nat", "parse_int", "parse_float64", "parse_bool",
-            "base64_decode",
+            "base64_decode", "url_decode",
         ):
             return "Result"
-        if call.name == "base64_encode":
+        if call.name in ("base64_encode", "url_encode"):
             return "String"
         # Numeric math builtins
         if call.name == "abs":


### PR DESCRIPTION
## Summary

- New `url_encode(@String -> @String)` — RFC 3986 percent-encoding, pure WASM
- New `url_decode(@String -> @Result<String, String>)` — percent-decoding with error handling, pure WASM
- Phase 1 of #232; `url_parse` and `url_join` will follow in a separate PR
- Version bump: 0.0.79 → 0.0.80

## Test plan

- [x] 4 new checker tests (ok + wrong_type for each function)
- [x] 17 new codegen tests (7 encode + 9 decode + 1 roundtrip)
- [x] Conformance test `ch09_url_encoding` (6 functions)
- [x] Example `examples/url_encoding.vera` (encode, decode, roundtrip)
- [x] All 2,003 tests pass, all 48 conformance programs pass, all 20 examples pass
- [x] mypy clean, all validation scripts pass

Closes partially #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)