### PR TITLE
Fix #283: branch-aware call-site precondition checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,8 @@ Vera has no `for` or `while` loops — iteration is always recursion. The `loop`
 
 Notice the separation of concerns: `fizzbuzz` is `effects(pure)` — the verifier can reason about it with SMT. `loop` has `effects(<IO>)` because it prints. `main` calls `loop` and also has `effects(<IO>)`. The effect annotations propagate up the call chain but never contaminate the pure classifier.
 
+The contract `requires(@Nat.0 <= @Nat.1)` on `loop` ensures the function is only called with valid bounds — and since the recursive call passes `@Nat.0 + 1` where `@Nat.0 < @Nat.1`, the precondition is maintained at every step.
+
 ```vera
 effect IO {
   op print(String -> Unit);
@@ -263,7 +265,7 @@ public fn fizzbuzz(@Nat -> @String)
 }
 
 private fn loop(@Nat, @Nat -> @Unit)
-  requires(true)
+  requires(@Nat.0 <= @Nat.1)
   ensures(true)
   effects(<IO>)
 {
@@ -577,12 +579,11 @@ For compiler architecture, pipeline internals, and how to extend the compiler, s
 
 ### Testing
 
-Testing is organized in three layers: **unit tests** (2,292 tests across 23 files, testing compiler internals and browser parity), a **conformance suite** (53 programs across 9 spec chapters, systematically validating every language feature against the spec), and **example programs** (25 end-to-end demos). The compiler has 91% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations plus a dedicated browser parity job (Node.js 22). Every commit validates all conformance programs, example programs, and specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference.
+Testing is organized in three layers: **unit tests** (2,298 tests across 23 files, testing compiler internals and browser parity), a **conformance suite** (53 programs across 9 spec chapters, systematically validating every language feature against the spec), and **example programs** (25 end-to-end demos). The compiler has 91% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations plus a dedicated browser parity job (Node.js 22). Every commit validates all conformance programs, example programs, and specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference.
 
 ### Known Bugs
 
 - [#274](https://github.com/aallan/vera/issues/274) — Formatter collapses multi-statement blocks in match arms to single unparseable lines; comments inside function bodies are repositioned outside. Workaround: extract multi-statement match arm logic into helper functions.
-- [#283](https://github.com/aallan/vera/issues/283) — Verifier doesn't use branch conditions when checking call-site preconditions: a recursive call guarded by `if @Nat.0 < @Nat.1` still reports E501 even though the counterexample is unreachable. Workaround: use `requires(true)` with an internal if-guard.
 
 ## Project Roadmap
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -414,7 +414,7 @@ Vera has no `for` or `while` loops. Iteration is always expressed as tail-recurs
 
 ```vera
 private fn loop(@Nat, @Nat -> @Unit)
