### PR TITLE
Add Markdown standard library types (MdInline, MdBlock); v0.0.84

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Read `SKILL.md` for the full language reference. It covers syntax, slot referenc
 
 ### Conformance programs as reference
 
-The conformance suite in `tests/conformance/` contains 50 small, self-contained programs — one per language feature — that all parse, type-check, verify, and (mostly) run correctly. These are the best minimal working examples of each feature. When you need to see how a specific construct works (e.g. effect handlers, match expressions, closures), check the corresponding conformance program before reading the spec. The `manifest.json` file maps features to programs.
+The conformance suite in `tests/conformance/` contains 52 small, self-contained programs — one per language feature — that all parse, type-check, verify, and (mostly) run correctly. These are the best minimal working examples of each feature. When you need to see how a specific construct works (e.g. effect handlers, match expressions, closures), check the corresponding conformance program before reading the spec. The `manifest.json` file maps features to programs.
 
 ### Workflow
 
@@ -140,8 +140,8 @@ Each stage is a module with a single public API function (`parse_file`, `transfo
 pytest tests/ -v                       # Run all tests (see TESTING.md)
 pytest tests/test_conformance.py -v    # Conformance suite only
 mypy vera/                             # Type-check the compiler
-python scripts/check_conformance.py    # All 50 conformance programs must pass
-python scripts/check_examples.py       # All 22 examples must pass
+python scripts/check_conformance.py    # All 52 conformance programs must pass
+python scripts/check_examples.py       # All 23 examples must pass
 ```
 
 Test helpers follow a pattern: `_check_ok(source)` / `_check_err(source, match)` / `_verify_ok(source)` / `_verify_err(source, match)`. See existing tests for examples.
@@ -150,8 +150,8 @@ When implementing a new language feature, write the conformance program *first* 
 
 ### Invariants
 
-- All 51 conformance programs in `tests/conformance/` must pass their declared level
-- All 22 examples in `examples/` must pass `vera check` and `vera verify`
+- All 52 conformance programs in `tests/conformance/` must pass their declared level
+- All 23 examples in `examples/` must pass `vera check` and `vera verify`
 - `mypy vera/` must be clean
 - `pytest tests/ -v` must pass
 - Version must be in sync across `vera/__init__.py`, `pyproject.toml`, and `CHANGELOG.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.84] - 2026-03-11
+
+### Added
+- **Markdown standard library** ([#147](https://github.com/aallan/vera/issues/147)):
+  Two new built-in ADTs for typed Markdown document representation:
+  `MdInline` (6 constructors: MdText, MdCode, MdEmph, MdStrong, MdLink, MdImage)
+  and `MdBlock` (8 constructors: MdParagraph, MdHeading, MdCodeBlock, MdBlockQuote,
+  MdList, MdThematicBreak, MdTable, MdDocument).
+  Five new pure functions: `md_parse(String → Result<MdBlock, String>)`,
+  `md_render(MdBlock → String)`, `md_has_heading(MdBlock, Nat → Bool)`,
+  `md_has_code_block(MdBlock, String → Bool)`,
+  `md_extract_code_blocks(MdBlock, String → Array<String>)`.
+  All implemented as WASM host imports with a hand-written Python parser —
+  the first pure functions using the host-binding pattern.
+  The WASM import interface is the portability contract: the same `.wasm`
+  binary works with any host runtime (Python, JavaScript, Rust) that provides
+  matching implementations.
+- New conformance test `ch09_markdown` (conformance suite: 51→52 programs)
+- New example `examples/markdown.vera` — parse, query, extract, and render Markdown
+- 78 new tests (59 parser/renderer + 6 type checker + 8 codegen + 5 conformance)
+
+### Changed
+- **Spec §9.3 reorganization:** UrlParts (from §9.6.13), Future\<T\> (from §9.5.4),
+  MdInline, and MdBlock are now documented in §9.3 (Built-in ADTs) as §9.3.3–§9.3.6.
+  Function specs remain in their original sections with cross-references.
+
 ## [0.0.83] - 2026-03-11
 
 ### Added
@@ -1267,7 +1293,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Grammar: handler body simplified to avoid LALR reduce/reduce conflict
 - `pyproject.toml`: corrected build backend, package discovery, PEP 639 compliance
 
-[Unreleased]: https://github.com/aallan/vera/compare/v0.0.83...HEAD
+[Unreleased]: https://github.com/aallan/vera/compare/v0.0.84...HEAD
+[0.0.84]: https://github.com/aallan/vera/compare/v0.0.83...v0.0.84
 [0.0.83]: https://github.com/aallan/vera/compare/v0.0.82...v0.0.83
 [0.0.82]: https://github.com/aallan/vera/compare/v0.0.81...v0.0.82
 [0.0.81]: https://github.com/aallan/vera/compare/v0.0.80...v0.0.81

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,8 +40,8 @@ vera fmt --check file.vera        # Check if already canonical
 pytest tests/ -v                  # Run the test suite (see TESTING.md)
 mypy vera/                        # Type-check the compiler itself
 
-python scripts/check_conformance.py    # Verify all 51 conformance programs pass their declared level
-python scripts/check_examples.py      # Verify all 22 examples parse + check + verify
+python scripts/check_conformance.py    # Verify all 52 conformance programs pass their declared level
+python scripts/check_examples.py      # Verify all 23 examples parse + check + verify
 python scripts/check_spec_examples.py # Verify spec code blocks parse
 python scripts/check_readme_examples.py # Verify README code blocks parse
 python scripts/check_skill_examples.py # Verify SKILL.md code blocks parse
@@ -54,9 +54,9 @@ python scripts/fix_allowlists.py --fix # Auto-fix stale allowlist line numbers
 
 - `spec/` — Language specification (Chapters 0-12)
 - `vera/` — Reference compiler: grammar, parser, AST, transformer, type checker, verifier, codegen, CLI
-- `examples/` — 22 example Vera programs (all must pass `vera check` and `vera verify`)
+- `examples/` — 23 example Vera programs (all must pass `vera check` and `vera verify`)
 - `tests/` — Test suite (unit tests + conformance suite)
-- `tests/conformance/` — 51 conformance programs validating every language feature against the spec
+- `tests/conformance/` — 52 conformance programs validating every language feature against the spec
 - `scripts/` — CI and validation scripts
 
 ## Writing Vera code
@@ -74,8 +74,8 @@ Each stage is a module with a public API function and is independently testable.
 ## What not to break
 
 - Pre-commit hooks run mypy + pytest + conformance suite + example validation on every commit
-- All 51 conformance programs in `tests/conformance/` must pass their declared level
-- All 22 examples in `examples/` must pass `vera check` and `vera verify`
+- All 52 conformance programs in `tests/conformance/` must pass their declared level
+- All 23 examples in `examples/` must pass `vera check` and `vera verify`
 - Version must stay in sync across `vera/__init__.py`, `pyproject.toml`, and `CHANGELOG.md`
 - All tests must pass: `pytest tests/ -v`
 - Type checking must be clean: `mypy vera/`

--- a/README.md
+++ b/README.md
@@ -183,11 +183,11 @@ The language specification is in draft across 13 chapters:
 
 ### Testing
 
-Testing is organized in three layers: **unit tests** (2,003 tests across 20 files, testing compiler internals), a **conformance suite** (49 programs across 9 spec chapters, systematically validating every language feature against the spec), and **example programs** (21 end-to-end demos). The compiler has 90% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations. Every commit validates all conformance programs, example programs, and 95 specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference -- coverage tables, conformance suite details, CI pipeline, and infrastructure.
+Testing is organized in three layers: **unit tests** (2,003 tests across 20 files, testing compiler internals), a **conformance suite** (52 programs across 9 spec chapters, systematically validating every language feature against the spec), and **example programs** (23 end-to-end demos). The compiler has 90% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations. Every commit validates all conformance programs, example programs, and 95 specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference -- coverage tables, conformance suite details, CI pipeline, and infrastructure.
 
 ### Known Bugs
 
-No known bugs.
+- [#274](https://github.com/aallan/vera/issues/274) — Formatter collapses multi-statement blocks in match arms to single unparseable lines; comments inside function bodies are repositioned outside. Workaround: extract multi-statement match arm logic into helper functions.
 
 ## Roadmap
 
@@ -374,7 +374,7 @@ New effects, types, abilities, and standard library extensions (spec §0.8).
 - [#62](https://github.com/aallan/vera/issues/62) standard library collections (Set, Map, Decimal)
 - [#133](https://github.com/aallan/vera/issues/133) array operations (map, fold, slice)
 - [#58](https://github.com/aallan/vera/issues/58) JSON standard library type
-- [#147](https://github.com/aallan/vera/issues/147) Markdown standard library type
+- <del>[#147](https://github.com/aallan/vera/issues/147) Markdown standard library type</del> ([v0.0.84](https://github.com/aallan/vera/releases/tag/v0.0.84))
 - [#211](https://github.com/aallan/vera/issues/211) Option and Result combinators
 - [#233](https://github.com/aallan/vera/issues/233) date and time handling (ISO 8601)
 - [#235](https://github.com/aallan/vera/issues/235) cryptographic hashing (SHA-256, HMAC)
@@ -396,6 +396,7 @@ New effects, types, abilities, and standard library extensions (spec §0.8).
 - [#238](https://github.com/aallan/vera/issues/238) Component Model (WIT) interop
 - [#239](https://github.com/aallan/vera/issues/239) resource limit configuration (fuel, memory, timeout)
 - [#163](https://github.com/aallan/vera/issues/163) standalone WASM runtime package
+- [#273](https://github.com/aallan/vera/issues/273) browser runtime for compiled WASM (JS host bindings)
 
 **Ecosystem**
 
@@ -406,7 +407,7 @@ New effects, types, abilities, and standard library extensions (spec §0.8).
 
 ### Where this is going
 
-The features on the C9 roadmap -- `<Http>` ([#57](https://github.com/aallan/vera/issues/57)), `<Inference>` ([#61](https://github.com/aallan/vera/issues/61)), and the `Markdown` type ([#147](https://github.com/aallan/vera/issues/147)) -- converge into a single design goal: an LLM should be able to write a short Vera function that searches the web, feeds the results into another model, and returns typed, contract-checked output. No scaffolding, no untyped string wrangling, no unchecked side effects.
+The features on the C9 roadmap -- `<Http>` ([#57](https://github.com/aallan/vera/issues/57)), `<Inference>` ([#61](https://github.com/aallan/vera/issues/61)), and the now-implemented `Markdown` type ([#147](https://github.com/aallan/vera/issues/147)) -- converge into a single design goal: an LLM should be able to write a short Vera function that searches the web, feeds the results into another model, and returns typed, contract-checked output. No scaffolding, no untyped string wrangling, no unchecked side effects.
 
 A research function that searches YouTube, summarises the results via LLM inference, and returns structured Markdown might look like this:
 
@@ -463,7 +464,7 @@ OK: examples/safe_divide.vera
 Verification: 4 verified (Tier 1)
 ```
 
-`vera verify` runs the type checker and then verifies contracts using Z3. Tier 1 contracts (decidable arithmetic, comparisons, Boolean logic, match expressions, ADT constructors, and decreases clauses) are proved automatically. Contracts that Z3 cannot decide are reported as Tier 3 (runtime checks) with a warning. Across all 22 examples, 127 of 134 contracts (94.8%) are verified statically.
+`vera verify` runs the type checker and then verifies contracts using Z3. Tier 1 contracts (decidable arithmetic, comparisons, Boolean logic, match expressions, ADT constructors, and decreases clauses) are proved automatically. Contracts that Z3 cannot decide are reported as Tier 3 (runtime checks) with a warning. Across all 23 examples, 131 of 138 contracts (94.9%) are verified statically.
 
 ### Format a program
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -418,6 +418,11 @@ url_encode(@String.0)                   -- returns String (RFC 3986 percent-enco
 url_decode(@String.0)                   -- returns Result<String, String>
 url_parse(@String.0)                    -- returns Result<UrlParts, String> (RFC 3986 decomposition)
 url_join(@UrlParts.0)                   -- returns String (reassemble URL from UrlParts)
+md_parse(@String.0)                     -- returns Result<MdBlock, String> (parse Markdown)
+md_render(@MdBlock.0)                   -- returns String (render to canonical Markdown)
+md_has_heading(@MdBlock.0, @Nat.0)      -- returns Bool (check if heading of level exists)
+md_has_code_block(@MdBlock.0, @String.0) -- returns Bool (check if code block of language exists)
+md_extract_code_blocks(@MdBlock.0, @String.0) -- returns Array<String> (extract code by language)
 async(@T.0)                            -- returns Future<T> (requires effects(<Async>))
 await(@Future<T>.0)                    -- returns T (requires effects(<Async>))
 to_string(@Int.0)                       -- returns String (integer to decimal)
@@ -465,6 +470,40 @@ join(@Array<String>.0, @String.0)               -- returns String (join with sep
 `to_upper` and `to_lower` convert ASCII letters only (a-z ↔ A-Z). `replace` substitutes all non-overlapping occurrences; an empty needle returns the original string unchanged. `split` returns an array of segments; an empty delimiter returns a single-element array. `join` concatenates array elements with the separator between each pair.
 
 String functions use the heap allocator (`$alloc`). Memory is managed automatically by a conservative mark-sweep garbage collector — there is no manual allocation or deallocation. All four parse functions return `Result<T, String>`: `parse_nat`, `parse_int`, `parse_float64`, and `parse_bool`. They return `Ok(value)` on valid input and `Err(msg)` on empty or invalid input; leading and trailing spaces are tolerated. `parse_int` accepts an optional `+` or `-` sign. `parse_bool` is strict: only `"true"` and `"false"` (lowercase) are valid. `base64_encode` encodes a string to standard Base64 (RFC 4648); `base64_decode` returns `Result<String, String>`, failing on invalid length or characters. `url_encode` percent-encodes a string for use in URLs (RFC 3986), leaving unreserved characters (`A-Z`, `a-z`, `0-9`, `-`, `_`, `.`, `~`) unchanged; `url_decode` returns `Result<String, String>`, failing on invalid `%XX` sequences. `url_parse` decomposes a URL into its RFC 3986 components, returning `Result<UrlParts, String>` where `UrlParts(scheme, authority, path, query, fragment)` is a built-in ADT with five String fields; it returns `Err("missing scheme")` if no `:` is found. `url_join` reassembles a `UrlParts` value into a URL string. Programs must redefine `UrlParts` locally (like `Result`) to use it in match expressions.
+
+### Markdown operations
+
+```vera
+md_parse(@String.0)                     -- returns Result<MdBlock, String>
+md_render(@MdBlock.0)                   -- returns String
+md_has_heading(@MdBlock.0, @Nat.0)      -- returns Bool
+md_has_code_block(@MdBlock.0, @String.0) -- returns Bool
+md_extract_code_blocks(@MdBlock.0, @String.0) -- returns Array<String>
+```
+
+`md_parse` parses a Markdown string into a typed `MdBlock` document tree. Returns `Ok(MdDocument(...))` on success. `md_render` converts an `MdBlock` back to canonical Markdown text. `md_has_heading` checks whether the document contains a heading at the given level (1–6). `md_has_code_block` checks for a fenced code block with the given language tag (use `""` for untagged blocks). `md_extract_code_blocks` returns an array of code content strings for all blocks matching the language.
+
+Two built-in ADTs represent the Markdown document structure:
+
+**MdInline** — inline content within blocks:
+- `MdText(String)` — plain text
+- `MdCode(String)` — inline code
+- `MdEmph(Array<MdInline>)` — emphasis (*italic*)
+- `MdStrong(Array<MdInline>)` — strong (**bold**)
+- `MdLink(Array<MdInline>, String)` — link with text and URL
+- `MdImage(String, String)` — image with alt text and source
+
+**MdBlock** — block-level content:
+- `MdParagraph(Array<MdInline>)` — paragraph
+- `MdHeading(Nat, Array<MdInline>)` — heading with level (1–6)
+- `MdCodeBlock(String, String)` — fenced code block (language, code)
+- `MdBlockQuote(Array<MdBlock>)` — block quote
+- `MdList(Bool, Array<Array<MdBlock>>)` — list (ordered?, items)
+- `MdThematicBreak` — horizontal rule
+- `MdTable(Array<Array<Array<MdInline>>>)` — table (rows of cells)
+- `MdDocument(Array<MdBlock>)` — top-level document
+
+All Markdown functions are pure and available without imports. Pattern match on `MdBlock` and `MdInline` constructors to traverse the document tree.
 
 ### Numeric operations
 

--- a/examples/markdown.vera
+++ b/examples/markdown.vera
@@ -1,0 +1,34 @@
+-- Markdown: parse, query, and extract from Markdown documents.
+--
+-- Demonstrates the typed Markdown ADTs (MdBlock, MdInline) and
+-- the five built-in functions: md_parse, md_render, md_has_heading,
+-- md_has_code_block, md_extract_code_blocks.
+effect IO {
+  op print(String -> Unit);
+}
+
+-- Process a parsed Markdown document: query headings, code blocks, and render.
+private fn process_doc(@MdBlock -> @Unit)
+  requires(true)
+  ensures(true)
+  effects(<IO>)
+{
+  if md_has_heading(@MdBlock.0, 1) then { IO.print("Has title heading") } else { IO.print("No title heading") };
+  if md_has_code_block(@MdBlock.0, "vera") then { IO.print("Has Vera code") } else { IO.print("No Vera code") };
+  let @Array<String> = md_extract_code_blocks(@MdBlock.0, "vera");
+  IO.print(int_to_string(array_length(@Array<String>.0)));
+  IO.print(md_render(@MdBlock.0))
+}
+
+-- Parse a Markdown string and process the result.
+public fn main(@Unit -> @Unit)
+  requires(true)
+  ensures(true)
+  effects(<IO>)
+{
+  let @Result<MdBlock, String> = md_parse("# Welcome\n\nHello, **world**!\n\n```vera\nlet x = 42\n```");
+  match @Result<MdBlock, String>.0 {
+    Ok(@MdBlock) -> process_doc(@MdBlock.0),
+    Err(@String) -> IO.print(@String.0)
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.83"
+version = "0.0.84"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/scripts/check_readme_examples.py
+++ b/scripts/check_readme_examples.py
@@ -36,7 +36,7 @@ ALLOWLIST: dict[int, tuple[str, str]] = {
     # =================================================================
 
     # Section "Where this is going" — depends on #57 (Http), #61 (Inference), #147 (Markdown)
-    413: ("FUTURE", "Vision example uses MdBlock, Http, Inference (issues #57, #61, #147)"),
+    414: ("FUTURE", "Vision example uses MdBlock, Http, Inference (issues #57, #61, #147)"),
 }
 
 

--- a/scripts/check_skill_examples.py
+++ b/scripts/check_skill_examples.py
@@ -39,69 +39,72 @@ ALLOWLIST: dict[int, tuple[str, str]] = {
     # String operations — bare function calls
     404: ("FRAGMENT", "String built-in examples, bare calls"),
 
+    # Markdown operations — bare function calls
+    476: ("FRAGMENT", "Markdown built-in examples, bare calls"),
+
     # String interpolation — bare expressions
-    434: ("FRAGMENT", "String interpolation examples, bare expressions"),
+    439: ("FRAGMENT", "String interpolation examples, bare expressions"),
 
     # String search — bare function calls
-    446: ("FRAGMENT", "String search built-in examples, bare calls"),
+    451: ("FRAGMENT", "String search built-in examples, bare calls"),
 
     # String transformation — bare function calls
-    457: ("FRAGMENT", "String transformation built-in examples, bare calls"),
+    462: ("FRAGMENT", "String transformation built-in examples, bare calls"),
 
     # Numeric operations — bare function calls
-    471: ("FRAGMENT", "Numeric built-in examples, bare calls"),
+    510: ("FRAGMENT", "Numeric built-in examples, bare calls"),
 
     # Contracts section — requires/ensures fragments
-    528: ("FRAGMENT", "Requires clause example, not full function"),
-    537: ("FRAGMENT", "Ensures clause example, not full function"),
-    564: ("FRAGMENT", "Quantified requires clause, not full function"),
+    567: ("FRAGMENT", "Requires clause example, not full function"),
+    576: ("FRAGMENT", "Ensures clause example, not full function"),
+    603: ("FRAGMENT", "Quantified requires clause, not full function"),
 
     # Effects section — bare effect rows
     # (old entry at 580 removed — block shifted to 582 with Async addition)
 
     # Effect handler syntax template
-    745: ("FRAGMENT", "Handler syntax template, not real code"),
+    784: ("FRAGMENT", "Handler syntax template, not real code"),
 
     # Effect declarations — bare effects(...) clauses
-    582: ("FRAGMENT", "Effect declarations list"),
-    703: ("FRAGMENT", "Async effect declarations list"),
+    621: ("FRAGMENT", "Effect declarations list"),
+    742: ("FRAGMENT", "Async effect declarations list"),
 
     # Qualified calls and handler fragments — bare expressions
-    757: ("FRAGMENT", "Handler with clause, bare expression"),
-    767: ("FRAGMENT", "Qualified call examples, bare expressions"),
+    796: ("FRAGMENT", "Handler with clause, bare expression"),
+    806: ("FRAGMENT", "Qualified call examples, bare expressions"),
 
     # Module declaration and import syntax
-    805: ("FRAGMENT", "Module declaration and import example"),
+    844: ("FRAGMENT", "Module declaration and import example"),
 
     # Line comments — bare comments
-    856: ("FRAGMENT", "Comment syntax example"),
+    895: ("FRAGMENT", "Comment syntax example"),
 
     # Type conversions — bare function calls
-    486: ("FRAGMENT", "Type conversion examples, bare calls"),
+    525: ("FRAGMENT", "Type conversion examples, bare calls"),
 
     # Float64 predicates — bare function calls
-    499: ("FRAGMENT", "Float64 predicate examples, bare calls"),
+    538: ("FRAGMENT", "Float64 predicate examples, bare calls"),
 
     # Common mistakes section — intentionally wrong code
-    884: ("FRAGMENT", "Wrong: missing contracts"),
-    904: ("FRAGMENT", "Wrong: missing effects clause"),
-    938: ("FRAGMENT", "Wrong: bare expression without indices"),
-    951: ("FRAGMENT", "Wrong: bare expression no indices"),
-    956: ("FRAGMENT", "Correct: expression with indices (not full fn)"),
-    1022: ("FRAGMENT", "Wrong: match arm with incorrect return"),
-    1046: ("FRAGMENT", "Wrong: non-exhaustive match"),
-    1053: ("FRAGMENT", "Correct: match arm example"),
-    1063: ("FRAGMENT", "Wrong: if/else without braces (bare expression)"),
-    1068: ("FRAGMENT", "Correct: if/else with braces"),
+    923: ("FRAGMENT", "Wrong: missing contracts"),
+    943: ("FRAGMENT", "Wrong: missing effects clause"),
+    977: ("FRAGMENT", "Wrong: bare expression without indices"),
+    990: ("FRAGMENT", "Wrong: bare expression no indices"),
+    995: ("FRAGMENT", "Correct: expression with indices (not full fn)"),
+    1061: ("FRAGMENT", "Wrong: match arm with incorrect return"),
+    1085: ("FRAGMENT", "Wrong: non-exhaustive match"),
+    1092: ("FRAGMENT", "Correct: match arm example"),
+    1102: ("FRAGMENT", "Wrong: if/else without braces (bare expression)"),
+    1107: ("FRAGMENT", "Correct: if/else with braces"),
 
     # Import syntax — intentionally unsupported
-    1079: ("FRAGMENT", "Wrong: import aliasing not supported"),
-    1084: ("FRAGMENT", "Correct: import syntax example"),
-    1094: ("FRAGMENT", "Wrong: import hiding not supported"),
-    1099: ("FRAGMENT", "Correct: multi-import syntax"),
+    1118: ("FRAGMENT", "Wrong: import aliasing not supported"),
+    1123: ("FRAGMENT", "Correct: import syntax example"),
+    1133: ("FRAGMENT", "Wrong: import hiding not supported"),
+    1138: ("FRAGMENT", "Correct: multi-import syntax"),
 
     # String escapes — bare expression
-    1113: ("FRAGMENT", "String escape example"),
+    1152: ("FRAGMENT", "String escape example"),
 
     # =================================================================
     # MISMATCH — uses syntax the parser doesn't handle in isolation.

--- a/scripts/check_spec_examples.py
+++ b/scripts/check_spec_examples.py
@@ -57,13 +57,21 @@ ALLOWLIST: dict[tuple[str, int], str] = {
     ("02-types.md", 250): "FUTURE",          # forall<T where Ord<T>> fn sort
 
     # Chapter 9 — future stdlib features and signature-only blocks
-    ("09-standard-library.md", 320): "FUTURE",   # fn classify — uses ++ (string concat)
+    ("09-standard-library.md", 396): "FUTURE",   # fn classify — uses ++ (string concat)
 
     # Chapter 9 — Array builtin signatures (no body)
-    ("09-standard-library.md", 334): "FRAGMENT",  # array_length signature (no body)
-    ("09-standard-library.md", 354): "FRAGMENT",  # array_append signature (no body)
-    ("09-standard-library.md", 372): "FRAGMENT",  # array_range signature (no body)
-    ("09-standard-library.md", 390): "FRAGMENT",  # array_concat signature (no body)
+    ("09-standard-library.md", 410): "FRAGMENT",  # array_length signature (no body)
+    ("09-standard-library.md", 430): "FRAGMENT",  # array_append signature (no body)
+    ("09-standard-library.md", 448): "FRAGMENT",  # array_range signature (no body)
+    ("09-standard-library.md", 466): "FRAGMENT",  # array_concat signature (no body)
+
+    # Chapter 9 — Numeric/string/encoding builtin signatures (no body)
+    ("09-standard-library.md", 573): "FRAGMENT",  # round signature (no body)
+    ("09-standard-library.md", 590): "FRAGMENT",  # sqrt signature (no body)
+    ("09-standard-library.md", 607): "FRAGMENT",  # pow signature (no body)
+    ("09-standard-library.md", 658): "FRAGMENT",  # byte_to_int signature (no body)
+    ("09-standard-library.md", 832): "FRAGMENT",  # ends_with signature (no body)
+    ("09-standard-library.md", 1095): "FRAGMENT",  # base64_decode signature (no body)
 
     # =================================================================
     # FRAGMENT — heuristic false positives (look like declarations but
@@ -113,75 +121,69 @@ ALLOWLIST: dict[tuple[str, int], str] = {
     ("07-effects.md", 315): "FRAGMENT",     # effect Diverge {} — no operations
 
     # Chapter 9 — Async builtin signatures (no body)
-    ("09-standard-library.md", 270): "FRAGMENT",  # async/await signatures (no body)
+    ("09-standard-library.md", 346): "FRAGMENT",  # async/await signatures (no body)
 
     # Chapter 9 — Numeric builtin signatures (no body)
-    ("09-standard-library.md", 412): "FRAGMENT",  # abs signature (no body)
-    ("09-standard-library.md", 429): "FRAGMENT",  # min signature (no body)
-    ("09-standard-library.md", 446): "FRAGMENT",  # max signature (no body)
-    ("09-standard-library.md", 463): "FRAGMENT",  # floor signature (no body)
-    ("09-standard-library.md", 480): "FRAGMENT",  # ceil signature (no body)
-    ("09-standard-library.md", 497): "FRAGMENT",  # round signature (no body)
-    ("09-standard-library.md", 514): "FRAGMENT",  # sqrt signature (no body)
-    ("09-standard-library.md", 531): "FRAGMENT",  # pow signature (no body)
+    ("09-standard-library.md", 488): "FRAGMENT",  # abs signature (no body)
+    ("09-standard-library.md", 505): "FRAGMENT",  # min signature (no body)
+    ("09-standard-library.md", 522): "FRAGMENT",  # max signature (no body)
+    ("09-standard-library.md", 539): "FRAGMENT",  # floor signature (no body)
+    ("09-standard-library.md", 556): "FRAGMENT",  # ceil signature (no body)
 
     # Chapter 9 — Numeric type conversion signatures (no body)
-    ("09-standard-library.md", 552): "FRAGMENT",  # to_float signature (no body)
-    ("09-standard-library.md", 567): "FRAGMENT",  # nat_to_int signature (no body)
-    ("09-standard-library.md", 582): "FRAGMENT",  # byte_to_int signature (no body)
-    ("09-standard-library.md", 597): "FRAGMENT",  # float_to_int signature (no body)
-    ("09-standard-library.md", 612): "FRAGMENT",  # int_to_nat signature (no body)
-    ("09-standard-library.md", 630): "FRAGMENT",  # int_to_byte signature (no body)
+    ("09-standard-library.md", 628): "FRAGMENT",  # to_float signature (no body)
+    ("09-standard-library.md", 643): "FRAGMENT",  # nat_to_int signature (no body)
+    ("09-standard-library.md", 673): "FRAGMENT",  # float_to_int signature (no body)
+    ("09-standard-library.md", 688): "FRAGMENT",  # int_to_nat signature (no body)
+    ("09-standard-library.md", 706): "FRAGMENT",  # int_to_byte signature (no body)
 
     # Chapter 9 — Float64 predicates (signatures, no body)
-    ("09-standard-library.md", 654): "FRAGMENT",  # is_nan signature (no body)
-    ("09-standard-library.md", 671): "FRAGMENT",  # is_infinite signature (no body)
-    ("09-standard-library.md", 690): "FRAGMENT",  # nan signature (no body)
-    ("09-standard-library.md", 705): "FRAGMENT",  # infinity signature (no body)
+    ("09-standard-library.md", 730): "FRAGMENT",  # is_nan signature (no body)
+    ("09-standard-library.md", 747): "FRAGMENT",  # is_infinite signature (no body)
+    ("09-standard-library.md", 766): "FRAGMENT",  # nan signature (no body)
+    ("09-standard-library.md", 781): "FRAGMENT",  # infinity signature (no body)
 
     # Chapter 9 — String search signatures (no body)
-    ("09-standard-library.md", 726): "FRAGMENT",  # string_contains signature (no body)
-    ("09-standard-library.md", 741): "FRAGMENT",  # starts_with signature (no body)
-    ("09-standard-library.md", 756): "FRAGMENT",  # ends_with signature (no body)
-    ("09-standard-library.md", 771): "FRAGMENT",  # index_of signature (no body)
+    ("09-standard-library.md", 802): "FRAGMENT",  # string_contains signature (no body)
+    ("09-standard-library.md", 817): "FRAGMENT",  # starts_with signature (no body)
+    ("09-standard-library.md", 847): "FRAGMENT",  # index_of signature (no body)
 
     # Chapter 9 — String transformation signatures (no body)
-    ("09-standard-library.md", 792): "FRAGMENT",  # to_upper signature (no body)
-    ("09-standard-library.md", 807): "FRAGMENT",  # to_lower signature (no body)
-    ("09-standard-library.md", 822): "FRAGMENT",  # replace signature (no body)
-    ("09-standard-library.md", 838): "FRAGMENT",  # split signature (no body)
-    ("09-standard-library.md", 853): "FRAGMENT",  # join signature (no body)
-    ("09-standard-library.md", 867): "FRAGMENT",  # from_char_code signature (no body)
-    ("09-standard-library.md", 882): "FRAGMENT",  # string_repeat signature (no body)
+    ("09-standard-library.md", 868): "FRAGMENT",  # to_upper signature (no body)
+    ("09-standard-library.md", 883): "FRAGMENT",  # to_lower signature (no body)
+    ("09-standard-library.md", 898): "FRAGMENT",  # replace signature (no body)
+    ("09-standard-library.md", 914): "FRAGMENT",  # split signature (no body)
+    ("09-standard-library.md", 929): "FRAGMENT",  # join signature (no body)
+    ("09-standard-library.md", 943): "FRAGMENT",  # from_char_code signature (no body)
+    ("09-standard-library.md", 958): "FRAGMENT",  # string_repeat signature (no body)
 
     # Chapter 9 — Parsing function signatures (no body)
-    ("09-standard-library.md", 910): "FRAGMENT",  # parse_nat signature (no body)
-    ("09-standard-library.md", 932): "FRAGMENT",  # parse_int signature (no body)
-    ("09-standard-library.md", 955): "FRAGMENT",  # parse_float64 signature (no body)
-    ("09-standard-library.md", 977): "FRAGMENT",  # parse_bool signature (no body)
+    ("09-standard-library.md", 986): "FRAGMENT",  # parse_nat signature (no body)
+    ("09-standard-library.md", 1008): "FRAGMENT",  # parse_int signature (no body)
+    ("09-standard-library.md", 1031): "FRAGMENT",  # parse_float64 signature (no body)
+    ("09-standard-library.md", 1053): "FRAGMENT",  # parse_bool signature (no body)
 
     # Chapter 9 — Base64 builtin signatures (no body)
-    ("09-standard-library.md", 1000): "FRAGMENT",  # base64_encode signature (no body)
-    ("09-standard-library.md", 1019): "FRAGMENT",  # base64_decode signature (no body)
+    ("09-standard-library.md", 1076): "FRAGMENT",  # base64_encode signature (no body)
 
     # Chapter 9 — URL encoding builtin signatures (no body)
-    ("09-standard-library.md", 1046): "FRAGMENT",  # url_encode signature (no body)
-    ("09-standard-library.md", 1065): "FRAGMENT",  # url_decode signature (no body)
+    ("09-standard-library.md", 1122): "FRAGMENT",  # url_encode signature (no body)
+    ("09-standard-library.md", 1141): "FRAGMENT",  # url_decode signature (no body)
 
     # Chapter 9 — URL parsing builtin signatures (no body)
-    ("09-standard-library.md", 1097): "FRAGMENT",  # url_parse signature (no body)
-    ("09-standard-library.md", 1117): "FRAGMENT",  # url_join signature (no body)
+    ("09-standard-library.md", 1167): "FRAGMENT",  # url_parse signature (no body)
+    ("09-standard-library.md", 1187): "FRAGMENT",  # url_join signature (no body)
 
     # Chapter 9 — ML/vector builtin signatures (no body)
-    ("09-standard-library.md", 1137): "FRAGMENT",  # similarity signature (no body)
+    ("09-standard-library.md", 1207): "FRAGMENT",  # similarity signature (no body)
 
     # Chapter 9 — Markdown stdlib type (future, uses MdBlock/MdInline types)
-    ("09-standard-library.md", 1241): "FUTURE",   # md_parse
-    ("09-standard-library.md", 1250): "FUTURE",   # md_render
-    ("09-standard-library.md", 1261): "FUTURE",   # md_has_heading
-    ("09-standard-library.md", 1270): "FUTURE",   # md_has_code_block
-    ("09-standard-library.md", 1279): "FUTURE",   # md_extract_code_blocks
-    ("09-standard-library.md", 1303): "FUTURE",   # convert_to_markdown
+    ("09-standard-library.md", 1309): "FUTURE",   # md_parse
+    ("09-standard-library.md", 1318): "FUTURE",   # md_render
+    ("09-standard-library.md", 1329): "FUTURE",   # md_has_heading
+    ("09-standard-library.md", 1338): "FUTURE",   # md_has_code_block
+    ("09-standard-library.md", 1347): "FUTURE",   # md_extract_code_blocks
+    ("09-standard-library.md", 1371): "FUTURE",   # convert_to_markdown
 }
 
 
@@ -232,13 +234,13 @@ CHECK_ALLOWLIST: dict[tuple[str, int], str] = {
     ("07-effects.md", 202): "INCOMPLETE",    # handle[Exn<String>] + parse_int
 
     # Chapter 9 — Http + Async composition example (Http not yet implemented)
-    ("09-standard-library.md", 244): "INCOMPLETE",  # fetch_both uses Http.get (future)
+    ("09-standard-library.md", 326): "INCOMPLETE",  # fetch_both uses Http.get (future)
 
     # Chapter 9 — Future<T> type definition (standalone, no visibility)
-    ("09-standard-library.md", 264): "INCOMPLETE",  # data Future<T> (no visibility keyword)
+    ("09-standard-library.md", 103): "INCOMPLETE",  # data Future<T> (no visibility keyword)
 
     # Chapter 9 — UrlParts type definition (standalone, no visibility)
-    ("09-standard-library.md", 1089): "INCOMPLETE",  # data UrlParts (no visibility keyword)
+    ("09-standard-library.md", 88): "INCOMPLETE",  # data UrlParts (no visibility keyword)
 }
 
 

--- a/spec/09-standard-library.md
+++ b/spec/09-standard-library.md
@@ -83,6 +83,88 @@ private fn parse_nat(@Int -> @Result<Nat, String>)
 }
 ```
 
+### 9.3.3 UrlParts
+
+```
+data UrlParts {
+  UrlParts(String, String, String, String, String)
+}
+```
+
+`UrlParts` is a built-in ADT representing the five components of a URL per RFC 3986: scheme, authority, path, query, and fragment. Programs must redefine `UrlParts` locally (like `Result` and `Option`) to use it in match expressions.
+
+Constructors:
+- `UrlParts(@String, @String, @String, @String, @String)` — scheme, authority, path, query, fragment.
+
+See §9.6.13 for the `url_parse` and `url_join` function specifications.
+
+### 9.3.4 Future\<T\>
+
+```
+data Future<T> { Future(T) }
+```
+
+`Future<T>` represents the result of an asynchronous computation. It is WASM-transparent: it has the same runtime representation as `T`, with no overhead.
+
+Constructors:
+- `Future(@T)` — wraps a value.
+
+See §9.5.4 for the `async` and `await` function specifications.
+
+### 9.3.5 MdInline
+
+```
+public data MdInline {
+  MdText(String),
+  MdCode(String),
+  MdEmph(Array<MdInline>),
+  MdStrong(Array<MdInline>),
+  MdLink(Array<MdInline>, String),
+  MdImage(String, String)
+}
+```
+
+`MdInline` represents inline-level Markdown content. It is one of two mutually defined ADTs (with `MdBlock`) that make illegal states unrepresentable — a heading cannot contain another heading at the type level.
+
+Constructors:
+- `MdText(@String)` — plain text run.
+- `MdCode(@String)` — inline code span.
+- `MdEmph(@Array<MdInline>)` — emphasis (italic).
+- `MdStrong(@Array<MdInline>)` — strong emphasis (bold).
+- `MdLink(@Array<MdInline>, @String)` — hyperlink: display text and URL.
+- `MdImage(@String, @String)` — image: alt text and source URL.
+
+See §9.7.3 for the Markdown function specifications.
+
+### 9.3.6 MdBlock
+
+```
+public data MdBlock {
+  MdParagraph(Array<MdInline>),
+  MdHeading(Nat, Array<MdInline>),
+  MdCodeBlock(String, String),
+  MdBlockQuote(Array<MdBlock>),
+  MdList(Bool, Array<Array<MdBlock>>),
+  MdThematicBreak,
+  MdTable(Array<Array<Array<MdInline>>>),
+  MdDocument(Array<MdBlock>)
+}
+```
+
+`MdBlock` represents block-level Markdown elements.
+
+Constructors:
+- `MdParagraph(@Array<MdInline>)` — paragraph.
+- `MdHeading(@Nat, @Array<MdInline>)` — heading: level (1--6) and content.
+- `MdCodeBlock(@String, @String)` — fenced code block: language and code body.
+- `MdBlockQuote(@Array<MdBlock>)` — block quote.
+- `MdList(@Bool, @Array<Array<MdBlock>>)` — list: ordered/unordered, with items.
+- `MdThematicBreak` — horizontal rule (nullary).
+- `MdTable(@Array<Array<Array<MdInline>>>)` — table: rows of cells of inlines.
+- `MdDocument(@Array<MdBlock>)` — top-level document.
+
+See §9.7.3 for the Markdown function specifications.
+
 ## 9.4 Built-in Collections
 
 ### 9.4.1 Array\<T\>
@@ -257,13 +339,7 @@ private fn fetch_both(@String, @String -> @Tuple<Json, Json>)
 
 ### 9.5.4 Async
 
-The `<Async>` effect enables asynchronous computation via `async(expr)` and `await(future)` operations with a `Future<T>` type.
-
-**Type:**
-
-```
-data Future<T> { Future(T) }
-```
+The `<Async>` effect enables asynchronous computation via `async(expr)` and `await(future)` operations with a `Future<T>` type (see §9.3.4 for the ADT definition).
 
 **Built-in functions:**
 
@@ -1086,13 +1162,7 @@ url_decode("%4")                   -- Err("invalid percent-encoding")
 
 ### 9.6.13 URL Parsing
 
-```
-data UrlParts {
-  UrlParts(String, String, String, String, String)
-}
-```
-
-`UrlParts` is a built-in ADT representing the five components of a URL per RFC 3986: scheme, authority, path, query, and fragment. Programs must redefine `UrlParts` locally (like `Result` and `Option`) to use it in match expressions.
+The `UrlParts` ADT is defined in §9.3.3. Programs must redefine `UrlParts` locally (like `Result` and `Option`) to use it in match expressions.
 
 ```
 public fn url_parse(@String -> @Result<UrlParts, String>)
@@ -1178,13 +1248,11 @@ This approach keeps the core language small while providing ergonomic JSON suppo
 
 `Decimal` will provide exact decimal arithmetic for financial and precision-sensitive applications. It will be implemented as a library type (not a primitive) since WebAssembly does not have native decimal floating-point. The runtime will provide a software implementation.
 
-### 9.7.3 Markdown (Future)
-
-> **Status: Not yet implemented.** Tracked in [#147](https://github.com/aallan/vera/issues/147). Dependencies resolved: dynamic string construction ([#52](https://github.com/aallan/vera/issues/52), done) and string built-in operations ([#134](https://github.com/aallan/vera/issues/134), done). Does **not** depend on `Map<K, V>`.
+### 9.7.3 Markdown
 
 Markdown is the lingua franca of large language models — they understand it natively and generate it naturally. A typed Markdown ADT makes document structure visible to the type system, enabling contracts that verify the structural properties of agent output.
 
-Markdown will be represented as two mutually defined ADTs: `MdBlock` for block-level elements and `MdInline` for inline-level content. The two-level design makes illegal states unrepresentable — a heading cannot contain another heading at the type level.
+Markdown is represented as two mutually defined ADTs: `MdBlock` for block-level elements (§9.3.6) and `MdInline` for inline-level content (§9.3.5). The two-level design makes illegal states unrepresentable — a heading cannot contain another heading at the type level.
 
 ```
 public data MdInline {

--- a/tests/conformance/ch09_markdown.vera
+++ b/tests/conformance/ch09_markdown.vera
@@ -1,0 +1,38 @@
+-- Chapter 9: Markdown Standard Library (§9.7.3)
+-- Tests: md_parse, md_render, md_has_heading, md_has_code_block,
+--        md_extract_code_blocks, MdBlock, MdInline constructors.
+-- Level: run (requires WASM execution with host bindings)
+effect IO {
+  op print(String -> Unit);
+}
+
+public fn main(@Unit -> @Unit)
+  requires(true)
+  ensures(true)
+  effects(<IO>)
+{
+  let @Result<MdBlock, String> = md_parse("# Hello World");
+  match @Result<MdBlock, String>.0 { Ok(@MdBlock) -> IO.print("parse: ok"), Err(_) -> IO.print("FAIL") };
+  let @Result<MdBlock, String> = md_parse("# Title\n\n## Section");
+  match @Result<MdBlock, String>.0 { Ok(@MdBlock) -> if md_has_heading(@MdBlock.0, 1) then { IO.print("h1: ok") } else { IO.print("FAIL") }, Err(_) -> IO.print("FAIL") };
+  let @Result<MdBlock, String> = md_parse("# Title");
+  match @Result<MdBlock, String>.0 { Ok(@MdBlock) -> if md_has_heading(@MdBlock.0, 3) then { IO.print("FAIL") } else { IO.print("h3: ok") }, Err(_) -> IO.print("FAIL") };
+  let @Result<MdBlock, String> = md_parse("```python\ncode\n```");
+  match @Result<MdBlock, String>.0 { Ok(@MdBlock) -> if md_has_code_block(@MdBlock.0, "python") then { IO.print("py: ok") } else { IO.print("FAIL") }, Err(_) -> IO.print("FAIL") };
+  let @Result<MdBlock, String> = md_parse("```python\ncode\n```");
+  match @Result<MdBlock, String>.0 { Ok(@MdBlock) -> if md_has_code_block(@MdBlock.0, "rust") then { IO.print("FAIL") } else { IO.print("rs: ok") }, Err(_) -> IO.print("FAIL") };
+  let @Result<MdBlock, String> = md_parse("# Hello");
+  match @Result<MdBlock, String>.0 { Ok(@MdBlock) -> IO.print(md_render(@MdBlock.0)), Err(_) -> IO.print("FAIL") };
+  let @Result<MdBlock, String> = md_parse("```vera\nx\n```\n\n```vera\ny\n```");
+  match @Result<MdBlock, String>.0 {
+    Ok(@MdBlock) -> IO.print(int_to_string(array_length(md_extract_code_blocks(@MdBlock.0, "vera")))),
+    Err(_) -> IO.print("FAIL")
+  }
+}
+-- 1. Parse a heading
+-- 2. has_heading true
+-- 3. has_heading false
+-- 4. has_code_block true
+-- 5. has_code_block false
+-- 6. Render
+-- 7. Extract code blocks

--- a/tests/conformance/manifest.json
+++ b/tests/conformance/manifest.json
@@ -457,5 +457,14 @@
     "level": "run",
     "spec_ref": "Section 9.5.4",
     "features": ["async", "await", "future", "async_effect"]
+  },
+  {
+    "id": "ch09_markdown",
+    "file": "ch09_markdown.vera",
+    "chapter": 9,
+    "title": "Markdown standard library",
+    "level": "run",
+    "spec_ref": "Section 9.7.3",
+    "features": ["md_parse", "md_render", "md_has_heading", "md_has_code_block", "md_extract_code_blocks"]
   }
 ]

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -3774,3 +3774,49 @@ private fn f(@Tuple<Int, Int> -> @Int)
   }
 }
 """)
+
+
+class TestMarkdownBuiltins:
+    """Type-checking for md_parse, md_render, md_has_heading, etc."""
+
+    def test_md_parse_ok(self) -> None:
+        _check_ok("""
+private fn f(@String -> @Result<MdBlock, String>)
+  requires(true) ensures(true) effects(pure)
+{ md_parse(@String.0) }
+""")
+
+    def test_md_parse_wrong_type(self) -> None:
+        _check_err("""
+private fn f(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ md_parse(@Int.0) }
+""", "expected String")
+
+    def test_md_render_ok(self) -> None:
+        _check_ok("""
+private fn f(@MdBlock -> @String)
+  requires(true) ensures(true) effects(pure)
+{ md_render(@MdBlock.0) }
+""")
+
+    def test_md_has_heading_ok(self) -> None:
+        _check_ok("""
+private fn f(@MdBlock, @Nat -> @Bool)
+  requires(true) ensures(true) effects(pure)
+{ md_has_heading(@MdBlock.0, @Nat.0) }
+""")
+
+    def test_md_has_code_block_ok(self) -> None:
+        _check_ok("""
+private fn f(@MdBlock, @String -> @Bool)
+  requires(true) ensures(true) effects(pure)
+{ md_has_code_block(@MdBlock.0, @String.0) }
+""")
+
+    def test_md_extract_code_blocks_ok(self) -> None:
+        _check_ok("""
+private fn f(@MdBlock, @String -> @Array<String>)
+  requires(true) ensures(true) effects(pure)
+{ md_extract_code_blocks(@MdBlock.0, @String.0) }
+""")

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -7294,3 +7294,152 @@ public fn main(-> @Unit)
 """
         # @String.4 = deepest binding = first field = "https"
         assert _run_io(source, fn="main") == "https"
+
+
+# =====================================================================
+# Markdown built-ins (§9.7.3) — host-imported functions
+# =====================================================================
+
+
+class TestMarkdown:
+    """Markdown built-in functions: md_parse, md_render, md_has_heading,
+    md_has_code_block, md_extract_code_blocks."""
+
+    _PREAMBLE = """
+effect IO { op print(String -> Unit); }
+"""
+
+    def test_md_parse_heading(self) -> None:
+        source = self._PREAMBLE + r"""
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  let @Result<MdBlock, String> = md_parse("# Hello");
+  match @Result<MdBlock, String>.0 {
+    Ok(@MdBlock) -> IO.print("ok"),
+    Err(@String) -> IO.print("err")
+  }
+}
+"""
+        assert _run_io(source, fn="main") == "ok"
+
+    def test_md_has_heading_true(self) -> None:
+        source = self._PREAMBLE + r"""
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  let @Result<MdBlock, String> = md_parse("# Title");
+  match @Result<MdBlock, String>.0 {
+    Ok(@MdBlock) -> {
+      let @Bool = md_has_heading(@MdBlock.0, 1);
+      if @Bool.0 then { IO.print("yes") } else { IO.print("no") }
+    },
+    Err(_) -> IO.print("err")
+  }
+}
+"""
+        assert _run_io(source, fn="main") == "yes"
+
+    def test_md_has_heading_false(self) -> None:
+        source = self._PREAMBLE + r"""
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  let @Result<MdBlock, String> = md_parse("# Title");
+  match @Result<MdBlock, String>.0 {
+    Ok(@MdBlock) -> {
+      let @Bool = md_has_heading(@MdBlock.0, 2);
+      if @Bool.0 then { IO.print("yes") } else { IO.print("no") }
+    },
+    Err(_) -> IO.print("err")
+  }
+}
+"""
+        assert _run_io(source, fn="main") == "no"
+
+    def test_md_has_code_block_true(self) -> None:
+        source = self._PREAMBLE + """
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  let @Result<MdBlock, String> = md_parse("```python\\ncode\\n```");
+  match @Result<MdBlock, String>.0 {
+    Ok(@MdBlock) -> {
+      let @Bool = md_has_code_block(@MdBlock.0, "python");
+      if @Bool.0 then { IO.print("yes") } else { IO.print("no") }
+    },
+    Err(_) -> IO.print("err")
+  }
+}
+"""
+        assert _run_io(source, fn="main") == "yes"
+
+    def test_md_has_code_block_false(self) -> None:
+        source = self._PREAMBLE + """
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  let @Result<MdBlock, String> = md_parse("```python\\ncode\\n```");
+  match @Result<MdBlock, String>.0 {
+    Ok(@MdBlock) -> {
+      let @Bool = md_has_code_block(@MdBlock.0, "rust");
+      if @Bool.0 then { IO.print("yes") } else { IO.print("no") }
+    },
+    Err(_) -> IO.print("err")
+  }
+}
+"""
+        assert _run_io(source, fn="main") == "no"
+
+    def test_md_render_round_trip(self) -> None:
+        source = self._PREAMBLE + r"""
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  let @Result<MdBlock, String> = md_parse("# Hello");
+  match @Result<MdBlock, String>.0 {
+    Ok(@MdBlock) -> {
+      let @String = md_render(@MdBlock.0);
+      IO.print(@String.0)
+    },
+    Err(_) -> IO.print("err")
+  }
+}
+"""
+        assert _run_io(source, fn="main") == "# Hello"
+
+    def test_md_extract_code_blocks(self) -> None:
+        source = self._PREAMBLE + """
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  let @Result<MdBlock, String> = md_parse("```python\\nprint(1)\\n```\\n\\n```python\\nprint(2)\\n```");
+  match @Result<MdBlock, String>.0 {
+    Ok(@MdBlock) -> {
+      let @Array<String> = md_extract_code_blocks(@MdBlock.0, "python");
+      IO.print(int_to_string(array_length(@Array<String>.0)));
+      IO.print(@Array<String>.0[0]);
+      IO.print(@Array<String>.0[1])
+    },
+    Err(_) -> IO.print("err")
+  }
+}
+"""
+        assert _run_io(source, fn="main") == "2print(1)print(2)"
+
+    def test_md_extract_code_blocks_empty(self) -> None:
+        source = self._PREAMBLE + """
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  let @Result<MdBlock, String> = md_parse("# Just a heading");
+  match @Result<MdBlock, String>.0 {
+    Ok(@MdBlock) -> {
+      let @Array<String> = md_extract_code_blocks(@MdBlock.0, "python");
+      IO.print(int_to_string(array_length(@Array<String>.0)))
+    },
+    Err(_) -> IO.print("err")
+  }
+}
+"""
+        assert _run_io(source, fn="main") == "0"

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -1,0 +1,394 @@
+"""Unit tests for the Python Markdown parser and renderer (§9.7.3).
+
+Tests the pure-Python reference implementation used by the host-imported
+md_parse, md_render, md_has_heading, md_has_code_block, and
+md_extract_code_blocks built-in functions.
+"""
+
+import pytest
+
+from vera.markdown import (
+    MdBlockQuote,
+    MdCode,
+    MdCodeBlock,
+    MdDocument,
+    MdEmph,
+    MdHeading,
+    MdImage,
+    MdLink,
+    MdList,
+    MdParagraph,
+    MdStrong,
+    MdTable,
+    MdText,
+    MdThematicBreak,
+    extract_code_blocks,
+    has_code_block,
+    has_heading,
+    parse_markdown,
+    render_markdown,
+)
+
+
+# =====================================================================
+# Parsing tests
+# =====================================================================
+
+
+class TestParseHeadings:
+    """ATX heading parsing."""
+
+    def test_h1(self) -> None:
+        doc = parse_markdown("# Hello")
+        assert len(doc.children) == 1
+        h = doc.children[0]
+        assert isinstance(h, MdHeading)
+        assert h.level == 1
+        assert h.children == (MdText("Hello"),)
+
+    def test_h2_through_h6(self) -> None:
+        for level in range(2, 7):
+            doc = parse_markdown("#" * level + " Heading")
+            h = doc.children[0]
+            assert isinstance(h, MdHeading)
+            assert h.level == level
+
+    def test_heading_with_closing_hashes(self) -> None:
+        doc = parse_markdown("## Title ##")
+        h = doc.children[0]
+        assert isinstance(h, MdHeading)
+        assert h.level == 2
+        assert h.children == (MdText("Title"),)
+
+
+class TestParseCodeBlocks:
+    """Fenced code block parsing."""
+
+    def test_backtick_fence(self) -> None:
+        doc = parse_markdown("```python\nprint(42)\n```")
+        assert len(doc.children) == 1
+        cb = doc.children[0]
+        assert isinstance(cb, MdCodeBlock)
+        assert cb.language == "python"
+        assert cb.code == "print(42)"
+
+    def test_tilde_fence(self) -> None:
+        doc = parse_markdown("~~~\ncode\n~~~")
+        cb = doc.children[0]
+        assert isinstance(cb, MdCodeBlock)
+        assert cb.language == ""
+        assert cb.code == "code"
+
+    def test_multiline_code(self) -> None:
+        doc = parse_markdown("```\nline1\nline2\nline3\n```")
+        cb = doc.children[0]
+        assert isinstance(cb, MdCodeBlock)
+        assert cb.code == "line1\nline2\nline3"
+
+    def test_code_block_no_language(self) -> None:
+        doc = parse_markdown("```\nstuff\n```")
+        cb = doc.children[0]
+        assert isinstance(cb, MdCodeBlock)
+        assert cb.language == ""
+
+
+class TestParseParagraphs:
+    """Paragraph parsing."""
+
+    def test_single_paragraph(self) -> None:
+        doc = parse_markdown("Hello world")
+        assert len(doc.children) == 1
+        p = doc.children[0]
+        assert isinstance(p, MdParagraph)
+        assert p.children == (MdText("Hello world"),)
+
+    def test_multiline_paragraph(self) -> None:
+        doc = parse_markdown("line one\nline two")
+        p = doc.children[0]
+        assert isinstance(p, MdParagraph)
+        assert p.children == (MdText("line one line two"),)
+
+    def test_paragraphs_separated_by_blank(self) -> None:
+        doc = parse_markdown("para one\n\npara two")
+        assert len(doc.children) == 2
+        assert isinstance(doc.children[0], MdParagraph)
+        assert isinstance(doc.children[1], MdParagraph)
+
+
+class TestParseLists:
+    """List parsing."""
+
+    def test_unordered_list(self) -> None:
+        doc = parse_markdown("- item 1\n- item 2\n- item 3")
+        assert len(doc.children) == 1
+        lst = doc.children[0]
+        assert isinstance(lst, MdList)
+        assert not lst.ordered
+        assert len(lst.items) == 3
+
+    def test_ordered_list(self) -> None:
+        doc = parse_markdown("1. first\n2. second")
+        lst = doc.children[0]
+        assert isinstance(lst, MdList)
+        assert lst.ordered
+        assert len(lst.items) == 2
+
+    def test_unordered_star(self) -> None:
+        doc = parse_markdown("* alpha\n* beta")
+        lst = doc.children[0]
+        assert isinstance(lst, MdList)
+        assert not lst.ordered
+
+    def test_ordered_paren(self) -> None:
+        doc = parse_markdown("1) first\n2) second")
+        lst = doc.children[0]
+        assert isinstance(lst, MdList)
+        assert lst.ordered
+
+
+class TestParseBlockQuotes:
+    """Block quote parsing."""
+
+    def test_simple_quote(self) -> None:
+        doc = parse_markdown("> quoted text")
+        bq = doc.children[0]
+        assert isinstance(bq, MdBlockQuote)
+        assert len(bq.children) == 1
+        assert isinstance(bq.children[0], MdParagraph)
+
+    def test_multiline_quote(self) -> None:
+        doc = parse_markdown("> line one\n> line two")
+        bq = doc.children[0]
+        assert isinstance(bq, MdBlockQuote)
+
+
+class TestParseTables:
+    """GFM table parsing."""
+
+    def test_simple_table(self) -> None:
+        doc = parse_markdown("| A | B |\n| --- | --- |\n| 1 | 2 |")
+        tbl = doc.children[0]
+        assert isinstance(tbl, MdTable)
+        assert len(tbl.rows) == 2  # header + 1 data row
+
+    def test_table_multiple_rows(self) -> None:
+        md = "| X | Y |\n| --- | --- |\n| a | b |\n| c | d |"
+        doc = parse_markdown(md)
+        tbl = doc.children[0]
+        assert isinstance(tbl, MdTable)
+        assert len(tbl.rows) == 3  # header + 2 data rows
+
+
+class TestParseThematicBreak:
+    """Thematic break / horizontal rule."""
+
+    def test_dashes(self) -> None:
+        doc = parse_markdown("---")
+        assert isinstance(doc.children[0], MdThematicBreak)
+
+    def test_asterisks(self) -> None:
+        doc = parse_markdown("***")
+        assert isinstance(doc.children[0], MdThematicBreak)
+
+    def test_underscores(self) -> None:
+        doc = parse_markdown("___")
+        assert isinstance(doc.children[0], MdThematicBreak)
+
+
+class TestParseInlines:
+    """Inline element parsing."""
+
+    def test_emphasis(self) -> None:
+        doc = parse_markdown("*italic*")
+        p = doc.children[0]
+        assert isinstance(p, MdParagraph)
+        assert p.children == (MdEmph((MdText("italic"),)),)
+
+    def test_strong(self) -> None:
+        doc = parse_markdown("**bold**")
+        p = doc.children[0]
+        assert isinstance(p, MdParagraph)
+        assert p.children == (MdStrong((MdText("bold"),)),)
+
+    def test_inline_code(self) -> None:
+        doc = parse_markdown("`code`")
+        p = doc.children[0]
+        assert isinstance(p, MdParagraph)
+        assert p.children == (MdCode("code"),)
+
+    def test_link(self) -> None:
+        doc = parse_markdown("[text](url)")
+        p = doc.children[0]
+        assert isinstance(p, MdParagraph)
+        link = p.children[0]
+        assert isinstance(link, MdLink)
+        assert link.children == (MdText("text"),)
+        assert link.url == "url"
+
+    def test_image(self) -> None:
+        doc = parse_markdown("![alt](src)")
+        p = doc.children[0]
+        assert isinstance(p, MdParagraph)
+        img = p.children[0]
+        assert isinstance(img, MdImage)
+        assert img.alt == "alt"
+        assert img.src == "src"
+
+    def test_mixed_inlines(self) -> None:
+        doc = parse_markdown("hello *world* `code`")
+        p = doc.children[0]
+        assert isinstance(p, MdParagraph)
+        assert len(p.children) == 4  # text, emph, text, code
+
+
+class TestParseMixed:
+    """Mixed document parsing."""
+
+    def test_heading_and_paragraph(self) -> None:
+        doc = parse_markdown("# Title\n\nSome text.")
+        assert len(doc.children) == 2
+        assert isinstance(doc.children[0], MdHeading)
+        assert isinstance(doc.children[1], MdParagraph)
+
+    def test_empty_document(self) -> None:
+        doc = parse_markdown("")
+        assert doc.children == ()
+
+    def test_whitespace_only(self) -> None:
+        doc = parse_markdown("   \n  \n  ")
+        assert doc.children == ()
+
+
+# =====================================================================
+# Rendering tests
+# =====================================================================
+
+
+class TestRender:
+    """Canonical Markdown rendering."""
+
+    def test_heading(self) -> None:
+        block = MdHeading(2, (MdText("Title"),))
+        assert render_markdown(block) == "## Title"
+
+    def test_paragraph(self) -> None:
+        block = MdParagraph((MdText("Hello"),))
+        assert render_markdown(block) == "Hello"
+
+    def test_code_block(self) -> None:
+        block = MdCodeBlock("python", "print(42)")
+        assert render_markdown(block) == "```python\nprint(42)\n```"
+
+    def test_thematic_break(self) -> None:
+        assert render_markdown(MdThematicBreak()) == "---"
+
+    def test_emphasis(self) -> None:
+        block = MdParagraph((MdEmph((MdText("italic"),)),))
+        assert render_markdown(block) == "*italic*"
+
+    def test_strong(self) -> None:
+        block = MdParagraph((MdStrong((MdText("bold"),)),))
+        assert render_markdown(block) == "**bold**"
+
+    def test_link(self) -> None:
+        block = MdParagraph(
+            (MdLink((MdText("click"),), "https://example.com"),),
+        )
+        assert render_markdown(block) == "[click](https://example.com)"
+
+    def test_image(self) -> None:
+        block = MdParagraph((MdImage("alt", "img.png"),))
+        assert render_markdown(block) == "![alt](img.png)"
+
+
+class TestRoundTrip:
+    """Parse → render → parse round-trip property."""
+
+    @pytest.mark.parametrize("markdown", [
+        "# Hello",
+        "Some text here.",
+        "```python\nprint(42)\n```",
+        "---",
+        "- item 1\n- item 2",
+        "1. first\n2. second",
+        "> quoted",
+        "| A | B |\n| --- | --- |\n| 1 | 2 |",
+    ])
+    def test_round_trip(self, markdown: str) -> None:
+        doc = parse_markdown(markdown)
+        rendered = render_markdown(doc)
+        doc2 = parse_markdown(rendered)
+        assert doc == doc2
+
+
+# =====================================================================
+# Query function tests
+# =====================================================================
+
+
+class TestHasHeading:
+    """has_heading query function."""
+
+    def test_has_h1(self) -> None:
+        doc = parse_markdown("# Title\n\nText")
+        assert has_heading(doc, 1)
+
+    def test_no_h2(self) -> None:
+        doc = parse_markdown("# Title\n\nText")
+        assert not has_heading(doc, 2)
+
+    def test_nested_in_blockquote(self) -> None:
+        doc = parse_markdown("> ## Quoted heading")
+        assert has_heading(doc, 2)
+
+    def test_empty_document(self) -> None:
+        doc = parse_markdown("")
+        assert not has_heading(doc, 1)
+
+
+class TestHasCodeBlock:
+    """has_code_block query function."""
+
+    def test_has_python(self) -> None:
+        doc = parse_markdown("```python\ncode\n```")
+        assert has_code_block(doc, "python")
+
+    def test_no_rust(self) -> None:
+        doc = parse_markdown("```python\ncode\n```")
+        assert not has_code_block(doc, "rust")
+
+    def test_no_language(self) -> None:
+        doc = parse_markdown("```\ncode\n```")
+        assert has_code_block(doc, "")
+
+    def test_empty_document(self) -> None:
+        doc = parse_markdown("")
+        assert not has_code_block(doc, "python")
+
+
+class TestExtractCodeBlocks:
+    """extract_code_blocks query function."""
+
+    def test_single_block(self) -> None:
+        doc = parse_markdown("```python\nprint(1)\n```")
+        assert extract_code_blocks(doc, "python") == ["print(1)"]
+
+    def test_multiple_blocks(self) -> None:
+        md = "```python\nprint(1)\n```\n\n```python\nprint(2)\n```"
+        doc = parse_markdown(md)
+        result = extract_code_blocks(doc, "python")
+        assert result == ["print(1)", "print(2)"]
+
+    def test_filter_by_language(self) -> None:
+        md = "```python\npy\n```\n\n```rust\nrs\n```"
+        doc = parse_markdown(md)
+        assert extract_code_blocks(doc, "python") == ["py"]
+        assert extract_code_blocks(doc, "rust") == ["rs"]
+
+    def test_no_matches(self) -> None:
+        doc = parse_markdown("```python\ncode\n```")
+        assert extract_code_blocks(doc, "java") == []
+
+    def test_empty_document(self) -> None:
+        doc = parse_markdown("")
+        assert extract_code_blocks(doc, "python") == []

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -19,7 +19,7 @@ README = Path(__file__).parent.parent / "README.md"
 # Each key is the 1-based line number of the opening ```vera fence.
 ALLOWLIST: dict[int, str] = {
     # "Where this is going" — depends on #57 (Http), #61 (Inference), #147 (Markdown)
-    413: "Vision example uses MdBlock, Http, Inference (issues #57, #61, #147)",
+    414: "Vision example uses MdBlock, Http, Inference (issues #57, #61, #147)",
 }
 
 

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -1480,9 +1480,9 @@ private fn sum(@List<Int> -> @Int)
             t1 += result.summary.tier1_verified
             t3 += result.summary.tier3_runtime
             total += result.summary.total
-        assert t1 == 127, f"Expected 127 T1, got {t1}"
+        assert t1 == 131, f"Expected 131 T1, got {t1}"
         assert t3 == 7, f"Expected 7 T3, got {t3}"
-        assert total == 134, f"Expected 134 total, got {total}"
+        assert total == 138, f"Expected 138 total, got {total}"
 
 
 # =====================================================================

--- a/vera/README.md
+++ b/vera/README.md
@@ -98,7 +98,9 @@ execute(compile_result, ...)    # → run WASM via wasmtime
 | ` ├ operators.py` | 430 | | Binary/unary operators, if, quantifiers, assert/assume, old/new | |
 | ` ├ calls.py` | 223 | | Function calls, generic resolution, effect handlers | |
 | ` ├ closures.py` | 248 | | Closures, anonymous functions, free variable analysis | |
-| ` └ data.py` | 590 | | Constructors, match expressions (incl. nested patterns), arrays, indexing | |
+| ` ├ data.py` | 590 | | Constructors, match expressions (incl. nested patterns), arrays, indexing |
+| ` └ markdown.py` | ~380 | | WASM memory marshalling for MdInline/MdBlock ADTs | |
+| `markdown.py` | ~450 | Compile | Python Markdown parser/renderer (§9.7.3 subset) | `parse_markdown()`, `render_markdown()`, `has_heading()`, `has_code_block()`, `extract_code_blocks()` |
 | `codegen/` | 3,137 | Compile | Codegen orchestrator (mixin package) | `compile()`, `execute()` |
 | `  api.py` | 265 | | Public API, dataclasses, host bindings, `execute()` | |
 | `  core.py` | 285 | | CodeGenerator class, orchestration, type helpers | |
@@ -290,6 +292,8 @@ Context flags (`in_ensures`, `in_contract`, `current_return_type`, `current_effe
 | `Option<T>` | ADT | `None`, `Some(T)` constructors |
 | `Result<T, E>` | ADT | `Ok(T)`, `Err(E)` constructors |
 | `Future<T>` | ADT | `Future(T)` constructor — WASM-transparent wrapper |
+| `MdInline` | ADT | `MdText(String)`, `MdCode(String)`, `MdEmph(Array<MdInline>)`, `MdStrong(Array<MdInline>)`, `MdLink(Array<MdInline>, String)`, `MdImage(String, String)` |
+| `MdBlock` | ADT | `MdParagraph(Array<MdInline>)`, `MdHeading(Nat, Array<MdInline>)`, `MdCodeBlock(String, String)`, `MdBlockQuote(Array<MdBlock>)`, `MdList(Bool, Array<Array<MdBlock>>)`, `MdThematicBreak`, `MdTable(Array<Array<Array<MdInline>>>)`, `MdDocument(Array<MdBlock>)` |
 | `State<T>` | Effect | `get(Unit) → T`, `put(T) → Unit` operations |
 | `IO` | Effect | `print`, `read_line`, `read_file`, `write_file`, `args`, `exit`, `get_env` |
 | `Async` | Effect | No operations — marker for async computation |
@@ -314,6 +318,11 @@ Context flags (`in_ensures`, `in_contract`, `current_return_type`, `current_effe
 | `url_decode` | Function | `String → Result<String, String>`, pure |
 | `url_parse` | Function | `String → Result<UrlParts, String>`, pure (RFC 3986 decomposition) |
 | `url_join` | Function | `UrlParts → String`, pure (reassemble URL) |
+| `md_parse` | Function | `String → Result<MdBlock, String>`, pure (Markdown → typed AST) |
+| `md_render` | Function | `MdBlock → String`, pure (typed AST → canonical Markdown) |
+| `md_has_heading` | Function | `MdBlock, Nat → Bool`, pure (query heading level) |
+| `md_has_code_block` | Function | `MdBlock, String → Bool`, pure (query code block language) |
+| `md_extract_code_blocks` | Function | `MdBlock, String → Array<String>`, pure (extract code by language) |
 | `async` | Function | `T → Future<T>`, `effects(<Async>)` (generic, eager evaluation) |
 | `await` | Function | `Future<T> → T`, `effects(<Async>)` (generic, identity unwrap) |
 | `to_string` | Function | `Int → String`, pure |
@@ -476,6 +485,18 @@ The two-pass architecture mirrors the type checker: pass 1 registers all functio
 
 `IO.print` compiles to a call to an imported host function. The `execute()` function in `codegen/api.py` provides the host implementation via wasmtime's `Linker`: it reads UTF-8 bytes from WASM linear memory and writes to stdout (or a capture buffer for testing).
 
+### Markdown host bindings
+
+`markdown.py` implements a hand-written Python Markdown parser and renderer (§9.7.3 subset). This is the **first set of pure functions implemented as host bindings** rather than inline WASM. The architectural rationale:
+
+- Markdown parsing is too complex for inline WASM (recursive tree construction, regex-based tokenization)
+- Functions are genuinely pure (deterministic, referentially transparent) — the host implementation is part of the trusted computing base
+- No external dependency — the parser handles ATX headings, fenced code blocks, paragraphs, lists, block quotes, GFM tables, thematic breaks, and inline formatting (emphasis, strong, code, links, images)
+
+`wasm/markdown.py` provides bidirectional WASM memory marshalling for the `MdInline` and `MdBlock` ADT trees. Write direction (`write_md_inline`, `write_md_block`) allocates ADT nodes in WASM linear memory using the same `$alloc` + tag-dispatch layout as user-defined ADTs. Read direction (`read_md_inline`, `read_md_block`) reconstructs Python objects from WASM memory. Helper functions `_read_i32`, `_read_i64`, and `_write_i64` handle raw memory access for struct fields.
+
+The WASM import interface is the portability contract: the compiled `.wasm` binary declares `(import "vera" "md_parse" ...)` etc., and any host runtime provides matching implementations. The Python implementation in `api.py` is the reference; a browser runtime would provide JavaScript host bindings (e.g., using `markdown-it`) with the same WASM memory allocation protocol. This is identical to how `IO.print` already works.
+
 ### Runtime contracts
 
 The code generator classifies contracts using the verifier's tier results:
@@ -597,7 +618,7 @@ The `ERROR_CODES` dict in `errors.py` maps every code to a short description (80
 
 ## Test Suite
 
-Testing is organized in three layers: **unit tests** (1,673 tests testing compiler internals), a **conformance suite** (43 programs in `tests/conformance/` validating every language feature against the spec), and **example programs** (18 end-to-end demos). The conformance suite is the definitive specification artifact — each program tests one feature and serves as a minimal working example.
+Testing is organized in three layers: **unit tests** (2,170 tests testing compiler internals), a **conformance suite** (52 programs in `tests/conformance/` validating every language feature against the spec), and **example programs** (23 end-to-end demos). The conformance suite is the definitive specification artifact — each program tests one feature and serves as a minimal working example.
 
 See **[TESTING.md](../TESTING.md)** for the comprehensive testing reference -- test file table, conformance suite details, compiler code coverage, language feature coverage, helper conventions, validation scripts, CI pipeline, and guidelines for adding tests.
 

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.83"
+__version__ = "0.0.84"

--- a/vera/codegen/api.py
+++ b/vera/codegen/api.py
@@ -79,6 +79,7 @@ class CompileResult:
     exports: list[str]
     diagnostics: list["Diagnostic"] = field(default_factory=list)
     state_types: list[tuple[str, str]] = field(default_factory=list)
+    md_ops_used: set[str] = field(default_factory=set)
 
     @property
     def ok(self) -> bool:
@@ -493,6 +494,129 @@ def execute(
         for key, val in initial_state.items():
             if key in state_store:
                 state_store[key] = val
+
+    # -----------------------------------------------------------------
+    # Markdown host functions (§9.7.3)
+    # -----------------------------------------------------------------
+
+    if result.md_ops_used:
+        from vera.markdown import (
+            extract_code_blocks as _md_extract_code_blocks,
+            has_code_block as _md_has_code_block,
+            has_heading as _md_has_heading,
+            parse_markdown as _md_parse,
+            render_markdown as _md_render,
+        )
+        from vera.wasm.markdown import (
+            read_md_block,
+            write_md_block,
+        )
+
+        def _alloc_result_ok_i32(
+            caller: wasmtime.Caller, value: int,
+        ) -> int:
+            """Allocate Result.Ok(i32) — wraps a heap pointer in Ok."""
+            # Layout: tag(i32)=0 at +0, value(i32) at +4
+            adt_ptr = _call_alloc(caller, 8)
+            _write_i32(caller, adt_ptr, 0)       # tag = Ok
+            _write_i32(caller, adt_ptr + 4, value)
+            return adt_ptr
+
+        # md_parse(ptr, len) → i32 (Result<MdBlock, String>)
+        def host_md_parse(
+            caller: wasmtime.Caller, ptr: int, length: int,
+        ) -> int:
+            text = _read_wasm_string(caller, ptr, length)
+            try:
+                doc = _md_parse(text)
+                block_ptr = write_md_block(
+                    caller, _call_alloc, _write_i32,
+                    _write_bytes, _alloc_string, doc,
+                )
+                return _alloc_result_ok_i32(caller, block_ptr)
+            except Exception as exc:
+                return _alloc_result_err_string(caller, str(exc))
+
+        md_parse_type = wasmtime.FuncType(
+            [wasmtime.ValType.i32(), wasmtime.ValType.i32()],
+            [wasmtime.ValType.i32()],
+        )
+        linker.define_func(
+            "vera", "md_parse", md_parse_type,
+            host_md_parse, access_caller=True,
+        )
+
+        # md_render(ptr) → (i32, i32) (String pair)
+        def host_md_render(
+            caller: wasmtime.Caller, ptr: int,
+        ) -> tuple[int, int]:
+            block = read_md_block(caller, ptr)
+            text = _md_render(block)
+            return _alloc_string(caller, text)
+
+        md_render_type = wasmtime.FuncType(
+            [wasmtime.ValType.i32()],
+            [wasmtime.ValType.i32(), wasmtime.ValType.i32()],
+        )
+        linker.define_func(
+            "vera", "md_render", md_render_type,
+            host_md_render, access_caller=True,
+        )
+
+        # md_has_heading(ptr, level_i64) → i32 (Bool)
+        def host_md_has_heading(
+            caller: wasmtime.Caller, ptr: int, level: int,
+        ) -> int:
+            block = read_md_block(caller, ptr)
+            return 1 if _md_has_heading(block, level) else 0
+
+        md_has_heading_type = wasmtime.FuncType(
+            [wasmtime.ValType.i32(), wasmtime.ValType.i64()],
+            [wasmtime.ValType.i32()],
+        )
+        linker.define_func(
+            "vera", "md_has_heading", md_has_heading_type,
+            host_md_has_heading, access_caller=True,
+        )
+
+        # md_has_code_block(ptr, lang_ptr, lang_len) → i32 (Bool)
+        def host_md_has_code_block(
+            caller: wasmtime.Caller,
+            ptr: int, lang_ptr: int, lang_len: int,
+        ) -> int:
+            block = read_md_block(caller, ptr)
+            lang = _read_wasm_string(caller, lang_ptr, lang_len)
+            return 1 if _md_has_code_block(block, lang) else 0
+
+        md_has_code_block_type = wasmtime.FuncType(
+            [wasmtime.ValType.i32(), wasmtime.ValType.i32(),
+             wasmtime.ValType.i32()],
+            [wasmtime.ValType.i32()],
+        )
+        linker.define_func(
+            "vera", "md_has_code_block", md_has_code_block_type,
+            host_md_has_code_block, access_caller=True,
+        )
+
+        # md_extract_code_blocks(ptr, lang_ptr, lang_len) → (i32, i32)
+        def host_md_extract_code_blocks(
+            caller: wasmtime.Caller,
+            ptr: int, lang_ptr: int, lang_len: int,
+        ) -> tuple[int, int]:
+            block = read_md_block(caller, ptr)
+            lang = _read_wasm_string(caller, lang_ptr, lang_len)
+            codes = _md_extract_code_blocks(block, lang)
+            return _alloc_array_of_strings(caller, codes)
+
+        md_extract_type = wasmtime.FuncType(
+            [wasmtime.ValType.i32(), wasmtime.ValType.i32(),
+             wasmtime.ValType.i32()],
+            [wasmtime.ValType.i32(), wasmtime.ValType.i32()],
+        )
+        linker.define_func(
+            "vera", "md_extract_code_blocks", md_extract_type,
+            host_md_extract_code_blocks, access_caller=True,
+        )
 
     instance = linker.instantiate(store, module)
 

--- a/vera/codegen/assembly.py
+++ b/vera/codegen/assembly.py
@@ -38,6 +38,29 @@ class AssemblyMixin:
         if self._io_ops_used & _IO_OPS_NEEDING_ALLOC:
             self._needs_alloc = True
 
+        # Import Markdown host-import builtins (pure functions)
+        _MD_IMPORTS: dict[str, str] = {
+            "md_parse":
+                "(func $vera.md_parse (param i32 i32) (result i32))",
+            "md_render":
+                "(func $vera.md_render (param i32) (result i32 i32))",
+            "md_has_heading":
+                "(func $vera.md_has_heading"
+                " (param i32 i64) (result i32))",
+            "md_has_code_block":
+                "(func $vera.md_has_code_block"
+                " (param i32 i32 i32) (result i32))",
+            "md_extract_code_blocks":
+                "(func $vera.md_extract_code_blocks"
+                " (param i32 i32 i32) (result i32 i32))",
+        }
+        for op_name in sorted(self._md_ops_used):
+            sig = _MD_IMPORTS.get(op_name)
+            if sig:
+                parts.append(f'  (import "vera" "{op_name}" {sig})')
+        if self._md_ops_used:
+            self._needs_alloc = True
+
         # Import contract_fail for informative violation messages
         if self._needs_contract_fail:
             parts.append(
@@ -100,7 +123,7 @@ class AssemblyMixin:
             parts.append(self._emit_gc_collect())
 
         # Export $alloc when host functions need to allocate WASM memory
-        if self._io_ops_used & _IO_OPS_NEEDING_ALLOC:
+        if (self._io_ops_used & _IO_OPS_NEEDING_ALLOC) or self._md_ops_used:
             parts.append('  (export "alloc" (func $alloc))')
 
         # Closure type declarations (for call_indirect)

--- a/vera/codegen/compilability.py
+++ b/vera/codegen/compilability.py
@@ -144,11 +144,17 @@ class CompilabilityMixin:
             self._exn_types.append((type_name, wt))
         return True
 
+    _MD_BUILTINS = frozenset({
+        "md_parse", "md_render", "md_has_heading",
+        "md_has_code_block", "md_extract_code_blocks",
+    })
+
     def _scan_io_ops(self, node: ast.Node) -> None:
-        """Walk a function body looking for IO qualified calls.
+        """Walk a function body looking for IO qualified calls and md_* builtins.
 
         Registers each distinct IO operation name (print, read_line, etc.)
-        into ``_io_ops_used`` for per-operation import emission.
+        into ``_io_ops_used`` for per-operation import emission.  Also
+        registers Markdown host-import builtins into ``_md_ops_used``.
         """
         if isinstance(node, ast.QualifiedCall):
             if node.qualifier == "IO":
@@ -164,6 +170,8 @@ class CompilabilityMixin:
                     self._scan_io_ops(stmt.expr)
             self._scan_io_ops(node.expr)
         elif isinstance(node, ast.FnCall):
+            if node.name in self._MD_BUILTINS:
+                self._md_ops_used.add(node.name)
             for arg in node.args:
                 self._scan_io_ops(arg)
         elif isinstance(node, ast.ConstructorCall):

--- a/vera/codegen/core.py
+++ b/vera/codegen/core.py
@@ -73,6 +73,7 @@ class CodeGenerator(
         self._needs_memory: bool = False
         self._state_types: list[tuple[str, str]] = []  # (type_name, wasm_type)
         self._exn_types: list[tuple[str, str]] = []  # (type_name, wasm_type)
+        self._md_ops_used: set[str] = set()  # Markdown host-import builtins
 
         # ADT layout metadata (populated during registration)
         self._adt_layouts: dict[str, dict[str, ConstructorLayout]] = {}
@@ -155,6 +156,7 @@ class CodeGenerator(
                 exports=[],
                 diagnostics=self.diagnostics,
                 state_types=list(self._state_types),
+                md_ops_used=set(self._md_ops_used),
             )
 
         # Pass 2: compile function bodies
@@ -224,6 +226,7 @@ class CodeGenerator(
                 exports=exports,
                 diagnostics=self.diagnostics,
                 state_types=list(self._state_types),
+                md_ops_used=set(self._md_ops_used),
             )
 
         return CompileResult(
@@ -232,6 +235,7 @@ class CodeGenerator(
             exports=exports,
             diagnostics=self.diagnostics,
             state_types=list(self._state_types),
+            md_ops_used=set(self._md_ops_used),
         )
 
     # -----------------------------------------------------------------

--- a/vera/codegen/modules.py
+++ b/vera/codegen/modules.py
@@ -253,6 +253,8 @@ class CrossModuleMixin:
             "byte_to_int", "int_to_byte",
             "is_nan", "is_infinite", "nan", "infinity",
             "async", "await",
+            "md_parse", "md_render", "md_has_heading",
+            "md_has_code_block", "md_extract_code_blocks",
         })
 
         seen: set[str] = set()  # deduplicate by function name

--- a/vera/codegen/registration.py
+++ b/vera/codegen/registration.py
@@ -69,6 +69,68 @@ class RegistrationMixin:
                 tag=0, field_offsets=(), total_size=8,
             ),
         }
+        # MdInline — inline Markdown elements (6 constructors)
+        # String/Array fields are i32_pair (8 bytes, 4-byte align)
+        self._adt_layouts["MdInline"] = {
+            "MdText": ConstructorLayout(
+                tag=0, field_offsets=((4, "i32_pair"),), total_size=16,
+            ),
+            "MdCode": ConstructorLayout(
+                tag=1, field_offsets=((4, "i32_pair"),), total_size=16,
+            ),
+            "MdEmph": ConstructorLayout(
+                tag=2, field_offsets=((4, "i32_pair"),), total_size=16,
+            ),
+            "MdStrong": ConstructorLayout(
+                tag=3, field_offsets=((4, "i32_pair"),), total_size=16,
+            ),
+            "MdLink": ConstructorLayout(
+                tag=4,
+                field_offsets=((4, "i32_pair"), (12, "i32_pair")),
+                total_size=24,
+            ),
+            "MdImage": ConstructorLayout(
+                tag=5,
+                field_offsets=((4, "i32_pair"), (12, "i32_pair")),
+                total_size=24,
+            ),
+        }
+        # MdBlock — block-level Markdown elements (8 constructors)
+        # MdHeading: Nat (i64, 8-byte align) at offset 8, Array at 16
+        # MdList: Bool (i32) at offset 4, Array at offset 8
+        # MdThematicBreak: no fields (tag only)
+        self._adt_layouts["MdBlock"] = {
+            "MdParagraph": ConstructorLayout(
+                tag=0, field_offsets=((4, "i32_pair"),), total_size=16,
+            ),
+            "MdHeading": ConstructorLayout(
+                tag=1,
+                field_offsets=((8, "i64"), (16, "i32_pair")),
+                total_size=24,
+            ),
+            "MdCodeBlock": ConstructorLayout(
+                tag=2,
+                field_offsets=((4, "i32_pair"), (12, "i32_pair")),
+                total_size=24,
+            ),
+            "MdBlockQuote": ConstructorLayout(
+                tag=3, field_offsets=((4, "i32_pair"),), total_size=16,
+            ),
+            "MdList": ConstructorLayout(
+                tag=4,
+                field_offsets=((4, "i32"), (8, "i32_pair")),
+                total_size=16,
+            ),
+            "MdThematicBreak": ConstructorLayout(
+                tag=5, field_offsets=(), total_size=8,
+            ),
+            "MdTable": ConstructorLayout(
+                tag=6, field_offsets=((4, "i32_pair"),), total_size=16,
+            ),
+            "MdDocument": ConstructorLayout(
+                tag=7, field_offsets=((4, "i32_pair"),), total_size=16,
+            ),
+        }
 
     def _register_data(self, decl: ast.DataDecl) -> None:
         """Register an ADT and precompute constructor layouts."""

--- a/vera/environment.py
+++ b/vera/environment.py
@@ -199,6 +199,84 @@ class TypeEnv:
         for c in self.data_types["Future"].constructors.values():
             self.constructors[c.name] = c
 
+        # MdInline — inline Markdown elements (§9.3.5 / §9.7.3)
+        _MD_INLINE = AdtType("MdInline", ())
+        _ARR_MD_INLINE = AdtType("Array", (_MD_INLINE,))
+        self.data_types["MdInline"] = AdtInfo(
+            name="MdInline",
+            type_params=(),
+            constructors={
+                "MdText": ConstructorInfo(
+                    "MdText", "MdInline", (), (STRING,),
+                ),
+                "MdCode": ConstructorInfo(
+                    "MdCode", "MdInline", (), (STRING,),
+                ),
+                "MdEmph": ConstructorInfo(
+                    "MdEmph", "MdInline", (), (_ARR_MD_INLINE,),
+                ),
+                "MdStrong": ConstructorInfo(
+                    "MdStrong", "MdInline", (), (_ARR_MD_INLINE,),
+                ),
+                "MdLink": ConstructorInfo(
+                    "MdLink", "MdInline", (),
+                    (_ARR_MD_INLINE, STRING),
+                ),
+                "MdImage": ConstructorInfo(
+                    "MdImage", "MdInline", (), (STRING, STRING),
+                ),
+            },
+        )
+        for c in self.data_types["MdInline"].constructors.values():
+            self.constructors[c.name] = c
+
+        # MdBlock — block-level Markdown elements (§9.3.6 / §9.7.3)
+        _MD_BLOCK = AdtType("MdBlock", ())
+        _ARR_MD_BLOCK = AdtType("Array", (_MD_BLOCK,))
+        _ARR_ARR_MD_BLOCK = AdtType("Array", (_ARR_MD_BLOCK,))
+        _ARR_ARR_ARR_MD_INLINE = AdtType(
+            "Array", (AdtType("Array", (_ARR_MD_INLINE,)),),
+        )
+        self.data_types["MdBlock"] = AdtInfo(
+            name="MdBlock",
+            type_params=(),
+            constructors={
+                "MdParagraph": ConstructorInfo(
+                    "MdParagraph", "MdBlock", (),
+                    (_ARR_MD_INLINE,),
+                ),
+                "MdHeading": ConstructorInfo(
+                    "MdHeading", "MdBlock", (),
+                    (NAT, _ARR_MD_INLINE),
+                ),
+                "MdCodeBlock": ConstructorInfo(
+                    "MdCodeBlock", "MdBlock", (),
+                    (STRING, STRING),
+                ),
+                "MdBlockQuote": ConstructorInfo(
+                    "MdBlockQuote", "MdBlock", (),
+                    (_ARR_MD_BLOCK,),
+                ),
+                "MdList": ConstructorInfo(
+                    "MdList", "MdBlock", (),
+                    (BOOL, _ARR_ARR_MD_BLOCK),
+                ),
+                "MdThematicBreak": ConstructorInfo(
+                    "MdThematicBreak", "MdBlock", (), (),
+                ),
+                "MdTable": ConstructorInfo(
+                    "MdTable", "MdBlock", (),
+                    (_ARR_ARR_ARR_MD_INLINE,),
+                ),
+                "MdDocument": ConstructorInfo(
+                    "MdDocument", "MdBlock", (),
+                    (_ARR_MD_BLOCK,),
+                ),
+            },
+        )
+        for c in self.data_types["MdBlock"].constructors.values():
+            self.constructors[c.name] = c
+
         # State<T> effect with get/put
         self.effects["State"] = EffectInfo(
             name="State",
@@ -407,6 +485,45 @@ class TypeEnv:
             forall_vars=None,
             param_types=(AdtType("UrlParts", ()),),
             return_type=STRING,
+            effect=PureEffectRow(),
+        )
+        # Markdown builtins — pure host-import functions (§9.7.3)
+        _MD_BLOCK_TYPE = AdtType("MdBlock", ())
+        self.functions["md_parse"] = FunctionInfo(
+            name="md_parse",
+            forall_vars=None,
+            param_types=(STRING,),
+            return_type=AdtType(
+                "Result", (_MD_BLOCK_TYPE, STRING),
+            ),
+            effect=PureEffectRow(),
+        )
+        self.functions["md_render"] = FunctionInfo(
+            name="md_render",
+            forall_vars=None,
+            param_types=(_MD_BLOCK_TYPE,),
+            return_type=STRING,
+            effect=PureEffectRow(),
+        )
+        self.functions["md_has_heading"] = FunctionInfo(
+            name="md_has_heading",
+            forall_vars=None,
+            param_types=(_MD_BLOCK_TYPE, NAT),
+            return_type=BOOL,
+            effect=PureEffectRow(),
+        )
+        self.functions["md_has_code_block"] = FunctionInfo(
+            name="md_has_code_block",
+            forall_vars=None,
+            param_types=(_MD_BLOCK_TYPE, STRING),
+            return_type=BOOL,
+            effect=PureEffectRow(),
+        )
+        self.functions["md_extract_code_blocks"] = FunctionInfo(
+            name="md_extract_code_blocks",
+            forall_vars=None,
+            param_types=(_MD_BLOCK_TYPE, STRING),
+            return_type=AdtType("Array", (STRING,)),
             effect=PureEffectRow(),
         )
         # Async builtins — require effects(<Async>)

--- a/vera/markdown.py
+++ b/vera/markdown.py
@@ -1,0 +1,651 @@
+"""Pure-Python Markdown parser and renderer for the §9.7.3 subset.
+
+Provides Python dataclasses mirroring the Vera MdInline/MdBlock ADTs,
+plus five functions: parse_markdown, render_markdown, has_heading,
+has_code_block, extract_code_blocks.
+
+This is the **reference implementation** for the host-imported Markdown
+functions.  The same .wasm binary works with any host runtime (Python,
+JavaScript, Rust) that provides matching implementations of the WASM
+import signatures defined in assembly.py.
+
+Design constraints:
+  - No external dependencies (hand-written parser for the §9.7.3 subset).
+  - CommonMark-inspired but intentionally simplified per §9.7.3 design
+    notes: no raw HTML, no link references, no setext headings, no
+    indented code blocks, no hard/soft line breaks.
+  - GFM tables are supported (ubiquitous in agent communication).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+
+# =====================================================================
+# ADT dataclasses — mirrors Vera MdInline / MdBlock
+# =====================================================================
+
+
+@dataclass(frozen=True, eq=True)
+class MdText:
+    """Plain text run."""
+    text: str
+
+
+@dataclass(frozen=True, eq=True)
+class MdCode:
+    """Inline code span."""
+    code: str
+
+
+@dataclass(frozen=True, eq=True)
+class MdEmph:
+    """Emphasis (italic)."""
+    children: tuple[MdInline, ...]
+
+
+@dataclass(frozen=True, eq=True)
+class MdStrong:
+    """Strong emphasis (bold)."""
+    children: tuple[MdInline, ...]
+
+
+@dataclass(frozen=True, eq=True)
+class MdLink:
+    """Hyperlink: display text + URL."""
+    children: tuple[MdInline, ...]
+    url: str
+
+
+@dataclass(frozen=True, eq=True)
+class MdImage:
+    """Image: alt text + source URL."""
+    alt: str
+    src: str
+
+
+MdInline = MdText | MdCode | MdEmph | MdStrong | MdLink | MdImage
+
+
+@dataclass(frozen=True, eq=True)
+class MdParagraph:
+    """Paragraph: sequence of inline content."""
+    children: tuple[MdInline, ...]
+
+
+@dataclass(frozen=True, eq=True)
+class MdHeading:
+    """Heading: level (1-6) + inline content."""
+    level: int
+    children: tuple[MdInline, ...]
+
+
+@dataclass(frozen=True, eq=True)
+class MdCodeBlock:
+    """Fenced code block: language + code body."""
+    language: str
+    code: str
+
+
+@dataclass(frozen=True, eq=True)
+class MdBlockQuote:
+    """Block quote: recursive block content."""
+    children: tuple[MdBlock, ...]
+
+
+@dataclass(frozen=True, eq=True)
+class MdList:
+    """List: ordered (True) or unordered (False), with items."""
+    ordered: bool
+    items: tuple[tuple[MdBlock, ...], ...]
+
+
+@dataclass(frozen=True, eq=True)
+class MdThematicBreak:
+    """Horizontal rule."""
+    pass
+
+
+@dataclass(frozen=True, eq=True)
+class MdTable:
+    """Table: rows × cells × inline content."""
+    rows: tuple[tuple[tuple[MdInline, ...], ...], ...]
+
+
+@dataclass(frozen=True, eq=True)
+class MdDocument:
+    """Top-level document: sequence of blocks."""
+    children: tuple[MdBlock, ...]
+
+
+MdBlock = (
+    MdParagraph | MdHeading | MdCodeBlock | MdBlockQuote
+    | MdList | MdThematicBreak | MdTable | MdDocument
+)
+
+
+# =====================================================================
+# Block-level parser
+# =====================================================================
+
+# Regex patterns for block-level constructs
+_ATX_HEADING = re.compile(r"^(#{1,6})\s+(.*?)(?:\s+#+\s*)?$")
+_FENCE_OPEN = re.compile(r"^(`{3,}|~{3,})\s*(.*?)$")
+_THEMATIC_BREAK = re.compile(r"^(?:---+|\*\*\*+|___+)\s*$")
+_BLOCKQUOTE_LINE = re.compile(r"^>\s?(.*)")
+_UNORDERED_ITEM = re.compile(r"^[-*+]\s+(.*)")
+_ORDERED_ITEM = re.compile(r"^(\d+)[.)]\s+(.*)")
+_TABLE_ROW = re.compile(r"^\|(.+)\|?\s*$")
+_TABLE_SEP = re.compile(r"^\|[\s:]*-[-\s:|]*\|?\s*$")
+
+
+def parse_markdown(text: str) -> MdDocument:
+    """Parse a Markdown string into an MdDocument.
+
+    This is the reference implementation for Vera's md_parse built-in.
+    Supports the §9.7.3 subset: ATX headings, fenced code blocks, block
+    quotes, ordered/unordered lists, thematic breaks, GFM tables, and
+    paragraphs.  Inline parsing handles emphasis, strong, code spans,
+    links, and images.
+    """
+    lines = text.split("\n")
+    blocks = _parse_blocks(lines, 0, len(lines))
+    return MdDocument(tuple(blocks))
+
+
+def _parse_blocks(lines: list[str], start: int, end: int) -> list[MdBlock]:
+    """Parse a range of lines into block-level elements."""
+    blocks: list[MdBlock] = []
+    i = start
+
+    while i < end:
+        line = lines[i]
+
+        # Blank line — skip
+        if not line.strip():
+            i += 1
+            continue
+
+        # ATX heading
+        m = _ATX_HEADING.match(line)
+        if m:
+            level = len(m.group(1))
+            content = m.group(2).strip()
+            blocks.append(MdHeading(level, tuple(_parse_inlines(content))))
+            i += 1
+            continue
+
+        # Fenced code block
+        m = _FENCE_OPEN.match(line)
+        if m:
+            fence_char = m.group(1)[0]
+            fence_len = len(m.group(1))
+            lang = m.group(2).strip()
+            code_lines: list[str] = []
+            i += 1
+            while i < end:
+                close_match = re.match(
+                    rf"^{re.escape(fence_char)}{{{fence_len},}}\s*$",
+                    lines[i],
+                )
+                if close_match:
+                    i += 1
+                    break
+                code_lines.append(lines[i])
+                i += 1
+            blocks.append(MdCodeBlock(lang, "\n".join(code_lines)))
+            continue
+
+        # Thematic break
+        if _THEMATIC_BREAK.match(line):
+            blocks.append(MdThematicBreak())
+            i += 1
+            continue
+
+        # Block quote
+        bq_match = _BLOCKQUOTE_LINE.match(line)
+        if bq_match:
+            bq_lines: list[str] = []
+            while i < end:
+                bq_m = _BLOCKQUOTE_LINE.match(lines[i])
+                if bq_m:
+                    bq_lines.append(bq_m.group(1))
+                elif lines[i].strip() and not _is_block_start(lines[i]):
+                    # Lazy continuation
+                    bq_lines.append(lines[i])
+                else:
+                    break
+                i += 1
+            inner = _parse_blocks(bq_lines, 0, len(bq_lines))
+            blocks.append(MdBlockQuote(tuple(inner)))
+            continue
+
+        # GFM table (must have header + separator row)
+        if _TABLE_ROW.match(line) and i + 1 < end and _TABLE_SEP.match(
+            lines[i + 1]
+        ):
+            table_rows: list[tuple[tuple[MdInline, ...], ...]] = []
+            # Header row
+            table_rows.append(_parse_table_row(line))
+            i += 2  # skip separator
+            while i < end and _TABLE_ROW.match(lines[i]):
+                table_rows.append(_parse_table_row(lines[i]))
+                i += 1
+            blocks.append(MdTable(tuple(table_rows)))
+            continue
+
+        # Unordered list
+        ul_match = _UNORDERED_ITEM.match(line)
+        if ul_match:
+            items: list[tuple[MdBlock, ...]] = []
+            while i < end:
+                ul_m = _UNORDERED_ITEM.match(lines[i])
+                if not ul_m:
+                    break
+                item_lines = [ul_m.group(1)]
+                i += 1
+                # Continuation lines (indented)
+                while i < end and lines[i].startswith("  ") and lines[i].strip():
+                    item_lines.append(lines[i][2:])
+                    i += 1
+                # Skip blank lines between items
+                while i < end and not lines[i].strip():
+                    i += 1
+                    # But only if next line is still a list item
+                    if i < end and not _UNORDERED_ITEM.match(lines[i]):
+                        break
+                item_blocks = _parse_blocks(item_lines, 0, len(item_lines))
+                items.append(tuple(item_blocks))
+            blocks.append(MdList(False, tuple(items)))
+            continue
+
+        # Ordered list
+        ol_match = _ORDERED_ITEM.match(line)
+        if ol_match:
+            items_ol: list[tuple[MdBlock, ...]] = []
+            while i < end:
+                ol_m = _ORDERED_ITEM.match(lines[i])
+                if not ol_m:
+                    break
+                item_lines_ol = [ol_m.group(2)]
+                i += 1
+                # Continuation lines (indented)
+                while i < end and lines[i].startswith("   ") and lines[i].strip():
+                    item_lines_ol.append(lines[i][3:])
+                    i += 1
+                # Skip blank lines between items
+                while i < end and not lines[i].strip():
+                    i += 1
+                    if i < end and not _ORDERED_ITEM.match(lines[i]):
+                        break
+                item_blocks_ol = _parse_blocks(
+                    item_lines_ol, 0, len(item_lines_ol),
+                )
+                items_ol.append(tuple(item_blocks_ol))
+            blocks.append(MdList(True, tuple(items_ol)))
+            continue
+
+        # Paragraph (default fallback — collect until blank or block start)
+        para_lines: list[str] = []
+        while i < end and lines[i].strip() and not _is_block_start(lines[i]):
+            para_lines.append(lines[i])
+            i += 1
+        if para_lines:
+            text_content = " ".join(para_lines)
+            blocks.append(
+                MdParagraph(tuple(_parse_inlines(text_content))),
+            )
+
+    return blocks
+
+
+def _is_block_start(line: str) -> bool:
+    """Check if a line starts a new block-level construct."""
+    if _ATX_HEADING.match(line):
+        return True
+    if _FENCE_OPEN.match(line):
+        return True
+    if _THEMATIC_BREAK.match(line):
+        return True
+    if _BLOCKQUOTE_LINE.match(line):
+        return True
+    if _UNORDERED_ITEM.match(line):
+        return True
+    if _ORDERED_ITEM.match(line):
+        return True
+    return False
+
+
+def _parse_table_row(line: str) -> tuple[tuple[MdInline, ...], ...]:
+    """Parse a GFM table row into cells of inline content."""
+    # Strip leading/trailing pipes and split
+    content = line.strip()
+    if content.startswith("|"):
+        content = content[1:]
+    if content.endswith("|"):
+        content = content[:-1]
+    cells = content.split("|")
+    return tuple(tuple(_parse_inlines(cell.strip())) for cell in cells)
+
+
+# =====================================================================
+# Inline-level parser
+# =====================================================================
+
+def _parse_inlines(text: str) -> list[MdInline]:
+    """Parse inline Markdown content into MdInline nodes.
+
+    Handles: code spans, images, links, strong (**), emphasis (*), and
+    plain text.  Processes left-to-right with greedy matching.
+    """
+    result: list[MdInline] = []
+    i = 0
+    buf: list[str] = []  # accumulator for plain text
+
+    def flush_text() -> None:
+        if buf:
+            result.append(MdText("".join(buf)))
+            buf.clear()
+
+    while i < len(text):
+        ch = text[i]
+
+        # Inline code span
+        if ch == "`":
+            # Count backtick run length
+            run_start = i
+            while i < len(text) and text[i] == "`":
+                i += 1
+            run_len = i - run_start
+            # Find matching closing run
+            close_pat = "`" * run_len
+            close_idx = text.find(close_pat, i)
+            if close_idx != -1:
+                flush_text()
+                code_content = text[i:close_idx]
+                # Strip one leading/trailing space if both present
+                if (len(code_content) >= 2
+                        and code_content[0] == " "
+                        and code_content[-1] == " "):
+                    code_content = code_content[1:-1]
+                result.append(MdCode(code_content))
+                i = close_idx + run_len
+            else:
+                buf.append(close_pat[:run_len])
+            continue
+
+        # Image: ![alt](src)
+        if ch == "!" and i + 1 < len(text) and text[i + 1] == "[":
+            close_bracket = _find_matching_bracket(text, i + 1)
+            if close_bracket is not None and close_bracket + 1 < len(text) and text[close_bracket + 1] == "(":
+                close_paren = text.find(")", close_bracket + 2)
+                if close_paren != -1:
+                    flush_text()
+                    alt = text[i + 2:close_bracket]
+                    src = text[close_bracket + 2:close_paren]
+                    result.append(MdImage(alt, src))
+                    i = close_paren + 1
+                    continue
+            buf.append(ch)
+            i += 1
+            continue
+
+        # Link: [text](url)
+        if ch == "[":
+            close_bracket = _find_matching_bracket(text, i)
+            if close_bracket is not None and close_bracket + 1 < len(text) and text[close_bracket + 1] == "(":
+                close_paren = text.find(")", close_bracket + 2)
+                if close_paren != -1:
+                    flush_text()
+                    link_text = text[i + 1:close_bracket]
+                    url = text[close_bracket + 2:close_paren]
+                    children = _parse_inlines(link_text)
+                    result.append(MdLink(tuple(children), url))
+                    i = close_paren + 1
+                    continue
+            buf.append(ch)
+            i += 1
+            continue
+
+        # Strong (**) or emphasis (*)
+        if ch == "*" or ch == "_":
+            # Count delimiter run
+            delim = ch
+            run_start = i
+            while i < len(text) and text[i] == delim:
+                i += 1
+            run_len = i - run_start
+
+            if run_len >= 2:
+                # Try strong first (**)
+                close_idx = text.find(delim * 2, i)
+                if close_idx != -1:
+                    flush_text()
+                    inner = _parse_inlines(text[i:close_idx])
+                    result.append(MdStrong(tuple(inner)))
+                    i = close_idx + 2
+                    # Handle remaining delimiters from the opening run
+                    remaining = run_len - 2
+                    if remaining > 0:
+                        # Leftover * becomes emphasis or text
+                        close_single = text.find(delim, i)
+                        if remaining == 1 and close_single != -1:
+                            inner2 = _parse_inlines(text[i:close_single])
+                            result.append(MdEmph(tuple(inner2)))
+                            i = close_single + 1
+                        else:
+                            buf.append(delim * remaining)
+                    continue
+                # Fall through to try single emphasis
+                i = run_start + 1
+                run_len = 1
+
+            if run_len == 1:
+                # Emphasis (*)
+                close_idx = text.find(delim, i)
+                if close_idx != -1:
+                    flush_text()
+                    inner = _parse_inlines(text[i:close_idx])
+                    result.append(MdEmph(tuple(inner)))
+                    i = close_idx + 1
+                    continue
+                else:
+                    buf.append(delim)
+                    continue
+
+        # Plain character
+        buf.append(ch)
+        i += 1
+
+    flush_text()
+    return result
+
+
+def _find_matching_bracket(text: str, start: int) -> int | None:
+    """Find the matching ] for a [ at position start."""
+    if start >= len(text) or text[start] != "[":
+        return None
+    depth = 0
+    i = start
+    while i < len(text):
+        if text[i] == "[":
+            depth += 1
+        elif text[i] == "]":
+            depth -= 1
+            if depth == 0:
+                return i
+        i += 1
+    return None
+
+
+# =====================================================================
+# Renderer — MdBlock/MdInline → canonical Markdown string
+# =====================================================================
+
+def render_markdown(block: MdBlock) -> str:
+    """Render an MdBlock to a canonical Markdown string.
+
+    The round-trip property md_parse(md_render(b)) ≈ b should hold
+    for well-formed documents.
+    """
+    lines = _render_block(block)
+    return "\n".join(lines)
+
+
+def _render_block(block: MdBlock) -> list[str]:
+    """Render a single block to lines of Markdown."""
+    if isinstance(block, MdDocument):
+        result: list[str] = []
+        for i, child in enumerate(block.children):
+            if i > 0:
+                result.append("")
+            result.extend(_render_block(child))
+        return result
+
+    if isinstance(block, MdParagraph):
+        return [_render_inlines(block.children)]
+
+    if isinstance(block, MdHeading):
+        prefix = "#" * block.level
+        return [f"{prefix} {_render_inlines(block.children)}"]
+
+    if isinstance(block, MdCodeBlock):
+        lines = [f"```{block.language}"]
+        lines.extend(block.code.split("\n"))
+        lines.append("```")
+        return lines
+
+    if isinstance(block, MdBlockQuote):
+        result = []
+        for child in block.children:
+            child_lines = _render_block(child)
+            for line in child_lines:
+                result.append(f"> {line}" if line else ">")
+        return result
+
+    if isinstance(block, MdList):
+        result = []
+        for idx, item in enumerate(block.items):
+            marker = f"{idx + 1}." if block.ordered else "-"
+            item_lines: list[str] = []
+            for child in item:
+                item_lines.extend(_render_block(child))
+            for j, line in enumerate(item_lines):
+                if j == 0:
+                    result.append(f"{marker} {line}")
+                else:
+                    indent = " " * (len(marker) + 1)
+                    result.append(f"{indent}{line}")
+        return result
+
+    if isinstance(block, MdThematicBreak):
+        return ["---"]
+
+    if isinstance(block, MdTable):
+        if not block.rows:
+            return []
+        result = []
+        # Header row
+        header = block.rows[0]
+        header_cells = [_render_inlines(cell) for cell in header]
+        result.append("| " + " | ".join(header_cells) + " |")
+        # Separator
+        sep_cells = ["---"] * len(header)
+        result.append("| " + " | ".join(sep_cells) + " |")
+        # Data rows
+        for row in block.rows[1:]:
+            cells = [_render_inlines(cell) for cell in row]
+            result.append("| " + " | ".join(cells) + " |")
+        return result
+
+    return []
+
+
+def _render_inlines(inlines: tuple[MdInline, ...]) -> str:
+    """Render inline content to a string."""
+    parts: list[str] = []
+    for inline in inlines:
+        if isinstance(inline, MdText):
+            parts.append(inline.text)
+        elif isinstance(inline, MdCode):
+            # Use backtick wrapping that avoids conflicts
+            if "`" in inline.code:
+                parts.append(f"`` {inline.code} ``")
+            else:
+                parts.append(f"`{inline.code}`")
+        elif isinstance(inline, MdEmph):
+            parts.append(f"*{_render_inlines(inline.children)}*")
+        elif isinstance(inline, MdStrong):
+            parts.append(f"**{_render_inlines(inline.children)}**")
+        elif isinstance(inline, MdLink):
+            text = _render_inlines(inline.children)
+            parts.append(f"[{text}]({inline.url})")
+        elif isinstance(inline, MdImage):
+            parts.append(f"![{inline.alt}]({inline.src})")
+    return "".join(parts)
+
+
+# =====================================================================
+# Query functions
+# =====================================================================
+
+def has_heading(block: MdBlock, level: int) -> bool:
+    """Return True if the block tree contains a heading of the given level."""
+    if isinstance(block, MdHeading):
+        return block.level == level
+    if isinstance(block, MdDocument):
+        return any(has_heading(child, level) for child in block.children)
+    if isinstance(block, MdBlockQuote):
+        return any(has_heading(child, level) for child in block.children)
+    if isinstance(block, MdList):
+        return any(
+            has_heading(child, level)
+            for item in block.items
+            for child in item
+        )
+    return False
+
+
+def has_code_block(block: MdBlock, language: str) -> bool:
+    """Return True if the block tree contains a code block with the given language."""
+    if isinstance(block, MdCodeBlock):
+        return block.language == language
+    if isinstance(block, MdDocument):
+        return any(has_code_block(child, language) for child in block.children)
+    if isinstance(block, MdBlockQuote):
+        return any(has_code_block(child, language) for child in block.children)
+    if isinstance(block, MdList):
+        return any(
+            has_code_block(child, language)
+            for item in block.items
+            for child in item
+        )
+    return False
+
+
+def extract_code_blocks(block: MdBlock, language: str) -> list[str]:
+    """Extract code from all code blocks with the given language tag."""
+    results: list[str] = []
+    _collect_code_blocks(block, language, results)
+    return results
+
+
+def _collect_code_blocks(
+    block: MdBlock, language: str, acc: list[str],
+) -> None:
+    """Recursively collect code block contents matching a language."""
+    if isinstance(block, MdCodeBlock):
+        if block.language == language:
+            acc.append(block.code)
+    elif isinstance(block, MdDocument):
+        for child in block.children:
+            _collect_code_blocks(child, language, acc)
+    elif isinstance(block, MdBlockQuote):
+        for child in block.children:
+            _collect_code_blocks(child, language, acc)
+    elif isinstance(block, MdList):
+        for item in block.items:
+            for child in item:
+                _collect_code_blocks(child, language, acc)

--- a/vera/wasm/calls.py
+++ b/vera/wasm/calls.py
@@ -72,6 +72,23 @@ class CallsMixin:
                 return self._translate_url_join(call.args[0], env)
             # Async builtins — identity (eager evaluation, Future<T>
             # is WASM-transparent)
+            # Markdown host-import builtins (pure, implemented in Python)
+            if call.name == "md_parse" and len(call.args) == 1:
+                return self._translate_md_parse(call.args[0], env)
+            if call.name == "md_render" and len(call.args) == 1:
+                return self._translate_md_render(call.args[0], env)
+            if call.name == "md_has_heading" and len(call.args) == 2:
+                return self._translate_md_has_heading(
+                    call.args[0], call.args[1], env,
+                )
+            if call.name == "md_has_code_block" and len(call.args) == 2:
+                return self._translate_md_has_code_block(
+                    call.args[0], call.args[1], env,
+                )
+            if call.name == "md_extract_code_blocks" and len(call.args) == 2:
+                return self._translate_md_extract_code_blocks(
+                    call.args[0], call.args[1], env,
+                )
             if call.name == "async" and len(call.args) == 1:
                 return self._translate_async(call.args[0], env)
             if call.name == "await" and len(call.args) == 1:
@@ -4079,6 +4096,94 @@ class CallsMixin:
         ins.append(f"local.get {dst}")
         ins.append(f"local.get {total}")
         return ins
+
+    # ---- Markdown host-import builtins ---------------------------------
+
+    def _translate_md_parse(
+        self, arg: ast.Expr, env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """md_parse(s) → Result<MdBlock, String> via host import.
+
+        String arg is (ptr, len) pair on stack → call $vera.md_parse → i32.
+        """
+        arg_instrs = self.translate_expr(arg, env)
+        if arg_instrs is None:
+            return None
+        self.needs_alloc = True
+        ins: list[str] = []
+        ins.extend(arg_instrs)
+        ins.append("call $vera.md_parse")
+        return ins
+
+    def _translate_md_render(
+        self, arg: ast.Expr, env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """md_render(block) → String via host import.
+
+        MdBlock arg is i32 (heap ptr) → call $vera.md_render → (i32, i32).
+        """
+        arg_instrs = self.translate_expr(arg, env)
+        if arg_instrs is None:
+            return None
+        self.needs_alloc = True
+        ins: list[str] = []
+        ins.extend(arg_instrs)
+        ins.append("call $vera.md_render")
+        return ins
+
+    def _translate_md_has_heading(
+        self, block_arg: ast.Expr, level_arg: ast.Expr, env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """md_has_heading(block, level) → Bool via host import.
+
+        (i32 ptr, i64 level) → call $vera.md_has_heading → i32.
+        """
+        b_instrs = self.translate_expr(block_arg, env)
+        l_instrs = self.translate_expr(level_arg, env)
+        if b_instrs is None or l_instrs is None:
+            return None
+        ins: list[str] = []
+        ins.extend(b_instrs)
+        ins.extend(l_instrs)
+        ins.append("call $vera.md_has_heading")
+        return ins
+
+    def _translate_md_has_code_block(
+        self, block_arg: ast.Expr, lang_arg: ast.Expr, env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """md_has_code_block(block, lang) → Bool via host import.
+
+        (i32 ptr, i32 lang_ptr, i32 lang_len) → call → i32.
+        """
+        b_instrs = self.translate_expr(block_arg, env)
+        l_instrs = self.translate_expr(lang_arg, env)
+        if b_instrs is None or l_instrs is None:
+            return None
+        ins: list[str] = []
+        ins.extend(b_instrs)
+        ins.extend(l_instrs)
+        ins.append("call $vera.md_has_code_block")
+        return ins
+
+    def _translate_md_extract_code_blocks(
+        self, block_arg: ast.Expr, lang_arg: ast.Expr, env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """md_extract_code_blocks(block, lang) → Array<String> via host import.
+
+        (i32 ptr, i32 lang_ptr, i32 lang_len) → call → (i32, i32).
+        """
+        b_instrs = self.translate_expr(block_arg, env)
+        l_instrs = self.translate_expr(lang_arg, env)
+        if b_instrs is None or l_instrs is None:
+            return None
+        self.needs_alloc = True
+        ins: list[str] = []
+        ins.extend(b_instrs)
+        ins.extend(l_instrs)
+        ins.append("call $vera.md_extract_code_blocks")
+        return ins
+
+    # ---- Async builtins -----------------------------------------------
 
     def _translate_async(
         self, arg: ast.Expr, env: WasmSlotEnv,

--- a/vera/wasm/context.py
+++ b/vera/wasm/context.py
@@ -369,8 +369,8 @@ class WasmContext(
         if isinstance(expr, ast.MatchExpr):
             return all(self._is_void_expr(arm.body) for arm in expr.arms)
         if isinstance(expr, ast.IfExpr):
-            return (self._is_void_expr(expr.then_expr)
-                    and self._is_void_expr(expr.else_expr))
+            return (self._is_void_expr(expr.then_branch)
+                    and self._is_void_expr(expr.else_branch))
         if isinstance(expr, ast.Block):
             return self._is_void_expr(expr.expr)
         return False

--- a/vera/wasm/inference.py
+++ b/vera/wasm/inference.py
@@ -231,6 +231,11 @@ class InferenceMixin:
             return "i32_pair"
         if expr.name == "url_parse":
             return "i32"
+        # Markdown builtins
+        if expr.name in ("md_parse", "md_has_heading", "md_has_code_block"):
+            return "i32"
+        if expr.name in ("md_render", "md_extract_code_blocks"):
+            return "i32_pair"
         # Async builtins — identity operations (Future<T> is transparent)
         if expr.name in ("async", "await") and expr.args:
             return self._infer_expr_wasm_type(expr.args[0])
@@ -414,6 +419,15 @@ class InferenceMixin:
             return "String"
         if call.name == "url_parse":
             return "Result"
+        # Markdown builtins
+        if call.name == "md_parse":
+            return "Result"
+        if call.name == "md_render":
+            return "String"
+        if call.name in ("md_has_heading", "md_has_code_block"):
+            return "Bool"
+        if call.name == "md_extract_code_blocks":
+            return "Array"
         # Async builtins — Future<T> is transparent
         if call.name == "async" and call.args:
             inner = self._infer_fncall_vera_type(call.args[0]) \

--- a/vera/wasm/markdown.py
+++ b/vera/wasm/markdown.py
@@ -1,0 +1,537 @@
+"""WASM memory marshalling for MdInline / MdBlock ADTs.
+
+Provides bidirectional conversion between Python Markdown dataclasses
+(vera.markdown) and their WASM memory representations.  Used by the
+host function bindings in vera.codegen.api.
+
+Write direction (Python → WASM):
+  write_md_inline(caller, alloc, write_i32, write_i64, write_bytes, inline) → ptr
+  write_md_block(caller, alloc, write_i32, write_i64, write_bytes, block) → ptr
+
+Read direction (WASM → Python):
+  read_md_block(caller, ptr) → MdBlock
+  read_md_inline(caller, ptr) → MdInline
+
+All layouts match the ConstructorLayout registrations in
+vera/codegen/registration.py.
+"""
+
+from __future__ import annotations
+
+import struct
+from typing import Callable
+
+import wasmtime
+
+from vera.markdown import (
+    MdBlock,
+    MdBlockQuote,
+    MdCode,
+    MdCodeBlock,
+    MdDocument,
+    MdEmph,
+    MdHeading,
+    MdImage,
+    MdInline,
+    MdLink,
+    MdList,
+    MdParagraph,
+    MdStrong,
+    MdTable,
+    MdText,
+    MdThematicBreak,
+)
+
+# Type aliases for the helper functions passed from api.py
+AllocFn = Callable[["wasmtime.Caller", int], int]
+WriteI32Fn = Callable[["wasmtime.Caller", int, int], None]
+WriteI64Fn = Callable[["wasmtime.Caller", int, int], None]
+WriteBytesFn = Callable[["wasmtime.Caller", int, bytes], None]
+AllocStringFn = Callable[["wasmtime.Caller", str], tuple[int, int]]
+
+
+# =====================================================================
+# Write direction: Python → WASM memory
+# =====================================================================
+
+
+def write_md_inline(
+    caller: wasmtime.Caller,
+    alloc: AllocFn,
+    write_i32: WriteI32Fn,
+    alloc_string: AllocStringFn,
+    inline: MdInline,
+) -> int:
+    """Allocate an MdInline ADT node in WASM memory.  Returns the heap pointer.
+
+    MdInline layouts (from registration.py):
+      MdText(String)           tag=0  (4, i32_pair)  total=16
+      MdCode(String)           tag=1  (4, i32_pair)  total=16
+      MdEmph(Array<MdInline>)  tag=2  (4, i32_pair)  total=16
+      MdStrong(Array<MdInline>)tag=3  (4, i32_pair)  total=16
+      MdLink(Array, String)    tag=4  (4, i32_pair) (12, i32_pair)  total=24
+      MdImage(String, String)  tag=5  (4, i32_pair) (12, i32_pair)  total=24
+    """
+    if isinstance(inline, MdText):
+        ptr = alloc(caller, 16)
+        write_i32(caller, ptr, 0)  # tag
+        s_ptr, s_len = alloc_string(caller, inline.text)
+        write_i32(caller, ptr + 4, s_ptr)
+        write_i32(caller, ptr + 8, s_len)
+        return ptr
+
+    if isinstance(inline, MdCode):
+        ptr = alloc(caller, 16)
+        write_i32(caller, ptr, 1)  # tag
+        s_ptr, s_len = alloc_string(caller, inline.code)
+        write_i32(caller, ptr + 4, s_ptr)
+        write_i32(caller, ptr + 8, s_len)
+        return ptr
+
+    if isinstance(inline, MdEmph):
+        ptr = alloc(caller, 16)
+        write_i32(caller, ptr, 2)  # tag
+        arr_ptr, arr_len = _write_inline_array(
+            caller, alloc, write_i32, alloc_string, inline.children,
+        )
+        write_i32(caller, ptr + 4, arr_ptr)
+        write_i32(caller, ptr + 8, arr_len)
+        return ptr
+
+    if isinstance(inline, MdStrong):
+        ptr = alloc(caller, 16)
+        write_i32(caller, ptr, 3)  # tag
+        arr_ptr, arr_len = _write_inline_array(
+            caller, alloc, write_i32, alloc_string, inline.children,
+        )
+        write_i32(caller, ptr + 4, arr_ptr)
+        write_i32(caller, ptr + 8, arr_len)
+        return ptr
+
+    if isinstance(inline, MdLink):
+        ptr = alloc(caller, 24)
+        write_i32(caller, ptr, 4)  # tag
+        arr_ptr, arr_len = _write_inline_array(
+            caller, alloc, write_i32, alloc_string, inline.children,
+        )
+        write_i32(caller, ptr + 4, arr_ptr)
+        write_i32(caller, ptr + 8, arr_len)
+        u_ptr, u_len = alloc_string(caller, inline.url)
+        write_i32(caller, ptr + 12, u_ptr)
+        write_i32(caller, ptr + 16, u_len)
+        return ptr
+
+    if isinstance(inline, MdImage):
+        ptr = alloc(caller, 24)
+        write_i32(caller, ptr, 5)  # tag
+        a_ptr, a_len = alloc_string(caller, inline.alt)
+        write_i32(caller, ptr + 4, a_ptr)
+        write_i32(caller, ptr + 8, a_len)
+        s_ptr, s_len = alloc_string(caller, inline.src)
+        write_i32(caller, ptr + 12, s_ptr)
+        write_i32(caller, ptr + 16, s_len)
+        return ptr
+
+    raise ValueError(f"Unknown MdInline type: {type(inline)}")
+
+
+def write_md_block(
+    caller: wasmtime.Caller,
+    alloc: AllocFn,
+    write_i32: WriteI32Fn,
+    write_bytes: WriteBytesFn,
+    alloc_string: AllocStringFn,
+    block: MdBlock,
+) -> int:
+    """Allocate an MdBlock ADT node in WASM memory.  Returns the heap pointer.
+
+    MdBlock layouts (from registration.py):
+      MdParagraph(Array<MdInline>)        tag=0  (4, i32_pair)         total=16
+      MdHeading(Nat, Array<MdInline>)     tag=1  (8, i64) (16, i32_pair) total=24
+      MdCodeBlock(String, String)         tag=2  (4, i32_pair) (12, i32_pair) total=24
+      MdBlockQuote(Array<MdBlock>)        tag=3  (4, i32_pair)         total=16
+      MdList(Bool, Array<Array<MdBlock>>) tag=4  (4, i32) (8, i32_pair) total=16
+      MdThematicBreak                     tag=5  ()                    total=8
+      MdTable(Array<Array<Array<MdInline>>>)  tag=6  (4, i32_pair)     total=16
+      MdDocument(Array<MdBlock>)          tag=7  (4, i32_pair)         total=16
+    """
+    if isinstance(block, MdParagraph):
+        ptr = alloc(caller, 16)
+        write_i32(caller, ptr, 0)  # tag
+        arr_ptr, arr_len = _write_inline_array(
+            caller, alloc, write_i32, alloc_string, block.children,
+        )
+        write_i32(caller, ptr + 4, arr_ptr)
+        write_i32(caller, ptr + 8, arr_len)
+        return ptr
+
+    if isinstance(block, MdHeading):
+        ptr = alloc(caller, 24)
+        write_i32(caller, ptr, 1)  # tag
+        # Nat at offset 8 as i64 (8-byte aligned)
+        _write_i64(caller, write_bytes, ptr + 8, block.level)
+        arr_ptr, arr_len = _write_inline_array(
+            caller, alloc, write_i32, alloc_string, block.children,
+        )
+        write_i32(caller, ptr + 16, arr_ptr)
+        write_i32(caller, ptr + 20, arr_len)
+        return ptr
+
+    if isinstance(block, MdCodeBlock):
+        ptr = alloc(caller, 24)
+        write_i32(caller, ptr, 2)  # tag
+        l_ptr, l_len = alloc_string(caller, block.language)
+        write_i32(caller, ptr + 4, l_ptr)
+        write_i32(caller, ptr + 8, l_len)
+        c_ptr, c_len = alloc_string(caller, block.code)
+        write_i32(caller, ptr + 12, c_ptr)
+        write_i32(caller, ptr + 16, c_len)
+        return ptr
+
+    if isinstance(block, MdBlockQuote):
+        ptr = alloc(caller, 16)
+        write_i32(caller, ptr, 3)  # tag
+        arr_ptr, arr_len = _write_block_array(
+            caller, alloc, write_i32, write_bytes, alloc_string,
+            block.children,
+        )
+        write_i32(caller, ptr + 4, arr_ptr)
+        write_i32(caller, ptr + 8, arr_len)
+        return ptr
+
+    if isinstance(block, MdList):
+        ptr = alloc(caller, 16)
+        write_i32(caller, ptr, 4)  # tag
+        write_i32(caller, ptr + 4, 1 if block.ordered else 0)  # Bool
+        # Array<Array<MdBlock>> — outer array of inner arrays
+        arr_ptr, arr_len = _write_array_of_block_arrays(
+            caller, alloc, write_i32, write_bytes, alloc_string,
+            block.items,
+        )
+        write_i32(caller, ptr + 8, arr_ptr)
+        write_i32(caller, ptr + 12, arr_len)
+        return ptr
+
+    if isinstance(block, MdThematicBreak):
+        ptr = alloc(caller, 8)
+        write_i32(caller, ptr, 5)  # tag
+        return ptr
+
+    if isinstance(block, MdTable):
+        ptr = alloc(caller, 16)
+        write_i32(caller, ptr, 6)  # tag
+        # Array<Array<Array<MdInline>>> — rows of cells of inlines
+        arr_ptr, arr_len = _write_table_data(
+            caller, alloc, write_i32, alloc_string, block.rows,
+        )
+        write_i32(caller, ptr + 4, arr_ptr)
+        write_i32(caller, ptr + 8, arr_len)
+        return ptr
+
+    if isinstance(block, MdDocument):
+        ptr = alloc(caller, 16)
+        write_i32(caller, ptr, 7)  # tag
+        arr_ptr, arr_len = _write_block_array(
+            caller, alloc, write_i32, write_bytes, alloc_string,
+            block.children,
+        )
+        write_i32(caller, ptr + 4, arr_ptr)
+        write_i32(caller, ptr + 8, arr_len)
+        return ptr
+
+    raise ValueError(f"Unknown MdBlock type: {type(block)}")
+
+
+# -----------------------------------------------------------------
+# Array writing helpers
+# -----------------------------------------------------------------
+
+
+def _write_i64(
+    caller: wasmtime.Caller,
+    write_bytes: WriteBytesFn,
+    offset: int,
+    value: int,
+) -> None:
+    """Write a little-endian i64 (unsigned) into WASM memory."""
+    write_bytes(caller, offset, struct.pack("<Q", value & 0xFFFF_FFFF_FFFF_FFFF))
+
+
+def _write_inline_array(
+    caller: wasmtime.Caller,
+    alloc: AllocFn,
+    write_i32: WriteI32Fn,
+    alloc_string: AllocStringFn,
+    inlines: tuple[MdInline, ...],
+) -> tuple[int, int]:
+    """Write Array<MdInline> — backing buffer of i32 element pointers."""
+    count = len(inlines)
+    if count == 0:
+        return (0, 0)
+    # Each element is an i32 pointer (4 bytes)
+    backing = alloc(caller, count * 4)
+    for i, inline in enumerate(inlines):
+        elem_ptr = write_md_inline(caller, alloc, write_i32, alloc_string, inline)
+        write_i32(caller, backing + i * 4, elem_ptr)
+    return (backing, count)
+
+
+def _write_block_array(
+    caller: wasmtime.Caller,
+    alloc: AllocFn,
+    write_i32: WriteI32Fn,
+    write_bytes: WriteBytesFn,
+    alloc_string: AllocStringFn,
+    blocks: tuple[MdBlock, ...],
+) -> tuple[int, int]:
+    """Write Array<MdBlock> — backing buffer of i32 element pointers."""
+    count = len(blocks)
+    if count == 0:
+        return (0, 0)
+    backing = alloc(caller, count * 4)
+    for i, block in enumerate(blocks):
+        elem_ptr = write_md_block(
+            caller, alloc, write_i32, write_bytes, alloc_string, block,
+        )
+        write_i32(caller, backing + i * 4, elem_ptr)
+    return (backing, count)
+
+
+def _write_array_of_block_arrays(
+    caller: wasmtime.Caller,
+    alloc: AllocFn,
+    write_i32: WriteI32Fn,
+    write_bytes: WriteBytesFn,
+    alloc_string: AllocStringFn,
+    items: tuple[tuple[MdBlock, ...], ...],
+) -> tuple[int, int]:
+    """Write Array<Array<MdBlock>> — each inner array is an i32_pair."""
+    count = len(items)
+    if count == 0:
+        return (0, 0)
+    # Each element is an i32_pair (ptr, len) = 8 bytes
+    backing = alloc(caller, count * 8)
+    for i, item in enumerate(items):
+        inner_ptr, inner_len = _write_block_array(
+            caller, alloc, write_i32, write_bytes, alloc_string, item,
+        )
+        write_i32(caller, backing + i * 8, inner_ptr)
+        write_i32(caller, backing + i * 8 + 4, inner_len)
+    return (backing, count)
+
+
+def _write_table_data(
+    caller: wasmtime.Caller,
+    alloc: AllocFn,
+    write_i32: WriteI32Fn,
+    alloc_string: AllocStringFn,
+    rows: tuple[tuple[tuple[MdInline, ...], ...], ...],
+) -> tuple[int, int]:
+    """Write Array<Array<Array<MdInline>>> — table rows."""
+    row_count = len(rows)
+    if row_count == 0:
+        return (0, 0)
+    # Each row is an i32_pair (ptr to Array<Array<MdInline>>, len)
+    backing = alloc(caller, row_count * 8)
+    for i, row in enumerate(rows):
+        # Each row is Array<Array<MdInline>> — cells
+        cell_count = len(row)
+        if cell_count == 0:
+            write_i32(caller, backing + i * 8, 0)
+            write_i32(caller, backing + i * 8 + 4, 0)
+            continue
+        # Each cell is an i32_pair (ptr to Array<MdInline>, len)
+        cell_backing = alloc(caller, cell_count * 8)
+        for j, cell in enumerate(row):
+            inline_ptr, inline_len = _write_inline_array(
+                caller, alloc, write_i32, alloc_string, cell,
+            )
+            write_i32(caller, cell_backing + j * 8, inline_ptr)
+            write_i32(caller, cell_backing + j * 8 + 4, inline_len)
+        write_i32(caller, backing + i * 8, cell_backing)
+        write_i32(caller, backing + i * 8 + 4, cell_count)
+    return (backing, row_count)
+
+
+# =====================================================================
+# Read direction: WASM memory → Python
+# =====================================================================
+
+
+def _read_i32(caller: wasmtime.Caller, offset: int) -> int:
+    """Read a little-endian i32 from WASM memory."""
+    memory = caller["memory"]
+    assert isinstance(memory, wasmtime.Memory)
+    buf = memory.data_ptr(caller)
+    val: int = struct.unpack_from("<I", bytes(buf[offset:offset + 4]))[0]
+    return val
+
+
+def _read_i64(caller: wasmtime.Caller, offset: int) -> int:
+    """Read a little-endian i64 from WASM memory."""
+    memory = caller["memory"]
+    assert isinstance(memory, wasmtime.Memory)
+    buf = memory.data_ptr(caller)
+    val: int = struct.unpack_from("<Q", bytes(buf[offset:offset + 8]))[0]
+    return val
+
+
+def _read_string(caller: wasmtime.Caller, ptr: int, length: int) -> str:
+    """Read a UTF-8 string from WASM memory."""
+    if length == 0:
+        return ""
+    memory = caller["memory"]
+    assert isinstance(memory, wasmtime.Memory)
+    buf = memory.data_ptr(caller)
+    return bytes(buf[ptr:ptr + length]).decode("utf-8")
+
+
+def _read_string_pair(caller: wasmtime.Caller, offset: int) -> str:
+    """Read a String (i32_pair: ptr, len) from WASM memory."""
+    ptr = _read_i32(caller, offset)
+    length = _read_i32(caller, offset + 4)
+    return _read_string(caller, ptr, length)
+
+
+def read_md_inline(caller: wasmtime.Caller, ptr: int) -> MdInline:
+    """Read an MdInline ADT node from WASM memory."""
+    tag = _read_i32(caller, ptr)
+
+    if tag == 0:  # MdText(String)
+        text = _read_string_pair(caller, ptr + 4)
+        return MdText(text)
+
+    if tag == 1:  # MdCode(String)
+        code = _read_string_pair(caller, ptr + 4)
+        return MdCode(code)
+
+    if tag == 2:  # MdEmph(Array<MdInline>)
+        children = _read_inline_array(caller, ptr + 4)
+        return MdEmph(children)
+
+    if tag == 3:  # MdStrong(Array<MdInline>)
+        children = _read_inline_array(caller, ptr + 4)
+        return MdStrong(children)
+
+    if tag == 4:  # MdLink(Array<MdInline>, String)
+        children = _read_inline_array(caller, ptr + 4)
+        url = _read_string_pair(caller, ptr + 12)
+        return MdLink(children, url)
+
+    if tag == 5:  # MdImage(String, String)
+        alt = _read_string_pair(caller, ptr + 4)
+        src = _read_string_pair(caller, ptr + 12)
+        return MdImage(alt, src)
+
+    raise ValueError(f"Unknown MdInline tag: {tag}")
+
+
+def read_md_block(caller: wasmtime.Caller, ptr: int) -> MdBlock:
+    """Read an MdBlock ADT node from WASM memory."""
+    tag = _read_i32(caller, ptr)
+
+    if tag == 0:  # MdParagraph(Array<MdInline>)
+        inlines_0 = _read_inline_array(caller, ptr + 4)
+        return MdParagraph(inlines_0)
+
+    if tag == 1:  # MdHeading(Nat, Array<MdInline>)
+        level = _read_i64(caller, ptr + 8)
+        inlines_1 = _read_inline_array(caller, ptr + 16)
+        return MdHeading(level, inlines_1)
+
+    if tag == 2:  # MdCodeBlock(String, String)
+        language = _read_string_pair(caller, ptr + 4)
+        code = _read_string_pair(caller, ptr + 12)
+        return MdCodeBlock(language, code)
+
+    if tag == 3:  # MdBlockQuote(Array<MdBlock>)
+        blocks_3 = _read_block_array(caller, ptr + 4)
+        return MdBlockQuote(blocks_3)
+
+    if tag == 4:  # MdList(Bool, Array<Array<MdBlock>>)
+        ordered = _read_i32(caller, ptr + 4) != 0
+        items = _read_array_of_block_arrays(caller, ptr + 8)
+        return MdList(ordered, items)
+
+    if tag == 5:  # MdThematicBreak
+        return MdThematicBreak()
+
+    if tag == 6:  # MdTable(Array<Array<Array<MdInline>>>)
+        rows = _read_table_data(caller, ptr + 4)
+        return MdTable(rows)
+
+    if tag == 7:  # MdDocument(Array<MdBlock>)
+        blocks_7 = _read_block_array(caller, ptr + 4)
+        return MdDocument(blocks_7)
+
+    raise ValueError(f"Unknown MdBlock tag: {tag}")
+
+
+# -----------------------------------------------------------------
+# Array reading helpers
+# -----------------------------------------------------------------
+
+
+def _read_inline_array(
+    caller: wasmtime.Caller, offset: int,
+) -> tuple[MdInline, ...]:
+    """Read Array<MdInline> from an i32_pair at the given offset."""
+    arr_ptr = _read_i32(caller, offset)
+    arr_len = _read_i32(caller, offset + 4)
+    if arr_len == 0:
+        return ()
+    result: list[MdInline] = []
+    for i in range(arr_len):
+        elem_ptr = _read_i32(caller, arr_ptr + i * 4)
+        result.append(read_md_inline(caller, elem_ptr))
+    return tuple(result)
+
+
+def _read_block_array(
+    caller: wasmtime.Caller, offset: int,
+) -> tuple[MdBlock, ...]:
+    """Read Array<MdBlock> from an i32_pair at the given offset."""
+    arr_ptr = _read_i32(caller, offset)
+    arr_len = _read_i32(caller, offset + 4)
+    if arr_len == 0:
+        return ()
+    result: list[MdBlock] = []
+    for i in range(arr_len):
+        elem_ptr = _read_i32(caller, arr_ptr + i * 4)
+        result.append(read_md_block(caller, elem_ptr))
+    return tuple(result)
+
+
+def _read_array_of_block_arrays(
+    caller: wasmtime.Caller, offset: int,
+) -> tuple[tuple[MdBlock, ...], ...]:
+    """Read Array<Array<MdBlock>> from an i32_pair at the given offset."""
+    arr_ptr = _read_i32(caller, offset)
+    arr_len = _read_i32(caller, offset + 4)
+    if arr_len == 0:
+        return ()
+    result: list[tuple[MdBlock, ...]] = []
+    for i in range(arr_len):
+        inner = _read_block_array(caller, arr_ptr + i * 8)
+        result.append(inner)
+    return tuple(result)
+
+
+def _read_table_data(
+    caller: wasmtime.Caller, offset: int,
+) -> tuple[tuple[tuple[MdInline, ...], ...], ...]:
+    """Read Array<Array<Array<MdInline>>> from an i32_pair."""
+    arr_ptr = _read_i32(caller, offset)
+    arr_len = _read_i32(caller, offset + 4)
+    if arr_len == 0:
+        return ()
+    rows: list[tuple[tuple[MdInline, ...], ...]] = []
+    for i in range(arr_len):
+        cell_ptr = _read_i32(caller, arr_ptr + i * 8)
+        cell_len = _read_i32(caller, arr_ptr + i * 8 + 4)
+        cells: list[tuple[MdInline, ...]] = []
+        for j in range(cell_len):
+            inline_arr = _read_inline_array(caller, cell_ptr + j * 8)
+            cells.append(inline_arr)
+        rows.append(tuple(cells))
+    return tuple(rows)


### PR DESCRIPTION
## Summary

Closes #147.

- Adds two mutually-recursive ADTs: **MdInline** (6 constructors: MdText, MdCode, MdEmph, MdStrong, MdLink, MdImage) and **MdBlock** (8 constructors: MdParagraph, MdHeading, MdCodeBlock, MdBlockQuote, MdList, MdThematicBreak, MdTable, MdDocument)
- Adds 5 pure functions as WASM host imports: `md_parse`, `md_render`, `md_has_heading`, `md_has_code_block`, `md_extract_code_blocks`
- Hand-written Python Markdown parser (~650 lines) with no external dependency — supports ATX headings, fenced code blocks, block quotes, lists, tables, thematic breaks, emphasis, strong, code spans, links, images
- Establishes the **host-side binding pattern** for pure functions: WASM import interface is the portability contract; any host runtime (Python, JS, Rust) provides matching implementations for the same `.wasm` binary
- Reorganizes spec §9.3 (Built-in ADTs) to graduate UrlParts and Future\<T\> from inline definitions
- Fixes `_is_void_expr` bug (IfExpr attribute names)
- Bumps to v0.0.84

**New files:** `vera/markdown.py` (parser/renderer), `vera/wasm/markdown.py` (WASM marshalling), `examples/markdown.vera`, `tests/conformance/ch09_markdown.vera`, `tests/test_markdown.py`

## Test plan

- [x] 2175 tests pass (6 skipped), including ~30 new parser/renderer unit tests, 6 type-checker tests, 8 codegen integration tests
- [x] 52 conformance programs pass (new: `ch09_markdown.vera`)
- [x] 23 examples pass (new: `markdown.vera`)
- [x] mypy clean
- [x] All validation scripts clean (spec, README, SKILL block checks)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)