### PR TITLE
Add Tuple type WASM codegen (#267)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,13 +148,9 @@ Test helpers follow a pattern: `_check_ok(source)` / `_check_err(source, match)`
 
 When implementing a new language feature, write the conformance program *first* — add a `.vera` file and manifest entry in `tests/conformance/`, then implement the feature until the conformance test passes.
 
-### Known codegen limitations
-
-- **Tuple types** have no WASM codegen (#267). Functions with Tuple expressions get E602 and are skipped. Use named ADTs as a workaround.
-
 ### Invariants
 
-- All 50 conformance programs in `tests/conformance/` must pass their declared level
+- All 51 conformance programs in `tests/conformance/` must pass their declared level
 - All 22 examples in `examples/` must pass `vera check` and `vera verify`
 - `mypy vera/` must be clean
 - `pytest tests/ -v` must pass

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.83] - 2026-03-11
+
+### Added
+- **Tuple type WASM codegen** ([#267](https://github.com/aallan/vera/issues/267)):
+  Tuple construction (`Tuple(1, "hello", true)`) and destructuring now compile to WASM.
+  Match destructuring (`Tuple(@Int, @String) -> ...`) extracts fields from heap-allocated Tuples.
+  `LetDestruct` (`let Tuple<@Int, @String> = expr;`) works for Tuples and all single-constructor
+  ADTs (including UrlParts, Future, and user-defined types).
+  Tuples are variadic — any arity from 1 field upward is supported.
+- New conformance test `ch02_tuple_basic` (conformance suite: 50→51 programs)
+- Updated `examples/url_parsing.vera` with LetDestruct demonstration
+- 15 new tests (5 type checker + 10 codegen)
+
 ## [0.0.82] - 2026-03-11
 
 ### Added
@@ -1254,7 +1267,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Grammar: handler body simplified to avoid LALR reduce/reduce conflict
 - `pyproject.toml`: corrected build backend, package discovery, PEP 639 compliance
 
-[Unreleased]: https://github.com/aallan/vera/compare/v0.0.82...HEAD
+[Unreleased]: https://github.com/aallan/vera/compare/v0.0.83...HEAD
+[0.0.83]: https://github.com/aallan/vera/compare/v0.0.82...v0.0.83
 [0.0.82]: https://github.com/aallan/vera/compare/v0.0.81...v0.0.82
 [0.0.81]: https://github.com/aallan/vera/compare/v0.0.80...v0.0.81
 [0.0.80]: https://github.com/aallan/vera/compare/v0.0.79...v0.0.80

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ vera fmt --check file.vera        # Check if already canonical
 pytest tests/ -v                  # Run the test suite (see TESTING.md)
 mypy vera/                        # Type-check the compiler itself
 
-python scripts/check_conformance.py    # Verify all 50 conformance programs pass their declared level
+python scripts/check_conformance.py    # Verify all 51 conformance programs pass their declared level
 python scripts/check_examples.py      # Verify all 22 examples parse + check + verify
 python scripts/check_spec_examples.py # Verify spec code blocks parse
 python scripts/check_readme_examples.py # Verify README code blocks parse
@@ -56,7 +56,7 @@ python scripts/fix_allowlists.py --fix # Auto-fix stale allowlist line numbers
 - `vera/` — Reference compiler: grammar, parser, AST, transformer, type checker, verifier, codegen, CLI
 - `examples/` — 22 example Vera programs (all must pass `vera check` and `vera verify`)
 - `tests/` — Test suite (unit tests + conformance suite)
-- `tests/conformance/` — 50 conformance programs validating every language feature against the spec
+- `tests/conformance/` — 51 conformance programs validating every language feature against the spec
 - `scripts/` — CI and validation scripts
 
 ## Writing Vera code
@@ -74,7 +74,7 @@ Each stage is a module with a public API function and is independently testable.
 ## What not to break
 
 - Pre-commit hooks run mypy + pytest + conformance suite + example validation on every commit
-- All 50 conformance programs in `tests/conformance/` must pass their declared level
+- All 51 conformance programs in `tests/conformance/` must pass their declared level
 - All 22 examples in `examples/` must pass `vera check` and `vera verify`
 - Version must stay in sync across `vera/__init__.py`, `pyproject.toml`, and `CHANGELOG.md`
 - All tests must pass: `pytest tests/ -v`

--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ Module refinements, lexical extensions, and IO runtime — completing the existi
 
 **Codegen** — WASM compilation gaps
 
-- [#267](https://github.com/aallan/vera/issues/267) Tuple type WASM codegen
+- <del>[#267](https://github.com/aallan/vera/issues/267) Tuple type WASM codegen</del> ([v0.0.83](https://github.com/aallan/vera/releases/tag/v0.0.83))
 
 **IO runtime** — host bindings for file and stdin access
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -285,7 +285,7 @@ private fn abs(@Int -> @Nat)
 @Array<Int>                              -- array of ints
 @Array<Option<Int>>                      -- array of ADT (compound element type)
 @Array<String>                           -- array of strings
-@Tuple<Int, String>                      -- tuple (type-checks but no WASM codegen yet, see #267)
+@Tuple<Int, String>                      -- tuple
 @Option<Int>                             -- Option type (Some/None)
 Fn(Int -> Int) effects(pure)              -- function type
 { @Int | @Int.0 > 0 }                   -- refinement type
@@ -846,10 +846,6 @@ Type aliases and effect declarations are module-local and cannot be imported. If
 Module-qualified calls use `::` between the module path and the function name: `vera.math::abs(42)`. The dot-separated path identifies the module and `::` separates it from the function name. This syntax can be used anywhere a function call is valid, and always resolves against the specific module's public declarations — it is not affected by local shadowing. Note: module-qualified calls (`math::abs(42)`) are available for readability but do not yet resolve name collisions in flat compilation — the compiler will still report a collision error. A future version will support qualified-call disambiguation via name mangling.
 
 There is no import aliasing (`import m(abs as math_abs)`) and no wildcard exclusion (`import m hiding(x)`). These are intentional design decisions, not limitations. When names clash across modules, rename the conflicting declaration in one of the source modules. This preserves the one-canonical-form principle — every function has exactly one name.
-
-### Known codegen limitations
-
-- **Tuple types** are specified and type-check but have no WASM codegen (#267). Functions containing Tuple expressions are silently skipped. Use named ADTs (e.g. `data Pair<A, B> { Pair(A, B) }`) as a workaround.
 
 There are no raw strings (`r"..."`) or multi-line string literals. Use escape sequences (`\\`, `\n`, `\t`, `\"`) for special characters. This is by design — alternative string syntaxes would create two representations for the same value.
 

--- a/examples/url_parsing.vera
+++ b/examples/url_parsing.vera
@@ -17,22 +17,17 @@ public fn main(@Unit -> @Unit)
   ensures(true)
   effects(<IO>)
 {
-  -- Parse a URL into components
-  match url_parse("https://example.com/path?q=1#frag") {
-    Ok(@UrlParts) -> match @UrlParts.0 {
-      UrlParts(@String, @String, @String, @String, @String) ->
-        IO.print("scheme=\(@String.4) auth=\(@String.3) path=\(@String.2) query=\(@String.1) frag=\(@String.0)")
-    },
-    Err(@String) -> IO.print("error: \(@String.0)")
-  };
-  -- Join components back into a URL
-  match url_parse("https://example.com/path?q=1#frag") {
-    Ok(@UrlParts) -> IO.print(url_join(@UrlParts.0)),
-    Err(@String) -> IO.print("error: \(@String.0)")
-  };
-  -- Error case: missing scheme
+  match url_parse("https://example.com/path?q=1#frag") { Ok(@UrlParts) -> match @UrlParts.0 { UrlParts(@String, @String, @String, @String, @String) -> IO.print("scheme=\(@String.4) auth=\(@String.3) path=\(@String.2) query=\(@String.1) frag=\(@String.0)") }, Err(@String) -> IO.print("error: \(@String.0)") };
+  match url_parse("https://example.com/path?q=1#frag") { Ok(@UrlParts) -> IO.print(url_join(@UrlParts.0)), Err(@String) -> IO.print("error: \(@String.0)") };
+  let @UrlParts = UrlParts("https", "api.example.com", "/v2", "key=abc", "");
+  let UrlParts<@String, @String, @String, @String, @String> = @UrlParts.0;
+  IO.print("scheme=\(@String.4) host=\(@String.3)");
   match url_parse("no-scheme") {
     Ok(_) -> IO.print("unexpected ok"),
     Err(@String) -> IO.print("error: \(@String.0)")
   }
 }
+-- Parse a URL into components
+-- Join components back into a URL
+-- LetDestruct: extract UrlParts fields directly (no nested match)
+-- Error case: missing scheme

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.82"
+version = "0.0.83"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/scripts/check_skill_examples.py
+++ b/scripts/check_skill_examples.py
@@ -74,7 +74,7 @@ ALLOWLIST: dict[int, tuple[str, str]] = {
     805: ("FRAGMENT", "Module declaration and import example"),
 
     # Line comments — bare comments
-    860: ("FRAGMENT", "Comment syntax example"),
+    856: ("FRAGMENT", "Comment syntax example"),
 
     # Type conversions — bare function calls
     486: ("FRAGMENT", "Type conversion examples, bare calls"),
@@ -83,25 +83,25 @@ ALLOWLIST: dict[int, tuple[str, str]] = {
     499: ("FRAGMENT", "Float64 predicate examples, bare calls"),
 
     # Common mistakes section — intentionally wrong code
-    888: ("FRAGMENT", "Wrong: missing contracts"),
-    908: ("FRAGMENT", "Wrong: missing effects clause"),
-    942: ("FRAGMENT", "Wrong: bare expression without indices"),
-    955: ("FRAGMENT", "Wrong: bare expression no indices"),
-    960: ("FRAGMENT", "Correct: expression with indices (not full fn)"),
-    1026: ("FRAGMENT", "Wrong: match arm with incorrect return"),
-    1050: ("FRAGMENT", "Wrong: non-exhaustive match"),
-    1057: ("FRAGMENT", "Correct: match arm example"),
-    1067: ("FRAGMENT", "Wrong: if/else without braces (bare expression)"),
-    1072: ("FRAGMENT", "Correct: if/else with braces"),
+    884: ("FRAGMENT", "Wrong: missing contracts"),
+    904: ("FRAGMENT", "Wrong: missing effects clause"),
+    938: ("FRAGMENT", "Wrong: bare expression without indices"),
+    951: ("FRAGMENT", "Wrong: bare expression no indices"),
+    956: ("FRAGMENT", "Correct: expression with indices (not full fn)"),
+    1022: ("FRAGMENT", "Wrong: match arm with incorrect return"),
+    1046: ("FRAGMENT", "Wrong: non-exhaustive match"),
+    1053: ("FRAGMENT", "Correct: match arm example"),
+    1063: ("FRAGMENT", "Wrong: if/else without braces (bare expression)"),
+    1068: ("FRAGMENT", "Correct: if/else with braces"),
 
     # Import syntax — intentionally unsupported
-    1083: ("FRAGMENT", "Wrong: import aliasing not supported"),
-    1088: ("FRAGMENT", "Correct: import syntax example"),
-    1098: ("FRAGMENT", "Wrong: import hiding not supported"),
-    1103: ("FRAGMENT", "Correct: multi-import syntax"),
+    1079: ("FRAGMENT", "Wrong: import aliasing not supported"),
+    1084: ("FRAGMENT", "Correct: import syntax example"),
+    1094: ("FRAGMENT", "Wrong: import hiding not supported"),
+    1099: ("FRAGMENT", "Correct: multi-import syntax"),
 
     # String escapes — bare expression
-    1117: ("FRAGMENT", "String escape example"),
+    1113: ("FRAGMENT", "String escape example"),
 
     # =================================================================
     # MISMATCH — uses syntax the parser doesn't handle in isolation.

--- a/spec/11-compilation.md
+++ b/spec/11-compilation.md
@@ -584,4 +584,3 @@ The current compilation model has the following limitations, each tracked as a G
 | Limitation | Issue | Notes |
 |-----------|-------|-------|
 | Flat module compilation | [#110](https://github.com/aallan/vera/issues/110) | Imported functions are compiled into the importing module; name collisions are detected (E608/E609/E610); qualified-call disambiguation via name mangling is tracked separately |
-| Tuple type codegen | [#267](https://github.com/aallan/vera/issues/267) | Tuple types are fully specified and type-checked but have no WASM backend; functions containing Tuple expressions are skipped with E602 |

--- a/tests/conformance/ch02_tuple_basic.vera
+++ b/tests/conformance/ch02_tuple_basic.vera
@@ -1,0 +1,46 @@
+-- Conformance: Tuple types (Chapter 2, Section 2.3.1)
+-- Tests: Tuple construction, match destructuring, LetDestruct, nested Tuple
+effect IO {
+  op print(String -> Unit);
+}
+
+private fn test_tuple_construct(@Unit -> @Int)
+  requires(true)
+  ensures(@Int.result == 30)
+  effects(pure)
+{
+  let @Tuple<Int, Int> = Tuple(10, 20);
+  match @Tuple<Int, Int>.0 {
+    Tuple(@Int, @Int) -> @Int.0 + @Int.1
+  }
+}
+
+private fn test_tuple_let_destruct(@Unit -> @Int)
+  requires(true)
+  ensures(@Int.result == 42)
+  effects(pure)
+{
+  let Tuple<@Int, @Int> = Tuple(42, 99);
+  @Int.1
+}
+
+private fn test_tuple_three(@Unit -> @Int)
+  requires(true)
+  ensures(@Int.result == 108)
+  effects(pure)
+{
+  let @Tuple<Int, Int, Int> = Tuple(100, 5, 3);
+  match @Tuple<Int, Int, Int>.0 {
+    Tuple(@Int, @Int, @Int) -> @Int.0 + @Int.1 + @Int.2
+  }
+}
+
+public fn main(@Unit -> @Unit)
+  requires(true)
+  ensures(true)
+  effects(<IO>)
+{
+  IO.print(to_string(test_tuple_construct(())));
+  IO.print(to_string(test_tuple_let_destruct(())));
+  IO.print(to_string(test_tuple_three(())))
+}

--- a/tests/conformance/manifest.json
+++ b/tests/conformance/manifest.json
@@ -108,6 +108,15 @@
     "features": ["generics", "forall", "monomorphization"]
   },
   {
+    "id": "ch02_tuple_basic",
+    "file": "ch02_tuple_basic.vera",
+    "chapter": 2,
+    "title": "Tuple types",
+    "level": "run",
+    "spec_ref": "Section 2.3.1",
+    "features": ["tuple", "let_destruct", "match", "constructor"]
+  },
+  {
     "id": "ch03_slot_basic",
     "file": "ch03_slot_basic.vera",
     "chapter": 3,

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -3723,3 +3723,54 @@ private fn f(-> @Unit)
   ()
 }
 """)
+
+
+class TestTuple:
+    """Tuple type construction, destructuring, and pattern matching."""
+
+    def test_tuple_constructor_ok(self) -> None:
+        """Tuple(42, 'hello') type-checks without E210 warning."""
+        _check_ok("""
+private fn f(-> @Tuple<Int, String>)
+  requires(true) ensures(true) effects(pure)
+{ Tuple(42, "hello") }
+""")
+
+    def test_tuple_constructor_int_int(self) -> None:
+        """Tuple(1, 2) produces Tuple<Int, Int>."""
+        _check_ok("""
+private fn f(-> @Tuple<Int, Int>)
+  requires(true) ensures(true) effects(pure)
+{ Tuple(1, 2) }
+""")
+
+    def test_tuple_empty_error(self) -> None:
+        """Tuple() with no fields is an error."""
+        _check_err("""
+private fn f(-> @Tuple<Int>)
+  requires(true) ensures(true) effects(pure)
+{ Tuple() }
+""", "at least one field")
+
+    def test_tuple_let_destruct_ok(self) -> None:
+        """let Tuple<@Int, @String> = ... type-checks."""
+        _check_ok("""
+private fn f(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  let Tuple<@Int, @String> = Tuple(42, "hello");
+  @Int.0
+}
+""")
+
+    def test_tuple_match_pattern_ok(self) -> None:
+        """Tuple pattern in match binds slots correctly."""
+        _check_ok("""
+private fn f(@Tuple<Int, Int> -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  match @Tuple<Int, Int>.0 {
+    Tuple(@Int, @Int) -> @Int.0 + @Int.1
+  }
+}
+""")

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -7141,3 +7141,156 @@ public fn f(-> @Float64)
 }
 """
         assert abs(_run_float(source, fn="f") - 3.14) < 0.001
+
+
+# =====================================================================
+# Tuple codegen
+# =====================================================================
+
+
+class TestTuple:
+    """Tuple construction, match destructuring, and LetDestruct codegen."""
+
+    def test_tuple_int_int(self) -> None:
+        """Tuple(10, 20) — match destructuring, @Int.0 is most recent (20)."""
+        source = """\
+public fn f(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  let @Tuple<Int, Int> = Tuple(10, 20);
+  match @Tuple<Int, Int>.0 {
+    Tuple(@Int, @Int) -> @Int.0
+  }
+}
+"""
+        # @Int.0 = most recently bound = second field = 20
+        assert _run(source, fn="f") == 20
+
+    def test_tuple_int_int_sum(self) -> None:
+        """Tuple(10, 20) — match destructure and sum both fields."""
+        source = """\
+public fn f(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  let @Tuple<Int, Int> = Tuple(10, 20);
+  match @Tuple<Int, Int>.0 {
+    Tuple(@Int, @Int) -> @Int.0 + @Int.1
+  }
+}
+"""
+        assert _run(source, fn="f") == 30
+
+    def test_tuple_int_string(self) -> None:
+        """Tuple(42, "hello") — mixed Int and String fields."""
+        source = _IO_PRELUDE + """\
+public fn main(-> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  let @Tuple<Int, String> = Tuple(42, "hello");
+  match @Tuple<Int, String>.0 {
+    Tuple(@Int, @String) -> IO.print(@String.0)
+  }
+}
+"""
+        assert _run_io(source, fn="main") == "hello"
+
+    def test_tuple_let_destruct_int(self) -> None:
+        """let Tuple<@Int, @Int> = Tuple(42, 99); @Int.0 → 99 (most recent)."""
+        source = """\
+public fn f(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  let Tuple<@Int, @Int> = Tuple(42, 99);
+  @Int.0
+}
+"""
+        # @Int.0 = most recently bound = second field = 99
+        assert _run(source, fn="f") == 99
+
+    def test_tuple_let_destruct_second(self) -> None:
+        """let Tuple<@Int, @Int> = Tuple(42, 99); @Int.1 → 42 (first field)."""
+        source = """\
+public fn f(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  let Tuple<@Int, @Int> = Tuple(42, 99);
+  @Int.1
+}
+"""
+        # @Int.1 = earlier binding = first field = 42
+        assert _run(source, fn="f") == 42
+
+    def test_tuple_let_destruct_string(self) -> None:
+        """LetDestruct Tuple with String field."""
+        source = _IO_PRELUDE + """\
+public fn main(-> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  let Tuple<@Int, @String> = Tuple(42, "world");
+  IO.print(@String.0)
+}
+"""
+        assert _run_io(source, fn="main") == "world"
+
+    def test_tuple_three_fields(self) -> None:
+        """3-field Tuple: Tuple(100, 5, 3) — sum all fields."""
+        source = """\
+public fn f(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  let @Tuple<Int, Int, Int> = Tuple(100, 5, 3);
+  match @Tuple<Int, Int, Int>.0 {
+    Tuple(@Int, @Int, @Int) -> @Int.0 + @Int.1 + @Int.2
+  }
+}
+"""
+        assert _run(source, fn="f") == 108
+
+    def test_tuple_in_result(self) -> None:
+        """Ok(Tuple(1, 2)) — nested Tuple inside Result."""
+        source = """\
+private data Result<T, E> { Ok(T), Err(E) }
+
+public fn f(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  let @Result<Tuple<Int, Int>, Int> = Ok(Tuple(10, 20));
+  match @Result<Tuple<Int, Int>, Int>.0 {
+    Ok(@Tuple<Int, Int>) -> match @Tuple<Int, Int>.0 {
+      Tuple(@Int, @Int) -> @Int.0 + @Int.1
+    },
+    Err(@Int) -> 0 - 1
+  }
+}
+"""
+        assert _run(source, fn="f") == 30
+
+    def test_let_destruct_user_adt(self) -> None:
+        """LetDestruct with a user-defined single-constructor ADT."""
+        source = """\
+private data Pair<A, B> { Pair(A, B) }
+
+public fn f(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  let Pair<@Int, @Int> = Pair(7, 8);
+  @Int.0 + @Int.1
+}
+"""
+        assert _run(source, fn="f") == 15
+
+    def test_let_destruct_urlparts(self) -> None:
+        """LetDestruct with UrlParts (5-field ADT, knock-on effect)."""
+        source = _IO_PRELUDE + """\
+private data UrlParts { UrlParts(String, String, String, String, String) }
+
+public fn main(-> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  let UrlParts<@String, @String, @String, @String, @String> =
+    UrlParts("https", "example.com", "/path", "q=1", "frag");
+  IO.print(@String.4)
+}
+"""
+        # @String.4 = deepest binding = first field = "https"
+        assert _run_io(source, fn="main") == "https"

--- a/vera/README.md
+++ b/vera/README.md
@@ -615,7 +615,6 @@ Honest inventory of what the compiler cannot do, and where each limitation is ad
 | **No incremental compilation** | Full file processed from scratch each time | [#56](https://github.com/aallan/vera/issues/56) |
 | **No LSP server** | No IDE integration or structured code intelligence for agents | [#222](https://github.com/aallan/vera/issues/222) |
 | **No REPL** | No interactive evaluation; all code must be written to files | [#224](https://github.com/aallan/vera/issues/224) |
-| **No Tuple codegen** | Tuple types are specified and type-checked but have zero WASM backend support; functions with Tuple expressions get E602 | [#267](https://github.com/aallan/vera/issues/267) |
 | **No string interpolation** | Strings built via `string_concat` or chained `IO.print` calls | [#230](https://github.com/aallan/vera/issues/230) |
 | **No regex** | String processing limited to builtin functions (contains, substring, etc.) | [#231](https://github.com/aallan/vera/issues/231) |
 | **No date/time, crypto, CSV** | Standard library limited to core types, strings, and arrays | [#233](https://github.com/aallan/vera/issues/233), [#235](https://github.com/aallan/vera/issues/235), [#236](https://github.com/aallan/vera/issues/236) |

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.82"
+__version__ = "0.0.83"

--- a/vera/checker/calls.py
+++ b/vera/checker/calls.py
@@ -223,6 +223,10 @@ class CallsMixin:
     def _check_constructor_call(self, expr: ast.ConstructorCall, *,
                                 expected: Type | None = None) -> Type | None:
         """Type-check a constructor call: Ctor(args)."""
+        # Tuple is a variadic built-in constructor — handle specially
+        if expr.name == "Tuple":
+            return self._check_tuple_constructor(expr)
+
         ci = self.env.lookup_constructor(expr.name)
         if ci is None:
             self._error(
@@ -316,6 +320,27 @@ class CallsMixin:
                 )
 
         return self._ctor_result_type(ci, arg_types, expected=expected)
+
+    def _check_tuple_constructor(
+        self, expr: ast.ConstructorCall
+    ) -> Type | None:
+        """Type-check a variadic Tuple constructor: Tuple(a, b, ...)."""
+        if not expr.args:
+            self._error(
+                expr,
+                "Tuple constructor requires at least one field.",
+                spec_ref='Chapter 2, Section 2.3.1 "Tuple Types"',
+                error_code="E210",
+            )
+            return UnknownType()
+        arg_types: list[Type] = []
+        for arg in expr.args:
+            t = self._synth_expr(arg)
+            if t is not None and not isinstance(t, UnknownType):
+                arg_types.append(t)
+            else:
+                arg_types.append(UnknownType())
+        return AdtType("Tuple", tuple(arg_types))
 
     def _check_nullary_constructor(self, expr: ast.NullaryConstructor, *,
                                     expected: Type | None = None) -> Type | None:

--- a/vera/checker/control.py
+++ b/vera/checker/control.py
@@ -274,6 +274,10 @@ class ControlFlowMixin:
     def _check_ctor_pattern(self, pat: ast.ConstructorPattern,
                             expected: Type | None) -> list[Binding]:
         """Check a constructor pattern."""
+        # Tuple is variadic — derive field types from sub-pattern bindings
+        if pat.name == "Tuple":
+            return self._check_tuple_pattern(pat, expected)
+
         ci = self.env.lookup_constructor(pat.name)
         if ci is None:
             self._error(pat, f"Unknown constructor '{pat.name}' in pattern.",
@@ -300,6 +304,28 @@ class ControlFlowMixin:
             )
             return []
 
+        bindings: list[Binding] = []
+        for sub_pat, field_ty in zip(pat.sub_patterns, field_types):
+            bindings.extend(self._check_pattern(sub_pat, field_ty))
+        return bindings
+
+    def _check_tuple_pattern(
+        self, pat: ast.ConstructorPattern, expected: Type | None,
+    ) -> list[Binding]:
+        """Check a variadic Tuple constructor pattern."""
+        if not pat.sub_patterns:
+            self._error(
+                pat,
+                "Tuple pattern requires at least one field.",
+                spec_ref='Chapter 2, Section 2.3.1 "Tuple Types"',
+                error_code="E320",
+            )
+            return []
+        # Derive field types from expected Tuple type if available
+        field_types: tuple[Type | None, ...] = (None,) * len(pat.sub_patterns)
+        if (isinstance(expected, AdtType) and expected.name == "Tuple"
+                and len(expected.type_args) == len(pat.sub_patterns)):
+            field_types = expected.type_args
         bindings: list[Binding] = []
         for sub_pat, field_ty in zip(pat.sub_patterns, field_types):
             bindings.extend(self._check_pattern(sub_pat, field_ty))

--- a/vera/codegen/registration.py
+++ b/vera/codegen/registration.py
@@ -63,6 +63,12 @@ class RegistrationMixin:
                 tag=1, field_offsets=((4, "i32"),), total_size=8,
             ),
         }
+        # Tuple — variadic product type (tag=0, layout recomputed per-call)
+        self._adt_layouts["Tuple"] = {
+            "Tuple": ConstructorLayout(
+                tag=0, field_offsets=(), total_size=8,
+            ),
+        }
 
     def _register_data(self, decl: ast.DataDecl) -> None:
         """Register an ADT and precompute constructor layouts."""

--- a/vera/wasm/context.py
+++ b/vera/wasm/context.py
@@ -322,8 +322,14 @@ class WasmContext(
                         instructions.extend(["drop", "drop"])
                     else:
                         instructions.append("drop")
+            elif isinstance(stmt, ast.LetDestruct):
+                result = self._translate_let_destruct(stmt, current_env)
+                if result is None:
+                    return None
+                destr_instrs, current_env = result
+                instructions.extend(destr_instrs)
             else:
-                # LetDestruct or unknown
+                # Unknown statement type
                 return None
 
         # Final expression

--- a/vera/wasm/data.py
+++ b/vera/wasm/data.py
@@ -123,6 +123,72 @@ class DataMixin:
         return instructions
 
     # -----------------------------------------------------------------
+    # Let destructuring
+    # -----------------------------------------------------------------
+
+    def _translate_let_destruct(
+        self, stmt: ast.LetDestruct, env: WasmSlotEnv
+    ) -> tuple[list[str], WasmSlotEnv] | None:
+        """Translate ``let Ctor<@T1, @T2> = expr;`` into field extractions.
+
+        Works for any single-constructor ADT (Tuple, UrlParts, user-defined).
+        The algorithm mirrors ``_extract_constructor_fields`` but iterates
+        over ``stmt.type_bindings`` (TypeExpr items) instead of match
+        sub-patterns.
+        """
+        # Translate the value expression — should produce a heap pointer (i32)
+        val_instrs = self.translate_expr(stmt.value, env)
+        if val_instrs is None:
+            return None
+
+        # Save to a local
+        scr_local = self.alloc_local("i32")
+        instrs: list[str] = list(val_instrs)
+        instrs.append(f"local.set {scr_local}")
+
+        # Extract each field using the same offset algorithm as constructors
+        _sizes = {"i32": 4, "i64": 8, "f64": 8, "i32_pair": 8}
+        _aligns = {"i32": 4, "i64": 8, "f64": 8, "i32_pair": 4}
+        offset = 4  # skip past tag (i32, 4 bytes)
+        new_env = env
+
+        for te in stmt.type_bindings:
+            type_name = self._type_expr_to_slot_name(te)
+            if type_name is None:
+                return None
+            # Unit bindings: no WASM representation, just bind with dummy
+            if type_name == "Unit":
+                continue
+            # Pair types (String, Array<T>): two consecutive i32 locals
+            if self._is_pair_type_name(type_name):
+                align = _aligns["i32"]
+                offset = (offset + align - 1) & ~(align - 1)
+                ptr_local = self.alloc_local("i32")
+                len_local = self.alloc_local("i32")
+                instrs.append(f"local.get {scr_local}")
+                instrs.append(f"i32.load offset={offset}")
+                instrs.append(f"local.set {ptr_local}")
+                instrs.append(f"local.get {scr_local}")
+                instrs.append(f"i32.load offset={offset + 4}")
+                instrs.append(f"local.set {len_local}")
+                new_env = new_env.push(type_name, ptr_local)
+                offset += 8
+                continue
+            wt = self._slot_name_to_wasm_type(type_name)
+            if wt is None:
+                return None
+            align = _aligns.get(wt, 8)
+            offset = (offset + align - 1) & ~(align - 1)
+            local_idx = self.alloc_local(wt)
+            instrs.append(f"local.get {scr_local}")
+            instrs.append(f"{wt}.load offset={offset}")
+            instrs.append(f"local.set {local_idx}")
+            new_env = new_env.push(type_name, local_idx)
+            offset += _sizes.get(wt, 8)
+
+        return (instrs, new_env)
+
+    # -----------------------------------------------------------------
     # Match expressions
     # -----------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- **Tuple construction** (`Tuple(1, "hello", true)`) and **match destructuring** (`Tuple(@Int, @String) -> ...`) now compile to WASM
- **LetDestruct** (`let Tuple<@Int, @String> = expr;`) works for Tuples and **all single-constructor ADTs** (UrlParts, Future, user-defined types)
- Tuples are variadic — any arity from 1 field upward is supported
- UrlParts stays as-is (semantic named ADT with hardcoded WASM for url_parse/url_join); LetDestruct is a follow-on benefit

### Changes
- `vera/checker/calls.py` — Special-case Tuple constructor type-checking (variadic, bypasses fixed-arity ConstructorInfo lookup)
- `vera/checker/control.py` — Special-case Tuple match pattern type-checking
- `vera/codegen/registration.py` — Register Tuple placeholder layout (tag=0, recomputed dynamically)
- `vera/wasm/context.py` — LetDestruct dispatch in block translation
- `vera/wasm/data.py` — New `_translate_let_destruct` method (mirrors `_extract_constructor_fields` for TypeExpr items)
- Removed Tuple limitation from spec/11-compilation.md, SKILL.md, AGENTS.md, vera/README.md
- New conformance test `ch02_tuple_basic` (51 total), updated `examples/url_parsing.vera` with LetDestruct demo
- 15 new tests (5 checker + 10 codegen), all 2092 tests pass

Closes #267

## Test plan
- [x] `vera check` on Tuple programs — no E210 warning
- [x] `vera run` on Tuple construction + match destructuring — correct field access
- [x] `vera run` on LetDestruct — correct field extraction for Tuples, UrlParts, user-defined ADTs
- [x] All 2092 tests pass, 51 conformance programs pass, 22 examples pass
- [x] `mypy vera/` clean
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)