-  requires(true)
+  requires(@Nat.0 <= @Nat.1)
   ensures(true)
   effects(<IO>)
 {
@@ -427,7 +427,7 @@ private fn loop(@Nat, @Nat -> @Unit)
 }
 ```
 
-Here `@Nat.0` is the counter (De Bruijn index 0 = most recent, i.e. the second parameter) and `@Nat.1` is the limit (the first parameter). The function prints, then either recurses with an incremented counter or returns `()`.
+Here `@Nat.0` is the counter (De Bruijn index 0 = most recent, i.e. the second parameter) and `@Nat.1` is the limit (the first parameter). The contract `requires(@Nat.0 <= @Nat.1)` ensures the counter never exceeds the limit — and since the recursive call passes `@Nat.0 + 1` where `@Nat.0 < @Nat.1`, the precondition is maintained at every step. The function prints, then either recurses with an incremented counter or returns `()`.
 
 Call with the limit first and counter second: `loop(100, 1)`.
 
@@ -1327,7 +1327,7 @@ public fn fizzbuzz(@Nat -> @String)
 }
 
 private fn loop(@Nat, @Nat -> @Unit)
-  requires(true)
+  requires(@Nat.0 <= @Nat.1)
   ensures(true)
   effects(<IO>)
 {

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,7 +6,7 @@ This is the single source of truth for Vera's testing infrastructure, coverage d
 
 | Metric | Value |
 |--------|-------|
-| **Tests** | 2,292 across 23 files (~24,000 lines of test code) |
+| **Tests** | 2,298 across 23 files (~24,000 lines of test code) |
 | **Compiler code coverage** | 91% of 14,298 statements (CI minimum: 80%) |
 | **Conformance programs** | 53 programs across 9 spec chapters, validating every language feature |
 | **Example programs** | 25, all validated through `vera check` + `vera verify` |
@@ -49,7 +49,7 @@ python scripts/fix_allowlists.py --fix               # auto-fix stale allowlists
 | `test_parser.py` | 114 | 888 | Grammar rules, operator precedence, parse errors |
 | `test_ast.py` | 112 | 1,046 | AST transformation, node structure, serialisation, string escape sequences |
 | `test_checker.py` | 342 | 3,869 | Type synthesis, slot resolution, effects, effect subtyping, contracts, exhaustiveness, cross-module typing, visibility, error codes, string built-ins, generic rejection, IO operation types, Markdown types, Regex types |
-| `test_verifier.py` | 110 | 1,582 | Z3 verification, counterexamples, tier classification, call-site preconditions, pipe operator, cross-module contracts, match/ADT verification, decreases verification, mutual recursion |
+| `test_verifier.py` | 116 | 1,709 | Z3 verification, counterexamples, tier classification, call-site preconditions, branch-aware preconditions, pipe operator, cross-module contracts, match/ADT verification, decreases verification, mutual recursion |
 | `test_codegen.py` | 654 | 7,608 | WASM compilation, arithmetic, Float64, Byte, arrays (incl. compound element types), ADTs, match (incl. nested patterns), generics, State\<T\>, Exn\<E\> handlers, control flow, strings, string escape sequences, IO (read\_line, read\_file, write\_file, args, exit, get\_env), bounds checking, quantifiers, assert/assume, refinement type aliases, pipe operator, string built-ins, built-in shadowing, parse\_nat Result, GC, Markdown host bindings, Regex host bindings, example round-trips |
 | `test_codegen_contracts.py` | 32 | 576 | Runtime pre/postconditions, contract fail messages, old/new state postconditions |
 | `test_codegen_monomorphize.py` | 17 | 361 | Generic instantiation, type inference, monomorphization edge cases |

--- a/examples/fizzbuzz.vera
+++ b/examples/fizzbuzz.vera
@@ -23,7 +23,7 @@ public fn fizzbuzz(@Nat -> @String)
 }
 
 private fn loop(@Nat, @Nat -> @Unit)
-  requires(true)
+  requires(@Nat.0 <= @Nat.1)
   ensures(true)
   effects(<IO>)
 {

--- a/scripts/check_readme_examples.py
+++ b/scripts/check_readme_examples.py
@@ -27,7 +27,7 @@ ALLOWLIST: dict[int, tuple[str, str]] = {
     # =================================================================
 
     # Section "Project Roadmap" — depends on #57 (Http), #61 (Inference)
-    593: ("FUTURE", "Vision example uses Http, Inference effects (issues #57, #61)"),
+    594: ("FUTURE", "Vision example uses Http, Inference effects (issues #57, #61)"),
 }
 
 

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -19,7 +19,7 @@ README = Path(__file__).parent.parent / "README.md"
 # Each key is the 1-based line number of the opening ```vera fence.
 ALLOWLIST: dict[int, str] = {
     # "Project Roadmap" — depends on #57 (Http), #61 (Inference)
-    593: "Vision example uses Http, Inference effects (issues #57, #61)",
+    594: "Vision example uses Http, Inference effects (issues #57, #61)",
 }
 
 

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -920,6 +920,133 @@ private fn bad(@Int -> @Int)
         # Check that the error mentions the callee name
         assert any("non_zero" in e.description for e in errors)
 
