### PR TITLE
Fix i32_pair layout crash for ADT constructors with String/Array fields

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Read `SKILL.md` for the full language reference. It covers syntax, slot referenc
 
 ### Conformance programs as reference
 
-The conformance suite in `tests/conformance/` contains 43 small, self-contained programs — one per language feature — that all parse, type-check, verify, and (mostly) run correctly. These are the best minimal working examples of each feature. When you need to see how a specific construct works (e.g. effect handlers, match expressions, closures), check the corresponding conformance program before reading the spec. The `manifest.json` file maps features to programs.
+The conformance suite in `tests/conformance/` contains 48 small, self-contained programs — one per language feature — that all parse, type-check, verify, and (mostly) run correctly. These are the best minimal working examples of each feature. When you need to see how a specific construct works (e.g. effect handlers, match expressions, closures), check the corresponding conformance program before reading the spec. The `manifest.json` file maps features to programs.
 
 ### Workflow
 
@@ -140,18 +140,23 @@ Each stage is a module with a single public API function (`parse_file`, `transfo
 pytest tests/ -v                       # Run all tests (see TESTING.md)
 pytest tests/test_conformance.py -v    # Conformance suite only
 mypy vera/                             # Type-check the compiler
-python scripts/check_conformance.py    # All 43 conformance programs must pass
-python scripts/check_examples.py       # All 18 examples must pass
+python scripts/check_conformance.py    # All 48 conformance programs must pass
+python scripts/check_examples.py       # All 20 examples must pass
 ```
 
 Test helpers follow a pattern: `_check_ok(source)` / `_check_err(source, match)` / `_verify_ok(source)` / `_verify_err(source, match)`. See existing tests for examples.
 
 When implementing a new language feature, write the conformance program *first* — add a `.vera` file and manifest entry in `tests/conformance/`, then implement the feature until the conformance test passes.
 
+### Known codegen limitations
+
+- **ADT constructors with String/Array fields** crash the layout computation (#266). Use only numeric fields in user-defined ADTs until this is fixed.
+- **Tuple types** have no WASM codegen (#267). Functions with Tuple expressions get E602 and are skipped. Use named ADTs as a workaround.
+
 ### Invariants
 
-- All 43 conformance programs in `tests/conformance/` must pass their declared level
-- All 18 examples in `examples/` must pass `vera check` and `vera verify`
+- All 48 conformance programs in `tests/conformance/` must pass their declared level
+- All 20 examples in `examples/` must pass `vera check` and `vera verify`
 - `mypy vera/` must be clean
 - `pytest tests/ -v` must pass
 - Version must be in sync across `vera/__init__.py`, `pyproject.toml`, and `CHANGELOG.md`

--- a/README.md
+++ b/README.md
@@ -331,6 +331,11 @@ Module refinements, lexical extensions, and IO runtime — completing the existi
 - [#187](https://github.com/aallan/vera/issues/187) module-qualified call disambiguation via name mangling
 - [#127](https://github.com/aallan/vera/issues/127) module re-exports
 
+**Codegen** — WASM compilation gaps
+
+- [#266](https://github.com/aallan/vera/issues/266) ADT constructors with String/Array fields crash codegen layout
+- [#267](https://github.com/aallan/vera/issues/267) Tuple type WASM codegen
+
 **IO runtime** — host bindings for file and stdin access
 
 - <del>[#135](https://github.com/aallan/vera/issues/135) IO operations (read_line, read_file, write_file, args, exit, get_env)</del> ([v0.0.66](https://github.com/aallan/vera/releases/tag/v0.0.66))

--- a/SKILL.md
+++ b/SKILL.md
@@ -285,7 +285,7 @@ private fn abs(@Int -> @Nat)
 @Array<Int>                              -- array of ints
 @Array<Option<Int>>                      -- array of ADT (compound element type)
 @Array<String>                           -- array of strings
-@Tuple<Int, String>                      -- tuple
+@Tuple<Int, String>                      -- tuple (type-checks but no WASM codegen yet, see #267)
 @Option<Int>                             -- Option type (Some/None)
 Fn(Int -> Int) effects(pure)              -- function type
 { @Int | @Int.0 > 0 }                   -- refinement type
@@ -816,6 +816,11 @@ Type aliases and effect declarations are module-local and cannot be imported. If
 Module-qualified calls use `::` between the module path and the function name: `vera.math::abs(42)`. The dot-separated path identifies the module and `::` separates it from the function name. This syntax can be used anywhere a function call is valid, and always resolves against the specific module's public declarations — it is not affected by local shadowing. Note: module-qualified calls (`math::abs(42)`) are available for readability but do not yet resolve name collisions in flat compilation — the compiler will still report a collision error. A future version will support qualified-call disambiguation via name mangling.
 
 There is no import aliasing (`import m(abs as math_abs)`) and no wildcard exclusion (`import m hiding(x)`). These are intentional design decisions, not limitations. When names clash across modules, rename the conflicting declaration in one of the source modules. This preserves the one-canonical-form principle — every function has exactly one name.
+
+### Known codegen limitations
+
+- **ADT constructors with String/Array fields** do not compile (#266). User-defined ADTs with only numeric fields (Int, Nat, Bool, Byte, Float64) work correctly. ADTs with String or Array fields crash the layout computation. Builtins returning `Result<String, String>` work because they use hand-coded WASM layout.
+- **Tuple types** are specified and type-check but have no WASM codegen (#267). Functions containing Tuple expressions are silently skipped. Use named ADTs (e.g. `data Pair<A, B> { Pair(A, B) }`) as a workaround.
 
 There are no raw strings (`r"..."`) or multi-line string literals. Use escape sequences (`\\`, `\n`, `\t`, `\"`) for special characters. This is by design — alternative string syntaxes would create two representations for the same value.
 

--- a/scripts/check_readme_examples.py
+++ b/scripts/check_readme_examples.py
@@ -36,7 +36,7 @@ ALLOWLIST: dict[int, tuple[str, str]] = {
     # =================================================================
 
     # Section "Where this is going" — depends on #57 (Http), #61 (Inference), #147 (Markdown)
-    404: ("FUTURE", "Vision example uses MdBlock, Http, Inference (issues #57, #61, #147)"),
+    409: ("FUTURE", "Vision example uses MdBlock, Http, Inference (issues #57, #61, #147)"),
 }
 
 

--- a/scripts/check_skill_examples.py
+++ b/scripts/check_skill_examples.py
@@ -70,7 +70,7 @@ ALLOWLIST: dict[int, tuple[str, str]] = {
     775: ("FRAGMENT", "Module declaration and import example"),
 
     # Line comments — bare comments
-    826: ("FRAGMENT", "Comment syntax example"),
+    831: ("FRAGMENT", "Comment syntax example"),
 
     # Type conversions — bare function calls
     482: ("FRAGMENT", "Type conversion examples, bare calls"),
@@ -79,25 +79,25 @@ ALLOWLIST: dict[int, tuple[str, str]] = {
     495: ("FRAGMENT", "Float64 predicate examples, bare calls"),
 
     # Common mistakes section — intentionally wrong code
-    854: ("FRAGMENT", "Wrong: missing contracts"),
-    874: ("FRAGMENT", "Wrong: missing effects clause"),
-    908: ("FRAGMENT", "Wrong: bare expression without indices"),
-    921: ("FRAGMENT", "Wrong: bare expression no indices"),
-    926: ("FRAGMENT", "Correct: expression with indices (not full fn)"),
-    992: ("FRAGMENT", "Wrong: match arm with incorrect return"),
-    1016: ("FRAGMENT", "Wrong: non-exhaustive match"),
-    1023: ("FRAGMENT", "Correct: match arm example"),
-    1033: ("FRAGMENT", "Wrong: if/else without braces (bare expression)"),
-    1038: ("FRAGMENT", "Correct: if/else with braces"),
+    859: ("FRAGMENT", "Wrong: missing contracts"),
+    879: ("FRAGMENT", "Wrong: missing effects clause"),
+    913: ("FRAGMENT", "Wrong: bare expression without indices"),
+    926: ("FRAGMENT", "Wrong: bare expression no indices"),
+    931: ("FRAGMENT", "Correct: expression with indices (not full fn)"),
+    997: ("FRAGMENT", "Wrong: match arm with incorrect return"),
+    1021: ("FRAGMENT", "Wrong: non-exhaustive match"),
+    1028: ("FRAGMENT", "Correct: match arm example"),
+    1038: ("FRAGMENT", "Wrong: if/else without braces (bare expression)"),
+    1043: ("FRAGMENT", "Correct: if/else with braces"),
 
     # Import syntax — intentionally unsupported
-    1049: ("FRAGMENT", "Wrong: import aliasing not supported"),
-    1054: ("FRAGMENT", "Correct: import syntax example"),
-    1064: ("FRAGMENT", "Wrong: import hiding not supported"),
-    1069: ("FRAGMENT", "Correct: multi-import syntax"),
+    1054: ("FRAGMENT", "Wrong: import aliasing not supported"),
+    1059: ("FRAGMENT", "Correct: import syntax example"),
+    1069: ("FRAGMENT", "Wrong: import hiding not supported"),
+    1074: ("FRAGMENT", "Correct: multi-import syntax"),
 
     # String escapes — bare expression
-    1083: ("FRAGMENT", "String escape example"),
+    1088: ("FRAGMENT", "String escape example"),
 
     # =================================================================
     # MISMATCH — uses syntax the parser doesn't handle in isolation.

--- a/spec/11-compilation.md
+++ b/spec/11-compilation.md
@@ -584,3 +584,5 @@ The current compilation model has the following limitations, each tracked as a G
 | Limitation | Issue | Notes |
 |-----------|-------|-------|
 | Flat module compilation | [#110](https://github.com/aallan/vera/issues/110) | Imported functions are compiled into the importing module; name collisions are detected (E608/E609/E610); qualified-call disambiguation via name mangling is tracked separately |
+| ADT constructors with String/Array fields | [#266](https://github.com/aallan/vera/issues/266) | ADT constructor layout computation crashes on `i32_pair` (String/Array) fields; builtins bypass this via hand-coded WASM layout |
+| Tuple type codegen | [#267](https://github.com/aallan/vera/issues/267) | Tuple types are fully specified and type-checked but have no WASM backend; functions containing Tuple expressions are skipped with E602 |

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -4758,6 +4758,97 @@ public fn f(@Unit -> @Unit) requires(true) ensures(true) effects(<IO>) {
         assert _run_io(src) == "Hello, World!"
 
 
+class TestAdtStringFields:
+    """ADT constructors with String/Array fields (bug #266)."""
+
+    def test_wrap_one_string(self) -> None:
+        src = """
+effect IO { op print(String -> Unit); }
+private data Wrap { Wrap(String) }
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  match Wrap("hello") {
+    Wrap(@String) -> IO.print(@String.0)
+  }
+}
+"""
+        assert _run_io(src) == "hello"
+
+    def test_pair_two_strings(self) -> None:
+        src = """
+effect IO { op print(String -> Unit); }
+private data Pair { Pair(String, String) }
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  match Pair("hello", "world") {
+    Pair(@String, @String) -> {
+      IO.print(@String.1);
+      IO.print(@String.0)
+    }
+  }
+}
+"""
+        assert _run_io(src) == "helloworld"
+
+    def test_mixed_int_string(self) -> None:
+        src = """
+effect IO { op print(String -> Unit); }
+private data Mixed { Mixed(Int, String) }
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  match Mixed(42, "hi") {
+    Mixed(@Int, @String) -> {
+      IO.print(to_string(@Int.0));
+      IO.print(@String.0)
+    }
+  }
+}
+"""
+        assert _run_io(src) == "42hi"
+
+    def test_multi_constructor_string(self) -> None:
+        src = """
+effect IO { op print(String -> Unit); }
+private data Either { Left(String), Right(String) }
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  match Left("left") {
+    Left(@String) -> IO.print(@String.0),
+    Right(@String) -> IO.print(@String.0)
+  };
+  match Right("right") {
+    Left(@String) -> IO.print(@String.0),
+    Right(@String) -> IO.print(@String.0)
+  }
+}
+"""
+        assert _run_io(src) == "leftright"
+
+    def test_five_string_fields(self) -> None:
+        src = """
+effect IO { op print(String -> Unit); }
+private data Parts { Parts(String, String, String, String, String) }
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  match Parts("a", "b", "c", "d", "e") {
+    Parts(@String, @String, @String, @String, @String) -> {
+      IO.print(@String.4);
+      IO.print(@String.3);
+      IO.print(@String.2);
+      IO.print(@String.1);
+      IO.print(@String.0)
+    }
+  }
+}
+"""
+        assert _run_io(src) == "abcde"
+
+
 class TestUrlEncode:
     """url_encode returns String."""
 

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -19,7 +19,7 @@ README = Path(__file__).parent.parent / "README.md"
 # Each key is the 1-based line number of the opening ```vera fence.
 ALLOWLIST: dict[int, str] = {
     # "Where this is going" — depends on #57 (Http), #61 (Inference), #147 (Markdown)
-    404: "Vision example uses MdBlock, Http, Inference (issues #57, #61, #147)",
+    409: "Vision example uses MdBlock, Http, Inference (issues #57, #61, #147)",
 }
 
 

--- a/vera/README.md
+++ b/vera/README.md
@@ -609,6 +609,8 @@ Honest inventory of what the compiler cannot do, and where each limitation is ad
 | **No incremental compilation** | Full file processed from scratch each time | [#56](https://github.com/aallan/vera/issues/56) |
 | **No LSP server** | No IDE integration or structured code intelligence for agents | [#222](https://github.com/aallan/vera/issues/222) |
 | **No REPL** | No interactive evaluation; all code must be written to files | [#224](https://github.com/aallan/vera/issues/224) |
+| **ADT constructors with String/Array fields crash** | Layout computation (`_wasm_type_align`) only handles `i32`, `i64`, `f64` — not `i32_pair` (String/Array representation); builtins work via hand-coded layout | [#266](https://github.com/aallan/vera/issues/266) |
+| **No Tuple codegen** | Tuple types are specified and type-checked but have zero WASM backend support; functions with Tuple expressions get E602 | [#267](https://github.com/aallan/vera/issues/267) |
 | **No string interpolation** | Strings built via `string_concat` or chained `IO.print` calls | [#230](https://github.com/aallan/vera/issues/230) |
 | **No regex** | String processing limited to builtin functions (contains, substring, etc.) | [#231](https://github.com/aallan/vera/issues/231) |
 | **No date/time, crypto, CSV** | Standard library limited to core types, strings, and arrays | [#233](https://github.com/aallan/vera/issues/233), [#235](https://github.com/aallan/vera/issues/235), [#236](https://github.com/aallan/vera/issues/236) |

--- a/vera/codegen/api.py
+++ b/vera/codegen/api.py
@@ -45,6 +45,8 @@ def _wasm_type_size(wt: str) -> int:
         return 4
     if wt in ("i64", "f64"):
         return 8
+    if wt == "i32_pair":
+        return 8
     raise ValueError(f"Unknown WASM type: {wt}")
 
 
@@ -54,6 +56,8 @@ def _wasm_type_align(wt: str) -> int:
         return 4
     if wt in ("i64", "f64"):
         return 8
+    if wt == "i32_pair":
+        return 4
     raise ValueError(f"Unknown WASM type: {wt}")
 
 

--- a/vera/wasm/data.py
+++ b/vera/wasm/data.py
@@ -340,8 +340,8 @@ class DataMixin:
         Computes field offsets from concrete binding types (same
         monomorphization approach as _translate_constructor_call).
         """
-        _sizes = {"i32": 4, "i64": 8, "f64": 8}
-        _aligns = {"i32": 4, "i64": 8, "f64": 8}
+        _sizes = {"i32": 4, "i64": 8, "f64": 8, "i32_pair": 8}
+        _aligns = {"i32": 4, "i64": 8, "f64": 8, "i32_pair": 4}
         offset = 4  # after tag (i32, 4 bytes)
         instrs: list[str] = []
         new_env = env


### PR DESCRIPTION
## Summary

- Fix `ValueError: Unknown WASM type: i32_pair` crash when compiling ADT constructors with String or Array fields
- Add `i32_pair` (size=8, align=4) handling to `_wasm_type_size()` and `_wasm_type_align()` in `codegen/api.py`
- Add `i32_pair` to `_extract_constructor_fields()` consistency dicts in `wasm/data.py`
- Add 5 codegen tests: wrap, pair, mixed int+string, multi-constructor, five-field
- Document ADT String field limitation (#266) and Tuple codegen gap (#267) across README, vera/README, SKILL.md, AGENTS.md, and spec
- Add Codegen subsection to C8.5 roadmap

## Test plan

- [x] `data Wrap { Wrap(String) }` compiles and runs (was crashing)
- [x] `data Pair { Pair(String, String) }` compiles and runs
- [x] `data Mixed { Mixed(Int, String) }` compiles and runs
- [x] Multi-constructor ADTs with String fields work
- [x] 5-field String ADT compiles correctly
- [x] All 2,008 tests pass
- [x] All 48 conformance programs pass
- [x] All 20 examples pass
- [x] mypy clean

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)