### PR TITLE
Fix formatter: preserve braces on multi-statement match arm blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,11 +579,11 @@ For compiler architecture, pipeline internals, and how to extend the compiler, s
 
 ### Testing
 
-Testing is organized in three layers: **unit tests** (2,298 tests across 23 files, testing compiler internals and browser parity), a **conformance suite** (53 programs across 9 spec chapters, systematically validating every language feature against the spec), and **example programs** (25 end-to-end demos). The compiler has 91% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations plus a dedicated browser parity job (Node.js 22). Every commit validates all conformance programs, example programs, and specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference.
+Testing is organized in three layers: **unit tests** (2,306 tests across 23 files, testing compiler internals and browser parity), a **conformance suite** (53 programs across 9 spec chapters, systematically validating every language feature against the spec), and **example programs** (25 end-to-end demos). The compiler has 91% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations plus a dedicated browser parity job (Node.js 22). Every commit validates all conformance programs, example programs, and specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference.
 
 ### Known Bugs
 
-- [#274](https://github.com/aallan/vera/issues/274) — Formatter collapses multi-statement blocks in match arms to single unparseable lines; comments inside function bodies are repositioned outside. Workaround: extract multi-statement match arm logic into helper functions.
+- [#274](https://github.com/aallan/vera/issues/274) — Formatter repositions comments inside function bodies to precede the function declaration.
 
 ## Project Roadmap
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,7 +6,7 @@ This is the single source of truth for Vera's testing infrastructure, coverage d
 
 | Metric | Value |
 |--------|-------|
-| **Tests** | 2,298 across 23 files (~24,000 lines of test code) |
+| **Tests** | 2,306 across 23 files (~24,000 lines of test code) |
 | **Compiler code coverage** | 91% of 14,298 statements (CI minimum: 80%) |
 | **Conformance programs** | 53 programs across 9 spec chapters, validating every language feature |
 | **Example programs** | 25, all validated through `vera check` + `vera verify` |
@@ -57,7 +57,7 @@ python scripts/fix_allowlists.py --fix               # auto-fix stale allowlists
 | `test_codegen_modules.py` | 18 | 529 | Cross-module guard rail, cross-module codegen, name collision detection (E608/E609/E610) |
 | `test_codegen_coverage.py` | 5 | 249 | Defensive error paths: E600, E601, E605, E606, unknown module calls |
 | `test_errors.py` | 52 | 525 | Error code registry, diagnostic formatting, serialisation, SourceLocation, error display sync (README/HTML/spec) |
-| `test_formatter.py` | 84 | 554 | Comment extraction, expression/declaration formatting, idempotency, parenthesization, spec rules |
+| `test_formatter.py` | 92 | 752 | Comment extraction, expression/declaration formatting, match arm block bodies, idempotency, parenthesization, spec rules |
 | `test_cli.py` | 111 | 1,440 | CLI commands (check, verify, compile, run, test, fmt), subprocess integration, JSON error paths, runtime traps, arg validation, multi-file resolution, IO exit codes |
 | `test_resolver.py` | 15 | 412 | Module resolution, path lookup, parse caching, circular import detection |
 | `test_types.py` | 73 | 390 | Type operations: subtyping, effect subtyping, equality, substitution, pretty-printing, canonical names |

--- a/examples/markdown.vera
+++ b/examples/markdown.vera
@@ -7,19 +7,6 @@ effect IO {
   op print(String -> Unit);
 }
 
--- Process a parsed Markdown document: query headings, code blocks, and render.
-private fn process_doc(@MdBlock -> @Unit)
-  requires(true)
-  ensures(true)
-  effects(<IO>)
-{
-  if md_has_heading(@MdBlock.0, 1) then { IO.print("Has title heading") } else { IO.print("No title heading") };
-  if md_has_code_block(@MdBlock.0, "vera") then { IO.print("Has Vera code") } else { IO.print("No Vera code") };
-  let @Array<String> = md_extract_code_blocks(@MdBlock.0, "vera");
-  IO.print(int_to_string(array_length(@Array<String>.0)));
-  IO.print(md_render(@MdBlock.0))
-}
-
 -- Parse a Markdown string and process the result.
 public fn main(@Unit -> @Unit)
   requires(true)
@@ -28,7 +15,13 @@ public fn main(@Unit -> @Unit)
 {
   let @Result<MdBlock, String> = md_parse("# Welcome\n\nHello, **world**!\n\n```vera\nlet x = 42\n```");
   match @Result<MdBlock, String>.0 {
-    Ok(@MdBlock) -> process_doc(@MdBlock.0),
+    Ok(@MdBlock) -> {
+      if md_has_heading(@MdBlock.0, 1) then { IO.print("Has title heading") } else { IO.print("No title heading") };
+      if md_has_code_block(@MdBlock.0, "vera") then { IO.print("Has Vera code") } else { IO.print("No Vera code") };
+      let @Array<String> = md_extract_code_blocks(@MdBlock.0, "vera");
+      IO.print(int_to_string(array_length(@Array<String>.0)));
+      IO.print(md_render(@MdBlock.0))
+    },
     Err(@String) -> IO.print(@String.0)
   }
 }

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -528,6 +528,204 @@ class TestParenthesization:
 
 
 # =====================================================================
+# Match arm block bodies (#274)
+# =====================================================================
+
+class TestMatchBlockArms:
+    """Formatter must preserve braces on multi-statement match arm blocks."""
+
+    def test_match_arm_block_body_multiline(self) -> None:
+        """Block arm body with statements emits multi-line with braces."""
+        _fmt_check(
+            """
+            effect IO { op print(String -> Unit); }
+
+            public fn f(@Int -> @Unit)
+              requires(true)
+              ensures(true)
+              effects(<IO>)
+            {
+              match @Int.0 {
+                0 -> {
+                  IO.print("zero");
+                  IO.print("done")
+                },
+                _ -> IO.print("other")
+              }
+            }
+            """,
+            """
+            effect IO {
+              op print(String -> Unit);
+            }
+
+            public fn f(@Int -> @Unit)
+              requires(true)
+              ensures(true)
+              effects(<IO>)
+            {
+              match @Int.0 {
+                0 -> {
+                  IO.print("zero");
+                  IO.print("done")
+                },
+                _ -> IO.print("other")
+              }
+            }
+            """,
+        )
+
+    def test_match_arm_block_body_idempotent(self) -> None:
+        """Formatting a match with block arms twice gives identical output."""
+        _fmt_roundtrip("""
+            effect IO { op print(String -> Unit); }
+
+            public fn f(@Int -> @Unit)
+              requires(true)
+              ensures(true)
+              effects(<IO>)
+            {
+              match @Int.0 {
+                0 -> {
+                  IO.print("hello");
+                  IO.print("world")
+                },
+                _ -> IO.print("other")
+              }
+            }
+        """)
+
+    def test_match_arm_block_body_roundtrip_parses(self) -> None:
+        """Formatted output with block arms must parse without error."""
+        from vera.parser import parse as vera_parse
+        from vera.transform import transform
+
+        src = _fmt("""
+            effect IO { op print(String -> Unit); }
+
+            public fn f(@Int -> @Unit)
+              requires(true)
+              ensures(true)
+              effects(<IO>)
+            {
+              match @Int.0 {
+                0 -> {
+                  IO.print("hello");
+                  IO.print("world")
+                },
+                _ -> IO.print("other")
+              }
+            }
+        """)
+        tree = vera_parse(src)
+        transform(tree)  # Should not raise
+
+    def test_match_arm_mixed_simple_and_block(self) -> None:
+        """Mix of simple and block arms: simple stays inline, block expands."""
+        src = _fmt("""
+            effect IO { op print(String -> Unit); }
+
+            private data Maybe { Nothing, Just(Int) }
+
+            public fn f(@Maybe -> @Unit)
+              requires(true)
+              ensures(true)
+              effects(<IO>)
+            {
+              match @Maybe.0 {
+                Nothing -> IO.print("none"),
+                Just(@Int) -> {
+                  IO.print("got:");
+                  IO.print(int_to_string(@Int.0))
+                }
+              }
+            }
+        """)
+        assert "Nothing -> IO.print(\"none\")," in src
+        assert "Just(@Int) -> {" in src
+        assert '  IO.print("got:");' in src
+        assert "  IO.print(int_to_string(@Int.0))" in src
+
+    def test_match_arm_block_trailing_comma(self) -> None:
+        """Non-final block arm gets comma after closing brace."""
+        src = _fmt("""
+            effect IO { op print(String -> Unit); }
+
+            public fn f(@Int -> @Unit)
+              requires(true)
+              ensures(true)
+              effects(<IO>)
+            {
+              match @Int.0 {
+                0 -> {
+                  IO.print("a");
+                  IO.print("b")
+                },
+                _ -> IO.print("c")
+              }
+            }
+        """)
+        assert "},\n" in src
+
+    def test_match_arm_block_no_trailing_comma_final(self) -> None:
+        """Final block arm has no comma after closing brace."""
+        src = _fmt("""
+            effect IO { op print(String -> Unit); }
+
+            public fn f(@Int -> @Unit)
+              requires(true)
+              ensures(true)
+              effects(<IO>)
+            {
+              match @Int.0 {
+                0 -> IO.print("a"),
+                _ -> {
+                  IO.print("b");
+                  IO.print("c")
+                }
+              }
+            }
+        """)
+        # Final arm: closing brace without comma
+        lines = src.strip().splitlines()
+        # Find the closing brace of the block arm
+        block_close = [l for l in lines if l.strip() == "}"]
+        assert len(block_close) >= 1  # at least one bare }
+
+    def test_match_arm_block_inline_context(self) -> None:
+        """Match in let-binding position wraps block arm in braces inline."""
+        src = _fmt("""
+            public fn f(@Int -> @Int)
+              requires(true)
+              ensures(true)
+              effects(pure)
+            {
+              let @Int = match @Int.0 { 0 -> { let @Int = 10; @Int.0 + 1 }, _ -> 0 };
+              @Int.0
+            }
+        """)
+        # Block arm body must be wrapped in braces in inline form
+        assert "{ let @Int = 10; @Int.0 + 1 }" in src
+
+    def test_match_arm_block_in_exprstmt(self) -> None:
+        """Match as ExprStmt preserves block arm braces in inline form."""
+        src = _fmt("""
+            effect IO { op print(String -> Unit); }
+
+            public fn f(@Int -> @Unit)
+              requires(true)
+              ensures(true)
+              effects(<IO>)
+            {
+              match @Int.0 { 0 -> { IO.print("a"); IO.print("b") }, _ -> IO.print("c") };
+              IO.print("done")
+            }
+        """)
+        # Block arm in inline match must have braces
+        assert "{ IO.print(\"a\"); IO.print(\"b\") }" in src
+
+
+# =====================================================================
 # Idempotency — all examples
 # =====================================================================
 

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -1607,9 +1607,9 @@ private fn sum(@List<Int> -> @Int)
             t1 += result.summary.tier1_verified
             t3 += result.summary.tier3_runtime
             total += result.summary.total
-        assert t1 == 139, f"Expected 139 T1, got {t1}"
+        assert t1 == 137, f"Expected 137 T1, got {t1}"
         assert t3 == 7, f"Expected 7 T3, got {t3}"
-        assert total == 146, f"Expected 146 total, got {total}"
+        assert total == 144, f"Expected 144 total, got {total}"
 
 
 # =====================================================================

--- a/vera/formatter.py
+++ b/vera/formatter.py
@@ -753,8 +753,16 @@ class Formatter:
         for i, arm in enumerate(expr.arms):
             comma = "," if i < len(expr.arms) - 1 else ""
             pat = self._fmt_pattern(arm.pattern)
-            body = self._fmt_expr(arm.body)
-            self._line(f"{pat} -> {body}{comma}")
+            if isinstance(arm.body, Block) and arm.body.statements:
+                # Multi-statement block: emit multi-line with braces
+                self._line(f"{pat} -> {{")
+                self._indent_inc()
+                self._emit_block_body(arm.body)
+                self._indent_dec()
+                self._line(f"}}{comma}")
+            else:
+                body = self._fmt_expr(arm.body)
+                self._line(f"{pat} -> {body}{comma}")
         self._indent_dec()
         self._line("}")
 
@@ -957,10 +965,16 @@ class Formatter:
         """Format match as inline."""
         scrut = self._fmt_expr(expr.scrutinee)
         arms = ", ".join(
-            f"{self._fmt_pattern(a.pattern)} -> {self._fmt_expr(a.body)}"
+            f"{self._fmt_pattern(a.pattern)} -> {self._fmt_arm_body(a.body)}"
             for a in expr.arms
         )
         return f"match {scrut} {{ {arms} }}"
+
+    def _fmt_arm_body(self, body: Expr) -> str:
+        """Format a match arm body, wrapping multi-statement blocks in braces."""
+        if isinstance(body, Block) and body.statements:
+            return f"{{ {self._fmt_block_inline(body)} }}"
+        return self._fmt_expr(body)
 
     def _fmt_handle_inline(self, expr: HandleExpr) -> str:
         """Format handle as inline (shouldn't normally be needed)."""


### PR DESCRIPTION
## Summary

- Fix `_emit_match` to detect `Block` arm bodies with statements and emit them multi-line with braces (follows the `_emit_if` pattern)
- Fix `_fmt_match_inline` via new `_fmt_arm_body` helper that wraps multi-statement blocks in braces for inline context
- Inline the `process_doc` workaround back into `examples/markdown.vera` — the helper was extracted solely to avoid this bug
- Add 8 new tests in `TestMatchBlockArms` (2,306 total)
- Update Known Bugs to reflect only the comment repositioning sub-issue remains

Partially addresses #274 (block formatting fixed; comment repositioning remains open).

## Test plan

- [x] 8 new tests cover: multi-line output, idempotency, roundtrip parsing, mixed arms, trailing comma, final arm, inline context, ExprStmt context
- [x] All 2,306 tests pass
- [x] mypy clean
- [x] All 25 examples pass (including inlined `markdown.vera`)
- [x] All 53 conformance programs pass
- [x] Doc counts consistent
- [x] `vera fmt --check examples/regex.vera` unchanged
- [x] `vera fmt --check examples/markdown.vera` canonical

:robot: Generated with [Claude Code](https://claude.com/claude-code)