+    # -- Branch-aware precondition checking (#283) -------------------------
+
+    def test_call_precondition_satisfied_by_if_guard(self) -> None:
+        """Call inside if-branch where branch condition implies precondition."""
+        _verify_ok("""
+private fn positive(@Int -> @Int)
+  requires(@Int.0 > 0)
+  ensures(true)
+  effects(pure)
+{ @Int.0 }
+
+private fn caller(@Int -> @Int)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  if @Int.0 > 0 then { positive(@Int.0) }
+  else { 0 }
+}
+""")
+
+    def test_call_precondition_with_else_guard(self) -> None:
+        """Call inside else-branch where negated condition implies precondition."""
+        _verify_ok("""
+private fn non_negative(@Int -> @Int)
+  requires(@Int.0 >= 0)
+  ensures(true)
+  effects(pure)
+{ @Int.0 }
+
+private fn caller(@Int -> @Int)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  if @Int.0 < 0 then { 0 }
+  else { non_negative(@Int.0) }
+}
+""")
+
+    def test_recursive_call_guarded_by_if(self) -> None:
+        """Recursive call guarded by if — the fizzbuzz pattern (#283).
+
+        De Bruijn: @Nat.0 = counter (second param, most recent),
+        @Nat.1 = limit (first param).  The recursive call passes
+        limit first, counter+1 second: loop(@Nat.1, @Nat.0 + 1).
+        """
+        _verify_ok("""
+private fn loop(@Nat, @Nat -> @Nat)
+  requires(@Nat.0 <= @Nat.1)
+  ensures(true)
+  effects(pure)
+{
+  if @Nat.0 < @Nat.1 then {
+    loop(@Nat.1, @Nat.0 + 1)
+  } else { @Nat.0 }
+}
+""")
+
+    def test_call_precondition_with_match_guard(self) -> None:
+        """Call inside match arm with nested if-guard."""
+        _verify_ok("""
+private data Maybe {
+  Nothing,
+  Just(Int)
+}
+
+private fn use_positive(@Int -> @Int)
+  requires(@Int.0 > 0)
+  ensures(true)
+  effects(pure)
+{ @Int.0 }
+
+private fn process(@Maybe -> @Int)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  match @Maybe.0 {
+    Just(@Int) -> if @Int.0 > 0 then { use_positive(@Int.0) } else { 0 },
+    Nothing -> 0
+  }
+}
+""")
+
+    def test_call_precondition_nested_if(self) -> None:
+        """Nested if-branches compounding conditions."""
+        _verify_ok("""
+private fn bounded(@Int -> @Int)
+  requires(@Int.0 > 0)
+  requires(@Int.0 < 100)
+  ensures(true)
+  effects(pure)
+{ @Int.0 }
+
+private fn caller(@Int -> @Int)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  if @Int.0 > 0 then {
+    if @Int.0 < 100 then {
+      bounded(@Int.0)
+    } else { 0 }
+  } else { 0 }
+}
+""")
+
+    def test_call_precondition_violated_despite_branch(self) -> None:
+        """Call violates precondition even inside an if-branch."""
+        _verify_err("""
+private fn positive(@Int -> @Int)
+  requires(@Int.0 > 0)
+  ensures(true)
+  effects(pure)
+{ @Int.0 }
+
+private fn bad_caller(@Int -> @Int)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  if @Int.0 > 10 then { positive(@Int.0) }
+  else { positive(@Int.0) }
+}
+""", "precondition")
+
 
 # =====================================================================
 # Pipe operator verification

--- a/vera/smt.py
+++ b/vera/smt.py
@@ -160,6 +160,9 @@ class SmtContext:
         self._module_fn_lookup = module_fn_lookup
         self._call_violations: list[CallViolation] = []
         self._fresh_counter: int = 0
+        # Path conditions accumulated from if/match branches so that
+        # call-site precondition checks can see which branch is active.
+        self._path_conditions: list[z3.ExprRef] = []
         # ADT support
         self._adt_registry: dict[str, AdtInfo] = {}
         self._ctor_to_adt: dict[str, str] = {}  # ctor name → ADT name
@@ -500,11 +503,32 @@ class SmtContext:
     def _translate_if(
         self, expr: ast.IfExpr, env: SlotEnv
     ) -> z3.ExprRef | None:
-        """Translate if-then-else to Z3 If."""
+        """Translate if-then-else to Z3 If.
+
+        Tracks the branch condition in ``_path_conditions`` while
+        translating each branch so that call-site precondition checks
+        (via ``check_valid``) can see which branch is active.
+        """
         cond = self.translate_expr(expr.condition, env)
