### PR TITLE
Add <Async> effect with Future<T> type (#59)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Read `SKILL.md` for the full language reference. It covers syntax, slot referenc
 
 ### Conformance programs as reference
 
-The conformance suite in `tests/conformance/` contains 49 small, self-contained programs — one per language feature — that all parse, type-check, verify, and (mostly) run correctly. These are the best minimal working examples of each feature. When you need to see how a specific construct works (e.g. effect handlers, match expressions, closures), check the corresponding conformance program before reading the spec. The `manifest.json` file maps features to programs.
+The conformance suite in `tests/conformance/` contains 50 small, self-contained programs — one per language feature — that all parse, type-check, verify, and (mostly) run correctly. These are the best minimal working examples of each feature. When you need to see how a specific construct works (e.g. effect handlers, match expressions, closures), check the corresponding conformance program before reading the spec. The `manifest.json` file maps features to programs.
 
 ### Workflow
 
@@ -140,8 +140,8 @@ Each stage is a module with a single public API function (`parse_file`, `transfo
 pytest tests/ -v                       # Run all tests (see TESTING.md)
 pytest tests/test_conformance.py -v    # Conformance suite only
 mypy vera/                             # Type-check the compiler
-python scripts/check_conformance.py    # All 49 conformance programs must pass
-python scripts/check_examples.py       # All 21 examples must pass
+python scripts/check_conformance.py    # All 50 conformance programs must pass
+python scripts/check_examples.py       # All 22 examples must pass
 ```
 
 Test helpers follow a pattern: `_check_ok(source)` / `_check_err(source, match)` / `_verify_ok(source)` / `_verify_err(source, match)`. See existing tests for examples.
@@ -154,8 +154,8 @@ When implementing a new language feature, write the conformance program *first* 
 
 ### Invariants
 
-- All 49 conformance programs in `tests/conformance/` must pass their declared level
-- All 21 examples in `examples/` must pass `vera check` and `vera verify`
+- All 50 conformance programs in `tests/conformance/` must pass their declared level
+- All 22 examples in `examples/` must pass `vera check` and `vera verify`
 - `mypy vera/` must be clean
 - `pytest tests/ -v` must pass
 - Version must be in sync across `vera/__init__.py`, `pyproject.toml`, and `CHANGELOG.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.82] - 2026-03-11
+
+### Added
+- **`<Async>` effect with `Future<T>` type** ([#59](https://github.com/aallan/vera/issues/59)):
+  New `Async` marker effect and `Future<T>` ADT for asynchronous computation.
+  New `async(@T -> @Future<T>)` — wraps a value in a future (eager evaluation).
+  New `await(@Future<T> -> @T)` — unwraps a future to its result.
+  `Future<T>` is WASM-transparent — same runtime representation as `T`, zero overhead.
+  The reference implementation uses sequential evaluation; true concurrency will be
+  available via WASI 0.3 native `future<T>` support ([#237](https://github.com/aallan/vera/issues/237)).
+- New conformance test `ch09_async` (conformance suite: 49→50 programs)
+- New example `examples/async_futures.vera` — async/await roundtrip and composition demo
+- 15 new tests (7 type checker + 8 codegen)
+
 ## [0.0.81] - 2026-03-10
 
 ### Added
@@ -1240,7 +1254,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Grammar: handler body simplified to avoid LALR reduce/reduce conflict
 - `pyproject.toml`: corrected build backend, package discovery, PEP 639 compliance
 
-[Unreleased]: https://github.com/aallan/vera/compare/v0.0.81...HEAD
+[Unreleased]: https://github.com/aallan/vera/compare/v0.0.82...HEAD
+[0.0.82]: https://github.com/aallan/vera/compare/v0.0.81...v0.0.82
 [0.0.81]: https://github.com/aallan/vera/compare/v0.0.80...v0.0.81
 [0.0.80]: https://github.com/aallan/vera/compare/v0.0.79...v0.0.80
 [0.0.79]: https://github.com/aallan/vera/compare/v0.0.78...v0.0.79

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,8 +40,8 @@ vera fmt --check file.vera        # Check if already canonical
 pytest tests/ -v                  # Run the test suite (see TESTING.md)
 mypy vera/                        # Type-check the compiler itself
 
-python scripts/check_conformance.py    # Verify all 49 conformance programs pass their declared level
-python scripts/check_examples.py      # Verify all 20 examples parse + check + verify
+python scripts/check_conformance.py    # Verify all 50 conformance programs pass their declared level
+python scripts/check_examples.py      # Verify all 22 examples parse + check + verify
 python scripts/check_spec_examples.py # Verify spec code blocks parse
 python scripts/check_readme_examples.py # Verify README code blocks parse
 python scripts/check_skill_examples.py # Verify SKILL.md code blocks parse
@@ -54,9 +54,9 @@ python scripts/fix_allowlists.py --fix # Auto-fix stale allowlist line numbers
 
 - `spec/` — Language specification (Chapters 0-12)
 - `vera/` — Reference compiler: grammar, parser, AST, transformer, type checker, verifier, codegen, CLI
-- `examples/` — 21 example Vera programs (all must pass `vera check` and `vera verify`)
+- `examples/` — 22 example Vera programs (all must pass `vera check` and `vera verify`)
 - `tests/` — Test suite (unit tests + conformance suite)
-- `tests/conformance/` — 49 conformance programs validating every language feature against the spec
+- `tests/conformance/` — 50 conformance programs validating every language feature against the spec
 - `scripts/` — CI and validation scripts
 
 ## Writing Vera code
@@ -74,8 +74,8 @@ Each stage is a module with a public API function and is independently testable.
 ## What not to break
 
 - Pre-commit hooks run mypy + pytest + conformance suite + example validation on every commit
-- All 49 conformance programs in `tests/conformance/` must pass their declared level
-- All 21 examples in `examples/` must pass `vera check` and `vera verify`
+- All 50 conformance programs in `tests/conformance/` must pass their declared level
+- All 22 examples in `examples/` must pass `vera check` and `vera verify`
 - Version must stay in sync across `vera/__init__.py`, `pyproject.toml`, and `CHANGELOG.md`
 - All tests must pass: `pytest tests/ -v`
 - Type checking must be clean: `mypy vera/`

--- a/README.md
+++ b/README.md
@@ -362,11 +362,12 @@ New effects, types, abilities, and standard library extensions (spec §0.8).
 **Effects** — new effect types for agent workloads
 
 - [#57](https://github.com/aallan/vera/issues/57) `<Http>` network access effect
-- [#59](https://github.com/aallan/vera/issues/59) `<Async>` futures and promises
+- <del>[#59](https://github.com/aallan/vera/issues/59) `<Async>` futures and promises</del> ([v0.0.82](https://github.com/aallan/vera/releases/tag/v0.0.82))
 - [#61](https://github.com/aallan/vera/issues/61) `<Inference>` LLM inference effect
 - [#227](https://github.com/aallan/vera/issues/227) `<Timeout>` timeout and cancellation effects
 - [#228](https://github.com/aallan/vera/issues/228) `<WebSocket>` / `<SSE>` streaming client effects
 - [#229](https://github.com/aallan/vera/issues/229) `<DB>` database access effect
+- [#270](https://github.com/aallan/vera/issues/270) `handle[Async]` custom scheduling strategies
 
 **Standard library** — types, data formats, and host-provided functions
 
@@ -462,7 +463,7 @@ OK: examples/safe_divide.vera
 Verification: 4 verified (Tier 1)
 ```
 
-`vera verify` runs the type checker and then verifies contracts using Z3. Tier 1 contracts (decidable arithmetic, comparisons, Boolean logic, match expressions, ADT constructors, and decreases clauses) are proved automatically. Contracts that Z3 cannot decide are reported as Tier 3 (runtime checks) with a warning. Across all 21 examples, 122 of 126 contracts (96.8%) are verified statically.
+`vera verify` runs the type checker and then verifies contracts using Z3. Tier 1 contracts (decidable arithmetic, comparisons, Boolean logic, match expressions, ADT constructors, and decreases clauses) are proved automatically. Contracts that Z3 cannot decide are reported as Tier 3 (runtime checks) with a warning. Across all 22 examples, 127 of 134 contracts (94.8%) are verified statically.
 
 ### Format a program
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -418,6 +418,8 @@ url_encode(@String.0)                   -- returns String (RFC 3986 percent-enco
 url_decode(@String.0)                   -- returns Result<String, String>
 url_parse(@String.0)                    -- returns Result<UrlParts, String> (RFC 3986 decomposition)
 url_join(@UrlParts.0)                   -- returns String (reassemble URL from UrlParts)
+async(@T.0)                            -- returns Future<T> (requires effects(<Async>))
+await(@Future<T>.0)                    -- returns T (requires effects(<Async>))
 to_string(@Int.0)                       -- returns String (integer to decimal)
 int_to_string(@Int.0)                   -- returns String (alias for to_string)
 bool_to_string(@Bool.0)                 -- returns String ("true" or "false")
@@ -582,6 +584,7 @@ effects(pure)                    -- no effects
 effects(<IO>)                    -- performs IO
 effects(<State<Int>>)            -- uses integer state
 effects(<State<Int>, IO>)        -- multiple effects
+effects(<Async>)                 -- async computation
 effects(<Diverge>)               -- may not terminate
 effects(<Diverge, IO>)           -- divergent with IO
 ```
@@ -692,6 +695,31 @@ private fn try_div(@Int, @Int -> @Option<Int>)
 ```
 
 The handler catches the exception and returns a fallback value. The `throw` handler clause receives the error value and must return the same type as the overall `handle` expression. Exception handlers do not use `resume` — throwing is non-resumable.
+
+### Async effect
+
+The `Async` effect enables asynchronous computation with `Future<T>`:
+
+```vera
+effects(<Async>)                 -- async computation
+effects(<IO, Async>)             -- async with IO
+```
+
+`async` and `await` are built-in generic functions:
+
+```vera
+private fn compute(@Int, @Int -> @Int)
+  requires(true)
+  ensures(true)
+  effects(<Async>)
+{
+  let @Future<Int> = async(@Int.1 * 2);
+  let @Future<Int> = async(@Int.0 * 3);
+  await(@Future<Int>.0) + await(@Future<Int>.1)
+}
+```
+
+`async(expr)` evaluates `expr` and wraps the result in `Future<T>`. `await(@Future<T>.n)` unwraps it. In the reference implementation, evaluation is eager/sequential — `Future<T>` has the same WASM representation as `T` with no runtime overhead.
 
 ### Effect handlers
 

--- a/examples/async_futures.vera
+++ b/examples/async_futures.vera
@@ -1,0 +1,43 @@
+-- Async effect with Future<T>
+--
+-- The Async effect enables async(expr) and await(future) operations.
+-- In the reference implementation, async(expr) evaluates eagerly and
+-- wraps the result in Future<T>; await(future) unwraps it.
+-- Future<T> is WASM-transparent — no runtime overhead.
+effect IO {
+  op print(String -> Unit);
+}
+
+-- Create a future and immediately await it
+private fn roundtrip(@Int -> @Int)
+  requires(true)
+  ensures(@Int.result == @Int.0)
+  effects(<Async>)
+{
+  let @Future<Int> = async(@Int.0);
+  await(@Future<Int>.0)
+}
+
+-- Multiple futures can be composed
+private fn sum_futures(@Int, @Int -> @Int)
+  requires(true)
+  ensures(@Int.result == @Int.0 + @Int.1)
+  effects(<Async>)
+{
+  let @Future<Int> = async(@Int.1);
+  let @Future<Int> = async(@Int.0);
+  await(@Future<Int>.0) + await(@Future<Int>.1)
+}
+
+-- Async composes with IO
+public fn main(@Unit -> @Unit)
+  requires(true)
+  ensures(true)
+  effects(<IO, Async>)
+{
+  let @Int = roundtrip(42);
+  IO.print("roundtrip(42) = \(@Int.0)");
+  let @Int = sum_futures(10, 20);
+  IO.print("sum_futures(10, 20) = \(@Int.0)");
+  ()
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.81"
+version = "0.0.82"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/scripts/check_readme_examples.py
+++ b/scripts/check_readme_examples.py
@@ -36,7 +36,7 @@ ALLOWLIST: dict[int, tuple[str, str]] = {
     # =================================================================
 
     # Section "Where this is going" — depends on #57 (Http), #61 (Inference), #147 (Markdown)
-    412: ("FUTURE", "Vision example uses MdBlock, Http, Inference (issues #57, #61, #147)"),
+    413: ("FUTURE", "Vision example uses MdBlock, Http, Inference (issues #57, #61, #147)"),
 }
 
 

--- a/scripts/check_skill_examples.py
+++ b/scripts/check_skill_examples.py
@@ -40,64 +40,68 @@ ALLOWLIST: dict[int, tuple[str, str]] = {
     404: ("FRAGMENT", "String built-in examples, bare calls"),
 
     # String interpolation — bare expressions
-    432: ("FRAGMENT", "String interpolation examples, bare expressions"),
+    434: ("FRAGMENT", "String interpolation examples, bare expressions"),
 
     # String search — bare function calls
-    444: ("FRAGMENT", "String search built-in examples, bare calls"),
+    446: ("FRAGMENT", "String search built-in examples, bare calls"),
 
     # String transformation — bare function calls
-    455: ("FRAGMENT", "String transformation built-in examples, bare calls"),
+    457: ("FRAGMENT", "String transformation built-in examples, bare calls"),
 
     # Numeric operations — bare function calls
-    469: ("FRAGMENT", "Numeric built-in examples, bare calls"),
+    471: ("FRAGMENT", "Numeric built-in examples, bare calls"),
 
     # Contracts section — requires/ensures fragments
-    526: ("FRAGMENT", "Requires clause example, not full function"),
-    535: ("FRAGMENT", "Ensures clause example, not full function"),
-    562: ("FRAGMENT", "Quantified requires clause, not full function"),
+    528: ("FRAGMENT", "Requires clause example, not full function"),
+    537: ("FRAGMENT", "Ensures clause example, not full function"),
+    564: ("FRAGMENT", "Quantified requires clause, not full function"),
 
     # Effects section — bare effect rows
-    580: ("FRAGMENT", "Effect row examples, bare annotations"),
+    # (old entry at 580 removed — block shifted to 582 with Async addition)
 
     # Effect handler syntax template
-    717: ("FRAGMENT", "Handler syntax template, not real code"),
+    745: ("FRAGMENT", "Handler syntax template, not real code"),
+
+    # Effect declarations — bare effects(...) clauses
+    582: ("FRAGMENT", "Effect declarations list"),
+    703: ("FRAGMENT", "Async effect declarations list"),
 
     # Qualified calls and handler fragments — bare expressions
-    729: ("FRAGMENT", "Handler with clause, bare expression"),
-    739: ("FRAGMENT", "Qualified call examples, bare expressions"),
+    757: ("FRAGMENT", "Handler with clause, bare expression"),
+    767: ("FRAGMENT", "Qualified call examples, bare expressions"),
 
     # Module declaration and import syntax
-    777: ("FRAGMENT", "Module declaration and import example"),
+    805: ("FRAGMENT", "Module declaration and import example"),
 
     # Line comments — bare comments
-    832: ("FRAGMENT", "Comment syntax example"),
+    860: ("FRAGMENT", "Comment syntax example"),
 
     # Type conversions — bare function calls
-    484: ("FRAGMENT", "Type conversion examples, bare calls"),
+    486: ("FRAGMENT", "Type conversion examples, bare calls"),
 
     # Float64 predicates — bare function calls
-    497: ("FRAGMENT", "Float64 predicate examples, bare calls"),
+    499: ("FRAGMENT", "Float64 predicate examples, bare calls"),
 
     # Common mistakes section — intentionally wrong code
-    860: ("FRAGMENT", "Wrong: missing contracts"),
-    880: ("FRAGMENT", "Wrong: missing effects clause"),
-    914: ("FRAGMENT", "Wrong: bare expression without indices"),
-    927: ("FRAGMENT", "Wrong: bare expression no indices"),
-    932: ("FRAGMENT", "Correct: expression with indices (not full fn)"),
-    998: ("FRAGMENT", "Wrong: match arm with incorrect return"),
-    1022: ("FRAGMENT", "Wrong: non-exhaustive match"),
-    1029: ("FRAGMENT", "Correct: match arm example"),
-    1039: ("FRAGMENT", "Wrong: if/else without braces (bare expression)"),
-    1044: ("FRAGMENT", "Correct: if/else with braces"),
+    888: ("FRAGMENT", "Wrong: missing contracts"),
+    908: ("FRAGMENT", "Wrong: missing effects clause"),
+    942: ("FRAGMENT", "Wrong: bare expression without indices"),
+    955: ("FRAGMENT", "Wrong: bare expression no indices"),
+    960: ("FRAGMENT", "Correct: expression with indices (not full fn)"),
+    1026: ("FRAGMENT", "Wrong: match arm with incorrect return"),
+    1050: ("FRAGMENT", "Wrong: non-exhaustive match"),
+    1057: ("FRAGMENT", "Correct: match arm example"),
+    1067: ("FRAGMENT", "Wrong: if/else without braces (bare expression)"),
+    1072: ("FRAGMENT", "Correct: if/else with braces"),
 
     # Import syntax — intentionally unsupported
-    1055: ("FRAGMENT", "Wrong: import aliasing not supported"),
-    1060: ("FRAGMENT", "Correct: import syntax example"),
-    1070: ("FRAGMENT", "Wrong: import hiding not supported"),
-    1075: ("FRAGMENT", "Correct: multi-import syntax"),
+    1083: ("FRAGMENT", "Wrong: import aliasing not supported"),
+    1088: ("FRAGMENT", "Correct: import syntax example"),
+    1098: ("FRAGMENT", "Wrong: import hiding not supported"),
+    1103: ("FRAGMENT", "Correct: multi-import syntax"),
 
     # String escapes — bare expression
-    1089: ("FRAGMENT", "String escape example"),
+    1117: ("FRAGMENT", "String escape example"),
 
     # =================================================================
     # MISMATCH — uses syntax the parser doesn't handle in isolation.

--- a/scripts/check_spec_examples.py
+++ b/scripts/check_spec_examples.py
@@ -57,13 +57,13 @@ ALLOWLIST: dict[tuple[str, int], str] = {
     ("02-types.md", 250): "FUTURE",          # forall<T where Ord<T>> fn sort
 
     # Chapter 9 — future stdlib features and signature-only blocks
-    ("09-standard-library.md", 290): "FUTURE",   # fn classify — uses ++ (string concat)
+    ("09-standard-library.md", 320): "FUTURE",   # fn classify — uses ++ (string concat)
 
     # Chapter 9 — Array builtin signatures (no body)
-    ("09-standard-library.md", 304): "FRAGMENT",  # array_length signature (no body)
-    ("09-standard-library.md", 324): "FRAGMENT",  # array_append signature (no body)
-    ("09-standard-library.md", 342): "FRAGMENT",  # array_range signature (no body)
-    ("09-standard-library.md", 360): "FRAGMENT",  # array_concat signature (no body)
+    ("09-standard-library.md", 334): "FRAGMENT",  # array_length signature (no body)
+    ("09-standard-library.md", 354): "FRAGMENT",  # array_append signature (no body)
+    ("09-standard-library.md", 372): "FRAGMENT",  # array_range signature (no body)
+    ("09-standard-library.md", 390): "FRAGMENT",  # array_concat signature (no body)
 
     # =================================================================
     # FRAGMENT — heuristic false positives (look like declarations but
@@ -112,73 +112,76 @@ ALLOWLIST: dict[tuple[str, int], str] = {
     # Chapter 7 — empty effect bodies (parser requires op_decl+)
     ("07-effects.md", 315): "FRAGMENT",     # effect Diverge {} — no operations
 
+    # Chapter 9 — Async builtin signatures (no body)
+    ("09-standard-library.md", 270): "FRAGMENT",  # async/await signatures (no body)
+
     # Chapter 9 — Numeric builtin signatures (no body)
-    ("09-standard-library.md", 382): "FRAGMENT",  # abs signature (no body)
-    ("09-standard-library.md", 399): "FRAGMENT",  # min signature (no body)
-    ("09-standard-library.md", 416): "FRAGMENT",  # max signature (no body)
-    ("09-standard-library.md", 433): "FRAGMENT",  # floor signature (no body)
-    ("09-standard-library.md", 450): "FRAGMENT",  # ceil signature (no body)
-    ("09-standard-library.md", 467): "FRAGMENT",  # round signature (no body)
-    ("09-standard-library.md", 484): "FRAGMENT",  # sqrt signature (no body)
-    ("09-standard-library.md", 501): "FRAGMENT",  # pow signature (no body)
+    ("09-standard-library.md", 412): "FRAGMENT",  # abs signature (no body)
+    ("09-standard-library.md", 429): "FRAGMENT",  # min signature (no body)
+    ("09-standard-library.md", 446): "FRAGMENT",  # max signature (no body)
+    ("09-standard-library.md", 463): "FRAGMENT",  # floor signature (no body)
+    ("09-standard-library.md", 480): "FRAGMENT",  # ceil signature (no body)
+    ("09-standard-library.md", 497): "FRAGMENT",  # round signature (no body)
+    ("09-standard-library.md", 514): "FRAGMENT",  # sqrt signature (no body)
+    ("09-standard-library.md", 531): "FRAGMENT",  # pow signature (no body)
 
     # Chapter 9 — Numeric type conversion signatures (no body)
-    ("09-standard-library.md", 522): "FRAGMENT",  # to_float signature (no body)
-    ("09-standard-library.md", 537): "FRAGMENT",  # nat_to_int signature (no body)
-    ("09-standard-library.md", 552): "FRAGMENT",  # byte_to_int signature (no body)
-    ("09-standard-library.md", 567): "FRAGMENT",  # float_to_int signature (no body)
-    ("09-standard-library.md", 582): "FRAGMENT",  # int_to_nat signature (no body)
-    ("09-standard-library.md", 600): "FRAGMENT",  # int_to_byte signature (no body)
+    ("09-standard-library.md", 552): "FRAGMENT",  # to_float signature (no body)
+    ("09-standard-library.md", 567): "FRAGMENT",  # nat_to_int signature (no body)
+    ("09-standard-library.md", 582): "FRAGMENT",  # byte_to_int signature (no body)
+    ("09-standard-library.md", 597): "FRAGMENT",  # float_to_int signature (no body)
+    ("09-standard-library.md", 612): "FRAGMENT",  # int_to_nat signature (no body)
+    ("09-standard-library.md", 630): "FRAGMENT",  # int_to_byte signature (no body)
 
     # Chapter 9 — Float64 predicates (signatures, no body)
-    ("09-standard-library.md", 624): "FRAGMENT",  # is_nan signature (no body)
-    ("09-standard-library.md", 641): "FRAGMENT",  # is_infinite signature (no body)
-    ("09-standard-library.md", 660): "FRAGMENT",  # nan signature (no body)
-    ("09-standard-library.md", 675): "FRAGMENT",  # infinity signature (no body)
+    ("09-standard-library.md", 654): "FRAGMENT",  # is_nan signature (no body)
+    ("09-standard-library.md", 671): "FRAGMENT",  # is_infinite signature (no body)
+    ("09-standard-library.md", 690): "FRAGMENT",  # nan signature (no body)
+    ("09-standard-library.md", 705): "FRAGMENT",  # infinity signature (no body)
 
     # Chapter 9 — String search signatures (no body)
-    ("09-standard-library.md", 696): "FRAGMENT",  # string_contains signature (no body)
-    ("09-standard-library.md", 711): "FRAGMENT",  # starts_with signature (no body)
-    ("09-standard-library.md", 726): "FRAGMENT",  # ends_with signature (no body)
-    ("09-standard-library.md", 741): "FRAGMENT",  # index_of signature (no body)
+    ("09-standard-library.md", 726): "FRAGMENT",  # string_contains signature (no body)
+    ("09-standard-library.md", 741): "FRAGMENT",  # starts_with signature (no body)
+    ("09-standard-library.md", 756): "FRAGMENT",  # ends_with signature (no body)
+    ("09-standard-library.md", 771): "FRAGMENT",  # index_of signature (no body)
 
     # Chapter 9 — String transformation signatures (no body)
-    ("09-standard-library.md", 762): "FRAGMENT",  # to_upper signature (no body)
-    ("09-standard-library.md", 777): "FRAGMENT",  # to_lower signature (no body)
-    ("09-standard-library.md", 792): "FRAGMENT",  # replace signature (no body)
-    ("09-standard-library.md", 808): "FRAGMENT",  # split signature (no body)
-    ("09-standard-library.md", 823): "FRAGMENT",  # join signature (no body)
-    ("09-standard-library.md", 837): "FRAGMENT",  # from_char_code signature (no body)
-    ("09-standard-library.md", 852): "FRAGMENT",  # string_repeat signature (no body)
+    ("09-standard-library.md", 792): "FRAGMENT",  # to_upper signature (no body)
+    ("09-standard-library.md", 807): "FRAGMENT",  # to_lower signature (no body)
+    ("09-standard-library.md", 822): "FRAGMENT",  # replace signature (no body)
+    ("09-standard-library.md", 838): "FRAGMENT",  # split signature (no body)
+    ("09-standard-library.md", 853): "FRAGMENT",  # join signature (no body)
+    ("09-standard-library.md", 867): "FRAGMENT",  # from_char_code signature (no body)
+    ("09-standard-library.md", 882): "FRAGMENT",  # string_repeat signature (no body)
 
     # Chapter 9 — Parsing function signatures (no body)
-    ("09-standard-library.md", 880): "FRAGMENT",  # parse_nat signature (no body)
-    ("09-standard-library.md", 902): "FRAGMENT",  # parse_int signature (no body)
-    ("09-standard-library.md", 925): "FRAGMENT",  # parse_float64 signature (no body)
-    ("09-standard-library.md", 947): "FRAGMENT",  # parse_bool signature (no body)
+    ("09-standard-library.md", 910): "FRAGMENT",  # parse_nat signature (no body)
+    ("09-standard-library.md", 932): "FRAGMENT",  # parse_int signature (no body)
+    ("09-standard-library.md", 955): "FRAGMENT",  # parse_float64 signature (no body)
+    ("09-standard-library.md", 977): "FRAGMENT",  # parse_bool signature (no body)
 
     # Chapter 9 — Base64 builtin signatures (no body)
-    ("09-standard-library.md", 970): "FRAGMENT",  # base64_encode signature (no body)
-    ("09-standard-library.md", 989): "FRAGMENT",  # base64_decode signature (no body)
+    ("09-standard-library.md", 1000): "FRAGMENT",  # base64_encode signature (no body)
+    ("09-standard-library.md", 1019): "FRAGMENT",  # base64_decode signature (no body)
 
     # Chapter 9 — URL encoding builtin signatures (no body)
-    ("09-standard-library.md", 1016): "FRAGMENT",  # url_encode signature (no body)
-    ("09-standard-library.md", 1035): "FRAGMENT",  # url_decode signature (no body)
+    ("09-standard-library.md", 1046): "FRAGMENT",  # url_encode signature (no body)
+    ("09-standard-library.md", 1065): "FRAGMENT",  # url_decode signature (no body)
 
     # Chapter 9 — URL parsing builtin signatures (no body)
-    ("09-standard-library.md", 1067): "FRAGMENT",  # url_parse signature (no body)
-    ("09-standard-library.md", 1087): "FRAGMENT",  # url_join signature (no body)
+    ("09-standard-library.md", 1097): "FRAGMENT",  # url_parse signature (no body)
+    ("09-standard-library.md", 1117): "FRAGMENT",  # url_join signature (no body)
 
     # Chapter 9 — ML/vector builtin signatures (no body)
-    ("09-standard-library.md", 1107): "FRAGMENT",  # similarity signature (no body)
+    ("09-standard-library.md", 1137): "FRAGMENT",  # similarity signature (no body)
 
     # Chapter 9 — Markdown stdlib type (future, uses MdBlock/MdInline types)
-    ("09-standard-library.md", 1211): "FUTURE",   # md_parse(@String -> @Result<MdBlock, String>)
-    ("09-standard-library.md", 1220): "FUTURE",   # md_render(@MdBlock -> @String)
-    ("09-standard-library.md", 1231): "FUTURE",   # md_has_heading(@MdBlock, @Nat -> @Bool)
-    ("09-standard-library.md", 1240): "FUTURE",   # md_has_code_block(@MdBlock, @String -> @Bool)
-    ("09-standard-library.md", 1249): "FUTURE",   # md_extract_code_blocks(@MdBlock, @String -> @Array<String>)
-    ("09-standard-library.md", 1273): "FUTURE",   # convert_to_markdown(@String -> @Result<MdBlock, String>)
+    ("09-standard-library.md", 1241): "FUTURE",   # md_parse
+    ("09-standard-library.md", 1250): "FUTURE",   # md_render
+    ("09-standard-library.md", 1261): "FUTURE",   # md_has_heading
+    ("09-standard-library.md", 1270): "FUTURE",   # md_has_code_block
+    ("09-standard-library.md", 1279): "FUTURE",   # md_extract_code_blocks
+    ("09-standard-library.md", 1303): "FUTURE",   # convert_to_markdown
 }
 
 
@@ -228,11 +231,14 @@ CHECK_ALLOWLIST: dict[tuple[str, int], str] = {
     # Chapter 7 — Exn handler references parse_int (not defined in block)
     ("07-effects.md", 202): "INCOMPLETE",    # handle[Exn<String>] + parse_int
 
-    # Chapter 9 — async/await (future feature, tracked in spec as not implemented)
-    ("09-standard-library.md", 248): "FUTURE",  # async, await, Http, Future
+    # Chapter 9 — Http + Async composition example (Http not yet implemented)
+    ("09-standard-library.md", 244): "INCOMPLETE",  # fetch_both uses Http.get (future)
+
+    # Chapter 9 — Future<T> type definition (standalone, no visibility)
+    ("09-standard-library.md", 264): "INCOMPLETE",  # data Future<T> (no visibility keyword)
 
     # Chapter 9 — UrlParts type definition (standalone, no visibility)
-    ("09-standard-library.md", 1059): "INCOMPLETE",  # data UrlParts (no visibility keyword)
+    ("09-standard-library.md", 1089): "INCOMPLETE",  # data UrlParts (no visibility keyword)
 }
 
 

--- a/spec/04-expressions.md
+++ b/spec/04-expressions.md
@@ -336,6 +336,8 @@ url_encode(@String.0)                   -- returns String (RFC 3986 percent-enco
 url_decode(@String.0)                   -- returns Result<String, String>
 url_parse(@String.0)                    -- returns Result<UrlParts, String>
 url_join(@UrlParts.0)                   -- returns String
+async(@T.0)                            -- returns Future<T> (effects(<Async>))
+await(@Future<T>.0)                    -- returns T (effects(<Async>))
 to_string(@Int.0)                       -- returns String
 int_to_string(@Int.0)                   -- returns String (alias for to_string)
 bool_to_string(@Bool.0)                 -- returns String ("true" or "false")

--- a/spec/09-standard-library.md
+++ b/spec/09-standard-library.md
@@ -239,11 +239,7 @@ effect Http {
 
 This fits naturally with Vera's algebraic effect system and makes network I/O explicit and testable.
 
-### 9.5.4 Async (Future)
-
-> **Status: Not yet implemented.** Tracked in [#59](https://github.com/aallan/vera/issues/59).
-
-Asynchronous operations will be modelled as an algebraic effect. An `<Async>` effect with `async` and `await` operations will allow concurrent computation:
+When the `<Async>` effect is available, Http naturally composes with it for concurrent requests:
 
 ```
 private fn fetch_both(@String, @String -> @Tuple<Json, Json>)
@@ -251,19 +247,53 @@ private fn fetch_both(@String, @String -> @Tuple<Json, Json>)
   ensures(true)
   effects(<Http, Async>)
 {
-  let @Future<Json> = async(http_get(@String.0));
-  let @Future<Json> = async(http_get(@String.1));
+  let @Future<Json> = async(Http.get(@String.0));
+  let @Future<Json> = async(Http.get(@String.1));
   let @Json = await(@Future<Json>.1);
   let @Json = await(@Future<Json>.0);
   Tuple(@Json.1, @Json.0)
 }
 ```
 
+### 9.5.4 Async
+
+The `<Async>` effect enables asynchronous computation via `async(expr)` and `await(future)` operations with a `Future<T>` type.
+
+**Type:**
+
+```
+data Future<T> { Future(T) }
+```
+
+**Built-in functions:**
+
+```
+fn async<T>(@T.0 -> @Future<T>) effects(<Async>)
+fn await<T>(@Future<T>.0 -> @T) effects(<Async>)
+```
+
+**Example:**
+
+```
+private fn compute(@Int, @Int -> @Int)
+  requires(true)
+  ensures(true)
+  effects(<Async>)
+{
+  let @Future<Int> = async(@Int.1 * 2);
+  let @Future<Int> = async(@Int.0 * 3);
+  await(@Future<Int>.0) + await(@Future<Int>.1)
+}
+```
+
 Key design points:
-- `async(expr)` wraps an effectful computation in a `Future<T>`, starting it concurrently.
-- `await(@Future<T>.n)` suspends until the future resolves, yielding the result.
+- `async(expr)` evaluates `expr` and wraps the result in `Future<T>`.
+- `await(@Future<T>.n)` unwraps the future, yielding the result of type `T`.
 - The `<Async>` effect must be declared, making concurrency explicit and trackable.
-- Handlers can provide different scheduling strategies (thread pool, event loop, sequential).
+- `Async` is a marker effect with no operations — `async` and `await` are built-in generic functions that require `effects(<Async>)`.
+- `Future<T>` is WASM-transparent: it has the same runtime representation as `T`, with no overhead.
+- The reference implementation evaluates `async(expr)` eagerly (sequential execution). True concurrent scheduling will be available when WASI 0.3 support is added ([#237](https://github.com/aallan/vera/issues/237)).
+- Custom scheduling strategies (thread pool, event loop) can be provided via `handle[Async]` handlers (see [#270](https://github.com/aallan/vera/issues/270)).
 - This avoids coloured-function problems because algebraic effects already separate the description of an operation from its execution.
 
 ### 9.5.5 Inference (Future)

--- a/tests/conformance/ch09_async.vera
+++ b/tests/conformance/ch09_async.vera
@@ -1,0 +1,62 @@
+-- Conformance: Async effect with Future<T> (Chapter 9)
+-- Tests: async, await, Future<T> type, Async effect
+effect IO {
+  op print(String -> Unit);
+}
+
+public fn test_async_int(@Unit -> @Int)
+  requires(true)
+  ensures(@Int.result == 42)
+  effects(<Async>)
+{
+  let @Future<Int> = async(42);
+  await(@Future<Int>.0)
+}
+
+public fn test_async_arithmetic(@Unit -> @Int)
+  requires(true)
+  ensures(@Int.result == 35)
+  effects(<Async>)
+{
+  let @Future<Int> = async(5 * 7);
+  await(@Future<Int>.0)
+}
+
+public fn test_async_multiple(@Unit -> @Int)
+  requires(true)
+  ensures(@Int.result == 30)
+  effects(<Async>)
+{
+  let @Future<Int> = async(10);
+  let @Future<Int> = async(20);
+  await(@Future<Int>.1) + await(@Future<Int>.0)
+}
+
+private fn async_helper(@Int -> @Int)
+  requires(true)
+  ensures(true)
+  effects(<Async>)
+{
+  let @Future<Int> = async(@Int.0 * 2);
+  await(@Future<Int>.0)
+}
+
+public fn test_async_composition(@Unit -> @Int)
+  requires(true)
+  ensures(true)
+  effects(<Async>)
+{
+  async_helper(25)
+}
+
+public fn main(@Unit -> @Unit)
+  requires(true)
+  ensures(true)
+  effects(<IO, Async>)
+{
+  IO.print(to_string(test_async_int(())));
+  IO.print(to_string(test_async_arithmetic(())));
+  IO.print(to_string(test_async_multiple(())));
+  IO.print(to_string(test_async_composition(())));
+  ()
+}

--- a/tests/conformance/manifest.json
+++ b/tests/conformance/manifest.json
@@ -439,5 +439,14 @@
     "level": "run",
     "spec_ref": "Section 9.6.5",
     "features": ["url_parse", "url_join", "urlparts", "result_type"]
+  },
+  {
+    "id": "ch09_async",
+    "file": "ch09_async.vera",
+    "chapter": 9,
+    "title": "Async effect with Future<T>",
+    "level": "run",
+    "spec_ref": "Section 9.5.4",
+    "features": ["async", "await", "future", "async_effect"]
   }
 ]

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -3651,3 +3651,75 @@ private fn f(-> @String)
   requires(true) ensures(true) effects(pure)
 { "color: \\(Red)" }
 """, "cannot be automatically converted to String")
+
+
+# =====================================================================
+# Async effect
+# =====================================================================
+
+
+class TestAsyncEffect:
+    """Async effect and Future<T> type checking."""
+
+    def test_async_ok(self) -> None:
+        """async(expr) in a function with effects(<Async>) type-checks."""
+        _check_ok("""
+private fn f(-> @Future<Int>)
+  requires(true) ensures(true) effects(<Async>)
+{ async(42) }
+""")
+
+    def test_await_ok(self) -> None:
+        """await(future) in a function with effects(<Async>) type-checks."""
+        _check_ok("""
+private fn f(-> @Int)
+  requires(true) ensures(true) effects(<Async>)
+{
+  let @Future<Int> = async(42);
+  await(@Future<Int>.0)
+}
+""")
+
+    def test_async_requires_effect(self) -> None:
+        """async(expr) in effects(pure) function produces an error."""
+        _check_err("""
+private fn f(-> @Future<Int>)
+  requires(true) ensures(true) effects(pure)
+{ async(42) }
+""", "effect")
+
+    def test_await_requires_effect(self) -> None:
+        """await(future) in effects(pure) function produces an error."""
+        _check_err("""
+private fn f(@Future<Int> -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ await(@Future<Int>.0) }
+""", "effect")
+
+    def test_async_wrong_arity(self) -> None:
+        """async() with no arguments is an error."""
+        _check_err("""
+private fn f(-> @Future<Int>)
+  requires(true) ensures(true) effects(<Async>)
+{ async() }
+""", "expects 1 argument")
+
+    def test_await_wrong_type(self) -> None:
+        """await(42) where 42 is Int not Future<T> is an error."""
+        _check_err("""
+private fn f(-> @Int)
+  requires(true) ensures(true) effects(<Async>)
+{ await(42) }
+""", "expected Future")
+
+    def test_async_with_io(self) -> None:
+        """Async composes with IO in the same effect set."""
+        _check_ok("""
+private fn f(-> @Unit)
+  requires(true) ensures(true) effects(<IO, Async>)
+{
+  let @Future<Int> = async(42);
+  IO.print(to_string(await(@Future<Int>.0)));
+  ()
+}
+""")

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -7031,3 +7031,113 @@ public fn main(-> @Unit)
 }
 """
         assert _run_io(source, fn="main") == "len=5"
+
+
+# =====================================================================
+# Async / Future<T>
+# =====================================================================
+
+
+class TestAsync:
+    """Async effect compiles and executes correctly (sequential/eager)."""
+
+    def test_async_await_int(self) -> None:
+        """async(42) → await → 42."""
+        source = """\
+public fn f(-> @Int)
+  requires(true) ensures(true) effects(<Async>)
+{
+  let @Future<Int> = async(42);
+  await(@Future<Int>.0)
+}
+"""
+        assert _run(source, fn="f") == 42
+
+    def test_async_await_arithmetic(self) -> None:
+        """async(5 * 7) → await → 35."""
+        source = """\
+public fn f(-> @Int)
+  requires(true) ensures(true) effects(<Async>)
+{
+  let @Future<Int> = async(5 * 7);
+  await(@Future<Int>.0)
+}
+"""
+        assert _run(source, fn="f") == 35
+
+    def test_async_await_bool(self) -> None:
+        """async(true) → await → 1 (Bool true)."""
+        source = """\
+public fn f(-> @Bool)
+  requires(true) ensures(true) effects(<Async>)
+{
+  let @Future<Bool> = async(true);
+  await(@Future<Bool>.0)
+}
+"""
+        assert _run(source, fn="f") == 1
+
+    def test_async_await_multiple(self) -> None:
+        """Two futures, await both, add results."""
+        source = """\
+public fn f(-> @Int)
+  requires(true) ensures(true) effects(<Async>)
+{
+  let @Future<Int> = async(10);
+  let @Future<Int> = async(20);
+  await(@Future<Int>.1) + await(@Future<Int>.0)
+}
+"""
+        assert _run(source, fn="f") == 30
+
+    def test_async_in_effectful_fn(self) -> None:
+        """Private helper with effects(<Async>) called from main."""
+        source = """\
+private fn compute(-> @Int)
+  requires(true) ensures(true) effects(<Async>)
+{
+  let @Future<Int> = async(100);
+  await(@Future<Int>.0)
+}
+
+public fn main(-> @Int)
+  requires(true) ensures(true) effects(<Async>)
+{ compute() }
+"""
+        assert _run(source, fn="main") == 100
+
+    def test_async_with_io(self) -> None:
+        """effects(<IO, Async>) — composition with IO."""
+        source = _IO_PRELUDE + """\
+public fn main(-> @Unit)
+  requires(true) ensures(true) effects(<IO, Async>)
+{
+  let @Future<Int> = async(42);
+  IO.print(to_string(await(@Future<Int>.0)))
+}
+"""
+        assert _run_io(source, fn="main") == "42"
+
+    def test_async_await_nat(self) -> None:
+        """Nat type roundtrip through Future."""
+        source = """\
+public fn f(-> @Nat)
+  requires(true) ensures(true) effects(<Async>)
+{
+  let @Future<Nat> = async(string_length("hello"));
+  await(@Future<Nat>.0)
+}
+"""
+        assert _run(source, fn="f") == 5
+
+    def test_async_await_float(self) -> None:
+        """Float64 type roundtrip through Future."""
+        source = """\
+public fn f(-> @Float64)
+  requires(true) ensures(true) effects(<Async>)
+{
+  let @Future<Float64> = async(3.14);
+  await(@Future<Float64>.0)
+}
+"""
+        assert abs(_run_float(source, fn="f") - 3.14) < 0.001

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -19,7 +19,7 @@ README = Path(__file__).parent.parent / "README.md"
 # Each key is the 1-based line number of the opening ```vera fence.
 ALLOWLIST: dict[int, str] = {
     # "Where this is going" — depends on #57 (Http), #61 (Inference), #147 (Markdown)
-    412: "Vision example uses MdBlock, Http, Inference (issues #57, #61, #147)",
+    413: "Vision example uses MdBlock, Http, Inference (issues #57, #61, #147)",
 }
 
 

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -1480,9 +1480,9 @@ private fn sum(@List<Int> -> @Int)
             t1 += result.summary.tier1_verified
             t3 += result.summary.tier3_runtime
             total += result.summary.total
-        assert t1 == 123, f"Expected 123 T1, got {t1}"
-        assert t3 == 5, f"Expected 5 T3, got {t3}"
-        assert total == 128, f"Expected 128 total, got {total}"
+        assert t1 == 127, f"Expected 127 T1, got {t1}"
+        assert t3 == 7, f"Expected 7 T3, got {t3}"
+        assert total == 134, f"Expected 134 total, got {total}"
 
 
 # =====================================================================

--- a/vera/README.md
+++ b/vera/README.md
@@ -289,8 +289,10 @@ Context flags (`in_ensures`, `in_contract`, `current_return_type`, `current_effe
 |----------|------|---------|
 | `Option<T>` | ADT | `None`, `Some(T)` constructors |
 | `Result<T, E>` | ADT | `Ok(T)`, `Err(E)` constructors |
+| `Future<T>` | ADT | `Future(T)` constructor — WASM-transparent wrapper |
 | `State<T>` | Effect | `get(Unit) → T`, `put(T) → Unit` operations |
 | `IO` | Effect | `print`, `read_line`, `read_file`, `write_file`, `args`, `exit`, `get_env` |
+| `Async` | Effect | No operations — marker for async computation |
 | `Diverge` | Effect | No operations — marker for non-termination |
 | `array_length` | Function | `forall<T> Array<T> → Int`, pure |
 | `array_append` | Function | `forall<T> Array<T>, T → Array<T>`, pure |
@@ -312,6 +314,8 @@ Context flags (`in_ensures`, `in_contract`, `current_return_type`, `current_effe
 | `url_decode` | Function | `String → Result<String, String>`, pure |
 | `url_parse` | Function | `String → Result<UrlParts, String>`, pure (RFC 3986 decomposition) |
 | `url_join` | Function | `UrlParts → String`, pure (reassemble URL) |
+| `async` | Function | `T → Future<T>`, `effects(<Async>)` (generic, eager evaluation) |
+| `await` | Function | `Future<T> → T`, `effects(<Async>)` (generic, identity unwrap) |
 | `to_string` | Function | `Int → String`, pure |
 | `int_to_string` | Function | `Int → String`, pure (alias for `to_string`) |
 | `bool_to_string` | Function | `Bool → String`, pure |

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.81"
+__version__ = "0.0.82"

--- a/vera/codegen/compilability.py
+++ b/vera/codegen/compilability.py
@@ -36,13 +36,15 @@ class CompilabilityMixin:
                         # Exn<E> — E must be a compilable type
                         if not self._check_exn_type(decl, eff):
                             return False
+                    elif eff.name == "Async":
+                        pass  # Sequential execution, no host imports
                     else:
                         self._warning(
                             decl,
                             f"Function '{decl.name}' uses unsupported "
                             f"effect '{eff.name}' — skipped.",
-                            rationale="Only pure, IO, and State<T> effects "
-                            "are compilable.",
+                            rationale="Only pure, IO, State<T>, Exn<E>, "
+                            "and Async effects are compilable.",
                             error_code="E603",
                         )
                         return False

--- a/vera/codegen/modules.py
+++ b/vera/codegen/modules.py
@@ -252,6 +252,7 @@ class CrossModuleMixin:
             "to_float", "float_to_int", "nat_to_int", "int_to_nat",
             "byte_to_int", "int_to_byte",
             "is_nan", "is_infinite", "nan", "infinity",
+            "async", "await",
         })
 
         seen: set[str] = set()  # deduplicate by function name

--- a/vera/environment.py
+++ b/vera/environment.py
@@ -186,6 +186,19 @@ class TypeEnv:
         for c in self.data_types["UrlParts"].constructors.values():
             self.constructors[c.name] = c
 
+        # Future<T> — async computation result (WASM-transparent wrapper)
+        self.data_types["Future"] = AdtInfo(
+            name="Future",
+            type_params=("T",),
+            constructors={
+                "Future": ConstructorInfo(
+                    "Future", "Future", ("T",), (TypeVar("T"),),
+                ),
+            },
+        )
+        for c in self.data_types["Future"].constructors.values():
+            self.constructors[c.name] = c
+
         # State<T> effect with get/put
         self.effects["State"] = EffectInfo(
             name="State",
@@ -229,6 +242,16 @@ class TypeEnv:
         # termination checking (Chapter 7, Section 7.7.3).
         self.effects["Diverge"] = EffectInfo(
             name="Diverge",
+            type_params=None,
+            operations={},
+        )
+
+        # Async effect — marker for concurrent computation.
+        # No operations; async/await are registered as built-in functions
+        # with effects(<Async>).  The reference implementation evaluates
+        # eagerly (sequential); WASI 0.3 will provide true concurrency.
+        self.effects["Async"] = EffectInfo(
+            name="Async",
             type_params=None,
             operations={},
         )
@@ -385,6 +408,24 @@ class TypeEnv:
             param_types=(AdtType("UrlParts", ()),),
             return_type=STRING,
             effect=PureEffectRow(),
+        )
+        # Async builtins — require effects(<Async>)
+        _ASYNC_EFFECT = ConcreteEffectRow(
+            frozenset({EffectInstance("Async", ())}), row_var=None,
+        )
+        self.functions["async"] = FunctionInfo(
+            name="async",
+            forall_vars=("T",),
+            param_types=(TypeVar("T"),),
+            return_type=AdtType("Future", (TypeVar("T"),)),
+            effect=_ASYNC_EFFECT,
+        )
+        self.functions["await"] = FunctionInfo(
+            name="await",
+            forall_vars=("T",),
+            param_types=(AdtType("Future", (TypeVar("T"),)),),
+            return_type=TypeVar("T"),
+            effect=_ASYNC_EFFECT,
         )
         self.functions["to_string"] = FunctionInfo(
             name="to_string",

--- a/vera/wasm/calls.py
+++ b/vera/wasm/calls.py
@@ -70,6 +70,12 @@ class CallsMixin:
                 return self._translate_url_parse(call.args[0], env)
             if call.name == "url_join" and len(call.args) == 1:
                 return self._translate_url_join(call.args[0], env)
+            # Async builtins — identity (eager evaluation, Future<T>
+            # is WASM-transparent)
+            if call.name == "async" and len(call.args) == 1:
+                return self._translate_async(call.args[0], env)
+            if call.name == "await" and len(call.args) == 1:
+                return self._translate_await(call.args[0], env)
             if call.name == "to_string" and len(call.args) == 1:
                 return self._translate_to_string(call.args[0], env)
             if call.name == "int_to_string" and len(call.args) == 1:
@@ -4073,6 +4079,26 @@ class CallsMixin:
         ins.append(f"local.get {dst}")
         ins.append(f"local.get {total}")
         return ins
+
+    def _translate_async(
+        self, arg: ast.Expr, env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """Translate async(expr) → Future<T> (identity, eager evaluation).
+
+        The reference implementation evaluates async(expr) eagerly.
+        Future<T> is WASM-transparent — same representation as T.
+        True concurrency will be available via WASI 0.3 (#237).
+        """
+        return self.translate_expr(arg, env)
+
+    def _translate_await(
+        self, arg: ast.Expr, env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """Translate await(future) → T (identity unwrap).
+
+        Future<T> is WASM-transparent, so await is a no-op.
+        """
+        return self.translate_expr(arg, env)
 
     def _translate_to_string(
         self, arg: ast.Expr, env: WasmSlotEnv,

--- a/vera/wasm/inference.py
+++ b/vera/wasm/inference.py
@@ -231,6 +231,9 @@ class InferenceMixin:
             return "i32_pair"
         if expr.name == "url_parse":
             return "i32"
+        # Async builtins — identity operations (Future<T> is transparent)
+        if expr.name in ("async", "await") and expr.args:
+            return self._infer_expr_wasm_type(expr.args[0])
         # Numeric math builtins
         if expr.name in ("abs", "min", "max", "floor", "ceil", "round"):
             return "i64"
@@ -411,6 +414,21 @@ class InferenceMixin:
             return "String"
         if call.name == "url_parse":
             return "Result"
+        # Async builtins — Future<T> is transparent
+        if call.name == "async" and call.args:
+            inner = self._infer_fncall_vera_type(call.args[0]) \
+                if isinstance(call.args[0], ast.FnCall) \
+                else self._infer_vera_type(call.args[0])
+            return f"Future<{inner}>" if inner else "Future"
+        if call.name == "await" and call.args:
+            # await(Future<T>) → T; at WASM level it's the inner type
+            inner = self._infer_fncall_vera_type(call.args[0]) \
+                if isinstance(call.args[0], ast.FnCall) \
+                else self._infer_vera_type(call.args[0])
+            # Strip the Future<...> wrapper if present
+            if inner and inner.startswith("Future<") and inner.endswith(">"):
+                return inner[7:-1]
+            return inner
         # Numeric math builtins
         if call.name == "abs":
             return "Nat"
@@ -674,6 +692,10 @@ class InferenceMixin:
             return "f64"
         if name in ("Bool", "Byte"):
             return "i32"
+        # Future<T> is WASM-transparent — same representation as T
+        if name.startswith("Future<") and name.endswith(">"):
+            inner = name[7:-1]
+            return self._slot_name_to_wasm_type(inner)
         # ADT types are heap pointers
         base = name.split("<")[0] if "<" in name else name
         if base in self._adt_type_names:


### PR DESCRIPTION
## Summary

- Implements **#59**: `<Async>` algebraic effect with `Future<T>` type for asynchronous computation
- `Future<T>` is a built-in ADT (single constructor) that is **WASM-transparent** — same runtime representation as `T`, zero overhead
- `Async` is a **marker effect** (no operations, runtime-discharged like IO) — calling `async`/`await` requires `effects(<Async>)`
- `async` and `await` are **built-in generic functions** using existing generic function infrastructure
- Reference implementation uses **eager/sequential evaluation** — both `async(expr)` and `await(future)` are identity operations at the WASM level
- Designed for **WASI 0.3 forward-compatibility** (#237) — when native `future<T>` support is added, only `_translate_async`/`_translate_await` in `vera/wasm/calls.py` change; user-facing API is unchanged
- Opens #270 for `handle[Async]` custom scheduling strategies (post-WASI 0.3)

## Files changed

| Area | Files |
|------|-------|
| Type system | `vera/environment.py` — Future<T> ADT, Async effect, async/await functions |
| Compilability | `vera/codegen/compilability.py` — Async as compilable effect |
| Type inference | `vera/wasm/inference.py` — Future<T> transparency, async/await type inference |
| Codegen | `vera/wasm/calls.py` — dispatch + identity `_translate_async`/`_translate_await` |
| Known builtins | `vera/codegen/modules.py` — add async, await |
| Tests | 7 checker + 8 codegen + conformance + example (25 new tests total) |
| Spec | `spec/09-standard-library.md` §9.5.4 — implemented status, sequential semantics |
| Docs | SKILL.md, vera/README.md, README.md, AGENTS.md, CLAUDE.md, CHANGELOG.md |
| Version | 0.0.81 → 0.0.82 |

## Test plan

- [x] `vera check` accepts `effects(<Async>)` with async/await calls
- [x] `vera check` rejects async/await in `effects(pure)` functions (E125/E122)
- [x] `vera run` with async/await returns expected values (identity semantics)
- [x] `pytest tests/ -v` — 2072 passed, 6 skipped
- [x] `python scripts/check_conformance.py` — all 50 conformance programs pass
- [x] `python scripts/check_examples.py` — all 22 examples pass
- [x] `mypy vera/` — clean
- [x] Pre-commit hooks pass (mypy, pytest, conformance, examples, spec, skill, readme)

🤖 Generated with [Claude Code](https://claude.com/claude-code)