### PR TITLE
Add FizzBuzz example and iteration docs — v0.0.87

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,7 +144,7 @@ pytest tests/ -v                       # Run all tests (see TESTING.md)
 pytest tests/test_conformance.py -v    # Conformance suite only
 mypy vera/                             # Type-check the compiler
 python scripts/check_conformance.py    # All 53 conformance programs must pass
-python scripts/check_examples.py       # All 24 examples must pass
+python scripts/check_examples.py       # All 25 examples must pass
 ```
 
 Test helpers follow a pattern: `_check_ok(source)` / `_check_err(source, match)` / `_verify_ok(source)` / `_verify_err(source, match)`. See existing tests for examples.
@@ -154,7 +154,7 @@ When implementing a new language feature, write the conformance program *first* 
 ### Invariants
 
 - All 53 conformance programs in `tests/conformance/` must pass their declared level
-- All 24 examples in `examples/` must pass `vera check` and `vera verify`
+- All 25 examples in `examples/` must pass `vera check` and `vera verify`
 - `mypy vera/` must be clean
 - `pytest tests/ -v` must pass
 - Version must be in sync across `vera/__init__.py`, `pyproject.toml`, and `CHANGELOG.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.87] - 2026-03-11
+
+### Added
+- **FizzBuzz example** — complete runnable program demonstrating recursion as iteration with IO effects (`examples/fizzbuzz.vera`)
+- **"Recursion as iteration" section** in README "What Vera Looks Like" — explains the standard Vera pattern for counted iteration
+- **"Iteration" section** in SKILL.md — documents the tail-recursive loop pattern for agents
+- **De Bruijn slot reference reminder** in CLAUDE.md — documents that `@T.0` = most recent (last) parameter
+
+### Fixed
+- **Verifier branch-condition bug** documented ([#283](https://github.com/aallan/vera/issues/283)) — call-site precondition checking doesn't use if-guard path conditions; added to Known Bugs with workaround
+
 ## [0.0.86] - 2026-03-11
 
 ### Added
@@ -1334,7 +1345,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Grammar: handler body simplified to avoid LALR reduce/reduce conflict
 - `pyproject.toml`: corrected build backend, package discovery, PEP 639 compliance
 
-[Unreleased]: https://github.com/aallan/vera/compare/v0.0.86...HEAD
+[Unreleased]: https://github.com/aallan/vera/compare/v0.0.87...HEAD
+[0.0.87]: https://github.com/aallan/vera/compare/v0.0.86...v0.0.87
 [0.0.86]: https://github.com/aallan/vera/compare/v0.0.85...v0.0.86
 [0.0.85]: https://github.com/aallan/vera/compare/v0.0.84...v0.0.85
 [0.0.84]: https://github.com/aallan/vera/compare/v0.0.83...v0.0.84

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ pytest tests/ -v                  # Run the test suite (see TESTING.md)
 mypy vera/                        # Type-check the compiler itself
 
 python scripts/check_conformance.py    # Verify all 53 conformance programs pass their declared level
-python scripts/check_examples.py      # Verify all 24 examples parse + check + verify
+python scripts/check_examples.py      # Verify all 25 examples parse + check + verify
 python scripts/check_spec_examples.py # Verify spec code blocks parse
 python scripts/check_readme_examples.py # Verify README code blocks parse
 python scripts/check_skill_examples.py # Verify SKILL.md code blocks parse
@@ -57,7 +57,7 @@ python scripts/fix_allowlists.py --fix # Auto-fix stale allowlist line numbers
 
 - `spec/` — Language specification (Chapters 0-12)
 - `vera/` — Reference compiler: grammar, parser, AST, transformer, type checker, verifier, codegen, CLI
-- `examples/` — 24 example Vera programs (all must pass `vera check` and `vera verify`)
+- `examples/` — 25 example Vera programs (all must pass `vera check` and `vera verify`)
 - `tests/` — Test suite (unit tests + conformance suite)
 - `tests/conformance/` — 53 conformance programs validating every language feature against the spec
 - `scripts/` — CI and validation scripts
@@ -65,6 +65,15 @@ python scripts/fix_allowlists.py --fix # Auto-fix stale allowlist line numbers
 ## Writing Vera code
 
 Read `SKILL.md` for the full language reference. It covers syntax, slot references, contracts, effects, common mistakes, and working examples.
+
+### De Bruijn slot references
+
+Vera uses De Bruijn indexing for slot references: `@T.0` = **most recent** (last) binding of type T, not the first. For a function `fn foo(@Int, @Int -> @Int)`:
+
+- `@Int.0` = second parameter (most recent)
+- `@Int.1` = first parameter
+
+This matters when multiple parameters share a type. See `tests/conformance/ch03_slot_indexing.vera` for the canonical test. Commutative operations like `@Int.0 + @Int.1` mask the ordering, so be especially careful with non-commutative operations (division, comparison, subtraction) and recursive calls where parameter position determines semantics.
 
 ## Working on the compiler
 
@@ -78,7 +87,7 @@ Each stage is a module with a public API function and is independently testable.
 
 - Pre-commit hooks run mypy + pytest + conformance suite + example validation on every commit
 - All 53 conformance programs in `tests/conformance/` must pass their declared level
-- All 24 examples in `examples/` must pass `vera check` and `vera verify`
+- All 25 examples in `examples/` must pass `vera check` and `vera verify`
 - Version must stay in sync across `vera/__init__.py`, `pyproject.toml`, and `CHANGELOG.md`
 - All tests must pass: `pytest tests/ -v`
 - Type checking must be clean: `mypy vera/`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ After running `pre-commit install`, every commit is automatically checked by 17 
 - mypy type checking
 - pytest test suite
 - All 53 conformance programs pass their declared level
-- All 24 `.vera` examples type-check and verify cleanly
+- All 25 `.vera` examples type-check and verify cleanly
 - README, SKILL.md, HTML, and spec code blocks parse correctly
 - Documentation counts match live codebase
 - Browser parity (JS runtime matches Python runtime)
@@ -104,7 +104,7 @@ mypy vera/
 
 ```bash
 python scripts/check_conformance.py      # verify all 53 conformance programs
-python scripts/check_examples.py         # verify all 24 .vera examples
+python scripts/check_examples.py         # verify all 25 .vera examples
 python scripts/check_spec_examples.py    # verify spec code blocks parse
 python scripts/check_readme_examples.py  # verify README code blocks parse
 python scripts/check_skill_examples.py   # verify SKILL.md code blocks parse

--- a/README.md
+++ b/README.md
@@ -231,6 +231,61 @@ public fn main(@Unit -> @Unit)
 
 > [`examples/async_futures.vera`](examples/async_futures.vera) — run with `vera run examples/async_futures.vera`
 
+### Recursion as iteration
+
+Vera has no `for` or `while` loops — iteration is always recursion. The `loop` function calls itself with `@Nat.0 + 1` until it reaches the bound. This is the standard Vera pattern for counted iteration.
+
+Notice the separation of concerns: `fizzbuzz` is `effects(pure)` — the verifier can reason about it with SMT. `loop` has `effects(<IO>)` because it prints. `main` calls `loop` and also has `effects(<IO>)`. The effect annotations propagate up the call chain but never contaminate the pure classifier.
+
+```vera
+effect IO {
+  op print(String -> Unit);
+}
+
+public fn fizzbuzz(@Nat -> @String)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  if @Nat.0 % 15 == 0 then {
+    "FizzBuzz"
+  } else {
+    if @Nat.0 % 3 == 0 then {
+      "Fizz"
+    } else {
+      if @Nat.0 % 5 == 0 then {
+        "Buzz"
+      } else {
+        "\(@Nat.0)"
+      }
+    }
+  }
+}
+
+private fn loop(@Nat, @Nat -> @Unit)
+  requires(true)
+  ensures(true)
+  effects(<IO>)
+{
+  IO.print(string_concat(fizzbuzz(@Nat.0), "\n"));
+  if @Nat.0 < @Nat.1 then {
+    loop(@Nat.1, @Nat.0 + 1)
+  } else {
+    ()
+  }
+}
+
+public fn main(@Unit -> @Unit)
+  requires(true)
+  ensures(true)
+  effects(<IO>)
+{
+  loop(100, 1)
+}
+```
+
+> [`examples/fizzbuzz.vera`](examples/fizzbuzz.vera) — run with `vera run examples/fizzbuzz.vera`
+
 ### Typed Markdown
 
 Vera has a built-in Markdown document type. `md_parse` produces a typed `MdBlock` tree; `md_has_heading` and `md_extract_code_blocks` query its structure. This is designed for agent workflows where an LLM produces structured output and the contract system validates its shape.
@@ -509,7 +564,7 @@ vera/
 │   ├── formatter.py               # Canonical code formatter
 │   ├── errors.py                  # LLM-oriented diagnostics
 │   └── cli.py                     # Command-line interface
-├── examples/                      # 24 example Vera programs
+├── examples/                      # 25 example Vera programs
 ├── tests/                         # Test suite (see TESTING.md)
 └── scripts/                       # CI and validation scripts
 ```
@@ -522,11 +577,12 @@ For compiler architecture, pipeline internals, and how to extend the compiler, s
 
 ### Testing
 
-Testing is organized in three layers: **unit tests** (2,287 tests across 23 files, testing compiler internals and browser parity), a **conformance suite** (53 programs across 9 spec chapters, systematically validating every language feature against the spec), and **example programs** (24 end-to-end demos). The compiler has 91% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations plus a dedicated browser parity job (Node.js 22). Every commit validates all conformance programs, example programs, and specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference.
+Testing is organized in three layers: **unit tests** (2,292 tests across 23 files, testing compiler internals and browser parity), a **conformance suite** (53 programs across 9 spec chapters, systematically validating every language feature against the spec), and **example programs** (25 end-to-end demos). The compiler has 91% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations plus a dedicated browser parity job (Node.js 22). Every commit validates all conformance programs, example programs, and specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference.
 
 ### Known Bugs
 
 - [#274](https://github.com/aallan/vera/issues/274) — Formatter collapses multi-statement blocks in match arms to single unparseable lines; comments inside function bodies are repositioned outside. Workaround: extract multi-statement match arm logic into helper functions.
+- [#283](https://github.com/aallan/vera/issues/283) — Verifier doesn't use branch conditions when checking call-site preconditions: a recursive call guarded by `if @Nat.0 < @Nat.1` still reports E501 even though the counterexample is unreachable. Workaround: use `requires(true)` with an internal if-guard.
 
 ## Project Roadmap
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -408,6 +408,31 @@ Blocks contain statements followed by a final expression:
 
 Statements end with `;`. The final expression (no `;`) is the block's value.
 
+## Iteration
+
+Vera has no `for` or `while` loops. Iteration is always expressed as tail-recursive functions. The standard pattern for counted iteration:
+
+```vera
+private fn loop(@Nat, @Nat -> @Unit)
+  requires(true)
+  ensures(true)
+  effects(<IO>)
+{
+  IO.print(string_concat(fizzbuzz(@Nat.0), "\n"));
+  if @Nat.0 < @Nat.1 then {
+    loop(@Nat.1, @Nat.0 + 1)
+  } else {
+    ()
+  }
+}
+```
+
+Here `@Nat.0` is the counter (De Bruijn index 0 = most recent, i.e. the second parameter) and `@Nat.1` is the limit (the first parameter). The function prints, then either recurses with an incremented counter or returns `()`.
+
+Call with the limit first and counter second: `loop(100, 1)`.
+
+For pure recursive functions that need termination proofs, add a `decreases` clause (see [Recursion](#recursion)). Effectful recursive functions like the loop above do not require `decreases`.
+
 ## Built-in Functions
 
 ### Array operations
@@ -1269,6 +1294,57 @@ public fn length(@List<Int> -> @Nat)
     Nil -> 0,
     Cons(@Int, @List<Int>) -> 1 + length(@List<Int>.0)
   }
+}
+```
+
+### Iteration with IO
+
+FizzBuzz with a recursive loop and IO effects. `fizzbuzz` is pure; `loop` and `main` have `effects(<IO>)`. Run with `vera run examples/fizzbuzz.vera`.
+
+```vera
+effect IO {
+  op print(String -> Unit);
+}
+
+public fn fizzbuzz(@Nat -> @String)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  if @Nat.0 % 15 == 0 then {
+    "FizzBuzz"
+  } else {
+    if @Nat.0 % 3 == 0 then {
+      "Fizz"
+    } else {
+      if @Nat.0 % 5 == 0 then {
+        "Buzz"
+      } else {
+        "\(@Nat.0)"
+      }
+    }
+  }
+}
+
+private fn loop(@Nat, @Nat -> @Unit)
+  requires(true)
+  ensures(true)
+  effects(<IO>)
+{
+  IO.print(string_concat(fizzbuzz(@Nat.0), "\n"));
+  if @Nat.0 < @Nat.1 then {
+    loop(@Nat.1, @Nat.0 + 1)
+  } else {
+    ()
+  }
+}
+
+public fn main(@Unit -> @Unit)
+  requires(true)
+  ensures(true)
+  effects(<IO>)
+{
+  loop(100, 1)
 }
 ```
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,10 +6,10 @@ This is the single source of truth for Vera's testing infrastructure, coverage d
 
 | Metric | Value |
 |--------|-------|
-| **Tests** | 2,287 across 23 files (~24,000 lines of test code) |
+| **Tests** | 2,292 across 23 files (~24,000 lines of test code) |
 | **Compiler code coverage** | 91% of 14,298 statements (CI minimum: 80%) |
 | **Conformance programs** | 53 programs across 9 spec chapters, validating every language feature |
-| **Example programs** | 24, all validated through `vera check` + `vera verify` |
+| **Example programs** | 25, all validated through `vera check` + `vera verify` |
 | **Spec code blocks** | 148 parseable blocks from 13 spec chapters: 81 parse, 67 type-check, 66 verify |
 | **README code blocks** | 9 Vera blocks (8 validated, 1 allowlisted future syntax) |
 | **HTML code blocks** | 2 Vera blocks in docs/index.html (2 validated: parse + check + verify) |
@@ -33,7 +33,7 @@ mypy vera/                                           # strict mode
 
 # Validation scripts
 python scripts/check_conformance.py                  # conformance suite (53 programs)
-python scripts/check_examples.py                     # 24 example programs
+python scripts/check_examples.py                     # 25 example programs
 python scripts/check_spec_examples.py                # spec code blocks
 python scripts/check_readme_examples.py              # README code blocks
 python scripts/check_skill_examples.py               # SKILL.md code blocks
@@ -46,10 +46,10 @@ python scripts/fix_allowlists.py --fix               # auto-fix stale allowlists
 
 | File | Tests | Lines | What it covers |
 |------|------:|------:|----------------|
-| `test_parser.py` | 113 | 888 | Grammar rules, operator precedence, parse errors |
-| `test_ast.py` | 111 | 1,046 | AST transformation, node structure, serialisation, string escape sequences |
+| `test_parser.py` | 114 | 888 | Grammar rules, operator precedence, parse errors |
+| `test_ast.py` | 112 | 1,046 | AST transformation, node structure, serialisation, string escape sequences |
 | `test_checker.py` | 342 | 3,869 | Type synthesis, slot resolution, effects, effect subtyping, contracts, exhaustiveness, cross-module typing, visibility, error codes, string built-ins, generic rejection, IO operation types, Markdown types, Regex types |
-| `test_verifier.py` | 109 | 1,582 | Z3 verification, counterexamples, tier classification, call-site preconditions, pipe operator, cross-module contracts, match/ADT verification, decreases verification, mutual recursion |
+| `test_verifier.py` | 110 | 1,582 | Z3 verification, counterexamples, tier classification, call-site preconditions, pipe operator, cross-module contracts, match/ADT verification, decreases verification, mutual recursion |
 | `test_codegen.py` | 654 | 7,608 | WASM compilation, arithmetic, Float64, Byte, arrays (incl. compound element types), ADTs, match (incl. nested patterns), generics, State\<T\>, Exn\<E\> handlers, control flow, strings, string escape sequences, IO (read\_line, read\_file, write\_file, args, exit, get\_env), bounds checking, quantifiers, assert/assume, refinement type aliases, pipe operator, string built-ins, built-in shadowing, parse\_nat Result, GC, Markdown host bindings, Regex host bindings, example round-trips |
 | `test_codegen_contracts.py` | 32 | 576 | Runtime pre/postconditions, contract fail messages, old/new state postconditions |
 | `test_codegen_monomorphize.py` | 17 | 361 | Generic instantiation, type inference, monomorphization edge cases |
@@ -57,7 +57,7 @@ python scripts/fix_allowlists.py --fix               # auto-fix stale allowlists
 | `test_codegen_modules.py` | 18 | 529 | Cross-module guard rail, cross-module codegen, name collision detection (E608/E609/E610) |
 | `test_codegen_coverage.py` | 5 | 249 | Defensive error paths: E600, E601, E605, E606, unknown module calls |
 | `test_errors.py` | 52 | 525 | Error code registry, diagnostic formatting, serialisation, SourceLocation, error display sync (README/HTML/spec) |
-| `test_formatter.py` | 82 | 554 | Comment extraction, expression/declaration formatting, idempotency, parenthesization, spec rules |
+| `test_formatter.py` | 84 | 554 | Comment extraction, expression/declaration formatting, idempotency, parenthesization, spec rules |
 | `test_cli.py` | 111 | 1,440 | CLI commands (check, verify, compile, run, test, fmt), subprocess integration, JSON error paths, runtime traps, arg validation, multi-file resolution, IO exit codes |
 | `test_resolver.py` | 15 | 412 | Module resolution, path lookup, parse caching, circular import detection |
 | `test_types.py` | 73 | 390 | Type operations: subtyping, effect subtyping, equality, substitution, pretty-printing, canonical names |
@@ -192,13 +192,13 @@ The lowest-coverage modules (`parser.py` at 64%, `cli.py` at 68%) reflect auto-g
 
 Vera's verifier classifies each contract into one of three tiers. **Tier 1** contracts are proved correct statically by Z3 — no runtime overhead. **Tier 3** contracts cannot be fully decided by the SMT solver and fall back to runtime assertion checks. The verifier never rejects a valid program; it simply warns when a contract drops to Tier 3.
 
-Across all 24 example programs:
+Across all 25 example programs:
 
 | Metric | Value |
 |--------|-------|
-| **Tier 1 (static)** | 131 contracts — proved automatically by Z3 |
+| **Tier 1 (static)** | 139 contracts — proved automatically by Z3 |
 | **Tier 3 (runtime)** | 7 contracts — verified at runtime via assertion checks |
-| **Total** | 138 contracts (94.9% static) |
+| **Total** | 146 contracts (95.2% static) |
 
 The 4 remaining Tier 3 contracts and why they cannot be promoted:
 
@@ -224,7 +224,7 @@ How Vera language features (by spec chapter) map to test files and example progr
 | Ch 2: Types | ADTs (algebraic data types), Option, Result | test_codegen, test_checker | ch02_adt_basic, ch02_adt_recursive, ch02_option_result | pattern_matching, list_ops |
 | Ch 2: Types | Refinement types | test_codegen, test_verifier | ch02_refinement_types | refinement_types, safe_divide |
 | Ch 2: Types | Generics (`forall<T>`) | test_codegen_monomorphize, test_checker | ch02_generics | generics |
-| Ch 3: Slots | `@T.n` references, De Bruijn indexing | test_checker, test_codegen | ch03_slot_basic, ch03_slot_indexing, ch03_slot_result | all 24 examples |
+| Ch 3: Slots | `@T.n` references, De Bruijn indexing | test_checker, test_codegen | ch03_slot_basic, ch03_slot_indexing, ch03_slot_result | all 25 examples |
 | Ch 4: Expressions | Arithmetic, comparison, boolean, unary ops | test_codegen, test_checker | ch04_arithmetic, ch04_comparison, ch04_boolean_ops | factorial, absolute_value |
 | Ch 4: Expressions | If/else, let, match, pipe operator | test_codegen, test_checker | ch04_if_else, ch04_let_binding, ch04_match_basic, ch04_match_nested, ch04_pipe_operator | pattern_matching |
 | Ch 4: Expressions | String and array builtins | test_codegen | ch04_string_builtins, ch04_array_ops | string_ops |
@@ -273,7 +273,7 @@ _run_trap(source, fn, args)    # compile + execute, assert WASM trap
 
 ## Round-Trip Testing
 
-Every one of the 24 example programs in `examples/` is tested through **every pipeline stage** via parametrised tests: parsing, AST transformation, type checking, contract verification, WASM compilation, and execution. If you add a new `.vera` example, it is automatically included in the round-trip suite.
+Every one of the 25 example programs in `examples/` is tested through **every pipeline stage** via parametrised tests: parsing, AST transformation, type checking, contract verification, WASM compilation, and execution. If you add a new `.vera` example, it is automatically included in the round-trip suite.
 
 The formatter has **idempotency tests**: `format(format(x)) == format(x)` for all tested programs.
 
@@ -337,7 +337,7 @@ After running `pre-commit install`, every commit is checked by 17 hooks:
 | `pytest tests/ -q` | Run full test suite |
 | `fix_allowlists.py --fix` | Auto-fix stale allowlist line numbers |
 | `check_conformance.py` | All 52 conformance programs pass their declared level |
-| `check_examples.py` | All 24 examples pass `vera check` + `vera verify` |
+| `check_examples.py` | All 25 examples pass `vera check` + `vera verify` |
 | `check_readme_examples.py` | README code blocks parse correctly |
 | `check_skill_examples.py` | SKILL.md code blocks parse correctly |
 | `check_html_examples.py` | HTML landing page code blocks pass parse + check + verify |

--- a/docs/index.html
+++ b/docs/index.html
@@ -508,7 +508,7 @@
         For Agents → SKILL.md
       </a>
     </div>
-    <p style="text-align: center; margin-top: 1rem; font-size: 0.9rem; color: var(--brown-400);">Current Version: <a href="https://github.com/aallan/vera/releases/tag/v0.0.86" style="color: var(--brown-500); font-weight: 500;">v0.0.86</a></p>
+    <p style="text-align: center; margin-top: 1rem; font-size: 0.9rem; color: var(--brown-400);">Current Version: <a href="https://github.com/aallan/vera/releases/tag/v0.0.87" style="color: var(--brown-500); font-weight: 500;">v0.0.87</a></p>
   </div>
 
   <!-- Why -->
@@ -669,7 +669,7 @@
       </div>
 
       <div class="code-subsection">
-        <p class="code-intro">String interpolation, conditionals, and the <code>@T.n</code> slot reference system &mdash; in a program everyone recognises. There are no naming decisions to make, and none to hallucinate.</p>
+        <p class="code-intro">String interpolation, conditionals, and the <code>@T.n</code> slot reference system &mdash; in <a href="https://github.com/aallan/vera/blob/main/examples/fizzbuzz.vera">a program</a> everyone recognises. There are no naming decisions to make, and none to hallucinate.</p>
         <div class="code-block">
 <pre><span class="kw">public</span> <span class="kw">fn</span> fizzbuzz(<span class="sl">@Nat</span> -> <span class="sl">@String</span>)
   <span class="ct">requires</span>(<span class="num">true</span>)

--- a/examples/fizzbuzz.vera
+++ b/examples/fizzbuzz.vera
@@ -1,0 +1,44 @@
+effect IO {
+  op print(String -> Unit);
+}
+
+public fn fizzbuzz(@Nat -> @String)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  if @Nat.0 % 15 == 0 then {
+    "FizzBuzz"
+  } else {
+    if @Nat.0 % 3 == 0 then {
+      "Fizz"
+    } else {
+      if @Nat.0 % 5 == 0 then {
+        "Buzz"
+      } else {
+        "\(@Nat.0)"
+      }
+    }
+  }
+}
+
+private fn loop(@Nat, @Nat -> @Unit)
+  requires(true)
+  ensures(true)
+  effects(<IO>)
+{
+  IO.print(string_concat(fizzbuzz(@Nat.0), "\n"));
+  if @Nat.0 < @Nat.1 then {
+    loop(@Nat.1, @Nat.0 + 1)
+  } else {
+    ()
+  }
+}
+
+public fn main(@Unit -> @Unit)
+  requires(true)
+  ensures(true)
+  effects(<IO>)
+{
+  loop(100, 1)
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.86"
+version = "0.0.87"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/scripts/check_readme_examples.py
+++ b/scripts/check_readme_examples.py
@@ -27,7 +27,7 @@ ALLOWLIST: dict[int, tuple[str, str]] = {
     # =================================================================
 
     # Section "Project Roadmap" — depends on #57 (Http), #61 (Inference)
-    537: ("FUTURE", "Vision example uses Http, Inference effects (issues #57, #61)"),
+    593: ("FUTURE", "Vision example uses Http, Inference effects (issues #57, #61)"),
 }
 
 

--- a/scripts/check_skill_examples.py
+++ b/scripts/check_skill_examples.py
@@ -34,85 +34,85 @@ ALLOWLIST: dict[int, tuple[str, str]] = {
     400: ("FRAGMENT", "Block expression example"),
 
     # Array operations — bare function calls
-    415: ("FRAGMENT", "Array built-in examples, bare calls"),
+    440: ("FRAGMENT", "Array built-in examples, bare calls"),
 
     # String operations — bare function calls
-    424: ("FRAGMENT", "String built-in examples, bare calls"),
+    449: ("FRAGMENT", "String built-in examples, bare calls"),
 
     # Markdown operations — bare function calls
-    500: ("FRAGMENT", "Markdown built-in examples, bare calls"),
+    525: ("FRAGMENT", "Markdown built-in examples, bare calls"),
 
     # Regex operations — bare function calls
-    534: ("FRAGMENT", "Regex built-in examples, bare calls"),
-    545: ("FRAGMENT", "Regex Result matching example, bare expression"),
+    559: ("FRAGMENT", "Regex built-in examples, bare calls"),
+    570: ("FRAGMENT", "Regex Result matching example, bare expression"),
 
     # String interpolation — bare expressions
-    463: ("FRAGMENT", "String interpolation examples, bare expressions"),
+    488: ("FRAGMENT", "String interpolation examples, bare expressions"),
 
     # String search — bare function calls
-    475: ("FRAGMENT", "String search built-in examples, bare calls"),
+    500: ("FRAGMENT", "String search built-in examples, bare calls"),
 
     # String transformation — bare function calls
-    486: ("FRAGMENT", "String transformation built-in examples, bare calls"),
+    511: ("FRAGMENT", "String transformation built-in examples, bare calls"),
 
     # Numeric operations — bare function calls
-    557: ("FRAGMENT", "Numeric built-in examples, bare calls"),
+    582: ("FRAGMENT", "Numeric built-in examples, bare calls"),
 
     # Contracts section — requires/ensures fragments
-    614: ("FRAGMENT", "Requires clause example, not full function"),
-    623: ("FRAGMENT", "Ensures clause example, not full function"),
+    639: ("FRAGMENT", "Requires clause example, not full function"),
+    648: ("FRAGMENT", "Ensures clause example, not full function"),
 
     # Quantified expressions — bare forall/exists calls
-    650: ("FRAGMENT", "Quantified expression examples, bare calls"),
+    675: ("FRAGMENT", "Quantified expression examples, bare calls"),
 
     # Effects section — bare effect rows
     # (old entry at 580 removed — block shifted to 582 with Async addition)
 
     # Effect handler syntax template
-    831: ("FRAGMENT", "Handler syntax template, not real code"),
+    856: ("FRAGMENT", "Handler syntax template, not real code"),
 
     # Effect declarations — bare effects(...) clauses
-    668: ("FRAGMENT", "Effect declarations list"),
-    769: ("FRAGMENT", "Async effect declarations list"),
-    789: ("FRAGMENT", "Async effect declarations, bare clauses"),
+    693: ("FRAGMENT", "Effect declarations list"),
+    794: ("FRAGMENT", "Async effect declarations list"),
+    814: ("FRAGMENT", "Async effect declarations, bare clauses"),
 
     # Qualified calls and handler fragments — bare expressions
-    843: ("FRAGMENT", "Handler with clause, bare expression"),
-    853: ("FRAGMENT", "Qualified call examples, bare expressions"),
+    868: ("FRAGMENT", "Handler with clause, bare expression"),
+    878: ("FRAGMENT", "Qualified call examples, bare expressions"),
 
     # Module declaration and import syntax
-    891: ("FRAGMENT", "Module declaration and import example"),
+    916: ("FRAGMENT", "Module declaration and import example"),
 
     # Line comments — bare comments
-    942: ("FRAGMENT", "Comment syntax example"),
+    967: ("FRAGMENT", "Comment syntax example"),
 
     # Type conversions — bare function calls
-    572: ("FRAGMENT", "Type conversion examples, bare calls"),
+    597: ("FRAGMENT", "Type conversion examples, bare calls"),
 
     # Float64 predicates — bare function calls
-    585: ("FRAGMENT", "Float64 predicate examples, bare calls"),
+    610: ("FRAGMENT", "Float64 predicate examples, bare calls"),
 
     # Common mistakes section — intentionally wrong code
-    970: ("FRAGMENT", "Wrong: missing contracts"),
-    990: ("FRAGMENT", "Wrong: missing effects clause"),
-    1024: ("FRAGMENT", "Wrong: bare expression without indices"),
-    1037: ("FRAGMENT", "Wrong: bare expression no indices"),
-    1042: ("FRAGMENT", "Correct: expression with indices (not full fn)"),
-    1108: ("FRAGMENT", "Wrong: match arm with incorrect return"),
-    1132: ("FRAGMENT", "Wrong: non-exhaustive match"),
+    995: ("FRAGMENT", "Wrong: missing contracts"),
+    1015: ("FRAGMENT", "Wrong: missing effects clause"),
+    1049: ("FRAGMENT", "Wrong: bare expression without indices"),
+    1062: ("FRAGMENT", "Wrong: bare expression no indices"),
+    1067: ("FRAGMENT", "Correct: expression with indices (not full fn)"),
+    1133: ("FRAGMENT", "Wrong: match arm with incorrect return"),
+    1157: ("FRAGMENT", "Wrong: non-exhaustive match"),
     1119: ("FRAGMENT", "Correct: match arm example"),
-    1139: ("FRAGMENT", "Correct: match expression (bare expression)"),
-    1149: ("FRAGMENT", "Wrong: if/else without braces (bare expression)"),
-    1154: ("FRAGMENT", "Correct: if/else with braces"),
+    1164: ("FRAGMENT", "Correct: match expression (bare expression)"),
+    1174: ("FRAGMENT", "Wrong: if/else without braces (bare expression)"),
+    1179: ("FRAGMENT", "Correct: if/else with braces"),
 
     # Import syntax — intentionally unsupported
-    1165: ("FRAGMENT", "Wrong: import aliasing not supported"),
-    1170: ("FRAGMENT", "Correct: import syntax example"),
-    1180: ("FRAGMENT", "Wrong: import hiding not supported"),
-    1165: ("FRAGMENT", "Correct: multi-import syntax"),
+    1190: ("FRAGMENT", "Wrong: import aliasing not supported"),
+    1195: ("FRAGMENT", "Correct: import syntax example"),
+    1205: ("FRAGMENT", "Wrong: import hiding not supported"),
+    1190: ("FRAGMENT", "Correct: multi-import syntax"),
 
     # String escapes — bare expression
-    1199: ("FRAGMENT", "String escape example"),
+    1224: ("FRAGMENT", "String escape example"),
 
     # =================================================================
     # MISMATCH — uses syntax the parser doesn't handle in isolation.

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -19,7 +19,7 @@ README = Path(__file__).parent.parent / "README.md"
 # Each key is the 1-based line number of the opening ```vera fence.
 ALLOWLIST: dict[int, str] = {
     # "Project Roadmap" — depends on #57 (Http), #61 (Inference)
-    537: "Vision example uses Http, Inference effects (issues #57, #61)",
+    593: "Vision example uses Http, Inference effects (issues #57, #61)",
 }
 
 
@@ -72,8 +72,8 @@ class TestReadmeCodeSamples:
         """README should have the expected number of Vera code blocks."""
         blocks = _extract_vera_blocks(README)
         # Currently: clamp, safe_divide, refinement_types, list_sum,
-        # increment+run_counter, exn_handler, async_io, markdown,
-        # research_topic (vision, allowlisted)
-        assert len(blocks) == 9, (
-            f"Expected 9 Vera blocks in README.md, found {len(blocks)}"
+        # increment+run_counter, exn_handler, async_io, fizzbuzz,
+        # markdown, research_topic (vision, allowlisted)
+        assert len(blocks) == 10, (
+            f"Expected 10 Vera blocks in README.md, found {len(blocks)}"
         )

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -1480,9 +1480,9 @@ private fn sum(@List<Int> -> @Int)
             t1 += result.summary.tier1_verified
             t3 += result.summary.tier3_runtime
             total += result.summary.total
-        assert t1 == 133, f"Expected 133 T1, got {t1}"
+        assert t1 == 139, f"Expected 139 T1, got {t1}"
         assert t3 == 7, f"Expected 7 T3, got {t3}"
-        assert total == 140, f"Expected 140 total, got {total}"
+        assert total == 146, f"Expected 146 total, got {total}"
 
 
 # =====================================================================

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.86"
+__version__ = "0.0.87"


### PR DESCRIPTION
## Summary
- Add `examples/fizzbuzz.vera`: complete FizzBuzz with recursive loop, IO effects, and contracts — demonstrates Vera's iteration pattern (tail-recursive functions instead of loops)
- Add "Recursion as iteration" section to README with full program and explanation of effect separation
- Add "Iteration" section and complete program example to SKILL.md
- Add De Bruijn slot reference reminder to CLAUDE.md
- Document verifier branch-condition limitation as Known Bug (#283)
- Add fizzbuzz link in `docs/index.html` landing page
- Bump version to 0.0.87
- Update doc counts (24 to 25 examples), tier counts, and allowlists

## Test plan
- [x] `vera check examples/fizzbuzz.vera` passes
- [x] `vera verify examples/fizzbuzz.vera` passes (6 T1 contracts)
- [x] `vera run examples/fizzbuzz.vera` prints 100 correct lines
- [x] All 2292 tests pass
- [x] mypy clean
- [x] Doc counts consistent
- [x] Version sync verified
- [x] All conformance, example, README, SKILL, and HTML code block checks pass

Closes #283 (documents as known bug)

Generated with [Claude Code](https://claude.com/claude-code)