### PR TITLE
Fix browser bundle docs: ES modules require HTTP serving

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ Browser bundle: examples/hello_world_browser/
   index.html
 ```
 
-This produces a ready-to-serve directory. Open `index.html` in any browser — no build step, no bundler, no dependencies. The JavaScript runtime provides browser-appropriate implementations of all Vera host bindings: `IO.print` writes to the page, `IO.read_line` uses `prompt()`, and all other operations (State, contracts, Markdown) work identically to the Python runtime. Mandatory parity tests enforce this on every PR.
+This produces a ready-to-serve directory — no build step, no bundler, no dependencies. Serve it with any HTTP server (`python -m http.server`) and open `index.html`. The JavaScript runtime provides browser-appropriate implementations of all Vera host bindings: `IO.print` writes to the page, `IO.read_line` uses `prompt()`, and all other operations (State, contracts, Markdown) work identically to the Python runtime. Mandatory parity tests enforce this on every PR.
 
 The runtime also works in Node.js:
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -69,7 +69,7 @@ vera compile --target browser file.vera            # Output to file_browser/
 vera compile --target browser file.vera -o dist/   # Output to dist/
 ```
 
-This generates three files: `module.wasm` (the compiled binary), `vera-runtime.mjs` (self-contained JavaScript runtime with all host bindings), and `index.html` (loads and runs the program). Open `index.html` in any browser or serve it with a local HTTP server.
+This generates three files: `module.wasm` (the compiled binary), `vera-runtime.mjs` (self-contained JavaScript runtime with all host bindings), and `index.html` (loads and runs the program). Serve the output directory with any HTTP server (`python -m http.server`) and open `index.html` — ES module imports require HTTP, not `file://`.
 
 The JavaScript runtime provides browser-appropriate implementations: `IO.print` writes to the page, `IO.read_line` uses `prompt()`, file IO returns `Result.Err`, and all other operations (State, contracts, Markdown) work identically to the Python runtime.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -751,7 +751,7 @@ Browser bundle: examples/hello_world_browser/
   runtime.mjs
   index.html</pre>
         </div>
-        <p class="runs-note">The browser bundle is self-contained &mdash; open <code>index.html</code> directly, no build step or bundler needed. <code>IO.print</code> writes to the page, <code>IO.read_line</code> uses <code>prompt()</code>, and all other operations work identically to the CLI runtime. Mandatory parity tests enforce this on every PR.</p>
+        <p class="runs-note">The browser bundle is self-contained &mdash; no build step or bundler needed. Serve the output directory with any HTTP server (<code>python&nbsp;-m&nbsp;http.server</code>) and open <code>index.html</code>. <code>IO.print</code> writes to the page, <code>IO.read_line</code> uses <code>prompt()</code>, and all other operations work identically to the CLI runtime. Mandatory parity tests enforce this on every PR.</p>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary

- Fix browser bundle instructions in `docs/index.html`, `README.md`, and `SKILL.md` to mention HTTP serving requirement
- ES module imports (`import ... from './runtime.mjs'`) are blocked by browsers over `file://` due to CORS — users need to serve the bundle directory

## Changes

| File | Before | After |
|------|--------|-------|
| `docs/index.html` | "open `index.html` directly" | "Serve the output directory with any HTTP server (`python -m http.server`) and open `index.html`" |
| `README.md` | "Open `index.html` in any browser" | "Serve it with any HTTP server (`python -m http.server`) and open `index.html`" |
| `SKILL.md` | "Open `index.html` in any browser or serve it with a local HTTP server" | "Serve the output directory with any HTTP server (`python -m http.server`) and open `index.html` — ES module imports require HTTP, not `file://`" |

Also checked `spec/12-runtime.md` and `vera/README.md` — both say "ready-to-serve" which is accurate and doesn't need changing.

## Test plan

- [x] `python scripts/check_readme_examples.py` — pass
- [x] `python scripts/check_skill_examples.py` — pass
- [x] `python scripts/check_doc_counts.py` — pass
- [x] All pre-commit hooks pass
