### PR TITLE
Add url_parse, url_join builtins and UrlParts type (v0.0.81)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Read `SKILL.md` for the full language reference. It covers syntax, slot referenc
 
 ### Conformance programs as reference
 
-The conformance suite in `tests/conformance/` contains 48 small, self-contained programs — one per language feature — that all parse, type-check, verify, and (mostly) run correctly. These are the best minimal working examples of each feature. When you need to see how a specific construct works (e.g. effect handlers, match expressions, closures), check the corresponding conformance program before reading the spec. The `manifest.json` file maps features to programs.
+The conformance suite in `tests/conformance/` contains 49 small, self-contained programs — one per language feature — that all parse, type-check, verify, and (mostly) run correctly. These are the best minimal working examples of each feature. When you need to see how a specific construct works (e.g. effect handlers, match expressions, closures), check the corresponding conformance program before reading the spec. The `manifest.json` file maps features to programs.
 
 ### Workflow
 
@@ -140,8 +140,8 @@ Each stage is a module with a single public API function (`parse_file`, `transfo
 pytest tests/ -v                       # Run all tests (see TESTING.md)
 pytest tests/test_conformance.py -v    # Conformance suite only
 mypy vera/                             # Type-check the compiler
-python scripts/check_conformance.py    # All 48 conformance programs must pass
-python scripts/check_examples.py       # All 20 examples must pass
+python scripts/check_conformance.py    # All 49 conformance programs must pass
+python scripts/check_examples.py       # All 21 examples must pass
 ```
 
 Test helpers follow a pattern: `_check_ok(source)` / `_check_err(source, match)` / `_verify_ok(source)` / `_verify_err(source, match)`. See existing tests for examples.
@@ -150,13 +150,12 @@ When implementing a new language feature, write the conformance program *first* 
 
 ### Known codegen limitations
 
-- **ADT constructors with String/Array fields** crash the layout computation (#266). Use only numeric fields in user-defined ADTs until this is fixed.
 - **Tuple types** have no WASM codegen (#267). Functions with Tuple expressions get E602 and are skipped. Use named ADTs as a workaround.
 
 ### Invariants
 
-- All 48 conformance programs in `tests/conformance/` must pass their declared level
-- All 20 examples in `examples/` must pass `vera check` and `vera verify`
+- All 49 conformance programs in `tests/conformance/` must pass their declared level
+- All 21 examples in `examples/` must pass `vera check` and `vera verify`
 - `mypy vera/` must be clean
 - `pytest tests/ -v` must pass
 - Version must be in sync across `vera/__init__.py`, `pyproject.toml`, and `CHANGELOG.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.81] - 2026-03-10
+
+### Added
+- **URL parsing and joining** ([#232](https://github.com/aallan/vera/issues/232), Phase 2):
+  New `url_parse(@String -> @Result<UrlParts, String>)` — RFC 3986 URL decomposition
+  into scheme, authority, path, query, and fragment components.
+  New `url_join(@UrlParts -> @String)` — reassembles a `UrlParts` value into a URL string.
+  New built-in `UrlParts` ADT type with five String fields.
+- New conformance test `ch09_url_parsing` (conformance suite: 48→49 programs)
+- New example `examples/url_parsing.vera` — parse, extract components, join, and error demo
+- 29 new tests (4 type checker + 25 codegen)
+
+### Fixed
+- **ADT constructors with String/Array fields** ([#266](https://github.com/aallan/vera/issues/266)):
+  Layout computation (`_wasm_type_size`, `_wasm_type_align`) now handles `i32_pair`
+  (String/Array representation). User-defined ADTs with String fields compile correctly.
+
 ## [0.0.80] - 2026-03-10
 
 ### Added
@@ -1223,7 +1240,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Grammar: handler body simplified to avoid LALR reduce/reduce conflict
 - `pyproject.toml`: corrected build backend, package discovery, PEP 639 compliance
 
-[Unreleased]: https://github.com/aallan/vera/compare/v0.0.80...HEAD
+[Unreleased]: https://github.com/aallan/vera/compare/v0.0.81...HEAD
+[0.0.81]: https://github.com/aallan/vera/compare/v0.0.80...v0.0.81
 [0.0.80]: https://github.com/aallan/vera/compare/v0.0.79...v0.0.80
 [0.0.79]: https://github.com/aallan/vera/compare/v0.0.78...v0.0.79
 [0.0.78]: https://github.com/aallan/vera/compare/v0.0.77...v0.0.78

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ vera fmt --check file.vera        # Check if already canonical
 pytest tests/ -v                  # Run the test suite (see TESTING.md)
 mypy vera/                        # Type-check the compiler itself
 
-python scripts/check_conformance.py    # Verify all 48 conformance programs pass their declared level
+python scripts/check_conformance.py    # Verify all 49 conformance programs pass their declared level
 python scripts/check_examples.py      # Verify all 20 examples parse + check + verify
 python scripts/check_spec_examples.py # Verify spec code blocks parse
 python scripts/check_readme_examples.py # Verify README code blocks parse
@@ -54,9 +54,9 @@ python scripts/fix_allowlists.py --fix # Auto-fix stale allowlist line numbers
 
 - `spec/` — Language specification (Chapters 0-12)
 - `vera/` — Reference compiler: grammar, parser, AST, transformer, type checker, verifier, codegen, CLI
-- `examples/` — 20 example Vera programs (all must pass `vera check` and `vera verify`)
+- `examples/` — 21 example Vera programs (all must pass `vera check` and `vera verify`)
 - `tests/` — Test suite (unit tests + conformance suite)
-- `tests/conformance/` — 48 conformance programs validating every language feature against the spec
+- `tests/conformance/` — 49 conformance programs validating every language feature against the spec
 - `scripts/` — CI and validation scripts
 
 ## Writing Vera code
@@ -74,8 +74,8 @@ Each stage is a module with a public API function and is independently testable.
 ## What not to break
 
 - Pre-commit hooks run mypy + pytest + conformance suite + example validation on every commit
-- All 48 conformance programs in `tests/conformance/` must pass their declared level
-- All 20 examples in `examples/` must pass `vera check` and `vera verify`
+- All 49 conformance programs in `tests/conformance/` must pass their declared level
+- All 21 examples in `examples/` must pass `vera check` and `vera verify`
 - Version must stay in sync across `vera/__init__.py`, `pyproject.toml`, and `CHANGELOG.md`
 - All tests must pass: `pytest tests/ -v`
 - Type checking must be clean: `mypy vera/`

--- a/README.md
+++ b/README.md
@@ -183,7 +183,11 @@ The language specification is in draft across 13 chapters:
 
 ### Testing
 
-Testing is organized in three layers: **unit tests** (2,003 tests across 20 files, testing compiler internals), a **conformance suite** (48 programs across 9 spec chapters, systematically validating every language feature against the spec), and **example programs** (20 end-to-end demos). The compiler has 90% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations. Every commit validates all conformance programs, example programs, and 95 specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference -- coverage tables, conformance suite details, CI pipeline, and infrastructure.
+Testing is organized in three layers: **unit tests** (2,003 tests across 20 files, testing compiler internals), a **conformance suite** (49 programs across 9 spec chapters, systematically validating every language feature against the spec), and **example programs** (21 end-to-end demos). The compiler has 90% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations. Every commit validates all conformance programs, example programs, and 95 specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference -- coverage tables, conformance suite details, CI pipeline, and infrastructure.
+
+### Known Bugs
+
+No known bugs.
 
 ## Roadmap
 
@@ -323,7 +327,7 @@ Module refinements, lexical extensions, and IO runtime — completing the existi
 - <del>[#213](https://github.com/aallan/vera/issues/213) string_repeat builtin</del> ([v0.0.75](https://github.com/aallan/vera/releases/tag/v0.0.75))
 - <del>[#230](https://github.com/aallan/vera/issues/230) string interpolation</del> ([v0.0.76](https://github.com/aallan/vera/releases/tag/v0.0.76))
 - [#231](https://github.com/aallan/vera/issues/231) regex support
-- [#232](https://github.com/aallan/vera/issues/232) URL parsing and construction builtins
+- <del>[#232](https://github.com/aallan/vera/issues/232) URL parsing and construction builtins</del> ([v0.0.81](https://github.com/aallan/vera/releases/tag/v0.0.81))
 - <del>[#234](https://github.com/aallan/vera/issues/234) base64 encoding and decoding</del> ([v0.0.79](https://github.com/aallan/vera/releases/tag/v0.0.79))
 
 **Module system** — sequential dependency (#187 before #127)
@@ -333,7 +337,6 @@ Module refinements, lexical extensions, and IO runtime — completing the existi
 
 **Codegen** — WASM compilation gaps
 
-- [#266](https://github.com/aallan/vera/issues/266) ADT constructors with String/Array fields crash codegen layout
 - [#267](https://github.com/aallan/vera/issues/267) Tuple type WASM codegen
 
 **IO runtime** — host bindings for file and stdin access
@@ -459,7 +462,7 @@ OK: examples/safe_divide.vera
 Verification: 4 verified (Tier 1)
 ```
 
-`vera verify` runs the type checker and then verifies contracts using Z3. Tier 1 contracts (decidable arithmetic, comparisons, Boolean logic, match expressions, ADT constructors, and decreases clauses) are proved automatically. Contracts that Z3 cannot decide are reported as Tier 3 (runtime checks) with a warning. Across all 20 examples, 122 of 126 contracts (96.8%) are verified statically.
+`vera verify` runs the type checker and then verifies contracts using Z3. Tier 1 contracts (decidable arithmetic, comparisons, Boolean logic, match expressions, ADT constructors, and decreases clauses) are proved automatically. Contracts that Z3 cannot decide are reported as Tier 3 (runtime checks) with a warning. Across all 21 examples, 122 of 126 contracts (96.8%) are verified statically.
 
 ### Format a program
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -416,6 +416,8 @@ base64_encode(@String.0)                -- returns String (RFC 4648)
 base64_decode(@String.0)                -- returns Result<String, String>
 url_encode(@String.0)                   -- returns String (RFC 3986 percent-encoding)
 url_decode(@String.0)                   -- returns Result<String, String>
+url_parse(@String.0)                    -- returns Result<UrlParts, String> (RFC 3986 decomposition)
+url_join(@UrlParts.0)                   -- returns String (reassemble URL from UrlParts)
 to_string(@Int.0)                       -- returns String (integer to decimal)
 int_to_string(@Int.0)                   -- returns String (alias for to_string)
 bool_to_string(@Bool.0)                 -- returns String ("true" or "false")
@@ -460,7 +462,7 @@ join(@Array<String>.0, @String.0)               -- returns String (join with sep
 
 `to_upper` and `to_lower` convert ASCII letters only (a-z ↔ A-Z). `replace` substitutes all non-overlapping occurrences; an empty needle returns the original string unchanged. `split` returns an array of segments; an empty delimiter returns a single-element array. `join` concatenates array elements with the separator between each pair.
 
-String functions use the heap allocator (`$alloc`). Memory is managed automatically by a conservative mark-sweep garbage collector — there is no manual allocation or deallocation. All four parse functions return `Result<T, String>`: `parse_nat`, `parse_int`, `parse_float64`, and `parse_bool`. They return `Ok(value)` on valid input and `Err(msg)` on empty or invalid input; leading and trailing spaces are tolerated. `parse_int` accepts an optional `+` or `-` sign. `parse_bool` is strict: only `"true"` and `"false"` (lowercase) are valid. `base64_encode` encodes a string to standard Base64 (RFC 4648); `base64_decode` returns `Result<String, String>`, failing on invalid length or characters. `url_encode` percent-encodes a string for use in URLs (RFC 3986), leaving unreserved characters (`A-Z`, `a-z`, `0-9`, `-`, `_`, `.`, `~`) unchanged; `url_decode` returns `Result<String, String>`, failing on invalid `%XX` sequences.
+String functions use the heap allocator (`$alloc`). Memory is managed automatically by a conservative mark-sweep garbage collector — there is no manual allocation or deallocation. All four parse functions return `Result<T, String>`: `parse_nat`, `parse_int`, `parse_float64`, and `parse_bool`. They return `Ok(value)` on valid input and `Err(msg)` on empty or invalid input; leading and trailing spaces are tolerated. `parse_int` accepts an optional `+` or `-` sign. `parse_bool` is strict: only `"true"` and `"false"` (lowercase) are valid. `base64_encode` encodes a string to standard Base64 (RFC 4648); `base64_decode` returns `Result<String, String>`, failing on invalid length or characters. `url_encode` percent-encodes a string for use in URLs (RFC 3986), leaving unreserved characters (`A-Z`, `a-z`, `0-9`, `-`, `_`, `.`, `~`) unchanged; `url_decode` returns `Result<String, String>`, failing on invalid `%XX` sequences. `url_parse` decomposes a URL into its RFC 3986 components, returning `Result<UrlParts, String>` where `UrlParts(scheme, authority, path, query, fragment)` is a built-in ADT with five String fields; it returns `Err("missing scheme")` if no `:` is found. `url_join` reassembles a `UrlParts` value into a URL string. Programs must redefine `UrlParts` locally (like `Result`) to use it in match expressions.
 
 ### Numeric operations
 
@@ -819,7 +821,6 @@ There is no import aliasing (`import m(abs as math_abs)`) and no wildcard exclus
 
 ### Known codegen limitations
 
-- **ADT constructors with String/Array fields** do not compile (#266). User-defined ADTs with only numeric fields (Int, Nat, Bool, Byte, Float64) work correctly. ADTs with String or Array fields crash the layout computation. Builtins returning `Result<String, String>` work because they use hand-coded WASM layout.
 - **Tuple types** are specified and type-check but have no WASM codegen (#267). Functions containing Tuple expressions are silently skipped. Use named ADTs (e.g. `data Pair<A, B> { Pair(A, B) }`) as a workaround.
 
 There are no raw strings (`r"..."`) or multi-line string literals. Use escape sequences (`\\`, `\n`, `\t`, `\"`) for special characters. This is by design — alternative string syntaxes would create two representations for the same value.

--- a/examples/url_parsing.vera
+++ b/examples/url_parsing.vera
@@ -1,0 +1,38 @@
+-- URL parsing and joining (RFC 3986)
+effect IO {
+  op print(String -> Unit);
+}
+
+private data UrlParts {
+  UrlParts(String, String, String, String, String)
+}
+
+private data Result<T, E> {
+  Ok(T),
+  Err(E)
+}
+
+public fn main(@Unit -> @Unit)
+  requires(true)
+  ensures(true)
+  effects(<IO>)
+{
+  -- Parse a URL into components
+  match url_parse("https://example.com/path?q=1#frag") {
+    Ok(@UrlParts) -> match @UrlParts.0 {
+      UrlParts(@String, @String, @String, @String, @String) ->
+        IO.print("scheme=\(@String.4) auth=\(@String.3) path=\(@String.2) query=\(@String.1) frag=\(@String.0)")
+    },
+    Err(@String) -> IO.print("error: \(@String.0)")
+  };
+  -- Join components back into a URL
+  match url_parse("https://example.com/path?q=1#frag") {
+    Ok(@UrlParts) -> IO.print(url_join(@UrlParts.0)),
+    Err(@String) -> IO.print("error: \(@String.0)")
+  };
+  -- Error case: missing scheme
+  match url_parse("no-scheme") {
+    Ok(_) -> IO.print("unexpected ok"),
+    Err(@String) -> IO.print("error: \(@String.0)")
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.80"
+version = "0.0.81"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/scripts/check_readme_examples.py
+++ b/scripts/check_readme_examples.py
@@ -36,7 +36,7 @@ ALLOWLIST: dict[int, tuple[str, str]] = {
     # =================================================================
 
     # Section "Where this is going" — depends on #57 (Http), #61 (Inference), #147 (Markdown)
-    409: ("FUTURE", "Vision example uses MdBlock, Http, Inference (issues #57, #61, #147)"),
+    412: ("FUTURE", "Vision example uses MdBlock, Http, Inference (issues #57, #61, #147)"),
 }
 
 

--- a/scripts/check_skill_examples.py
+++ b/scripts/check_skill_examples.py
@@ -40,64 +40,64 @@ ALLOWLIST: dict[int, tuple[str, str]] = {
     404: ("FRAGMENT", "String built-in examples, bare calls"),
 
     # String interpolation — bare expressions
-    430: ("FRAGMENT", "String interpolation examples, bare expressions"),
+    432: ("FRAGMENT", "String interpolation examples, bare expressions"),
 
     # String search — bare function calls
-    442: ("FRAGMENT", "String search built-in examples, bare calls"),
+    444: ("FRAGMENT", "String search built-in examples, bare calls"),
 
     # String transformation — bare function calls
-    453: ("FRAGMENT", "String transformation built-in examples, bare calls"),
+    455: ("FRAGMENT", "String transformation built-in examples, bare calls"),
 
     # Numeric operations — bare function calls
-    467: ("FRAGMENT", "Numeric built-in examples, bare calls"),
+    469: ("FRAGMENT", "Numeric built-in examples, bare calls"),
 
     # Contracts section — requires/ensures fragments
-    524: ("FRAGMENT", "Requires clause example, not full function"),
-    533: ("FRAGMENT", "Ensures clause example, not full function"),
-    560: ("FRAGMENT", "Quantified requires clause, not full function"),
+    526: ("FRAGMENT", "Requires clause example, not full function"),
+    535: ("FRAGMENT", "Ensures clause example, not full function"),
+    562: ("FRAGMENT", "Quantified requires clause, not full function"),
 
     # Effects section — bare effect rows
-    578: ("FRAGMENT", "Effect row examples, bare annotations"),
+    580: ("FRAGMENT", "Effect row examples, bare annotations"),
 
     # Effect handler syntax template
-    715: ("FRAGMENT", "Handler syntax template, not real code"),
+    717: ("FRAGMENT", "Handler syntax template, not real code"),
 
     # Qualified calls and handler fragments — bare expressions
-    727: ("FRAGMENT", "Handler with clause, bare expression"),
-    737: ("FRAGMENT", "Qualified call examples, bare expressions"),
+    729: ("FRAGMENT", "Handler with clause, bare expression"),
+    739: ("FRAGMENT", "Qualified call examples, bare expressions"),
 
     # Module declaration and import syntax
-    775: ("FRAGMENT", "Module declaration and import example"),
+    777: ("FRAGMENT", "Module declaration and import example"),
 
     # Line comments — bare comments
-    831: ("FRAGMENT", "Comment syntax example"),
+    832: ("FRAGMENT", "Comment syntax example"),
 
     # Type conversions — bare function calls
-    482: ("FRAGMENT", "Type conversion examples, bare calls"),
+    484: ("FRAGMENT", "Type conversion examples, bare calls"),
 
     # Float64 predicates — bare function calls
-    495: ("FRAGMENT", "Float64 predicate examples, bare calls"),
+    497: ("FRAGMENT", "Float64 predicate examples, bare calls"),
 
     # Common mistakes section — intentionally wrong code
-    859: ("FRAGMENT", "Wrong: missing contracts"),
-    879: ("FRAGMENT", "Wrong: missing effects clause"),
-    913: ("FRAGMENT", "Wrong: bare expression without indices"),
-    926: ("FRAGMENT", "Wrong: bare expression no indices"),
-    931: ("FRAGMENT", "Correct: expression with indices (not full fn)"),
-    997: ("FRAGMENT", "Wrong: match arm with incorrect return"),
-    1021: ("FRAGMENT", "Wrong: non-exhaustive match"),
-    1028: ("FRAGMENT", "Correct: match arm example"),
-    1038: ("FRAGMENT", "Wrong: if/else without braces (bare expression)"),
-    1043: ("FRAGMENT", "Correct: if/else with braces"),
+    860: ("FRAGMENT", "Wrong: missing contracts"),
+    880: ("FRAGMENT", "Wrong: missing effects clause"),
+    914: ("FRAGMENT", "Wrong: bare expression without indices"),
+    927: ("FRAGMENT", "Wrong: bare expression no indices"),
+    932: ("FRAGMENT", "Correct: expression with indices (not full fn)"),
+    998: ("FRAGMENT", "Wrong: match arm with incorrect return"),
+    1022: ("FRAGMENT", "Wrong: non-exhaustive match"),
+    1029: ("FRAGMENT", "Correct: match arm example"),
+    1039: ("FRAGMENT", "Wrong: if/else without braces (bare expression)"),
+    1044: ("FRAGMENT", "Correct: if/else with braces"),
 
     # Import syntax — intentionally unsupported
-    1054: ("FRAGMENT", "Wrong: import aliasing not supported"),
-    1059: ("FRAGMENT", "Correct: import syntax example"),
-    1069: ("FRAGMENT", "Wrong: import hiding not supported"),
-    1074: ("FRAGMENT", "Correct: multi-import syntax"),
+    1055: ("FRAGMENT", "Wrong: import aliasing not supported"),
+    1060: ("FRAGMENT", "Correct: import syntax example"),
+    1070: ("FRAGMENT", "Wrong: import hiding not supported"),
+    1075: ("FRAGMENT", "Correct: multi-import syntax"),
 
     # String escapes — bare expression
-    1088: ("FRAGMENT", "String escape example"),
+    1089: ("FRAGMENT", "String escape example"),
 
     # =================================================================
     # MISMATCH — uses syntax the parser doesn't handle in isolation.

--- a/scripts/check_spec_examples.py
+++ b/scripts/check_spec_examples.py
@@ -165,16 +165,20 @@ ALLOWLIST: dict[tuple[str, int], str] = {
     ("09-standard-library.md", 1016): "FRAGMENT",  # url_encode signature (no body)
     ("09-standard-library.md", 1035): "FRAGMENT",  # url_decode signature (no body)
 
+    # Chapter 9 — URL parsing builtin signatures (no body)
+    ("09-standard-library.md", 1067): "FRAGMENT",  # url_parse signature (no body)
+    ("09-standard-library.md", 1087): "FRAGMENT",  # url_join signature (no body)
+
     # Chapter 9 — ML/vector builtin signatures (no body)
-    ("09-standard-library.md", 1061): "FRAGMENT",  # similarity signature (no body)
+    ("09-standard-library.md", 1107): "FRAGMENT",  # similarity signature (no body)
 
     # Chapter 9 — Markdown stdlib type (future, uses MdBlock/MdInline types)
-    ("09-standard-library.md", 1165): "FUTURE",   # md_parse(@String -> @Result<MdBlock, String>)
-    ("09-standard-library.md", 1174): "FUTURE",   # md_render(@MdBlock -> @String)
-    ("09-standard-library.md", 1185): "FUTURE",   # md_has_heading(@MdBlock, @Nat -> @Bool)
-    ("09-standard-library.md", 1194): "FUTURE",   # md_has_code_block(@MdBlock, @String -> @Bool)
-    ("09-standard-library.md", 1203): "FUTURE",   # md_extract_code_blocks(@MdBlock, @String -> @Array<String>)
-    ("09-standard-library.md", 1227): "FUTURE",   # convert_to_markdown(@String -> @Result<MdBlock, String>)
+    ("09-standard-library.md", 1211): "FUTURE",   # md_parse(@String -> @Result<MdBlock, String>)
+    ("09-standard-library.md", 1220): "FUTURE",   # md_render(@MdBlock -> @String)
+    ("09-standard-library.md", 1231): "FUTURE",   # md_has_heading(@MdBlock, @Nat -> @Bool)
+    ("09-standard-library.md", 1240): "FUTURE",   # md_has_code_block(@MdBlock, @String -> @Bool)
+    ("09-standard-library.md", 1249): "FUTURE",   # md_extract_code_blocks(@MdBlock, @String -> @Array<String>)
+    ("09-standard-library.md", 1273): "FUTURE",   # convert_to_markdown(@String -> @Result<MdBlock, String>)
 }
 
 
@@ -226,6 +230,9 @@ CHECK_ALLOWLIST: dict[tuple[str, int], str] = {
 
     # Chapter 9 — async/await (future feature, tracked in spec as not implemented)
     ("09-standard-library.md", 248): "FUTURE",  # async, await, Http, Future
+
+    # Chapter 9 — UrlParts type definition (standalone, no visibility)
+    ("09-standard-library.md", 1059): "INCOMPLETE",  # data UrlParts (no visibility keyword)
 }
 
 

--- a/spec/04-expressions.md
+++ b/spec/04-expressions.md
@@ -334,6 +334,8 @@ base64_encode(@String.0)                -- returns String (RFC 4648)
 base64_decode(@String.0)                -- returns Result<String, String>
 url_encode(@String.0)                   -- returns String (RFC 3986 percent-encoding)
 url_decode(@String.0)                   -- returns Result<String, String>
+url_parse(@String.0)                    -- returns Result<UrlParts, String>
+url_join(@UrlParts.0)                   -- returns String
 to_string(@Int.0)                       -- returns String
 int_to_string(@Int.0)                   -- returns String (alias for to_string)
 bool_to_string(@Bool.0)                 -- returns String ("true" or "false")

--- a/spec/09-standard-library.md
+++ b/spec/09-standard-library.md
@@ -1054,7 +1054,53 @@ url_decode("%ZZ")                  -- Err("invalid percent-encoding")
 url_decode("%4")                   -- Err("invalid percent-encoding")
 ```
 
-### 9.6.13 similarity (Future)
+### 9.6.13 URL Parsing
+
+```
+data UrlParts {
+  UrlParts(String, String, String, String, String)
+}
+```
+
+`UrlParts` is a built-in ADT representing the five components of a URL per RFC 3986: scheme, authority, path, query, and fragment. Programs must redefine `UrlParts` locally (like `Result` and `Option`) to use it in match expressions.
+
+```
+public fn url_parse(@String -> @Result<UrlParts, String>)
+  requires(true)
+  ensures(true)
+  effects(pure)
+```
+
+Decomposes a URL string into its RFC 3986 components. Returns `Ok(UrlParts(scheme, authority, path, query, fragment))` on success, or `Err("missing scheme")` if no `:` delimiter is found. Missing optional components (authority, query, fragment) are represented as empty strings.
+
+```
+url_parse("https://example.com/path?q=1#frag")
+  -- Ok(UrlParts("https", "example.com", "/path", "q=1", "frag"))
+url_parse("http:")
+  -- Ok(UrlParts("http", "", "", "", ""))
+url_parse("file:///path")
+  -- Ok(UrlParts("file", "", "/path", "", ""))
+url_parse("no-scheme")
+  -- Err("missing scheme")
+```
+
+```
+public fn url_join(@UrlParts -> @String)
+  requires(true)
+  ensures(true)
+  effects(pure)
+```
+
+Reassembles a `UrlParts` value into a URL string. If the scheme is non-empty, the `://` separator is inserted. The `?` and `#` delimiters are only included when their respective components are non-empty.
+
+```
+url_join(UrlParts("https", "example.com", "/path", "q=1", "frag"))
+  -- "https://example.com/path?q=1#frag"
+url_join(UrlParts("", "", "", "", ""))
+  -- ""
+```
+
+### 9.6.14 similarity (Future)
 
 > **Status: Not yet implemented.** Will be introduced alongside the `Inference` effect ([#61](https://github.com/aallan/vera/issues/61)).
 

--- a/spec/11-compilation.md
+++ b/spec/11-compilation.md
@@ -584,5 +584,4 @@ The current compilation model has the following limitations, each tracked as a G
 | Limitation | Issue | Notes |
 |-----------|-------|-------|
 | Flat module compilation | [#110](https://github.com/aallan/vera/issues/110) | Imported functions are compiled into the importing module; name collisions are detected (E608/E609/E610); qualified-call disambiguation via name mangling is tracked separately |
-| ADT constructors with String/Array fields | [#266](https://github.com/aallan/vera/issues/266) | ADT constructor layout computation crashes on `i32_pair` (String/Array) fields; builtins bypass this via hand-coded WASM layout |
 | Tuple type codegen | [#267](https://github.com/aallan/vera/issues/267) | Tuple types are fully specified and type-checked but have no WASM backend; functions containing Tuple expressions are skipped with E602 |

--- a/tests/conformance/ch09_url_parsing.vera
+++ b/tests/conformance/ch09_url_parsing.vera
@@ -1,0 +1,82 @@
+-- Conformance: url_parse, url_join (Chapter 9)
+-- Tests: url_parse returning Result<UrlParts, String>, url_join
+effect IO {
+  op print(String -> Unit);
+}
+
+private data UrlParts {
+  UrlParts(String, String, String, String, String)
+}
+
+private data Result<T, E> {
+  Ok(T),
+  Err(E)
+}
+
+public fn test_parse_full(@Unit -> @Int)
+  requires(true)
+  ensures(@Int.result == 5)
+  effects(pure)
+{
+  match url_parse("https://example.com/path?q=1#frag") {
+    Ok(@UrlParts) -> match @UrlParts.0 { UrlParts(@String, @String, @String, @String, @String) -> string_length(@String.4) },
+    Err(_) -> 0 - 1
+  }
+}
+
+public fn test_parse_no_query(@Unit -> @Int)
+  requires(true)
+  ensures(@Int.result == 5)
+  effects(pure)
+{
+  match url_parse("https://example.com/path") {
+    Ok(@UrlParts) -> match @UrlParts.0 { UrlParts(@String, @String, @String, @String, @String) -> string_length(@String.2) },
+    Err(_) -> 0 - 1
+  }
+}
+
+public fn test_parse_err(@Unit -> @Int)
+  requires(true)
+  ensures(@Int.result == 1)
+  effects(pure)
+{
+  match url_parse("no-scheme") {
+    Ok(_) -> 0,
+    Err(_) -> 1
+  }
+}
+
+public fn test_join_full(@Unit -> @Int)
+  requires(true)
+  ensures(@Int.result == 33)
+  effects(pure)
+{
+  match url_parse("https://example.com/path?q=1#frag") {
+    Ok(@UrlParts) -> string_length(url_join(@UrlParts.0)),
+    Err(_) -> 0 - 1
+  }
+}
+
+public fn test_roundtrip(@Unit -> @Int)
+  requires(true)
+  ensures(@Int.result == 5)
+  effects(pure)
+{
+  match url_parse("https://example.com/path?q=1#frag") {
+    Ok(@UrlParts) -> match url_parse(url_join(@UrlParts.0)) { Ok(@UrlParts) -> match @UrlParts.0 { UrlParts(@String, @String, @String, @String, @String) -> string_length(@String.4) }, Err(_) -> 0 - 2 },
+    Err(_) -> 0 - 1
+  }
+}
+
+public fn main(@Unit -> @Unit)
+  requires(true)
+  ensures(true)
+  effects(<IO>)
+{
+  IO.print(to_string(test_parse_full(())));
+  IO.print(to_string(test_parse_no_query(())));
+  IO.print(to_string(test_parse_err(())));
+  IO.print(to_string(test_join_full(())));
+  IO.print(to_string(test_roundtrip(())));
+  ()
+}

--- a/tests/conformance/manifest.json
+++ b/tests/conformance/manifest.json
@@ -430,5 +430,14 @@
     "level": "run",
     "spec_ref": "Section 9.6.5",
     "features": ["url_encode", "url_decode", "result_type"]
+  },
+  {
+    "id": "ch09_url_parsing",
+    "file": "ch09_url_parsing.vera",
+    "chapter": 9,
+    "title": "URL parsing and joining",
+    "level": "run",
+    "spec_ref": "Section 9.6.5",
+    "features": ["url_parse", "url_join", "urlparts", "result_type"]
   }
 ]

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -2672,6 +2672,37 @@ private fn f(@Int -> @String)
 { url_decode(@Int.0) }
 """, "expected String")
 
+    def test_url_parse_ok(self) -> None:
+        _check_ok("""
+private data UrlParts { UrlParts(String, String, String, String, String) }
+private data Result<T, E> { Ok(T), Err(E) }
+private fn f(@String -> @Result<UrlParts, String>)
+  requires(true) ensures(true) effects(pure)
+{ url_parse(@String.0) }
+""")
+
+    def test_url_parse_wrong_type(self) -> None:
+        _check_err("""
+private fn f(@Int -> @String)
+  requires(true) ensures(true) effects(pure)
+{ url_parse(@Int.0) }
+""", "expected String")
+
+    def test_url_join_ok(self) -> None:
+        _check_ok("""
+private data UrlParts { UrlParts(String, String, String, String, String) }
+private fn f(@UrlParts -> @String)
+  requires(true) ensures(true) effects(pure)
+{ url_join(@UrlParts.0) }
+""")
+
+    def test_url_join_wrong_type(self) -> None:
+        _check_err("""
+private fn f(@String -> @String)
+  requires(true) ensures(true) effects(pure)
+{ url_join(@String.0) }
+""", "expected UrlParts")
+
     def test_to_string_ok(self) -> None:
         _check_ok("""
 private fn f(@Int -> @String)

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -4952,6 +4952,201 @@ public fn f(@Unit -> @Unit) requires(true) ensures(true) effects(<IO>) {
         assert _run_io(src) == "Hello, World!"
 
 
+class TestUrlParse:
+    """url_parse returns Result<UrlParts, String>."""
+
+    _PREAMBLE = """
+private data UrlParts { UrlParts(String, String, String, String, String) }
+private data Result<T, E> { Ok(T), Err(E) }
+"""
+
+    def _component_prog(self, url: str, index: int) -> str:
+        """Extract a single component from a parsed URL by field index.
+
+        index 0=scheme, 1=authority, 2=path, 3=query, 4=fragment.
+        Slot refs are stack-indexed, so .4=scheme, .3=auth, .2=path,
+        .1=query, .0=fragment.
+        """
+        slot = 4 - index
+        return self._PREAMBLE + f"""
+effect IO {{ op print(String -> Unit); }}
+public fn f(@Unit -> @Unit) requires(true) ensures(true) effects(<IO>) {{
+  match url_parse("{url}") {{
+    Ok(@UrlParts) -> match @UrlParts.0 {{
+      UrlParts(@String, @String, @String, @String, @String) ->
+        IO.print(@String.{slot})
+    }},
+    Err(@String) -> IO.print(@String.0)
+  }}
+}}
+"""
+
+    def _err_prog(self, url: str) -> str:
+        return self._PREAMBLE + f"""
+public fn f(-> @Int) requires(true) ensures(true) effects(pure) {{
+  match url_parse("{url}") {{
+    Ok(_) -> 0,
+    Err(_) -> 1
+  }}
+}}
+"""
+
+    def _join_prog(self, url: str) -> str:
+        return self._PREAMBLE + f"""
+effect IO {{ op print(String -> Unit); }}
+public fn f(@Unit -> @Unit) requires(true) ensures(true) effects(<IO>) {{
+  match url_parse("{url}") {{
+    Ok(@UrlParts) -> IO.print(url_join(@UrlParts.0)),
+    Err(@String) -> IO.print(@String.0)
+  }}
+}}
+"""
+
+    # Full URL decomposition
+    def test_full_scheme(self) -> None:
+        assert _run_io(self._component_prog(
+            "https://example.com/path?q=1#frag", 0)) == "https"
+
+    def test_full_authority(self) -> None:
+        assert _run_io(self._component_prog(
+            "https://example.com/path?q=1#frag", 1)) == "example.com"
+
+    def test_full_path(self) -> None:
+        assert _run_io(self._component_prog(
+            "https://example.com/path?q=1#frag", 2)) == "/path"
+
+    def test_full_query(self) -> None:
+        assert _run_io(self._component_prog(
+            "https://example.com/path?q=1#frag", 3)) == "q=1"
+
+    def test_full_fragment(self) -> None:
+        assert _run_io(self._component_prog(
+            "https://example.com/path?q=1#frag", 4)) == "frag"
+
+    # Edge cases
+    def test_scheme_only(self) -> None:
+        assert _run_io(self._component_prog("http:", 0)) == "http"
+
+    def test_no_authority(self) -> None:
+        """file:///path has scheme=file, empty authority, path=/path."""
+        assert _run_io(self._component_prog("file:///path", 0)) == "file"
+
+    def test_no_authority_path(self) -> None:
+        assert _run_io(self._component_prog("file:///path", 2)) == "/path"
+
+    def test_no_query_fragment(self) -> None:
+        assert _run_io(self._component_prog(
+            "https://example.com/path", 3)) == ""
+
+    def test_query_no_fragment(self) -> None:
+        assert _run_io(self._component_prog(
+            "https://example.com/?q=1", 3)) == "q=1"
+
+    def test_fragment_no_query(self) -> None:
+        assert _run_io(self._component_prog(
+            "https://example.com/#frag", 4)) == "frag"
+
+    def test_empty_path(self) -> None:
+        assert _run_io(self._component_prog(
+            "https://example.com", 2)) == ""
+
+    # Error cases
+    def test_missing_scheme(self) -> None:
+        assert _run(self._err_prog("no-scheme")) == 1
+
+    def test_empty_string(self) -> None:
+        assert _run(self._err_prog("")) == 1
+
+    # Complex URL
+    def test_complex_authority(self) -> None:
+        assert _run_io(self._component_prog(
+            "https://user:pass@host:8080/p?a=b&c=d#sec", 1,
+        )) == "user:pass@host:8080"
+
+    def test_complex_query(self) -> None:
+        assert _run_io(self._component_prog(
+            "https://user:pass@host:8080/p?a=b&c=d#sec", 3,
+        )) == "a=b&c=d"
+
+    # Roundtrip
+    def test_roundtrip_full(self) -> None:
+        assert _run_io(self._join_prog(
+            "https://example.com/path?q=1#frag",
+        )) == "https://example.com/path?q=1#frag"
+
+    def test_roundtrip_no_query(self) -> None:
+        assert _run_io(self._join_prog(
+            "https://example.com/path",
+        )) == "https://example.com/path"
+
+    def test_roundtrip_fragment_only(self) -> None:
+        assert _run_io(self._join_prog(
+            "https://example.com#frag",
+        )) == "https://example.com#frag"
+
+
+class TestUrlJoin:
+    """url_join reassembles a UrlParts into a URL string."""
+
+    _PREAMBLE = """
+private data UrlParts { UrlParts(String, String, String, String, String) }
+"""
+
+    def test_all_components(self) -> None:
+        src = self._PREAMBLE + """
+effect IO { op print(String -> Unit); }
+public fn f(@Unit -> @Unit) requires(true) ensures(true) effects(<IO>) {
+  IO.print(url_join(UrlParts("https", "example.com", "/path", "q=1", "frag")))
+}
+"""
+        assert _run_io(src) == "https://example.com/path?q=1#frag"
+
+    def test_scheme_authority_path(self) -> None:
+        src = self._PREAMBLE + """
+effect IO { op print(String -> Unit); }
+public fn f(@Unit -> @Unit) requires(true) ensures(true) effects(<IO>) {
+  IO.print(url_join(UrlParts("https", "example.com", "/path", "", "")))
+}
+"""
+        assert _run_io(src) == "https://example.com/path"
+
+    def test_with_query_no_fragment(self) -> None:
+        src = self._PREAMBLE + """
+effect IO { op print(String -> Unit); }
+public fn f(@Unit -> @Unit) requires(true) ensures(true) effects(<IO>) {
+  IO.print(url_join(UrlParts("https", "example.com", "/", "key=val", "")))
+}
+"""
+        assert _run_io(src) == "https://example.com/?key=val"
+
+    def test_with_fragment_no_query(self) -> None:
+        src = self._PREAMBLE + """
+effect IO { op print(String -> Unit); }
+public fn f(@Unit -> @Unit) requires(true) ensures(true) effects(<IO>) {
+  IO.print(url_join(UrlParts("https", "example.com", "", "", "top")))
+}
+"""
+        assert _run_io(src) == "https://example.com#top"
+
+    def test_scheme_only(self) -> None:
+        src = self._PREAMBLE + """
+effect IO { op print(String -> Unit); }
+public fn f(@Unit -> @Unit) requires(true) ensures(true) effects(<IO>) {
+  IO.print(url_join(UrlParts("http", "", "", "", "")))
+}
+"""
+        assert _run_io(src) == "http://"
+
+    def test_empty_parts(self) -> None:
+        src = self._PREAMBLE + """
+effect IO { op print(String -> Unit); }
+public fn f(@Unit -> @Unit) requires(true) ensures(true) effects(<IO>) {
+  IO.print(url_join(UrlParts("", "", "", "", "")))
+}
+"""
+        assert _run_io(src) == ""
+
+
 class TestToString:
     def test_positive(self) -> None:
         src = """

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -19,7 +19,7 @@ README = Path(__file__).parent.parent / "README.md"
 # Each key is the 1-based line number of the opening ```vera fence.
 ALLOWLIST: dict[int, str] = {
     # "Where this is going" — depends on #57 (Http), #61 (Inference), #147 (Markdown)
-    409: "Vision example uses MdBlock, Http, Inference (issues #57, #61, #147)",
+    412: "Vision example uses MdBlock, Http, Inference (issues #57, #61, #147)",
 }
 
 

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -1480,9 +1480,9 @@ private fn sum(@List<Int> -> @Int)
             t1 += result.summary.tier1_verified
             t3 += result.summary.tier3_runtime
             total += result.summary.total
-        assert t1 == 121, f"Expected 121 T1, got {t1}"
+        assert t1 == 123, f"Expected 123 T1, got {t1}"
         assert t3 == 5, f"Expected 5 T3, got {t3}"
-        assert total == 126, f"Expected 126 total, got {total}"
+        assert total == 128, f"Expected 128 total, got {total}"
 
 
 # =====================================================================

--- a/vera/README.md
+++ b/vera/README.md
@@ -310,6 +310,8 @@ Context flags (`in_ensures`, `in_contract`, `current_return_type`, `current_effe
 | `base64_decode` | Function | `String → Result<String, String>`, pure |
 | `url_encode` | Function | `String → String`, pure (RFC 3986 percent-encoding) |
 | `url_decode` | Function | `String → Result<String, String>`, pure |
+| `url_parse` | Function | `String → Result<UrlParts, String>`, pure (RFC 3986 decomposition) |
+| `url_join` | Function | `UrlParts → String`, pure (reassemble URL) |
 | `to_string` | Function | `Int → String`, pure |
 | `int_to_string` | Function | `Int → String`, pure (alias for `to_string`) |
 | `bool_to_string` | Function | `Bool → String`, pure |
@@ -609,7 +611,6 @@ Honest inventory of what the compiler cannot do, and where each limitation is ad
 | **No incremental compilation** | Full file processed from scratch each time | [#56](https://github.com/aallan/vera/issues/56) |
 | **No LSP server** | No IDE integration or structured code intelligence for agents | [#222](https://github.com/aallan/vera/issues/222) |
 | **No REPL** | No interactive evaluation; all code must be written to files | [#224](https://github.com/aallan/vera/issues/224) |
-| **ADT constructors with String/Array fields crash** | Layout computation (`_wasm_type_align`) only handles `i32`, `i64`, `f64` — not `i32_pair` (String/Array representation); builtins work via hand-coded layout | [#266](https://github.com/aallan/vera/issues/266) |
 | **No Tuple codegen** | Tuple types are specified and type-checked but have zero WASM backend support; functions with Tuple expressions get E602 | [#267](https://github.com/aallan/vera/issues/267) |
 | **No string interpolation** | Strings built via `string_concat` or chained `IO.print` calls | [#230](https://github.com/aallan/vera/issues/230) |
 | **No regex** | String processing limited to builtin functions (contains, substring, etc.) | [#231](https://github.com/aallan/vera/issues/231) |

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.80"
+__version__ = "0.0.81"

--- a/vera/codegen/modules.py
+++ b/vera/codegen/modules.py
@@ -242,7 +242,7 @@ class CrossModuleMixin:
             "char_code", "from_char_code", "string_repeat",
             "parse_nat", "parse_int", "parse_float64", "parse_bool",
             "base64_encode", "base64_decode",
-            "url_encode", "url_decode",
+            "url_encode", "url_decode", "url_parse", "url_join",
             "to_string", "int_to_string", "bool_to_string",
             "nat_to_string", "byte_to_string", "float_to_string",
             "strip",

--- a/vera/environment.py
+++ b/vera/environment.py
@@ -172,6 +172,20 @@ class TypeEnv:
         for c in self.data_types["Result"].constructors.values():
             self.constructors[c.name] = c
 
+        # UrlParts — URL components (scheme, authority, path, query, fragment)
+        self.data_types["UrlParts"] = AdtInfo(
+            name="UrlParts",
+            type_params=(),
+            constructors={
+                "UrlParts": ConstructorInfo(
+                    "UrlParts", "UrlParts", (),
+                    (STRING, STRING, STRING, STRING, STRING),
+                ),
+            },
+        )
+        for c in self.data_types["UrlParts"].constructors.values():
+            self.constructors[c.name] = c
+
         # State<T> effect with get/put
         self.effects["State"] = EffectInfo(
             name="State",
@@ -354,6 +368,22 @@ class TypeEnv:
             forall_vars=None,
             param_types=(STRING,),
             return_type=AdtType("Result", (STRING, STRING)),
+            effect=PureEffectRow(),
+        )
+        self.functions["url_parse"] = FunctionInfo(
+            name="url_parse",
+            forall_vars=None,
+            param_types=(STRING,),
+            return_type=AdtType(
+                "Result", (AdtType("UrlParts", ()), STRING)
+            ),
+            effect=PureEffectRow(),
+        )
+        self.functions["url_join"] = FunctionInfo(
+            name="url_join",
+            forall_vars=None,
+            param_types=(AdtType("UrlParts", ()),),
+            return_type=STRING,
             effect=PureEffectRow(),
         )
         self.functions["to_string"] = FunctionInfo(

--- a/vera/wasm/calls.py
+++ b/vera/wasm/calls.py
@@ -66,6 +66,10 @@ class CallsMixin:
                 return self._translate_url_encode(call.args[0], env)
             if call.name == "url_decode" and len(call.args) == 1:
                 return self._translate_url_decode(call.args[0], env)
+            if call.name == "url_parse" and len(call.args) == 1:
+                return self._translate_url_parse(call.args[0], env)
+            if call.name == "url_join" and len(call.args) == 1:
+                return self._translate_url_join(call.args[0], env)
             if call.name == "to_string" and len(call.args) == 1:
                 return self._translate_to_string(call.args[0], env)
             if call.name == "int_to_string" and len(call.args) == 1:
@@ -3300,6 +3304,774 @@ class CallsMixin:
         ins.append("end")  # block $done_ud
 
         ins.append(f"local.get {out}")
+        return ins
+
+    def _translate_url_parse(
+        self, arg: ast.Expr, env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """Translate url_parse(s) → Result<UrlParts, String> (i32 ptr).
+
+        RFC 3986 simplified URL decomposition.  Scans the input for
+        delimiters (:, ://, /, ?, #) and records each component as a
+        substring of the original input (no copies needed for scheme,
+        authority, path, query, fragment).
+
+        UrlParts layout (48 bytes):
+          [tag=0     : i32 @ 0 ]
+          [scheme_ptr: i32 @ 4 ] [scheme_len: i32 @ 8 ]
+          [auth_ptr  : i32 @ 12] [auth_len  : i32 @ 16]
+          [path_ptr  : i32 @ 20] [path_len  : i32 @ 24]
+          [query_ptr : i32 @ 28] [query_len : i32 @ 32]
+          [frag_ptr  : i32 @ 36] [frag_len  : i32 @ 40]
+          [pad 4     @ 44]
+
+        Result layout (16 bytes):
+          Ok(UrlParts):  [tag=0 : i32] [urlparts_ptr : i32] [pad 8]
+          Err(String):   [tag=1 : i32] [ptr : i32] [len : i32] [pad 4]
+        """
+        arg_instrs = self.translate_expr(arg, env)
+        if arg_instrs is None:
+            return None
+
+        self.needs_alloc = True
+
+        err_off, err_ln = self.string_pool.intern("missing scheme")
+        empty_off, empty_len = self.string_pool.intern("")
+
+        # Input string
+        ptr = self.alloc_local("i32")
+        slen = self.alloc_local("i32")
+        # Scanning index
+        i = self.alloc_local("i32")
+        ch = self.alloc_local("i32")
+        # Component boundaries (offsets relative to ptr)
+        colon_pos = self.alloc_local("i32")   # position of first ':'
+        auth_start = self.alloc_local("i32")  # start of authority
+        auth_end = self.alloc_local("i32")    # end of authority
+        path_start = self.alloc_local("i32")  # start of path
+        path_end = self.alloc_local("i32")    # end of path
+        query_start = self.alloc_local("i32")  # start of query (after '?')
+        query_end = self.alloc_local("i32")    # end of query
+        frag_start = self.alloc_local("i32")   # start of fragment (after '#')
+        has_auth = self.alloc_local("i32")     # bool: found ://
+        has_query = self.alloc_local("i32")    # bool: found ?
+        has_frag = self.alloc_local("i32")     # bool: found #
+        # Output pointers
+        up = self.alloc_local("i32")   # UrlParts heap pointer
+        out = self.alloc_local("i32")  # Result heap pointer
+
+        ins: list[str] = []
+
+        # Evaluate string arg → (ptr, len)
+        ins.extend(arg_instrs)
+        ins.append(f"local.set {slen}")
+        ins.append(f"local.set {ptr}")
+
+        ins.append("block $done_up")
+        ins.append("block $err_up")
+
+        # ---- Step 1: Find colon (scheme delimiter) ----
+        # Scan for first ':'
+        ins.append("i32.const 0")
+        ins.append(f"local.set {i}")
+        ins.append("i32.const -1")
+        ins.append(f"local.set {colon_pos}")
+
+        ins.append("block $found_colon")
+        ins.append("  loop $scan_colon")
+        ins.append(f"    local.get {i}")
+        ins.append(f"    local.get {slen}")
+        ins.append("    i32.ge_u")
+        ins.append("    if")
+        # No colon found → Err
+        ins.append("      br $err_up")
+        ins.append("    end")
+        ins.append(f"    local.get {ptr}")
+        ins.append(f"    local.get {i}")
+        ins.append("    i32.add")
+        ins.append("    i32.load8_u offset=0")
+        ins.append(f"    local.set {ch}")
+        ins.append(f"    local.get {ch}")
+        ins.append("    i32.const 58")   # ':'
+        ins.append("    i32.eq")
+        ins.append("    if")
+        ins.append(f"      local.get {i}")
+        ins.append(f"      local.set {colon_pos}")
+        ins.append("      br $found_colon")
+        ins.append("    end")
+        ins.append(f"    local.get {i}")
+        ins.append("    i32.const 1")
+        ins.append("    i32.add")
+        ins.append(f"    local.set {i}")
+        ins.append("    br $scan_colon")
+        ins.append("  end")  # loop
+        ins.append("end")    # block $found_colon
+
+        # scheme is input[0..colon_pos]
+        # Now check if :// follows the colon
+
+        # ---- Step 2: Check for :// (authority indicator) ----
+        ins.append("i32.const 0")
+        ins.append(f"local.set {has_auth}")
+
+        # Need colon_pos + 3 <= slen  and  input[colon_pos+1] == '/'
+        # and input[colon_pos+2] == '/'
+        ins.append(f"local.get {colon_pos}")
+        ins.append("i32.const 3")
+        ins.append("i32.add")
+        ins.append(f"local.get {slen}")
+        ins.append("i32.le_u")
+        ins.append("if")
+        # Check input[colon_pos+1] == '/' (47)
+        ins.append(f"  local.get {ptr}")
+        ins.append(f"  local.get {colon_pos}")
+        ins.append("  i32.add")
+        ins.append("  i32.load8_u offset=1")
+        ins.append("  i32.const 47")
+        ins.append("  i32.eq")
+        ins.append("  if")
+        # Check input[colon_pos+2] == '/' (47)
+        ins.append(f"    local.get {ptr}")
+        ins.append(f"    local.get {colon_pos}")
+        ins.append("    i32.add")
+        ins.append("    i32.load8_u offset=2")
+        ins.append("    i32.const 47")
+        ins.append("    i32.eq")
+        ins.append("    if")
+        ins.append("      i32.const 1")
+        ins.append(f"      local.set {has_auth}")
+        ins.append("    end")
+        ins.append("  end")
+        ins.append("end")
+
+        # ---- Step 3: Determine authority, path, query, fragment ----
+        # Set cursor position after scheme
+        ins.append("i32.const 0")
+        ins.append(f"local.set {has_query}")
+        ins.append("i32.const 0")
+        ins.append(f"local.set {has_frag}")
+
+        # If has_auth: cursor = colon_pos + 3 (after ://)
+        # Else: cursor = colon_pos + 1 (after :)
+        ins.append(f"local.get {has_auth}")
+        ins.append("if")
+        ins.append(f"  local.get {colon_pos}")
+        ins.append("  i32.const 3")
+        ins.append("  i32.add")
+        ins.append(f"  local.set {auth_start}")
+        ins.append("else")
+        # No authority — set auth to empty
+        ins.append(f"  local.get {colon_pos}")
+        ins.append("  i32.const 1")
+        ins.append("  i32.add")
+        ins.append(f"  local.set {auth_start}")
+        ins.append("end")
+
+        # auth_end = auth_start initially (will scan to find end)
+        ins.append(f"local.get {auth_start}")
+        ins.append(f"local.set {auth_end}")
+
+        # If has_auth: scan authority until /, ?, #, or end
+        ins.append(f"local.get {has_auth}")
+        ins.append("if")
+        ins.append(f"  local.get {auth_start}")
+        ins.append(f"  local.set {i}")
+        ins.append("  block $auth_done")
+        ins.append("    loop $scan_auth")
+        ins.append(f"      local.get {i}")
+        ins.append(f"      local.get {slen}")
+        ins.append("      i32.ge_u")
+        ins.append("      if")
+        ins.append(f"        local.get {i}")
+        ins.append(f"        local.set {auth_end}")
+        ins.append("        br $auth_done")
+        ins.append("      end")
+        ins.append(f"      local.get {ptr}")
+        ins.append(f"      local.get {i}")
+        ins.append("      i32.add")
+        ins.append("      i32.load8_u offset=0")
+        ins.append(f"      local.set {ch}")
+        # Check for / (47), ? (63), # (35)
+        ins.append(f"      local.get {ch}")
+        ins.append("      i32.const 47")
+        ins.append("      i32.eq")
+        ins.append(f"      local.get {ch}")
+        ins.append("      i32.const 63")
+        ins.append("      i32.eq")
+        ins.append("      i32.or")
+        ins.append(f"      local.get {ch}")
+        ins.append("      i32.const 35")
+        ins.append("      i32.eq")
+        ins.append("      i32.or")
+        ins.append("      if")
+        ins.append(f"        local.get {i}")
+        ins.append(f"        local.set {auth_end}")
+        ins.append("        br $auth_done")
+        ins.append("      end")
+        ins.append(f"      local.get {i}")
+        ins.append("      i32.const 1")
+        ins.append("      i32.add")
+        ins.append(f"      local.set {i}")
+        ins.append("      br $scan_auth")
+        ins.append("    end")  # loop
+        ins.append("  end")    # block $auth_done
+        ins.append("else")
+        # No authority: auth_end = auth_start (empty)
+        ins.append(f"  local.get {auth_start}")
+        ins.append(f"  local.set {auth_end}")
+        ins.append("end")
+
+        # ---- Path: from auth_end until ? or # or end ----
+        ins.append(f"local.get {auth_end}")
+        ins.append(f"local.set {path_start}")
+        ins.append(f"local.get {auth_end}")
+        ins.append(f"local.set {i}")
+
+        ins.append("block $path_done")
+        ins.append("  loop $scan_path")
+        ins.append(f"    local.get {i}")
+        ins.append(f"    local.get {slen}")
+        ins.append("    i32.ge_u")
+        ins.append("    if")
+        ins.append(f"      local.get {i}")
+        ins.append(f"      local.set {path_end}")
+        ins.append("      br $path_done")
+        ins.append("    end")
+        ins.append(f"    local.get {ptr}")
+        ins.append(f"    local.get {i}")
+        ins.append("    i32.add")
+        ins.append("    i32.load8_u offset=0")
+        ins.append(f"    local.set {ch}")
+        # Check for ? (63) or # (35)
+        ins.append(f"    local.get {ch}")
+        ins.append("    i32.const 63")
+        ins.append("    i32.eq")
+        ins.append(f"    local.get {ch}")
+        ins.append("    i32.const 35")
+        ins.append("    i32.eq")
+        ins.append("    i32.or")
+        ins.append("    if")
+        ins.append(f"      local.get {i}")
+        ins.append(f"      local.set {path_end}")
+        ins.append("      br $path_done")
+        ins.append("    end")
+        ins.append(f"    local.get {i}")
+        ins.append("    i32.const 1")
+        ins.append("    i32.add")
+        ins.append(f"    local.set {i}")
+        ins.append("    br $scan_path")
+        ins.append("  end")  # loop
+        ins.append("end")    # block $path_done
+
+        # ---- Query: if input[path_end] == '?', scan until # or end ----
+        ins.append(f"local.get {path_end}")
+        ins.append(f"local.get {slen}")
+        ins.append("i32.lt_u")
+        ins.append("if")
+        ins.append(f"  local.get {ptr}")
+        ins.append(f"  local.get {path_end}")
+        ins.append("  i32.add")
+        ins.append("  i32.load8_u offset=0")
+        ins.append("  i32.const 63")   # '?'
+        ins.append("  i32.eq")
+        ins.append("  if")
+        ins.append("    i32.const 1")
+        ins.append(f"    local.set {has_query}")
+        ins.append(f"    local.get {path_end}")
+        ins.append("    i32.const 1")
+        ins.append("    i32.add")
+        ins.append(f"    local.set {query_start}")
+        # Scan query until # or end
+        ins.append(f"    local.get {query_start}")
+        ins.append(f"    local.set {i}")
+        ins.append("    block $query_done")
+        ins.append("      loop $scan_query")
+        ins.append(f"        local.get {i}")
+        ins.append(f"        local.get {slen}")
+        ins.append("        i32.ge_u")
+        ins.append("        if")
+        ins.append(f"          local.get {i}")
+        ins.append(f"          local.set {query_end}")
+        ins.append("          br $query_done")
+        ins.append("        end")
+        ins.append(f"        local.get {ptr}")
+        ins.append(f"        local.get {i}")
+        ins.append("        i32.add")
+        ins.append("        i32.load8_u offset=0")
+        ins.append("        i32.const 35")   # '#'
+        ins.append("        i32.eq")
+        ins.append("        if")
+        ins.append(f"          local.get {i}")
+        ins.append(f"          local.set {query_end}")
+        ins.append("          br $query_done")
+        ins.append("        end")
+        ins.append(f"        local.get {i}")
+        ins.append("        i32.const 1")
+        ins.append("        i32.add")
+        ins.append(f"        local.set {i}")
+        ins.append("        br $scan_query")
+        ins.append("      end")  # loop
+        ins.append("    end")    # block $query_done
+        ins.append("  end")  # if '?'
+        ins.append("end")   # if path_end < slen
+
+        # ---- Fragment: check after query (or after path if no query) ----
+        # The fragment start is wherever we stopped + 1 if we see '#'
+        # We need to check: if has_query, check at query_end; else at path_end
+        ins.append(f"local.get {has_query}")
+        ins.append("if")
+        # Check if query_end < slen and input[query_end] == '#'
+        ins.append(f"  local.get {query_end}")
+        ins.append(f"  local.get {slen}")
+        ins.append("  i32.lt_u")
+        ins.append("  if")
+        ins.append(f"    local.get {ptr}")
+        ins.append(f"    local.get {query_end}")
+        ins.append("    i32.add")
+        ins.append("    i32.load8_u offset=0")
+        ins.append("    i32.const 35")
+        ins.append("    i32.eq")
+        ins.append("    if")
+        ins.append("      i32.const 1")
+        ins.append(f"      local.set {has_frag}")
+        ins.append(f"      local.get {query_end}")
+        ins.append("      i32.const 1")
+        ins.append("      i32.add")
+        ins.append(f"      local.set {frag_start}")
+        ins.append("    end")
+        ins.append("  end")
+        ins.append("else")
+        # No query — check at path_end for '#'
+        ins.append(f"  local.get {path_end}")
+        ins.append(f"  local.get {slen}")
+        ins.append("  i32.lt_u")
+        ins.append("  if")
+        ins.append(f"    local.get {ptr}")
+        ins.append(f"    local.get {path_end}")
+        ins.append("    i32.add")
+        ins.append("    i32.load8_u offset=0")
+        ins.append("    i32.const 35")
+        ins.append("    i32.eq")
+        ins.append("    if")
+        ins.append("      i32.const 1")
+        ins.append(f"      local.set {has_frag}")
+        ins.append(f"      local.get {path_end}")
+        ins.append("      i32.const 1")
+        ins.append("      i32.add")
+        ins.append(f"      local.set {frag_start}")
+        ins.append("    end")
+        ins.append("  end")
+        ins.append("end")
+
+        # ---- Step 4: Allocate UrlParts (48 bytes) ----
+        ins.append("i32.const 48")
+        ins.append("call $alloc")
+        ins.append(f"local.tee {up}")
+        ins.append("i32.const 0")
+        ins.append("i32.store")              # tag = 0 (UrlParts constructor)
+        ins.extend(gc_shadow_push(up))
+
+        # Scheme: input[0..colon_pos]
+        ins.append(f"local.get {up}")
+        ins.append(f"local.get {ptr}")
+        ins.append("i32.store offset=4")     # scheme_ptr
+        ins.append(f"local.get {up}")
+        ins.append(f"local.get {colon_pos}")
+        ins.append("i32.store offset=8")     # scheme_len
+
+        # Authority: input[auth_start..auth_end]  (empty if no ://)
+        ins.append(f"local.get {up}")
+        ins.append(f"local.get {has_auth}")
+        ins.append("if (result i32)")
+        ins.append(f"  local.get {ptr}")
+        ins.append(f"  local.get {auth_start}")
+        ins.append("  i32.add")
+        ins.append("else")
+        ins.append(f"  i32.const {empty_off}")
+        ins.append("end")
+        ins.append("i32.store offset=12")    # auth_ptr
+        ins.append(f"local.get {up}")
+        ins.append(f"local.get {has_auth}")
+        ins.append("if (result i32)")
+        ins.append(f"  local.get {auth_end}")
+        ins.append(f"  local.get {auth_start}")
+        ins.append("  i32.sub")
+        ins.append("else")
+        ins.append(f"  i32.const {empty_len}")
+        ins.append("end")
+        ins.append("i32.store offset=16")    # auth_len
+
+        # Path: input[path_start..path_end]
+        ins.append(f"local.get {up}")
+        ins.append(f"local.get {path_start}")
+        ins.append(f"local.get {path_end}")
+        ins.append("i32.lt_u")
+        ins.append("if (result i32)")
+        ins.append(f"  local.get {ptr}")
+        ins.append(f"  local.get {path_start}")
+        ins.append("  i32.add")
+        ins.append("else")
+        ins.append(f"  i32.const {empty_off}")
+        ins.append("end")
+        ins.append("i32.store offset=20")    # path_ptr
+        ins.append(f"local.get {up}")
+        ins.append(f"local.get {path_end}")
+        ins.append(f"local.get {path_start}")
+        ins.append("i32.sub")
+        ins.append("i32.store offset=24")    # path_len
+
+        # Query: input[query_start..query_end]  (empty if no ?)
+        ins.append(f"local.get {up}")
+        ins.append(f"local.get {has_query}")
+        ins.append("if (result i32)")
+        ins.append(f"  local.get {ptr}")
+        ins.append(f"  local.get {query_start}")
+        ins.append("  i32.add")
+        ins.append("else")
+        ins.append(f"  i32.const {empty_off}")
+        ins.append("end")
+        ins.append("i32.store offset=28")    # query_ptr
+        ins.append(f"local.get {up}")
+        ins.append(f"local.get {has_query}")
+        ins.append("if (result i32)")
+        ins.append(f"  local.get {query_end}")
+        ins.append(f"  local.get {query_start}")
+        ins.append("  i32.sub")
+        ins.append("else")
+        ins.append(f"  i32.const {empty_len}")
+        ins.append("end")
+        ins.append("i32.store offset=32")    # query_len
+
+        # Fragment: input[frag_start..slen]  (empty if no #)
+        ins.append(f"local.get {up}")
+        ins.append(f"local.get {has_frag}")
+        ins.append("if (result i32)")
+        ins.append(f"  local.get {ptr}")
+        ins.append(f"  local.get {frag_start}")
+        ins.append("  i32.add")
+        ins.append("else")
+        ins.append(f"  i32.const {empty_off}")
+        ins.append("end")
+        ins.append("i32.store offset=36")    # frag_ptr
+        ins.append(f"local.get {up}")
+        ins.append(f"local.get {has_frag}")
+        ins.append("if (result i32)")
+        ins.append(f"  local.get {slen}")
+        ins.append(f"  local.get {frag_start}")
+        ins.append("  i32.sub")
+        ins.append("else")
+        ins.append(f"  i32.const {empty_len}")
+        ins.append("end")
+        ins.append("i32.store offset=40")    # frag_len
+
+        # ---- Step 5: Allocate Result (16 bytes), Ok(UrlParts) ----
+        ins.append("i32.const 16")
+        ins.append("call $alloc")
+        ins.append(f"local.tee {out}")
+        ins.append("i32.const 0")
+        ins.append("i32.store")              # tag = 0 (Ok)
+        ins.extend(gc_shadow_push(out))
+        ins.append(f"local.get {out}")
+        ins.append(f"local.get {up}")
+        ins.append("i32.store offset=4")     # UrlParts ptr
+        ins.append("br $done_up")
+
+        # ---- Err path ----
+        ins.append("end")  # block $err_up
+        ins.append("i32.const 16")
+        ins.append("call $alloc")
+        ins.append(f"local.tee {out}")
+        ins.append("i32.const 1")
+        ins.append("i32.store")              # tag = 1 (Err)
+        ins.extend(gc_shadow_push(out))
+        ins.append(f"local.get {out}")
+        ins.append(f"i32.const {err_off}")
+        ins.append("i32.store offset=4")
+        ins.append(f"local.get {out}")
+        ins.append(f"i32.const {err_ln}")
+        ins.append("i32.store offset=8")
+
+        ins.append("end")  # block $done_up
+
+        ins.append(f"local.get {out}")
+        return ins
+
+    def _translate_url_join(
+        self, arg: ast.Expr, env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """Translate url_join(parts) → String (i32_pair).
+
+        Takes a UrlParts heap pointer and reassembles a URL string.
+        Components: scheme://authority/path?query#fragment
+        Empty components are omitted (including their delimiters).
+
+        The argument is an i32 (heap pointer to UrlParts struct).
+        Returns i32_pair (ptr, len) on the stack.
+        """
+        arg_instrs = self.translate_expr(arg, env)
+        if arg_instrs is None:
+            return None
+
+        self.needs_alloc = True
+
+        # Intern "://" for the scheme separator
+        sep_off, sep_len = self.string_pool.intern("://")
+        q_off, _ = self.string_pool.intern("?")
+        h_off, _ = self.string_pool.intern("#")
+
+        # UrlParts pointer
+        up = self.alloc_local("i32")
+        # Component locals (5 pairs: ptr, len)
+        s_ptr = self.alloc_local("i32")    # scheme
+        s_len = self.alloc_local("i32")
+        a_ptr = self.alloc_local("i32")    # authority
+        a_len = self.alloc_local("i32")
+        p_ptr = self.alloc_local("i32")    # path
+        p_len = self.alloc_local("i32")
+        q_ptr = self.alloc_local("i32")    # query
+        q_len = self.alloc_local("i32")
+        f_ptr = self.alloc_local("i32")    # fragment
+        f_len = self.alloc_local("i32")
+        # Output
+        total = self.alloc_local("i32")
+        dst = self.alloc_local("i32")
+        k = self.alloc_local("i32")        # write cursor
+
+        ins: list[str] = []
+
+        # Evaluate arg → i32 (UrlParts heap pointer)
+        ins.extend(arg_instrs)
+        ins.append(f"local.set {up}")
+
+        # Load all 5 String fields (each is ptr + len at known offsets)
+        ins.append(f"local.get {up}")
+        ins.append("i32.load offset=4")
+        ins.append(f"local.set {s_ptr}")
+        ins.append(f"local.get {up}")
+        ins.append("i32.load offset=8")
+        ins.append(f"local.set {s_len}")
+
+        ins.append(f"local.get {up}")
+        ins.append("i32.load offset=12")
+        ins.append(f"local.set {a_ptr}")
+        ins.append(f"local.get {up}")
+        ins.append("i32.load offset=16")
+        ins.append(f"local.set {a_len}")
+
+        ins.append(f"local.get {up}")
+        ins.append("i32.load offset=20")
+        ins.append(f"local.set {p_ptr}")
+        ins.append(f"local.get {up}")
+        ins.append("i32.load offset=24")
+        ins.append(f"local.set {p_len}")
+
+        ins.append(f"local.get {up}")
+        ins.append("i32.load offset=28")
+        ins.append(f"local.set {q_ptr}")
+        ins.append(f"local.get {up}")
+        ins.append("i32.load offset=32")
+        ins.append(f"local.set {q_len}")
+
+        ins.append(f"local.get {up}")
+        ins.append("i32.load offset=36")
+        ins.append(f"local.set {f_ptr}")
+        ins.append(f"local.get {up}")
+        ins.append("i32.load offset=40")
+        ins.append(f"local.set {f_len}")
+
+        # ---- Pass 1: compute total output length ----
+        # total = scheme_len + path_len
+        ins.append(f"local.get {s_len}")
+        ins.append(f"local.get {p_len}")
+        ins.append("i32.add")
+        ins.append(f"local.set {total}")
+        # If scheme_len > 0: total += 3 (for "://")
+        ins.append(f"local.get {s_len}")
+        ins.append("i32.const 0")
+        ins.append("i32.gt_u")
+        ins.append("if")
+        ins.append(f"  local.get {total}")
+        ins.append("  i32.const 3")
+        ins.append("  i32.add")
+        ins.append(f"  local.set {total}")
+        ins.append("end")
+        # total += auth_len
+        ins.append(f"local.get {total}")
+        ins.append(f"local.get {a_len}")
+        ins.append("i32.add")
+        ins.append(f"local.set {total}")
+        # If query_len > 0: total += 1 + query_len
+        ins.append(f"local.get {q_len}")
+        ins.append("i32.const 0")
+        ins.append("i32.gt_u")
+        ins.append("if")
+        ins.append(f"  local.get {total}")
+        ins.append("  i32.const 1")
+        ins.append("  i32.add")
+        ins.append(f"  local.get {q_len}")
+        ins.append("  i32.add")
+        ins.append(f"  local.set {total}")
+        ins.append("end")
+        # If frag_len > 0: total += 1 + frag_len
+        ins.append(f"local.get {f_len}")
+        ins.append("i32.const 0")
+        ins.append("i32.gt_u")
+        ins.append("if")
+        ins.append(f"  local.get {total}")
+        ins.append("  i32.const 1")
+        ins.append("  i32.add")
+        ins.append(f"  local.get {f_len}")
+        ins.append("  i32.add")
+        ins.append(f"  local.set {total}")
+        ins.append("end")
+
+        # If total == 0: skip allocation, use empty string
+        empty_off2, empty_len2 = self.string_pool.intern("")
+        ins.append(f"local.get {total}")
+        ins.append("i32.eqz")
+        ins.append("if")
+        ins.append(f"  i32.const {empty_off2}")
+        ins.append(f"  local.set {dst}")
+        ins.append("end")
+
+        ins.append("block $uj_done")
+        ins.append(f"local.get {total}")
+        ins.append("i32.eqz")
+        ins.append("br_if $uj_done")
+
+        # ---- Pass 2: allocate and write ----
+        ins.append(f"local.get {total}")
+        ins.append("call $alloc")
+        ins.append(f"local.set {dst}")
+        ins.extend(gc_shadow_push(dst))
+
+        ins.append("i32.const 0")
+        ins.append(f"local.set {k}")
+
+        # If scheme non-empty: copy scheme, write "://"
+        ins.append(f"local.get {s_len}")
+        ins.append("i32.const 0")
+        ins.append("i32.gt_u")
+        ins.append("if")
+        # memory.copy(dst+k, s_ptr, s_len)
+        ins.append(f"  local.get {dst}")
+        ins.append(f"  local.get {k}")
+        ins.append("  i32.add")
+        ins.append(f"  local.get {s_ptr}")
+        ins.append(f"  local.get {s_len}")
+        ins.append("  memory.copy")
+        ins.append(f"  local.get {k}")
+        ins.append(f"  local.get {s_len}")
+        ins.append("  i32.add")
+        ins.append(f"  local.set {k}")
+        # Write "://" (3 bytes from string pool)
+        ins.append(f"  local.get {dst}")
+        ins.append(f"  local.get {k}")
+        ins.append("  i32.add")
+        ins.append(f"  i32.const {sep_off}")
+        ins.append("  i32.const 3")
+        ins.append("  memory.copy")
+        ins.append(f"  local.get {k}")
+        ins.append("  i32.const 3")
+        ins.append("  i32.add")
+        ins.append(f"  local.set {k}")
+        ins.append("end")
+
+        # Copy authority (even if empty — zero-length copy is a no-op)
+        ins.append(f"local.get {a_len}")
+        ins.append("i32.const 0")
+        ins.append("i32.gt_u")
+        ins.append("if")
+        ins.append(f"  local.get {dst}")
+        ins.append(f"  local.get {k}")
+        ins.append("  i32.add")
+        ins.append(f"  local.get {a_ptr}")
+        ins.append(f"  local.get {a_len}")
+        ins.append("  memory.copy")
+        ins.append(f"  local.get {k}")
+        ins.append(f"  local.get {a_len}")
+        ins.append("  i32.add")
+        ins.append(f"  local.set {k}")
+        ins.append("end")
+
+        # Copy path
+        ins.append(f"local.get {p_len}")
+        ins.append("i32.const 0")
+        ins.append("i32.gt_u")
+        ins.append("if")
+        ins.append(f"  local.get {dst}")
+        ins.append(f"  local.get {k}")
+        ins.append("  i32.add")
+        ins.append(f"  local.get {p_ptr}")
+        ins.append(f"  local.get {p_len}")
+        ins.append("  memory.copy")
+        ins.append(f"  local.get {k}")
+        ins.append(f"  local.get {p_len}")
+        ins.append("  i32.add")
+        ins.append(f"  local.set {k}")
+        ins.append("end")
+
+        # If query non-empty: write "?" + query
+        ins.append(f"local.get {q_len}")
+        ins.append("i32.const 0")
+        ins.append("i32.gt_u")
+        ins.append("if")
+        # Write '?' (1 byte)
+        ins.append(f"  local.get {dst}")
+        ins.append(f"  local.get {k}")
+        ins.append("  i32.add")
+        ins.append("  i32.const 63")   # '?'
+        ins.append("  i32.store8 offset=0")
+        ins.append(f"  local.get {k}")
+        ins.append("  i32.const 1")
+        ins.append("  i32.add")
+        ins.append(f"  local.set {k}")
+        # Copy query
+        ins.append(f"  local.get {dst}")
+        ins.append(f"  local.get {k}")
+        ins.append("  i32.add")
+        ins.append(f"  local.get {q_ptr}")
+        ins.append(f"  local.get {q_len}")
+        ins.append("  memory.copy")
+        ins.append(f"  local.get {k}")
+        ins.append(f"  local.get {q_len}")
+        ins.append("  i32.add")
+        ins.append(f"  local.set {k}")
+        ins.append("end")
+
+        # If fragment non-empty: write "#" + fragment
+        ins.append(f"local.get {f_len}")
+        ins.append("i32.const 0")
+        ins.append("i32.gt_u")
+        ins.append("if")
+        # Write '#' (1 byte)
+        ins.append(f"  local.get {dst}")
+        ins.append(f"  local.get {k}")
+        ins.append("  i32.add")
+        ins.append("  i32.const 35")   # '#'
+        ins.append("  i32.store8 offset=0")
+        ins.append(f"  local.get {k}")
+        ins.append("  i32.const 1")
+        ins.append("  i32.add")
+        ins.append(f"  local.set {k}")
+        # Copy fragment
+        ins.append(f"  local.get {dst}")
+        ins.append(f"  local.get {k}")
+        ins.append("  i32.add")
+        ins.append(f"  local.get {f_ptr}")
+        ins.append(f"  local.get {f_len}")
+        ins.append("  memory.copy")
+        ins.append(f"  local.get {k}")
+        ins.append(f"  local.get {f_len}")
+        ins.append("  i32.add")
+        ins.append(f"  local.set {k}")
+        ins.append("end")
+
+        ins.append("end")  # block $uj_done
+
+        # Return (dst, total) as i32_pair
+        ins.append(f"local.get {dst}")
+        ins.append(f"local.get {total}")
         return ins
 
     def _translate_to_string(

--- a/vera/wasm/inference.py
+++ b/vera/wasm/inference.py
@@ -227,8 +227,10 @@ class InferenceMixin:
             "base64_decode", "url_decode",
         ):
             return "i32"
-        if expr.name in ("base64_encode", "url_encode"):
+        if expr.name in ("base64_encode", "url_encode", "url_join"):
             return "i32_pair"
+        if expr.name == "url_parse":
+            return "i32"
         # Numeric math builtins
         if expr.name in ("abs", "min", "max", "floor", "ceil", "round"):
             return "i64"
@@ -405,8 +407,10 @@ class InferenceMixin:
             "base64_decode", "url_decode",
         ):
             return "Result"
-        if call.name in ("base64_encode", "url_encode"):
+        if call.name in ("base64_encode", "url_encode", "url_join"):
             return "String"
+        if call.name == "url_parse":
+            return "Result"
         # Numeric math builtins
         if call.name == "abs":
             return "Nat"


### PR DESCRIPTION
## Summary

- Implements #232 Phase 2: `url_parse` and `url_join` builtins for RFC 3986 URL decomposition/recomposition
- Adds new `UrlParts` ADT type with 5 String fields (scheme, authority, path, query, fragment)
- `url_parse` does zero-copy parsing — component strings point directly into the original input memory
- `url_join` conditionally reassembles components with `://`, `?`, `#` delimiters
- Removes #266 limitation (fixed in #268), adds "Known Bugs" section to README
- Bumps version 0.0.80 → 0.0.81

Closes #232

## Test plan

- [x] 4 checker tests (url_parse ok/wrong_type, url_join ok/wrong_type)
- [x] 19 codegen tests for url_parse (full URL, edge cases, error cases, roundtrips)
- [x] 6 codegen tests for url_join (all components, partial, empty)
- [x] Conformance program `ch09_url_parsing.vera` (49 total)
- [x] Example `url_parsing.vera` (21 total)
- [x] All 2047 tests pass, mypy clean
- [x] All conformance/example/spec/README/SKILL validation scripts pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)