### PR TITLE
Add regex support (#231) — v0.0.86

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,8 +143,8 @@ Each stage is a module with a single public API function (`parse_file`, `transfo
 pytest tests/ -v                       # Run all tests (see TESTING.md)
 pytest tests/test_conformance.py -v    # Conformance suite only
 mypy vera/                             # Type-check the compiler
-python scripts/check_conformance.py    # All 52 conformance programs must pass
-python scripts/check_examples.py       # All 23 examples must pass
+python scripts/check_conformance.py    # All 53 conformance programs must pass
+python scripts/check_examples.py       # All 24 examples must pass
 ```
 
 Test helpers follow a pattern: `_check_ok(source)` / `_check_err(source, match)` / `_verify_ok(source)` / `_verify_err(source, match)`. See existing tests for examples.
@@ -153,8 +153,8 @@ When implementing a new language feature, write the conformance program *first* 
 
 ### Invariants
 
-- All 52 conformance programs in `tests/conformance/` must pass their declared level
-- All 23 examples in `examples/` must pass `vera check` and `vera verify`
+- All 53 conformance programs in `tests/conformance/` must pass their declared level
+- All 24 examples in `examples/` must pass `vera check` and `vera verify`
 - `mypy vera/` must be clean
 - `pytest tests/ -v` must pass
 - Version must be in sync across `vera/__init__.py`, `pyproject.toml`, and `CHANGELOG.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.86] - 2026-03-11
+
+### Added
+- **Regex support** ([#231](https://github.com/aallan/vera/issues/231)):
+  Four new pure functions for regular expression matching on strings:
+  `regex_match`, `regex_find`, `regex_find_all`, `regex_replace`.
+  All return `Result` types for safe handling of invalid patterns.
+  Implemented as WASM host imports — Python's `re` module for wasmtime,
+  JavaScript's `RegExp` for the browser runtime. Browser parity verified.
+- New conformance test `ch09_regex` (conformance suite: 52→53 programs)
+- New example `examples/regex.vera` (example suite: 23→24 programs)
+- Spec §9.6.15 "Regular Expressions"
+- 16 new tests (10 codegen + 6 type checker) plus browser parity coverage
+
 ## [0.0.85] - 2026-03-11
 
 ### Added
@@ -1320,7 +1334,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Grammar: handler body simplified to avoid LALR reduce/reduce conflict
 - `pyproject.toml`: corrected build backend, package discovery, PEP 639 compliance
 
-[Unreleased]: https://github.com/aallan/vera/compare/v0.0.85...HEAD
+[Unreleased]: https://github.com/aallan/vera/compare/v0.0.86...HEAD
+[0.0.86]: https://github.com/aallan/vera/compare/v0.0.85...v0.0.86
 [0.0.85]: https://github.com/aallan/vera/compare/v0.0.84...v0.0.85
 [0.0.84]: https://github.com/aallan/vera/compare/v0.0.83...v0.0.84
 [0.0.83]: https://github.com/aallan/vera/compare/v0.0.82...v0.0.83

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,8 +41,8 @@ vera fmt --check file.vera        # Check if already canonical
 pytest tests/ -v                  # Run the test suite (see TESTING.md)
 mypy vera/                        # Type-check the compiler itself
 
-python scripts/check_conformance.py    # Verify all 52 conformance programs pass their declared level
-python scripts/check_examples.py      # Verify all 23 examples parse + check + verify
+python scripts/check_conformance.py    # Verify all 53 conformance programs pass their declared level
+python scripts/check_examples.py      # Verify all 24 examples parse + check + verify
 python scripts/check_spec_examples.py # Verify spec code blocks parse
 python scripts/check_readme_examples.py # Verify README code blocks parse
 python scripts/check_skill_examples.py # Verify SKILL.md code blocks parse
@@ -57,9 +57,9 @@ python scripts/fix_allowlists.py --fix # Auto-fix stale allowlist line numbers
 
 - `spec/` — Language specification (Chapters 0-12)
 - `vera/` — Reference compiler: grammar, parser, AST, transformer, type checker, verifier, codegen, CLI
-- `examples/` — 23 example Vera programs (all must pass `vera check` and `vera verify`)
+- `examples/` — 24 example Vera programs (all must pass `vera check` and `vera verify`)
 - `tests/` — Test suite (unit tests + conformance suite)
-- `tests/conformance/` — 52 conformance programs validating every language feature against the spec
+- `tests/conformance/` — 53 conformance programs validating every language feature against the spec
 - `scripts/` — CI and validation scripts
 
 ## Writing Vera code
@@ -77,8 +77,8 @@ Each stage is a module with a public API function and is independently testable.
 ## What not to break
 
 - Pre-commit hooks run mypy + pytest + conformance suite + example validation on every commit
-- All 52 conformance programs in `tests/conformance/` must pass their declared level
-- All 23 examples in `examples/` must pass `vera check` and `vera verify`
+- All 53 conformance programs in `tests/conformance/` must pass their declared level
+- All 24 examples in `examples/` must pass `vera check` and `vera verify`
 - Version must stay in sync across `vera/__init__.py`, `pyproject.toml`, and `CHANGELOG.md`
 - All tests must pass: `pytest tests/ -v`
 - Type checking must be clean: `mypy vera/`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,8 +77,8 @@ After running `pre-commit install`, every commit is automatically checked by 17 
 - Python debug statements
 - mypy type checking
 - pytest test suite
-- All 52 conformance programs pass their declared level
-- All 23 `.vera` examples type-check and verify cleanly
+- All 53 conformance programs pass their declared level
+- All 24 `.vera` examples type-check and verify cleanly
 - README, SKILL.md, HTML, and spec code blocks parse correctly
 - Documentation counts match live codebase
 - Browser parity (JS runtime matches Python runtime)
@@ -103,8 +103,8 @@ mypy vera/
 ### Validation Scripts
 
 ```bash
-python scripts/check_conformance.py      # verify all 52 conformance programs
-python scripts/check_examples.py         # verify all 23 .vera examples
+python scripts/check_conformance.py      # verify all 53 conformance programs
+python scripts/check_examples.py         # verify all 24 .vera examples
 python scripts/check_spec_examples.py    # verify spec code blocks parse
 python scripts/check_readme_examples.py  # verify README code blocks parse
 python scripts/check_skill_examples.py   # verify SKILL.md code blocks parse

--- a/README.md
+++ b/README.md
@@ -509,7 +509,7 @@ vera/
 │   ├── formatter.py               # Canonical code formatter
 │   ├── errors.py                  # LLM-oriented diagnostics
 │   └── cli.py                     # Command-line interface
-├── examples/                      # 23 example Vera programs
+├── examples/                      # 24 example Vera programs
 ├── tests/                         # Test suite (see TESTING.md)
 └── scripts/                       # CI and validation scripts
 ```
@@ -522,7 +522,7 @@ For compiler architecture, pipeline internals, and how to extend the compiler, s
 
 ### Testing
 
-Testing is organized in three layers: **unit tests** (2,259 tests across 23 files, testing compiler internals and browser parity), a **conformance suite** (52 programs across 9 spec chapters, systematically validating every language feature against the spec), and **example programs** (23 end-to-end demos). The compiler has 91% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations plus a dedicated browser parity job (Node.js 22). Every commit validates all conformance programs, example programs, and specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference.
+Testing is organized in three layers: **unit tests** (2,287 tests across 23 files, testing compiler internals and browser parity), a **conformance suite** (53 programs across 9 spec chapters, systematically validating every language feature against the spec), and **example programs** (24 end-to-end demos). The compiler has 91% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations plus a dedicated browser parity job (Node.js 22). Every commit validates all conformance programs, example programs, and specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference.
 
 ### Known Bugs
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,8 +14,8 @@ Development follows an **interleaved spiral** — each phase adds a complete com
 | C7 | [v0.0.31](https://github.com/aallan/vera/releases/tag/v0.0.31)–[v0.0.39](https://github.com/aallan/vera/releases/tag/v0.0.39) | **Module system** — cross-file imports, visibility, multi-module compilation | Done |
 | C8 | [v0.0.40](https://github.com/aallan/vera/releases/tag/v0.0.40)–[v0.0.65](https://github.com/aallan/vera/releases/tag/v0.0.65) | **Polish** — refactoring, tooling, diagnostics, verification depth, codegen gaps | Done |
 | C8.5 | — | **Completeness** — module refinements, lexical extensions, IO runtime | In progress |
-| C9 | — | **Language design** — abilities, new effects, stdlib extensions | Planned |
-| C10 | — | **Ecosystem** — package management and registry | Planned |
+| C9 | — | **Language design** — abilities, new effects, stdlib extensions | In progress |
+| C10 | — | **Ecosystem** — package management and registry | In progress |
 
 <details>
 <summary>C6 — Codegen Completeness (<a href="https://github.com/aallan/vera/releases/tag/v0.0.10">v0.0.10</a>–<a href="https://github.com/aallan/vera/releases/tag/v0.0.24">v0.0.24</a>) ✓</summary>
@@ -135,7 +135,7 @@ Module refinements, lexical extensions, and IO runtime — completing the existi
 - <del>[#212](https://github.com/aallan/vera/issues/212) Float64 special value operations (is_nan, is_infinite)</del> ([v0.0.72](https://github.com/aallan/vera/releases/tag/v0.0.72))
 - <del>[#213](https://github.com/aallan/vera/issues/213) string_repeat builtin</del> ([v0.0.75](https://github.com/aallan/vera/releases/tag/v0.0.75))
 - <del>[#230](https://github.com/aallan/vera/issues/230) string interpolation</del> ([v0.0.76](https://github.com/aallan/vera/releases/tag/v0.0.76))
-- [#231](https://github.com/aallan/vera/issues/231) regex support
+- <del>[#231](https://github.com/aallan/vera/issues/231) regex support</del> ([v0.0.86](https://github.com/aallan/vera/releases/tag/v0.0.86))
 - <del>[#232](https://github.com/aallan/vera/issues/232) URL parsing and construction builtins</del> ([v0.0.81](https://github.com/aallan/vera/releases/tag/v0.0.81))
 - <del>[#234](https://github.com/aallan/vera/issues/234) base64 encoding and decoding</del> ([v0.0.79](https://github.com/aallan/vera/releases/tag/v0.0.79))
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -443,6 +443,10 @@ md_render(@MdBlock.0)                   -- returns String (render to canonical M
 md_has_heading(@MdBlock.0, @Nat.0)      -- returns Bool (check if heading of level exists)
 md_has_code_block(@MdBlock.0, @String.0) -- returns Bool (check if code block of language exists)
 md_extract_code_blocks(@MdBlock.0, @String.0) -- returns Array<String> (extract code by language)
+regex_match(@String.0, @String.1)      -- returns Result<Bool, String> (test if pattern matches)
+regex_find(@String.0, @String.1)       -- returns Result<Option<String>, String> (first match)
+regex_find_all(@String.0, @String.1)   -- returns Result<Array<String>, String> (all matches)
+regex_replace(@String.0, @String.1, @String.2) -- returns Result<String, String> (replace first match)
 async(@T.0)                            -- returns Future<T> (requires effects(<Async>))
 await(@Future<T>.0)                    -- returns T (requires effects(<Async>))
 to_string(@Int.0)                       -- returns String (integer to decimal)
@@ -524,6 +528,29 @@ Two built-in ADTs represent the Markdown document structure:
 - `MdDocument(Array<MdBlock>)` — top-level document
 
 All Markdown functions are pure and available without imports. Pattern match on `MdBlock` and `MdInline` constructors to traverse the document tree.
+
+### Regular expressions
+
+```vera
+regex_match(@String.0, @String.1)                -- returns Result<Bool, String>
+regex_find(@String.0, @String.1)                 -- returns Result<Option<String>, String>
+regex_find_all(@String.0, @String.1)             -- returns Result<Array<String>, String>
+regex_replace(@String.0, @String.1, @String.2)   -- returns Result<String, String>
+```
+
+All four regex functions take the input string as the first argument and the regex pattern as the second. `regex_replace` takes a third argument for the replacement string. All return `Result` types — `Err(msg)` for invalid patterns, `Ok(value)` on success.
+
+`regex_match` tests whether the pattern matches anywhere in the input (substring match, not full-string). `regex_find` returns the first matching substring wrapped in `Option`. `regex_find_all` returns all non-overlapping matches as an `Array<String>` — always returns full match strings (group 0), even when the pattern contains capture groups. `regex_replace` replaces only the **first** match.
+
+```vera
+let @Result<Bool, String> = regex_match("hello123", "\\d+");
+match @Result<Bool, String>.0 {
+  Ok(@Bool) -> if @Bool.0 then { IO.print("found digits") } else { IO.print("no digits") },
+  Err(@String) -> IO.print(string_concat("Error: ", @String.0))
+}
+```
+
+All regex functions are pure and implemented as host imports (Python `re` / JavaScript `RegExp`).
 
 ### Numeric operations
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,10 +6,10 @@ This is the single source of truth for Vera's testing infrastructure, coverage d
 
 | Metric | Value |
 |--------|-------|
-| **Tests** | 2,259 across 23 files (~24,000 lines of test code) |
+| **Tests** | 2,287 across 23 files (~24,000 lines of test code) |
 | **Compiler code coverage** | 91% of 14,298 statements (CI minimum: 80%) |
-| **Conformance programs** | 52 programs across 9 spec chapters, validating every language feature |
-| **Example programs** | 23, all validated through `vera check` + `vera verify` |
+| **Conformance programs** | 53 programs across 9 spec chapters, validating every language feature |
+| **Example programs** | 24, all validated through `vera check` + `vera verify` |
 | **Spec code blocks** | 148 parseable blocks from 13 spec chapters: 81 parse, 67 type-check, 66 verify |
 | **README code blocks** | 9 Vera blocks (8 validated, 1 allowlisted future syntax) |
 | **HTML code blocks** | 2 Vera blocks in docs/index.html (2 validated: parse + check + verify) |
@@ -32,8 +32,8 @@ pytest tests/ --cov=vera --cov-report=term-missing   # with coverage
 mypy vera/                                           # strict mode
 
 # Validation scripts
-python scripts/check_conformance.py                  # conformance suite (52 programs)
-python scripts/check_examples.py                     # 23 example programs
+python scripts/check_conformance.py                  # conformance suite (53 programs)
+python scripts/check_examples.py                     # 24 example programs
 python scripts/check_spec_examples.py                # spec code blocks
 python scripts/check_readme_examples.py              # README code blocks
 python scripts/check_skill_examples.py               # SKILL.md code blocks
@@ -46,18 +46,18 @@ python scripts/fix_allowlists.py --fix               # auto-fix stale allowlists
 
 | File | Tests | Lines | What it covers |
 |------|------:|------:|----------------|
-| `test_parser.py` | 112 | 888 | Grammar rules, operator precedence, parse errors |
-| `test_ast.py` | 110 | 1,046 | AST transformation, node structure, serialisation, string escape sequences |
-| `test_checker.py` | 336 | 3,822 | Type synthesis, slot resolution, effects, effect subtyping, contracts, exhaustiveness, cross-module typing, visibility, error codes, string built-ins, generic rejection, IO operation types, Markdown types |
-| `test_verifier.py` | 108 | 1,582 | Z3 verification, counterexamples, tier classification, call-site preconditions, pipe operator, cross-module contracts, match/ADT verification, decreases verification, mutual recursion |
-| `test_codegen.py` | 644 | 7,445 | WASM compilation, arithmetic, Float64, Byte, arrays (incl. compound element types), ADTs, match (incl. nested patterns), generics, State\<T\>, Exn\<E\> handlers, control flow, strings, string escape sequences, IO (read\_line, read\_file, write\_file, args, exit, get\_env), bounds checking, quantifiers, assert/assume, refinement type aliases, pipe operator, string built-ins, built-in shadowing, parse\_nat Result, GC, Markdown host bindings, example round-trips |
+| `test_parser.py` | 113 | 888 | Grammar rules, operator precedence, parse errors |
+| `test_ast.py` | 111 | 1,046 | AST transformation, node structure, serialisation, string escape sequences |
+| `test_checker.py` | 342 | 3,869 | Type synthesis, slot resolution, effects, effect subtyping, contracts, exhaustiveness, cross-module typing, visibility, error codes, string built-ins, generic rejection, IO operation types, Markdown types, Regex types |
+| `test_verifier.py` | 109 | 1,582 | Z3 verification, counterexamples, tier classification, call-site preconditions, pipe operator, cross-module contracts, match/ADT verification, decreases verification, mutual recursion |
+| `test_codegen.py` | 654 | 7,608 | WASM compilation, arithmetic, Float64, Byte, arrays (incl. compound element types), ADTs, match (incl. nested patterns), generics, State\<T\>, Exn\<E\> handlers, control flow, strings, string escape sequences, IO (read\_line, read\_file, write\_file, args, exit, get\_env), bounds checking, quantifiers, assert/assume, refinement type aliases, pipe operator, string built-ins, built-in shadowing, parse\_nat Result, GC, Markdown host bindings, Regex host bindings, example round-trips |
 | `test_codegen_contracts.py` | 32 | 576 | Runtime pre/postconditions, contract fail messages, old/new state postconditions |
 | `test_codegen_monomorphize.py` | 17 | 361 | Generic instantiation, type inference, monomorphization edge cases |
 | `test_codegen_closures.py` | 17 | 416 | Closure lifting, captured variables, higher-order functions |
 | `test_codegen_modules.py` | 18 | 529 | Cross-module guard rail, cross-module codegen, name collision detection (E608/E609/E610) |
 | `test_codegen_coverage.py` | 5 | 249 | Defensive error paths: E600, E601, E605, E606, unknown module calls |
 | `test_errors.py` | 52 | 525 | Error code registry, diagnostic formatting, serialisation, SourceLocation, error display sync (README/HTML/spec) |
-| `test_formatter.py` | 80 | 554 | Comment extraction, expression/declaration formatting, idempotency, parenthesization, spec rules |
+| `test_formatter.py` | 82 | 554 | Comment extraction, expression/declaration formatting, idempotency, parenthesization, spec rules |
 | `test_cli.py` | 111 | 1,440 | CLI commands (check, verify, compile, run, test, fmt), subprocess integration, JSON error paths, runtime traps, arg validation, multi-file resolution, IO exit codes |
 | `test_resolver.py` | 15 | 412 | Module resolution, path lookup, parse caching, circular import detection |
 | `test_types.py` | 73 | 390 | Type operations: subtyping, effect subtyping, equality, substitution, pretty-printing, canonical names |
@@ -65,8 +65,8 @@ python scripts/fix_allowlists.py --fix               # auto-fix stale allowlists
 | `test_wasm_coverage.py` | 113 | 1,738 | WASM coverage gaps: helpers unit tests, inference branches, closure free-var walking, operator/data/context edge cases |
 | `test_tester.py` | 13 | 345 | Contract-driven testing: tier classification, input generation, test execution |
 | `test_markdown.py` | 59 | 394 | Markdown parser: block/inline parsing, rendering, round-trips, edge cases |
-| `test_browser.py` | 56 | 705 | Browser parity: Python/wasmtime vs Node.js/JS-runtime output equivalence across IO, State, contracts, Markdown, and all compilable examples |
-| `test_conformance.py` | 260 | 102 | Parametrized conformance suite: parse, check, verify, run, format idempotency across 52 programs |
+| `test_browser.py` | 58 | 706 | Browser parity: Python/wasmtime vs Node.js/JS-runtime output equivalence across IO, State, contracts, Markdown, Regex, and all compilable examples |
+| `test_conformance.py` | 265 | 102 | Parametrized conformance suite: parse, check, verify, run, format idempotency across 53 programs |
 | `test_readme.py` | 2 | 79 | README code sample parsing |
 | `test_html.py` | 4 | 164 | HTML landing page code samples: parse, check, verify |
 
@@ -97,7 +97,7 @@ Each conformance program declares the deepest pipeline stage it must pass:
 | `parse` | Source text is syntactically valid | 0 |
 | `check` | Parses and type-checks cleanly | 0 |
 | `verify` | Type-checks and all contracts verified by Z3 | 0 |
-| `run` | Compiles to WASM and executes correctly | 52 |
+| `run` | Compiles to WASM and executes correctly | 53 |
 
 All programs are at the `run` level — they compile and execute, producing correct results.
 
@@ -109,12 +109,13 @@ tests/conformance/
 ├── ch01_int_literals.vera     # Chapter 1: Integer literals
 ├── ch01_float_literals.vera   # Chapter 1: Float64 literals
 ├── ch01_string_escapes.vera   # Chapter 1: String escape sequences
-├── ...                        # 52 programs total, organized by spec chapter
+├── ...                        # 53 programs total, organized by spec chapter
 ├── ch07_state_handler.vera    # Chapter 7: State<T> effect handler
 ├── ch07_exn_handler.vera      # Chapter 7: Exn<E> effect handler
 ├── ch09_numeric_builtins.vera # Chapter 9: Numeric built-in functions
 ├── ch09_type_conversions.vera # Chapter 9: Numeric type conversions
 ├── ch09_markdown.vera         # Chapter 9: Markdown standard library
+├── ch09_regex.vera            # Chapter 9: Regular expression matching
 └── ch10_float_predicates.vera # Chapter 9: Float64 predicates and constants
 ```
 
@@ -191,7 +192,7 @@ The lowest-coverage modules (`parser.py` at 64%, `cli.py` at 68%) reflect auto-g
 
 Vera's verifier classifies each contract into one of three tiers. **Tier 1** contracts are proved correct statically by Z3 — no runtime overhead. **Tier 3** contracts cannot be fully decided by the SMT solver and fall back to runtime assertion checks. The verifier never rejects a valid program; it simply warns when a contract drops to Tier 3.
 
-Across all 23 example programs:
+Across all 24 example programs:
 
 | Metric | Value |
 |--------|-------|
@@ -223,7 +224,7 @@ How Vera language features (by spec chapter) map to test files and example progr
 | Ch 2: Types | ADTs (algebraic data types), Option, Result | test_codegen, test_checker | ch02_adt_basic, ch02_adt_recursive, ch02_option_result | pattern_matching, list_ops |
 | Ch 2: Types | Refinement types | test_codegen, test_verifier | ch02_refinement_types | refinement_types, safe_divide |
 | Ch 2: Types | Generics (`forall<T>`) | test_codegen_monomorphize, test_checker | ch02_generics | generics |
-| Ch 3: Slots | `@T.n` references, De Bruijn indexing | test_checker, test_codegen | ch03_slot_basic, ch03_slot_indexing, ch03_slot_result | all 23 examples |
+| Ch 3: Slots | `@T.n` references, De Bruijn indexing | test_checker, test_codegen | ch03_slot_basic, ch03_slot_indexing, ch03_slot_result | all 24 examples |
 | Ch 4: Expressions | Arithmetic, comparison, boolean, unary ops | test_codegen, test_checker | ch04_arithmetic, ch04_comparison, ch04_boolean_ops | factorial, absolute_value |
 | Ch 4: Expressions | If/else, let, match, pipe operator | test_codegen, test_checker | ch04_if_else, ch04_let_binding, ch04_match_basic, ch04_match_nested, ch04_pipe_operator | pattern_matching |
 | Ch 4: Expressions | String and array builtins | test_codegen | ch04_string_builtins, ch04_array_ops | string_ops |
@@ -245,6 +246,7 @@ How Vera language features (by spec chapter) map to test files and example progr
 | Ch 8: Modules | Imports, cross-module typing and codegen | test_codegen_modules, test_resolver | — | modules |
 | Ch 11: Compilation | Cross-module name collision detection (E608/E609/E610) | test_codegen_modules | — | — |
 | Ch 9: Stdlib | Markdown (md_parse, md_render, md_has_heading, md_has_code_block, md_extract_code_blocks) | test_codegen, test_markdown | ch09_markdown | markdown |
+| Ch 9: Stdlib | Regex (regex_match, regex_find, regex_find_all, regex_replace) | test_codegen, test_checker | ch09_regex | regex |
 | Ch 11: Compilation | Contract-driven testing (Z3 input gen + WASM execution) | test_tester, test_cli | — | safe_divide, factorial |
 | Ch 12: Runtime | Browser runtime parity (JS host bindings match Python) | test_browser | — | — |
 
@@ -271,7 +273,7 @@ _run_trap(source, fn, args)    # compile + execute, assert WASM trap
 
 ## Round-Trip Testing
 
-Every one of the 23 example programs in `examples/` is tested through **every pipeline stage** via parametrised tests: parsing, AST transformation, type checking, contract verification, WASM compilation, and execution. If you add a new `.vera` example, it is automatically included in the round-trip suite.
+Every one of the 24 example programs in `examples/` is tested through **every pipeline stage** via parametrised tests: parsing, AST transformation, type checking, contract verification, WASM compilation, and execution. If you add a new `.vera` example, it is automatically included in the round-trip suite.
 
 The formatter has **idempotency tests**: `format(format(x)) == format(x)` for all tested programs.
 
@@ -335,7 +337,7 @@ After running `pre-commit install`, every commit is checked by 17 hooks:
 | `pytest tests/ -q` | Run full test suite |
 | `fix_allowlists.py --fix` | Auto-fix stale allowlist line numbers |
 | `check_conformance.py` | All 52 conformance programs pass their declared level |
-| `check_examples.py` | All 23 examples pass `vera check` + `vera verify` |
+| `check_examples.py` | All 24 examples pass `vera check` + `vera verify` |
 | `check_readme_examples.py` | README code blocks parse correctly |
 | `check_skill_examples.py` | SKILL.md code blocks parse correctly |
 | `check_html_examples.py` | HTML landing page code blocks pass parse + check + verify |

--- a/docs/index.html
+++ b/docs/index.html
@@ -508,7 +508,7 @@
         For Agents → SKILL.md
       </a>
     </div>
-    <p style="text-align: center; margin-top: 1rem; font-size: 0.9rem; color: var(--brown-400);">Current Version: <a href="https://github.com/aallan/vera/releases/tag/v0.0.85" style="color: var(--brown-500); font-weight: 500;">v0.0.85</a></p>
+    <p style="text-align: center; margin-top: 1rem; font-size: 0.9rem; color: var(--brown-400);">Current Version: <a href="https://github.com/aallan/vera/releases/tag/v0.0.86" style="color: var(--brown-500); font-weight: 500;">v0.0.86</a></p>
   </div>
 
   <!-- Why -->

--- a/examples/regex.vera
+++ b/examples/regex.vera
@@ -1,0 +1,40 @@
+-- Regex: pattern matching on strings using regular expressions.
+--
+-- Demonstrates the four regex builtins: regex_match, regex_find,
+-- regex_find_all, regex_replace. All return Result types to handle
+-- invalid patterns safely.
+effect IO {
+  op print(String -> Unit);
+}
+
+public fn main(@Unit -> @Unit)
+  requires(true)
+  ensures(true)
+  effects(<IO>)
+{
+  IO.print("-- Matching --");
+  let @Result<Bool, String> = regex_match("hello123", "\\d+");
+  match @Result<Bool, String>.0 { Ok(@Bool) -> if @Bool.0 then { IO.print("hello123: matched") } else { IO.print("hello123: no match") }, Err(@String) -> IO.print(string_concat("Error: ", @String.0)) };
+  let @Result<Bool, String> = regex_match("hello", "\\d+");
+  match @Result<Bool, String>.0 { Ok(@Bool) -> if @Bool.0 then { IO.print("hello: matched") } else { IO.print("hello: no match") }, Err(@String) -> IO.print(string_concat("Error: ", @String.0)) };
+  IO.print("-- Finding --");
+  let @Result<Option<String>, String> = regex_find("contact: user@example.com today", "[a-zA-Z0-9.]+@[a-zA-Z0-9.]+");
+  match @Result<Option<String>, String>.0 { Ok(@Option<String>) -> match @Option<String>.0 { Some(@String) -> IO.print(string_concat("Found: ", @String.0)), None -> IO.print("Not found") }, Err(@String) -> IO.print(string_concat("Error: ", @String.0)) };
+  IO.print("-- Find all --");
+  let @Result<Array<String>, String> = regex_find_all("2024-01-15 and 2024-06-30", "\\d{4}-\\d{2}-\\d{2}");
+  match @Result<Array<String>, String>.0 { Ok(@Array<String>) -> IO.print(string_concat("Dates found: ", int_to_string(array_length(@Array<String>.0)))), Err(@String) -> IO.print(string_concat("Error: ", @String.0)) };
+  IO.print("-- Replacing --");
+  let @Result<String, String> = regex_replace("Hello World", "[A-Z]", "_");
+  match @Result<String, String>.0 { Ok(@String) -> IO.print(@String.0), Err(@String) -> IO.print(string_concat("Error: ", @String.0)) };
+  IO.print("-- Error handling --");
+  let @Result<Bool, String> = regex_match("test", "[unclosed");
+  match @Result<Bool, String>.0 {
+    Ok(_) -> IO.print("Unexpected success"),
+    Err(_) -> IO.print("Caught: invalid pattern")
+  }
+}
+-- Match: does the string contain digits?
+-- Find: extract the first match
+-- Find all: extract all matches
+-- Replace: substitute the first match
+-- Error handling: invalid pattern

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.85"
+version = "0.0.86"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/scripts/check_skill_examples.py
+++ b/scripts/check_skill_examples.py
@@ -40,73 +40,79 @@ ALLOWLIST: dict[int, tuple[str, str]] = {
     424: ("FRAGMENT", "String built-in examples, bare calls"),
 
     # Markdown operations — bare function calls
-    496: ("FRAGMENT", "Markdown built-in examples, bare calls"),
+    500: ("FRAGMENT", "Markdown built-in examples, bare calls"),
+
+    # Regex operations — bare function calls
+    534: ("FRAGMENT", "Regex built-in examples, bare calls"),
+    545: ("FRAGMENT", "Regex Result matching example, bare expression"),
 
     # String interpolation — bare expressions
-    459: ("FRAGMENT", "String interpolation examples, bare expressions"),
+    463: ("FRAGMENT", "String interpolation examples, bare expressions"),
 
     # String search — bare function calls
-    471: ("FRAGMENT", "String search built-in examples, bare calls"),
+    475: ("FRAGMENT", "String search built-in examples, bare calls"),
 
     # String transformation — bare function calls
-    482: ("FRAGMENT", "String transformation built-in examples, bare calls"),
+    486: ("FRAGMENT", "String transformation built-in examples, bare calls"),
 
     # Numeric operations — bare function calls
-    530: ("FRAGMENT", "Numeric built-in examples, bare calls"),
+    557: ("FRAGMENT", "Numeric built-in examples, bare calls"),
 
     # Contracts section — requires/ensures fragments
-    587: ("FRAGMENT", "Requires clause example, not full function"),
-    596: ("FRAGMENT", "Ensures clause example, not full function"),
-    623: ("FRAGMENT", "Quantified requires clause, not full function"),
+    614: ("FRAGMENT", "Requires clause example, not full function"),
+    623: ("FRAGMENT", "Ensures clause example, not full function"),
+
+    # Quantified expressions — bare forall/exists calls
+    650: ("FRAGMENT", "Quantified expression examples, bare calls"),
 
     # Effects section — bare effect rows
     # (old entry at 580 removed — block shifted to 582 with Async addition)
 
     # Effect handler syntax template
-    804: ("FRAGMENT", "Handler syntax template, not real code"),
+    831: ("FRAGMENT", "Handler syntax template, not real code"),
 
     # Effect declarations — bare effects(...) clauses
-    641: ("FRAGMENT", "Effect declarations list"),
-    742: ("FRAGMENT", "Async effect declarations list"),
-    762: ("FRAGMENT", "Async effect declarations, bare clauses"),
+    668: ("FRAGMENT", "Effect declarations list"),
+    769: ("FRAGMENT", "Async effect declarations list"),
+    789: ("FRAGMENT", "Async effect declarations, bare clauses"),
 
     # Qualified calls and handler fragments — bare expressions
-    816: ("FRAGMENT", "Handler with clause, bare expression"),
-    826: ("FRAGMENT", "Qualified call examples, bare expressions"),
+    843: ("FRAGMENT", "Handler with clause, bare expression"),
+    853: ("FRAGMENT", "Qualified call examples, bare expressions"),
 
     # Module declaration and import syntax
-    864: ("FRAGMENT", "Module declaration and import example"),
+    891: ("FRAGMENT", "Module declaration and import example"),
 
     # Line comments — bare comments
-    915: ("FRAGMENT", "Comment syntax example"),
+    942: ("FRAGMENT", "Comment syntax example"),
 
     # Type conversions — bare function calls
-    545: ("FRAGMENT", "Type conversion examples, bare calls"),
+    572: ("FRAGMENT", "Type conversion examples, bare calls"),
 
     # Float64 predicates — bare function calls
-    558: ("FRAGMENT", "Float64 predicate examples, bare calls"),
+    585: ("FRAGMENT", "Float64 predicate examples, bare calls"),
 
     # Common mistakes section — intentionally wrong code
-    943: ("FRAGMENT", "Wrong: missing contracts"),
-    963: ("FRAGMENT", "Wrong: missing effects clause"),
-    997: ("FRAGMENT", "Wrong: bare expression without indices"),
-    1010: ("FRAGMENT", "Wrong: bare expression no indices"),
-    1015: ("FRAGMENT", "Correct: expression with indices (not full fn)"),
-    1081: ("FRAGMENT", "Wrong: match arm with incorrect return"),
-    1105: ("FRAGMENT", "Wrong: non-exhaustive match"),
-    1092: ("FRAGMENT", "Correct: match arm example"),
-    1112: ("FRAGMENT", "Correct: match expression (bare expression)"),
-    1122: ("FRAGMENT", "Wrong: if/else without braces (bare expression)"),
-    1127: ("FRAGMENT", "Correct: if/else with braces"),
+    970: ("FRAGMENT", "Wrong: missing contracts"),
+    990: ("FRAGMENT", "Wrong: missing effects clause"),
+    1024: ("FRAGMENT", "Wrong: bare expression without indices"),
+    1037: ("FRAGMENT", "Wrong: bare expression no indices"),
+    1042: ("FRAGMENT", "Correct: expression with indices (not full fn)"),
+    1108: ("FRAGMENT", "Wrong: match arm with incorrect return"),
+    1132: ("FRAGMENT", "Wrong: non-exhaustive match"),
+    1119: ("FRAGMENT", "Correct: match arm example"),
+    1139: ("FRAGMENT", "Correct: match expression (bare expression)"),
+    1149: ("FRAGMENT", "Wrong: if/else without braces (bare expression)"),
+    1154: ("FRAGMENT", "Correct: if/else with braces"),
 
     # Import syntax — intentionally unsupported
-    1138: ("FRAGMENT", "Wrong: import aliasing not supported"),
-    1143: ("FRAGMENT", "Correct: import syntax example"),
-    1153: ("FRAGMENT", "Wrong: import hiding not supported"),
-    1138: ("FRAGMENT", "Correct: multi-import syntax"),
+    1165: ("FRAGMENT", "Wrong: import aliasing not supported"),
+    1170: ("FRAGMENT", "Correct: import syntax example"),
+    1180: ("FRAGMENT", "Wrong: import hiding not supported"),
+    1165: ("FRAGMENT", "Correct: multi-import syntax"),
 
     # String escapes — bare expression
-    1172: ("FRAGMENT", "String escape example"),
+    1199: ("FRAGMENT", "String escape example"),
 
     # =================================================================
     # MISMATCH — uses syntax the parser doesn't handle in isolation.

--- a/scripts/check_spec_examples.py
+++ b/scripts/check_spec_examples.py
@@ -72,6 +72,10 @@ ALLOWLIST: dict[tuple[str, int], str] = {
     ("09-standard-library.md", 658): "FRAGMENT",  # byte_to_int signature (no body)
     ("09-standard-library.md", 832): "FRAGMENT",  # ends_with signature (no body)
     ("09-standard-library.md", 1095): "FRAGMENT",  # base64_decode signature (no body)
+    ("09-standard-library.md", 1224): "FRAGMENT",  # regex_match signature (no body)
+    ("09-standard-library.md", 1240): "FRAGMENT",  # regex_find signature (no body)
+    ("09-standard-library.md", 1256): "FRAGMENT",  # regex_find_all signature (no body)
+    ("09-standard-library.md", 1272): "FRAGMENT",  # regex_replace signature (no body)
 
     # =================================================================
     # FRAGMENT — heuristic false positives (look like declarations but
@@ -178,12 +182,12 @@ ALLOWLIST: dict[tuple[str, int], str] = {
     ("09-standard-library.md", 1207): "FRAGMENT",  # similarity signature (no body)
 
     # Chapter 9 — Markdown stdlib type (future, uses MdBlock/MdInline types)
-    ("09-standard-library.md", 1309): "FUTURE",   # md_parse
-    ("09-standard-library.md", 1318): "FUTURE",   # md_render
-    ("09-standard-library.md", 1329): "FUTURE",   # md_has_heading
-    ("09-standard-library.md", 1338): "FUTURE",   # md_has_code_block
-    ("09-standard-library.md", 1347): "FUTURE",   # md_extract_code_blocks
-    ("09-standard-library.md", 1371): "FUTURE",   # convert_to_markdown
+    ("09-standard-library.md", 1379): "FUTURE",   # md_parse
+    ("09-standard-library.md", 1388): "FUTURE",   # md_render
+    ("09-standard-library.md", 1399): "FUTURE",   # md_has_heading
+    ("09-standard-library.md", 1408): "FUTURE",   # md_has_code_block
+    ("09-standard-library.md", 1417): "FUTURE",   # md_extract_code_blocks
+    ("09-standard-library.md", 1441): "FUTURE",   # convert_to_markdown
 }
 
 

--- a/spec/09-standard-library.md
+++ b/spec/09-standard-library.md
@@ -9,7 +9,7 @@ The standard library comprises:
 - **Built-in ADTs**: `Option<T>` and `Result<T, E>` for representing partiality and fallibility.
 - **Built-in collections**: `Array<T>` for fixed-size homogeneous sequences, plus future collections (`Set<T>`, `Map<K, V>`).
 - **Built-in effects**: `IO` for output, `State<T>` for mutable state, plus future effects for networking, concurrency, and LLM inference.
-- **Built-in functions**: `array_length`, `array_append`, `array_range`, and `array_concat` for arrays, numeric operations (`abs`, `min`, `max`, `floor`, `ceil`, `round`, `sqrt`, `pow`), type conversions (`to_float`, `float_to_int`, `nat_to_int`, `int_to_nat`, `byte_to_int`, `int_to_byte`), Float64 predicates (`is_nan`, `is_infinite`, `nan`, `infinity`), string search (`string_contains`, `starts_with`, `ends_with`, `index_of`), string transformation (`to_upper`, `to_lower`, `replace`, `split`, `join`, `from_char_code`), plus future functions for vector similarity.
+- **Built-in functions**: `array_length`, `array_append`, `array_range`, and `array_concat` for arrays, numeric operations (`abs`, `min`, `max`, `floor`, `ceil`, `round`, `sqrt`, `pow`), type conversions (`to_float`, `float_to_int`, `nat_to_int`, `int_to_nat`, `byte_to_int`, `int_to_byte`), Float64 predicates (`is_nan`, `is_infinite`, `nan`, `infinity`), string search (`string_contains`, `starts_with`, `ends_with`, `index_of`), string transformation (`to_upper`, `to_lower`, `replace`, `split`, `join`, `from_char_code`), regular expressions (`regex_match`, `regex_find`, `regex_find_all`, `regex_replace`), plus future functions for vector similarity.
 - **Future types**: `Json` for structured data interchange, `Markdown` for agent-oriented document structure, `Decimal` for exact arithmetic.
 - **Future abilities**: Type constraints for generic programming (post-v0.1).
 
@@ -1214,6 +1214,76 @@ public fn similarity(@Array<Float64>, @Array<Float64> -> @Float64)
 Computes the cosine similarity between two vectors (embeddings). The arrays must have equal length (enforced by precondition). The result is in the range \[-1, 1\], where 1 indicates identical direction, 0 indicates orthogonality, and -1 indicates opposite direction.
 
 This function is pure — it performs no effects. It is intended for use with the `Inference.embed` operation to compare semantic similarity of text.
+
+### 9.6.15 Regular Expressions
+
+Four pure functions for pattern matching on strings using regular expressions. All accept patterns in standard regex syntax and return `Result` types to safely handle invalid patterns.
+
+#### regex\_match
+
+```
+public fn regex_match(@String, @String -> @Result<Bool, String>)
+  requires(true)
+  ensures(true)
+  effects(pure)
+```
+
+Tests whether the input string (first argument) contains a substring matching the regex pattern (second argument). Returns `Ok(true)` if a match is found, `Ok(false)` otherwise, or `Err(msg)` if the pattern is invalid.
+
+```vera
+let @Result<Bool, String> = regex_match("hello123", "\\d+");
+-- Ok(true) — digits found
+```
+
+#### regex\_find
+
+```
+public fn regex_find(@String, @String -> @Result<Option<String>, String>)
+  requires(true)
+  ensures(true)
+  effects(pure)
+```
+
+Returns the first substring of the input that matches the pattern. Returns `Ok(Some(match))` if found, `Ok(None)` if not found, or `Err(msg)` for invalid patterns.
+
+```vera
+let @Result<Option<String>, String> = regex_find("abc123def", "\\d+");
+-- Ok(Some("123"))
+```
+
+#### regex\_find\_all
+
+```
+public fn regex_find_all(@String, @String -> @Result<Array<String>, String>)
+  requires(true)
+  ensures(true)
+  effects(pure)
+```
+
+Returns all non-overlapping substrings of the input that match the pattern. Always returns full match strings (group 0), even when the pattern contains capture groups. Returns `Ok([])` (empty array) if no matches are found, or `Err(msg)` for invalid patterns.
+
+```vera
+let @Result<Array<String>, String> = regex_find_all("a1b2c3", "\\d");
+-- Ok(["1", "2", "3"])
+```
+
+#### regex\_replace
+
+```
+public fn regex_replace(@String, @String, @String -> @Result<String, String>)
+  requires(true)
+  ensures(true)
+  effects(pure)
+```
+
+Replaces the **first** occurrence of the pattern in the input string with the replacement string (third argument). Returns the modified string, or the original string unchanged if no match is found. Returns `Err(msg)` for invalid patterns.
+
+```vera
+let @Result<String, String> = regex_replace("hello world", "world", "vera");
+-- Ok("hello vera")
+```
+
+**Implementation note:** These functions are implemented as host imports — they delegate to the runtime's native regex engine (Python's `re` module for wasmtime, JavaScript's `RegExp` for the browser runtime). This avoids embedding a regex engine in WASM while providing access to mature, well-tested implementations.
 
 ## 9.7 Built-in Types (Future)
 

--- a/tests/conformance/ch09_regex.vera
+++ b/tests/conformance/ch09_regex.vera
@@ -1,0 +1,45 @@
+-- Chapter 9: Regular Expression Matching (§9.6.15)
+-- Tests: regex_match, regex_find, regex_find_all, regex_replace
+-- Level: run (requires WASM execution with host bindings)
+effect IO {
+  op print(String -> Unit);
+}
+
+public fn main(@Unit -> @Unit)
+  requires(true)
+  ensures(true)
+  effects(<IO>)
+{
+  let @Result<Bool, String> = regex_match("hello123", "\\d+");
+  match @Result<Bool, String>.0 { Ok(@Bool) -> if @Bool.0 then { IO.print("match_found: ok") } else { IO.print("FAIL") }, Err(_) -> IO.print("FAIL") };
+  let @Result<Bool, String> = regex_match("hello", "\\d+");
+  match @Result<Bool, String>.0 { Ok(@Bool) -> if @Bool.0 then { IO.print("FAIL") } else { IO.print("match_none: ok") }, Err(_) -> IO.print("FAIL") };
+  let @Result<Option<String>, String> = regex_find("abc123def", "\\d+");
+  match @Result<Option<String>, String>.0 { Ok(@Option<String>) -> match @Option<String>.0 { Some(@String) -> IO.print(string_concat("find: ", @String.0)), None -> IO.print("FAIL") }, Err(_) -> IO.print("FAIL") };
+  let @Result<Option<String>, String> = regex_find("hello", "\\d+");
+  match @Result<Option<String>, String>.0 { Ok(@Option<String>) -> match @Option<String>.0 { Some(_) -> IO.print("FAIL"), None -> IO.print("find_none: ok") }, Err(_) -> IO.print("FAIL") };
+  let @Result<Array<String>, String> = regex_find_all("a1b2c3", "\\d");
+  match @Result<Array<String>, String>.0 { Ok(@Array<String>) -> IO.print(string_concat("find_all: ", int_to_string(array_length(@Array<String>.0)))), Err(_) -> IO.print("FAIL") };
+  let @Result<String, String> = regex_replace("hello world", "world", "vera");
+  match @Result<String, String>.0 { Ok(@String) -> IO.print(string_concat("replace: ", @String.0)), Err(_) -> IO.print("FAIL") };
+  let @Result<Bool, String> = regex_match("test", "[invalid");
+  match @Result<Bool, String>.0 {
+    Ok(_) -> IO.print("FAIL"),
+    Err(@String) -> IO.print("err: ok")
+  }
+}
+-- regex_match: pattern found
+-- regex_match: pattern not found
+-- regex_find: match found
+-- regex_find: no match
+-- regex_find_all: multiple matches
+-- regex_replace: first match only
+-- regex_match: invalid pattern produces Err
+-- Expected output:
+-- match_found: ok
+-- match_none: ok
+-- find: 123
+-- find_none: ok
+-- find_all: 3
+-- replace: hello vera
+-- err: ok

--- a/tests/conformance/manifest.json
+++ b/tests/conformance/manifest.json
@@ -466,5 +466,14 @@
     "level": "run",
     "spec_ref": "Section 9.7.3",
     "features": ["md_parse", "md_render", "md_has_heading", "md_has_code_block", "md_extract_code_blocks"]
+  },
+  {
+    "id": "ch09_regex",
+    "file": "ch09_regex.vera",
+    "chapter": 9,
+    "title": "Regular expression matching",
+    "level": "run",
+    "spec_ref": "Section 9.6.15",
+    "features": ["regex_match", "regex_find", "regex_find_all", "regex_replace"]
   }
 ]

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -182,6 +182,7 @@ EXAMPLES_WITH_MAIN = [
     "url_encoding",
     "url_parsing",
     "markdown",
+    "regex",
     "effect_handler",
     "gc_pressure",
     "async_futures",

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -3820,3 +3820,50 @@ private fn f(@MdBlock, @String -> @Array<String>)
   requires(true) ensures(true) effects(pure)
 { md_extract_code_blocks(@MdBlock.0, @String.0) }
 """)
+
+
+class TestRegexBuiltins:
+    """Type-checking for regex_match, regex_find, regex_find_all,
+    regex_replace."""
+
+    def test_regex_match_ok(self) -> None:
+        _check_ok(r"""
+private fn f(@String -> @Result<Bool, String>)
+  requires(true) ensures(true) effects(pure)
+{ regex_match(@String.0, "\\d+") }
+""")
+
+    def test_regex_match_wrong_type(self) -> None:
+        _check_err("""
+private fn f(@Int -> @Int)
+  requires(true) ensures(true) effects(pure)
+{ regex_match(@Int.0, @Int.0) }
+""", "expected String")
+
+    def test_regex_find_ok(self) -> None:
+        _check_ok(r"""
+private fn f(@String -> @Result<Option<String>, String>)
+  requires(true) ensures(true) effects(pure)
+{ regex_find(@String.0, "\\d+") }
+""")
+
+    def test_regex_find_all_ok(self) -> None:
+        _check_ok(r"""
+private fn f(@String -> @Result<Array<String>, String>)
+  requires(true) ensures(true) effects(pure)
+{ regex_find_all(@String.0, "\\d+") }
+""")
+
+    def test_regex_replace_ok(self) -> None:
+        _check_ok(r"""
+private fn f(@String -> @Result<String, String>)
+  requires(true) ensures(true) effects(pure)
+{ regex_replace(@String.0, "\\d+", "X") }
+""")
+
+    def test_regex_replace_wrong_arity(self) -> None:
+        _check_err(r"""
+private fn f(@String -> @Result<String, String>)
+  requires(true) ensures(true) effects(pure)
+{ regex_replace(@String.0, "\\d+") }
+""", "expects 3 argument")

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -7443,3 +7443,166 @@ public fn main(@Unit -> @Unit)
 }
 """
         assert _run_io(source, fn="main") == "0"
+
+
+class TestRegex:
+    """Regex built-in functions: regex_match, regex_find, regex_find_all,
+    regex_replace."""
+
+    _PREAMBLE = """
+effect IO { op print(String -> Unit); }
+"""
+
+    # ---- regex_match ----
+
+    def test_regex_match_found(self) -> None:
+        source = self._PREAMBLE + r"""
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  let @Result<Bool, String> = regex_match("hello123", "\\d+");
+  match @Result<Bool, String>.0 {
+    Ok(@Bool) -> if @Bool.0 then { IO.print("yes") } else { IO.print("no") },
+    Err(_) -> IO.print("err")
+  }
+}
+"""
+        assert _run_io(source, fn="main") == "yes"
+
+    def test_regex_match_not_found(self) -> None:
+        source = self._PREAMBLE + r"""
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  let @Result<Bool, String> = regex_match("hello", "\\d+");
+  match @Result<Bool, String>.0 {
+    Ok(@Bool) -> if @Bool.0 then { IO.print("yes") } else { IO.print("no") },
+    Err(_) -> IO.print("err")
+  }
+}
+"""
+        assert _run_io(source, fn="main") == "no"
+
+    def test_regex_match_invalid_pattern(self) -> None:
+        source = self._PREAMBLE + r"""
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  let @Result<Bool, String> = regex_match("test", "[bad");
+  match @Result<Bool, String>.0 {
+    Ok(_) -> IO.print("unexpected"),
+    Err(@String) -> IO.print("caught")
+  }
+}
+"""
+        assert _run_io(source, fn="main") == "caught"
+
+    # ---- regex_find ----
+
+    def test_regex_find_some(self) -> None:
+        source = self._PREAMBLE + r"""
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  let @Result<Option<String>, String> = regex_find("abc123def", "\\d+");
+  match @Result<Option<String>, String>.0 {
+    Ok(@Option<String>) -> match @Option<String>.0 {
+      Some(@String) -> IO.print(@String.0),
+      None -> IO.print("none")
+    },
+    Err(_) -> IO.print("err")
+  }
+}
+"""
+        assert _run_io(source, fn="main") == "123"
+
+    def test_regex_find_none(self) -> None:
+        source = self._PREAMBLE + r"""
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  let @Result<Option<String>, String> = regex_find("hello", "\\d+");
+  match @Result<Option<String>, String>.0 {
+    Ok(@Option<String>) -> match @Option<String>.0 {
+      Some(_) -> IO.print("some"),
+      None -> IO.print("none")
+    },
+    Err(_) -> IO.print("err")
+  }
+}
+"""
+        assert _run_io(source, fn="main") == "none"
+
+    # ---- regex_find_all ----
+
+    def test_regex_find_all_multiple(self) -> None:
+        source = self._PREAMBLE + r"""
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  let @Result<Array<String>, String> = regex_find_all("a1b2c3", "\\d");
+  match @Result<Array<String>, String>.0 {
+    Ok(@Array<String>) -> IO.print(int_to_string(array_length(@Array<String>.0))),
+    Err(_) -> IO.print("err")
+  }
+}
+"""
+        assert _run_io(source, fn="main") == "3"
+
+    def test_regex_find_all_no_matches(self) -> None:
+        source = self._PREAMBLE + r"""
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  let @Result<Array<String>, String> = regex_find_all("hello", "\\d");
+  match @Result<Array<String>, String>.0 {
+    Ok(@Array<String>) -> IO.print(int_to_string(array_length(@Array<String>.0))),
+    Err(_) -> IO.print("err")
+  }
+}
+"""
+        assert _run_io(source, fn="main") == "0"
+
+    # ---- regex_replace ----
+
+    def test_regex_replace_first_only(self) -> None:
+        source = self._PREAMBLE + r"""
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  let @Result<String, String> = regex_replace("hello world", "world", "vera");
+  match @Result<String, String>.0 {
+    Ok(@String) -> IO.print(@String.0),
+    Err(_) -> IO.print("err")
+  }
+}
+"""
+        assert _run_io(source, fn="main") == "hello vera"
+
+    def test_regex_replace_pattern(self) -> None:
+        source = self._PREAMBLE + r"""
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  let @Result<String, String> = regex_replace("abc123def", "\\d+", "NUM");
+  match @Result<String, String>.0 {
+    Ok(@String) -> IO.print(@String.0),
+    Err(_) -> IO.print("err")
+  }
+}
+"""
+        assert _run_io(source, fn="main") == "abcNUMdef"
+
+    def test_regex_replace_no_match(self) -> None:
+        source = self._PREAMBLE + r"""
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  let @Result<String, String> = regex_replace("hello", "\\d+", "NUM");
+  match @Result<String, String>.0 {
+    Ok(@String) -> IO.print(@String.0),
+    Err(_) -> IO.print("err")
+  }
+}
+"""
+        assert _run_io(source, fn="main") == "hello"

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -1480,9 +1480,9 @@ private fn sum(@List<Int> -> @Int)
             t1 += result.summary.tier1_verified
             t3 += result.summary.tier3_runtime
             total += result.summary.total
-        assert t1 == 131, f"Expected 131 T1, got {t1}"
+        assert t1 == 133, f"Expected 133 T1, got {t1}"
         assert t3 == 7, f"Expected 7 T3, got {t3}"
-        assert total == 138, f"Expected 138 total, got {total}"
+        assert total == 140, f"Expected 140 total, got {total}"
 
 
 # =====================================================================

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.85"
+__version__ = "0.0.86"

--- a/vera/browser/runtime.mjs
+++ b/vera/browser/runtime.mjs
@@ -925,6 +925,81 @@ function hostMdExtractCodeBlocks(blockPtr, langPtr, langLen) {
 }
 
 // ---------------------------------------------------------------------------
+// Regex host functions (mirror api.py host_regex_* — §9.6.15)
+// ---------------------------------------------------------------------------
+
+/** vera.regex_match(inPtr, inLen, patPtr, patLen) → Result<Bool, String>. */
+function hostRegexMatch(inPtr, inLen, patPtr, patLen) {
+  const input = readString(inPtr, inLen);
+  const pattern = readString(patPtr, patLen);
+  try {
+    const re = new RegExp(pattern);
+    const matched = re.test(input);
+    return allocResultOkI32(matched ? 1 : 0);
+  } catch (e) {
+    return allocResultErrString(`invalid regex: ${e.message}`);
+  }
+}
+
+/** vera.regex_find(inPtr, inLen, patPtr, patLen) → Result<Option<String>, String>. */
+function hostRegexFind(inPtr, inLen, patPtr, patLen) {
+  const input = readString(inPtr, inLen);
+  const pattern = readString(patPtr, patLen);
+  try {
+    const re = new RegExp(pattern);
+    const m = input.match(re);
+    let optionPtr;
+    if (m) {
+      optionPtr = allocOptionSomeString(m[0]);
+    } else {
+      optionPtr = allocOptionNone();
+    }
+    return allocResultOkI32(optionPtr);
+  } catch (e) {
+    return allocResultErrString(`invalid regex: ${e.message}`);
+  }
+}
+
+/** vera.regex_find_all(inPtr, inLen, patPtr, patLen) → Result<Array<String>, String>. */
+function hostRegexFindAll(inPtr, inLen, patPtr, patLen) {
+  const input = readString(inPtr, inLen);
+  const pattern = readString(patPtr, patLen);
+  try {
+    const re = new RegExp(pattern, 'g');
+    const matches = [];
+    let m;
+    while ((m = re.exec(input)) !== null) {
+      matches.push(m[0]);
+      // Prevent infinite loop on zero-length matches
+      if (m[0].length === 0) re.lastIndex++;
+    }
+    const [backingPtr, count] = allocArrayOfStrings(matches);
+    // Wrap in Result.Ok — layout: tag=0, backing_ptr, count (12 bytes)
+    const ptr = alloc(12);
+    writeI32(ptr, 0);              // tag = Ok
+    writeI32(ptr + 4, backingPtr);
+    writeI32(ptr + 8, count);
+    return ptr;
+  } catch (e) {
+    return allocResultErrString(`invalid regex: ${e.message}`);
+  }
+}
+
+/** vera.regex_replace(inPtr, inLen, patPtr, patLen, repPtr, repLen) → Result<String, String>. */
+function hostRegexReplace(inPtr, inLen, patPtr, patLen, repPtr, repLen) {
+  const input = readString(inPtr, inLen);
+  const pattern = readString(patPtr, patLen);
+  const replacement = readString(repPtr, repLen);
+  try {
+    const re = new RegExp(pattern);  // no 'g' flag — first match only
+    const result = input.replace(re, replacement);
+    return allocResultOkString(result);
+  } catch (e) {
+    return allocResultErrString(`invalid regex: ${e.message}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Import object builder (dynamic introspection)
 // ---------------------------------------------------------------------------
 
@@ -944,6 +1019,13 @@ const MD_BINDINGS = {
   md_has_heading: hostMdHasHeading,
   md_has_code_block: hostMdHasCodeBlock,
   md_extract_code_blocks: hostMdExtractCodeBlocks,
+};
+
+const REGEX_BINDINGS = {
+  regex_match: hostRegexMatch,
+  regex_find: hostRegexFind,
+  regex_find_all: hostRegexFindAll,
+  regex_replace: hostRegexReplace,
 };
 
 function buildImportObject(module) {
@@ -986,6 +1068,11 @@ function buildImportObject(module) {
 
   // Markdown bindings
   for (const [name, fn] of Object.entries(MD_BINDINGS)) {
+    if (needed.has(name)) imports.vera[name] = fn;
+  }
+
+  // Regex bindings
+  for (const [name, fn] of Object.entries(REGEX_BINDINGS)) {
     if (needed.has(name)) imports.vera[name] = fn;
   }
 

--- a/vera/codegen/api.py
+++ b/vera/codegen/api.py
@@ -80,6 +80,7 @@ class CompileResult:
     diagnostics: list["Diagnostic"] = field(default_factory=list)
     state_types: list[tuple[str, str]] = field(default_factory=list)
     md_ops_used: set[str] = field(default_factory=set)
+    regex_ops_used: set[str] = field(default_factory=set)
 
     @property
     def ok(self) -> bool:
@@ -286,6 +287,16 @@ def execute(
             _write_i32(caller, backing_ptr + i * 8, str_ptr)
             _write_i32(caller, backing_ptr + i * 8 + 4, str_len)
         return (backing_ptr, count)
+
+    def _alloc_result_ok_i32(
+        caller: wasmtime.Caller, value: int,
+    ) -> int:
+        """Allocate Result.Ok(i32) — wraps a heap pointer in Ok."""
+        # Layout: tag(i32)=0 at +0, value(i32) at +4
+        adt_ptr = _call_alloc(caller, 8)
+        _write_i32(caller, adt_ptr, 0)       # tag = Ok
+        _write_i32(caller, adt_ptr + 4, value)
+        return adt_ptr
 
     # -----------------------------------------------------------------
     # IO host functions
@@ -512,16 +523,6 @@ def execute(
             write_md_block,
         )
 
-        def _alloc_result_ok_i32(
-            caller: wasmtime.Caller, value: int,
-        ) -> int:
-            """Allocate Result.Ok(i32) — wraps a heap pointer in Ok."""
-            # Layout: tag(i32)=0 at +0, value(i32) at +4
-            adt_ptr = _call_alloc(caller, 8)
-            _write_i32(caller, adt_ptr, 0)       # tag = Ok
-            _write_i32(caller, adt_ptr + 4, value)
-            return adt_ptr
-
         # md_parse(ptr, len) → i32 (Result<MdBlock, String>)
         def host_md_parse(
             caller: wasmtime.Caller, ptr: int, length: int,
@@ -616,6 +617,129 @@ def execute(
         linker.define_func(
             "vera", "md_extract_code_blocks", md_extract_type,
             host_md_extract_code_blocks, access_caller=True,
+        )
+
+    # -----------------------------------------------------------------
+    # Regex host functions (§9.6.15)
+    # -----------------------------------------------------------------
+
+    if result.regex_ops_used:
+        import re as _re
+
+        def host_regex_match(
+            caller: wasmtime.Caller,
+            in_ptr: int, in_len: int, pat_ptr: int, pat_len: int,
+        ) -> int:
+            input_str = _read_wasm_string(caller, in_ptr, in_len)
+            pattern = _read_wasm_string(caller, pat_ptr, pat_len)
+            try:
+                matched = _re.search(pattern, input_str) is not None
+                return _alloc_result_ok_i32(caller, 1 if matched else 0)
+            except _re.error as exc:
+                return _alloc_result_err_string(
+                    caller, f"invalid regex: {exc}",
+                )
+
+        regex_match_type = wasmtime.FuncType(
+            [wasmtime.ValType.i32()] * 4,
+            [wasmtime.ValType.i32()],
+        )
+        linker.define_func(
+            "vera", "regex_match", regex_match_type,
+            host_regex_match, access_caller=True,
+        )
+
+        def host_regex_find(
+            caller: wasmtime.Caller,
+            in_ptr: int, in_len: int, pat_ptr: int, pat_len: int,
+        ) -> int:
+            input_str = _read_wasm_string(caller, in_ptr, in_len)
+            pattern = _read_wasm_string(caller, pat_ptr, pat_len)
+            try:
+                m = _re.search(pattern, input_str)
+                if m:
+                    option_ptr = _alloc_option_some_string(
+                        caller, m.group(0),
+                    )
+                else:
+                    option_ptr = _alloc_option_none(caller)
+                return _alloc_result_ok_i32(caller, option_ptr)
+            except _re.error as exc:
+                return _alloc_result_err_string(
+                    caller, f"invalid regex: {exc}",
+                )
+
+        regex_find_type = wasmtime.FuncType(
+            [wasmtime.ValType.i32()] * 4,
+            [wasmtime.ValType.i32()],
+        )
+        linker.define_func(
+            "vera", "regex_find", regex_find_type,
+            host_regex_find, access_caller=True,
+        )
+
+        def host_regex_find_all(
+            caller: wasmtime.Caller,
+            in_ptr: int, in_len: int, pat_ptr: int, pat_len: int,
+        ) -> int:
+            input_str = _read_wasm_string(caller, in_ptr, in_len)
+            pattern = _read_wasm_string(caller, pat_ptr, pat_len)
+            try:
+                # Use finditer + group(0) to always get full match
+                # strings, even when the pattern has capture groups.
+                matches = [
+                    m.group(0)
+                    for m in _re.finditer(pattern, input_str)
+                ]
+                backing_ptr, count = _alloc_array_of_strings(
+                    caller, matches,
+                )
+                # Wrap in Result.Ok: tag=0, backing_ptr, count (12 bytes)
+                adt_ptr = _call_alloc(caller, 12)
+                _write_i32(caller, adt_ptr, 0)            # tag = Ok
+                _write_i32(caller, adt_ptr + 4, backing_ptr)
+                _write_i32(caller, adt_ptr + 8, count)
+                return adt_ptr
+            except _re.error as exc:
+                return _alloc_result_err_string(
+                    caller, f"invalid regex: {exc}",
+                )
+
+        regex_find_all_type = wasmtime.FuncType(
+            [wasmtime.ValType.i32()] * 4,
+            [wasmtime.ValType.i32()],
+        )
+        linker.define_func(
+            "vera", "regex_find_all", regex_find_all_type,
+            host_regex_find_all, access_caller=True,
+        )
+
+        def host_regex_replace(
+            caller: wasmtime.Caller,
+            in_ptr: int, in_len: int,
+            pat_ptr: int, pat_len: int,
+            rep_ptr: int, rep_len: int,
+        ) -> int:
+            input_str = _read_wasm_string(caller, in_ptr, in_len)
+            pattern = _read_wasm_string(caller, pat_ptr, pat_len)
+            replacement = _read_wasm_string(caller, rep_ptr, rep_len)
+            try:
+                result_str = _re.sub(
+                    pattern, replacement, input_str, count=1,
+                )
+                return _alloc_result_ok_string(caller, result_str)
+            except _re.error as exc:
+                return _alloc_result_err_string(
+                    caller, f"invalid regex: {exc}",
+                )
+
+        regex_replace_type = wasmtime.FuncType(
+            [wasmtime.ValType.i32()] * 6,
+            [wasmtime.ValType.i32()],
+        )
+        linker.define_func(
+            "vera", "regex_replace", regex_replace_type,
+            host_regex_replace, access_caller=True,
         )
 
     instance = linker.instantiate(store, module)

--- a/vera/codegen/assembly.py
+++ b/vera/codegen/assembly.py
@@ -61,6 +61,28 @@ class AssemblyMixin:
         if self._md_ops_used:
             self._needs_alloc = True
 
+        # Import Regex host-import builtins (pure functions)
+        _REGEX_IMPORTS: dict[str, str] = {
+            "regex_match":
+                "(func $vera.regex_match"
+                " (param i32 i32 i32 i32) (result i32))",
+            "regex_find":
+                "(func $vera.regex_find"
+                " (param i32 i32 i32 i32) (result i32))",
+            "regex_find_all":
+                "(func $vera.regex_find_all"
+                " (param i32 i32 i32 i32) (result i32))",
+            "regex_replace":
+                "(func $vera.regex_replace"
+                " (param i32 i32 i32 i32 i32 i32) (result i32))",
+        }
+        for op_name in sorted(self._regex_ops_used):
+            sig = _REGEX_IMPORTS.get(op_name)
+            if sig:
+                parts.append(f'  (import "vera" "{op_name}" {sig})')
+        if self._regex_ops_used:
+            self._needs_alloc = True
+
         # Import contract_fail for informative violation messages
         if self._needs_contract_fail:
             parts.append(
@@ -123,7 +145,11 @@ class AssemblyMixin:
             parts.append(self._emit_gc_collect())
 
         # Export $alloc when host functions need to allocate WASM memory
-        if (self._io_ops_used & _IO_OPS_NEEDING_ALLOC) or self._md_ops_used:
+        if (
+            (self._io_ops_used & _IO_OPS_NEEDING_ALLOC)
+            or self._md_ops_used
+            or self._regex_ops_used
+        ):
             parts.append('  (export "alloc" (func $alloc))')
 
         # Closure type declarations (for call_indirect)

--- a/vera/codegen/compilability.py
+++ b/vera/codegen/compilability.py
@@ -149,12 +149,17 @@ class CompilabilityMixin:
         "md_has_code_block", "md_extract_code_blocks",
     })
 
+    _REGEX_BUILTINS = frozenset({
+        "regex_match", "regex_find", "regex_find_all", "regex_replace",
+    })
+
     def _scan_io_ops(self, node: ast.Node) -> None:
-        """Walk a function body looking for IO qualified calls and md_* builtins.
+        """Walk a function body looking for IO, Markdown, and Regex builtins.
 
         Registers each distinct IO operation name (print, read_line, etc.)
         into ``_io_ops_used`` for per-operation import emission.  Also
-        registers Markdown host-import builtins into ``_md_ops_used``.
+        registers Markdown host-import builtins into ``_md_ops_used``
+        and regex host-import builtins into ``_regex_ops_used``.
         """
         if isinstance(node, ast.QualifiedCall):
             if node.qualifier == "IO":
@@ -172,6 +177,8 @@ class CompilabilityMixin:
         elif isinstance(node, ast.FnCall):
             if node.name in self._MD_BUILTINS:
                 self._md_ops_used.add(node.name)
+            if node.name in self._REGEX_BUILTINS:
+                self._regex_ops_used.add(node.name)
             for arg in node.args:
                 self._scan_io_ops(arg)
         elif isinstance(node, ast.ConstructorCall):

--- a/vera/codegen/core.py
+++ b/vera/codegen/core.py
@@ -74,6 +74,7 @@ class CodeGenerator(
         self._state_types: list[tuple[str, str]] = []  # (type_name, wasm_type)
         self._exn_types: list[tuple[str, str]] = []  # (type_name, wasm_type)
         self._md_ops_used: set[str] = set()  # Markdown host-import builtins
+        self._regex_ops_used: set[str] = set()  # Regex host-import builtins
 
         # ADT layout metadata (populated during registration)
         self._adt_layouts: dict[str, dict[str, ConstructorLayout]] = {}
@@ -157,6 +158,7 @@ class CodeGenerator(
                 diagnostics=self.diagnostics,
                 state_types=list(self._state_types),
                 md_ops_used=set(self._md_ops_used),
+                regex_ops_used=set(self._regex_ops_used),
             )
 
         # Pass 2: compile function bodies
@@ -227,6 +229,7 @@ class CodeGenerator(
                 diagnostics=self.diagnostics,
                 state_types=list(self._state_types),
                 md_ops_used=set(self._md_ops_used),
+                regex_ops_used=set(self._regex_ops_used),
             )
 
         return CompileResult(
@@ -236,6 +239,7 @@ class CodeGenerator(
             diagnostics=self.diagnostics,
             state_types=list(self._state_types),
             md_ops_used=set(self._md_ops_used),
+            regex_ops_used=set(self._regex_ops_used),
         )
 
     # -----------------------------------------------------------------

--- a/vera/codegen/modules.py
+++ b/vera/codegen/modules.py
@@ -255,6 +255,8 @@ class CrossModuleMixin:
             "async", "await",
             "md_parse", "md_render", "md_has_heading",
             "md_has_code_block", "md_extract_code_blocks",
+            "regex_match", "regex_find", "regex_find_all",
+            "regex_replace",
         })
 
         seen: set[str] = set()  # deduplicate by function name

--- a/vera/environment.py
+++ b/vera/environment.py
@@ -526,6 +526,39 @@ class TypeEnv:
             return_type=AdtType("Array", (STRING,)),
             effect=PureEffectRow(),
         )
+        # Regex builtins (§9.6.15) — host-imported, pure
+        self.functions["regex_match"] = FunctionInfo(
+            name="regex_match",
+            forall_vars=None,
+            param_types=(STRING, STRING),
+            return_type=AdtType("Result", (BOOL, STRING)),
+            effect=PureEffectRow(),
+        )
+        self.functions["regex_find"] = FunctionInfo(
+            name="regex_find",
+            forall_vars=None,
+            param_types=(STRING, STRING),
+            return_type=AdtType(
+                "Result", (AdtType("Option", (STRING,)), STRING),
+            ),
+            effect=PureEffectRow(),
+        )
+        self.functions["regex_find_all"] = FunctionInfo(
+            name="regex_find_all",
+            forall_vars=None,
+            param_types=(STRING, STRING),
+            return_type=AdtType(
+                "Result", (AdtType("Array", (STRING,)), STRING),
+            ),
+            effect=PureEffectRow(),
+        )
+        self.functions["regex_replace"] = FunctionInfo(
+            name="regex_replace",
+            forall_vars=None,
+            param_types=(STRING, STRING, STRING),
+            return_type=AdtType("Result", (STRING, STRING)),
+            effect=PureEffectRow(),
+        )
         # Async builtins — require effects(<Async>)
         _ASYNC_EFFECT = ConcreteEffectRow(
             frozenset({EffectInstance("Async", ())}), row_var=None,

--- a/vera/wasm/calls.py
+++ b/vera/wasm/calls.py
@@ -89,6 +89,23 @@ class CallsMixin:
                 return self._translate_md_extract_code_blocks(
                     call.args[0], call.args[1], env,
                 )
+            # Regex host-import builtins (pure, host-provided)
+            if call.name == "regex_match" and len(call.args) == 2:
+                return self._translate_regex_match(
+                    call.args[0], call.args[1], env,
+                )
+            if call.name == "regex_find" and len(call.args) == 2:
+                return self._translate_regex_find(
+                    call.args[0], call.args[1], env,
+                )
+            if call.name == "regex_find_all" and len(call.args) == 2:
+                return self._translate_regex_find_all(
+                    call.args[0], call.args[1], env,
+                )
+            if call.name == "regex_replace" and len(call.args) == 3:
+                return self._translate_regex_replace(
+                    call.args[0], call.args[1], call.args[2], env,
+                )
             if call.name == "async" and len(call.args) == 1:
                 return self._translate_async(call.args[0], env)
             if call.name == "await" and len(call.args) == 1:
@@ -4181,6 +4198,86 @@ class CallsMixin:
         ins.extend(b_instrs)
         ins.extend(l_instrs)
         ins.append("call $vera.md_extract_code_blocks")
+        return ins
+
+    # ---- Regex host-import builtins -------------------------------------
+
+    def _translate_regex_match(
+        self, input_arg: ast.Expr, pattern_arg: ast.Expr,
+        env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """regex_match(input, pattern) → Result<Bool, String> via host import.
+
+        Two string args → (i32, i32, i32, i32) → call $vera.regex_match → i32.
+        """
+        in_instrs = self.translate_expr(input_arg, env)
+        pat_instrs = self.translate_expr(pattern_arg, env)
+        if in_instrs is None or pat_instrs is None:
+            return None
+        self.needs_alloc = True
+        ins: list[str] = []
+        ins.extend(in_instrs)
+        ins.extend(pat_instrs)
+        ins.append("call $vera.regex_match")
+        return ins
+
+    def _translate_regex_find(
+        self, input_arg: ast.Expr, pattern_arg: ast.Expr,
+        env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """regex_find(input, pattern) → Result<Option<String>, String>.
+
+        Two string args → (i32, i32, i32, i32) → call $vera.regex_find → i32.
+        """
+        in_instrs = self.translate_expr(input_arg, env)
+        pat_instrs = self.translate_expr(pattern_arg, env)
+        if in_instrs is None or pat_instrs is None:
+            return None
+        self.needs_alloc = True
+        ins: list[str] = []
+        ins.extend(in_instrs)
+        ins.extend(pat_instrs)
+        ins.append("call $vera.regex_find")
+        return ins
+
+    def _translate_regex_find_all(
+        self, input_arg: ast.Expr, pattern_arg: ast.Expr,
+        env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """regex_find_all(input, pattern) → Result<Array<String>, String>.
+
+        Two string args → (i32, i32, i32, i32) → call → i32.
+        """
+        in_instrs = self.translate_expr(input_arg, env)
+        pat_instrs = self.translate_expr(pattern_arg, env)
+        if in_instrs is None or pat_instrs is None:
+            return None
+        self.needs_alloc = True
+        ins: list[str] = []
+        ins.extend(in_instrs)
+        ins.extend(pat_instrs)
+        ins.append("call $vera.regex_find_all")
+        return ins
+
+    def _translate_regex_replace(
+        self, input_arg: ast.Expr, pattern_arg: ast.Expr,
+        replacement_arg: ast.Expr, env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """regex_replace(input, pattern, replacement) → Result<String, String>.
+
+        Three string args → (i32, i32, i32, i32, i32, i32) → call → i32.
+        """
+        in_instrs = self.translate_expr(input_arg, env)
+        pat_instrs = self.translate_expr(pattern_arg, env)
+        rep_instrs = self.translate_expr(replacement_arg, env)
+        if in_instrs is None or pat_instrs is None or rep_instrs is None:
+            return None
+        self.needs_alloc = True
+        ins: list[str] = []
+        ins.extend(in_instrs)
+        ins.extend(pat_instrs)
+        ins.extend(rep_instrs)
+        ins.append("call $vera.regex_replace")
         return ins
 
     # ---- Async builtins -----------------------------------------------

--- a/vera/wasm/inference.py
+++ b/vera/wasm/inference.py
@@ -236,6 +236,12 @@ class InferenceMixin:
             return "i32"
         if expr.name in ("md_render", "md_extract_code_blocks"):
             return "i32_pair"
+        # Regex builtins — all return Result<T, String> → heap ptr (i32)
+        if expr.name in (
+            "regex_match", "regex_find", "regex_find_all",
+            "regex_replace",
+        ):
+            return "i32"
         # Async builtins — identity operations (Future<T> is transparent)
         if expr.name in ("async", "await") and expr.args:
             return self._infer_expr_wasm_type(expr.args[0])
@@ -428,6 +434,12 @@ class InferenceMixin:
             return "Bool"
         if call.name == "md_extract_code_blocks":
             return "Array"
+        # Regex builtins — all return Result
+        if call.name in (
+            "regex_match", "regex_find", "regex_find_all",
+            "regex_replace",
+        ):
+            return "Result"
         # Async builtins — Future<T> is transparent
         if call.name == "async" and call.args:
             inner = self._infer_fncall_vera_type(call.args[0]) \


### PR DESCRIPTION
## Summary

- Four new pure functions for regular expression matching: `regex_match`, `regex_find`, `regex_find_all`, `regex_replace`
- All return `Result` types for safe invalid-pattern handling, consistent with every other fallible builtin
- Implemented as WASM host imports — Python `re` for wasmtime, JS `RegExp` for browser runtime, with identical semantics across both
- Clears the C8.5 builtin extensions; C9 and C10 marked "In Progress"

## Details

**Compiler** (8 files): type checker registration, codegen tracking/scanning/imports/assembly, WASM call translation and type inference, host bindings for both Python and JavaScript runtimes.

**Tests** (28 new, 2287 total): 10 codegen, 6 type checker, browser parity, conformance `ch09_regex` (53 programs), example `regex.vera` (24 examples), verifier tier count update.

**Docs**: spec §9.6.15, SKILL.md, CHANGELOG, ROADMAP (#231 struck, C9/C10 → In Progress), README, CLAUDE.md, AGENTS.md, TESTING.md, CONTRIBUTING.md.

## Runtime parity

| Function | Python | JavaScript |
|----------|--------|------------|
| `regex_match` | `re.search()` | `RegExp.test()` |
| `regex_find` | `re.search().group(0)` | `input.match(re)?.[0]` |
| `regex_find_all` | `re.finditer()` + `group(0)` | `re.exec()` loop with `g` flag |
| `regex_replace` | `re.sub(count=1)` | `input.replace(re)` — no `g` flag |

Uses `re.finditer` (not `re.findall`) to avoid Python capture-group return type change. JS `find_all` uses manual `exec()` loop with zero-length match guard to prevent infinite loops.

## Test plan

- [x] `pytest tests/ -v` — 2287 passed
- [x] `mypy vera/` — clean
- [x] `python scripts/check_conformance.py` — 53 programs pass
- [x] `python scripts/check_examples.py` — 24 examples pass
- [x] `python scripts/check_spec_examples.py` — all spec blocks pass
- [x] `python scripts/check_skill_examples.py` — all SKILL.md blocks pass
- [x] `python scripts/check_version_sync.py` — 0.0.86 consistent
- [x] `python scripts/check_doc_counts.py` — all counts match
- [x] All 17 pre-commit hooks pass

Closes #231
