### PR TITLE
Fix browser bundle link: point to veralang.dev

### DIFF
--- a/vera/browser/emit.py
+++ b/vera/browser/emit.py
@@ -75,7 +75,7 @@ _INDEX_HTML_TEMPLATE = """\
 <body>
   <h1>{title}</h1>
   <pre id="output">Loading...</pre>
-  <p class="meta">Compiled with <a href="https://github.com/negroniclub/vera">Vera</a></p>
+  <p class="meta">Compiled with <a href="https://veralang.dev">Vera</a></p>
   <script type="module">
     import init, {{ call, getStdout, getState, getExitCode }} from './runtime.mjs';
 


### PR DESCRIPTION
The generated `index.html` in browser bundles (`vera/browser/emit.py`) linked to `github.com/negroniclub/vera` — an unrelated URL with no affiliation to this project. Fixed to point to `veralang.dev`.