+        if cond is None:
+            # Can't translate condition — no path condition available
+            then = self.translate_expr(expr.then_branch, env)
+            else_ = self.translate_expr(expr.else_branch, env)
+            if then is None or else_ is None:
+                return None
+            return None
+
+        # Translate then-branch with cond as path condition
+        self._path_conditions.append(cond)
         then = self.translate_expr(expr.then_branch, env)
+        self._path_conditions.pop()
+
+        # Translate else-branch with Not(cond) as path condition
+        self._path_conditions.append(z3.Not(cond))
         else_ = self.translate_expr(expr.else_branch, env)
-        if cond is None or then is None or else_ is None:
+        self._path_conditions.pop()
+
+        if then is None or else_ is None:
             return None
         return z3.If(cond, then, else_)
 
@@ -717,7 +741,12 @@ class SmtContext:
     def _translate_match(
         self, expr: ast.MatchExpr, env: SlotEnv
     ) -> z3.ExprRef | None:
-        """Translate a match expression to a Z3 If-chain."""
+        """Translate a match expression to a Z3 If-chain.
+
+        Tracks pattern conditions in ``_path_conditions`` while
+        translating each arm's body so that call-site precondition
+        checks can see which arm is active.
+        """
         scrutinee = self.translate_expr(expr.scrutinee, env)
         if scrutinee is None:
             return None
@@ -727,11 +756,25 @@ class SmtContext:
         if not arms:
             return None
 
+        # Collect preceding arm conditions for the default case
+        preceding_conds: list[z3.ExprRef] = []
+        for arm in arms[:-1]:
+            pc = self._pattern_condition(scrutinee, arm.pattern)
+            if pc is not None:
+                preceding_conds.append(pc)
+
         # Translate last arm body (default case)
         last_env = self._bind_pattern(scrutinee, arms[-1].pattern, env)
         if last_env is None:
             return None
+
+        # Default arm: none of the preceding patterns matched
+        for pc in preceding_conds:
+            self._path_conditions.append(z3.Not(pc))
         result = self.translate_expr(arms[-1].body, last_env)
+        for _ in preceding_conds:
+            self._path_conditions.pop()
+
         if result is None:
             return None
 
@@ -743,7 +786,11 @@ class SmtContext:
             arm_env = self._bind_pattern(scrutinee, arm.pattern, env)
             if arm_env is None:
                 return None
+
+            self._path_conditions.append(cond)
             arm_body = self.translate_expr(arm.body, arm_env)
+            self._path_conditions.pop()
+
             if arm_body is None:
                 return None
             result = z3.If(cond, arm_body, result)
@@ -900,6 +947,8 @@ class SmtContext:
         """Check if assumptions ⟹ goal is valid.
 
         Uses refutation: assert assumptions and ¬goal.
+        Also includes any accumulated ``_path_conditions`` from
+        if/match branches so branch-guarded preconditions verify.
         - unsat → goal always holds (verified)
         - sat → counterexample found (violated)
         - unknown → solver timeout or incomplete (unknown)
@@ -907,6 +956,8 @@ class SmtContext:
         self.solver.push()
         for a in assumptions:
             self.solver.add(a)
+        for pc in self._path_conditions:
+            self.solver.add(pc)
         self.solver.add(z3.Not(goal))
 
         result = self.solver.check()


### PR DESCRIPTION
## Summary

- Track path conditions through if-branches and match-arms in the SMT translator so call-site precondition checks (E501) see which branch is active
- Eliminates false positives where a branch guard implies the callee precondition (e.g. `if x < limit then { loop(limit, x + 1) }` with `requires(@Nat.0 <= @Nat.1)`)
- Strengthen fizzbuzz `loop` precondition from `requires(true)` to `requires(@Nat.0 <= @Nat.1)` in example, README, and SKILL.md
- Remove #283 from Known Bugs in README
- Add 6 new tests in `TestCallSiteVerification` (2,298 total)

## Test plan

- [x] 6 new tests cover: if-guard, else-guard, recursive call, match-arm, nested-if, and negative case
- [x] All 2,298 tests pass
- [x] mypy clean
- [x] `vera verify examples/fizzbuzz.vera` — 6 Tier 1 contracts verified
- [x] `vera run examples/fizzbuzz.vera` — correct output
- [x] All pre-commit hooks pass (conformance, examples, doc counts, allowlists)

Closes #283

:robot: Generated with [Claude Code](https://claude.com/claude-code)