### PR TITLE
Fix #274: preserve interior comments during formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.88] - 2026-03-12
+
+### Fixed
+- **Formatter comment repositioning** ([#274](https://github.com/aallan/vera/issues/274)) — comments inside function bodies were moved to the file footer during formatting. Extended the anchor system to collect interior AST spans (statements, result expressions) and emit comments at the correct positions within blocks, if/else branches, match arms, and handler bodies. Added `_collect_interior_anchors` recursive walker. 7 new tests, `examples/string_ops.vera` reformatted to canonical form. Closes #274.
+
 ## [0.0.87] - 2026-03-11
 
 ### Added
@@ -1345,7 +1350,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Grammar: handler body simplified to avoid LALR reduce/reduce conflict
 - `pyproject.toml`: corrected build backend, package discovery, PEP 639 compliance
 
-[Unreleased]: https://github.com/aallan/vera/compare/v0.0.87...HEAD
+[Unreleased]: https://github.com/aallan/vera/compare/v0.0.88...HEAD
+[0.0.88]: https://github.com/aallan/vera/compare/v0.0.87...v0.0.88
 [0.0.87]: https://github.com/aallan/vera/compare/v0.0.86...v0.0.87
 [0.0.86]: https://github.com/aallan/vera/compare/v0.0.85...v0.0.86
 [0.0.85]: https://github.com/aallan/vera/compare/v0.0.84...v0.0.85

--- a/README.md
+++ b/README.md
@@ -579,11 +579,11 @@ For compiler architecture, pipeline internals, and how to extend the compiler, s
 
 ### Testing
 
-Testing is organized in three layers: **unit tests** (2,306 tests across 23 files, testing compiler internals and browser parity), a **conformance suite** (53 programs across 9 spec chapters, systematically validating every language feature against the spec), and **example programs** (25 end-to-end demos). The compiler has 91% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations plus a dedicated browser parity job (Node.js 22). Every commit validates all conformance programs, example programs, and specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference.
+Testing is organized in three layers: **unit tests** (2,313 tests across 23 files, testing compiler internals and browser parity), a **conformance suite** (53 programs across 9 spec chapters, systematically validating every language feature against the spec), and **example programs** (25 end-to-end demos). The compiler has 91% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations plus a dedicated browser parity job (Node.js 22). Every commit validates all conformance programs, example programs, and specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference.
 
 ### Known Bugs
 
-- [#274](https://github.com/aallan/vera/issues/274) — Formatter repositions comments inside function bodies to precede the function declaration.
+No open issues.
 
 ## Project Roadmap
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,7 +6,7 @@ This is the single source of truth for Vera's testing infrastructure, coverage d
 
 | Metric | Value |
 |--------|-------|
-| **Tests** | 2,306 across 23 files (~24,000 lines of test code) |
+| **Tests** | 2,313 across 23 files (~24,000 lines of test code) |
 | **Compiler code coverage** | 91% of 14,298 statements (CI minimum: 80%) |
 | **Conformance programs** | 53 programs across 9 spec chapters, validating every language feature |
 | **Example programs** | 25, all validated through `vera check` + `vera verify` |
@@ -57,7 +57,7 @@ python scripts/fix_allowlists.py --fix               # auto-fix stale allowlists
 | `test_codegen_modules.py` | 18 | 529 | Cross-module guard rail, cross-module codegen, name collision detection (E608/E609/E610) |
 | `test_codegen_coverage.py` | 5 | 249 | Defensive error paths: E600, E601, E605, E606, unknown module calls |
 | `test_errors.py` | 52 | 525 | Error code registry, diagnostic formatting, serialisation, SourceLocation, error display sync (README/HTML/spec) |
-| `test_formatter.py` | 92 | 752 | Comment extraction, expression/declaration formatting, match arm block bodies, idempotency, parenthesization, spec rules |
+| `test_formatter.py` | 99 | 986 | Comment extraction, interior comment positioning, expression/declaration formatting, match arm block bodies, idempotency, parenthesization, spec rules |
 | `test_cli.py` | 111 | 1,440 | CLI commands (check, verify, compile, run, test, fmt), subprocess integration, JSON error paths, runtime traps, arg validation, multi-file resolution, IO exit codes |
 | `test_resolver.py` | 15 | 412 | Module resolution, path lookup, parse caching, circular import detection |
 | `test_types.py` | 73 | 390 | Type operations: subtyping, effect subtyping, equality, substitution, pretty-printing, canonical names |

--- a/docs/index.html
+++ b/docs/index.html
@@ -508,7 +508,7 @@
         For Agents → SKILL.md
       </a>
     </div>
-    <p style="text-align: center; margin-top: 1rem; font-size: 0.9rem; color: var(--brown-400);">Current Version: <a href="https://github.com/aallan/vera/releases/tag/v0.0.87" style="color: var(--brown-500); font-weight: 500;">v0.0.87</a></p>
+    <p style="text-align: center; margin-top: 1rem; font-size: 0.9rem; color: var(--brown-400);">Current Version: <a href="https://github.com/aallan/vera/releases/tag/v0.0.88" style="color: var(--brown-500); font-weight: 500;">v0.0.88</a></p>
   </div>
 
   <!-- Why -->

--- a/examples/string_ops.vera
+++ b/examples/string_ops.vera
@@ -1,10 +1,12 @@
 -- String operations and type-to-string conversions
-
 effect IO {
   op print(String -> Unit);
 }
 
-private data Result<T, E> { Ok(T), Err(E) }
+private data Result<T, E> {
+  Ok(T),
+  Err(E)
+}
 
 public fn main(@Unit -> @Unit)
   requires(true)
@@ -13,63 +15,33 @@ public fn main(@Unit -> @Unit)
 {
   -- string_length
   let @Int = string_length("hello");
-
   -- string_concat
   IO.print(string_concat("hello", " world"));
-
   -- string_slice
   IO.print(string_slice("MPCORB", 0, 3));
-
   -- char_code: 'A' = 65
   let @Nat = char_code("A", 0);
-
   -- parse_nat (returns Result<Nat, String>)
-  let @Nat = match parse_nat("42") {
-    Ok(@Nat) -> @Nat.0,
-    Err(_) -> 0
-  };
-
+  let @Nat = match parse_nat("42") { Ok(@Nat) -> @Nat.0, Err(_) -> 0 };
   -- parse_float64 (returns Result<Float64, String>)
-  let @Float64 = match parse_float64("3.14") {
-    Ok(@Float64) -> @Float64.0,
-    Err(_) -> 0.0
-  };
-
+  let @Float64 = match parse_float64("3.14") { Ok(@Float64) -> @Float64.0, Err(_) -> 0.0 };
   -- parse_int (returns Result<Int, String>)
-  let @Int = match parse_int("-7") {
-    Ok(@Int) -> @Int.0,
-    Err(_) -> 0
-  };
-
+  let @Int = match parse_int("-7") { Ok(@Int) -> @Int.0, Err(_) -> 0 };
   -- parse_bool (returns Result<Bool, String>)
-  let @Bool = match parse_bool("true") {
-    Ok(@Bool) -> @Bool.0,
-    Err(_) -> false
-  };
-
+  let @Bool = match parse_bool("true") { Ok(@Bool) -> @Bool.0, Err(_) -> false };
   -- to_string
   IO.print(to_string(2025));
-
   -- strip
   IO.print(strip("  hello  "));
-
   -- compose: parse then convert back
-  IO.print(match parse_nat("99") {
-    Ok(@Nat) -> to_string(@Nat.0),
-    Err(_) -> "error"
-  });
-
+  IO.print(match parse_nat("99") { Ok(@Nat) -> to_string(@Nat.0), Err(_) -> "error" });
   -- bool_to_string
   IO.print(bool_to_string(true));
-
   -- nat_to_string
   IO.print(nat_to_string(42));
-
   -- int_to_string (alias for to_string)
   IO.print(int_to_string(-7));
-
   -- float_to_string
   IO.print(float_to_string(3.14));
-
   ()
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.87"
+version = "0.0.88"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -726,6 +726,240 @@ class TestMatchBlockArms:
 
 
 # =====================================================================
+# Interior comment positioning (#274)
+# =====================================================================
+
+class TestInteriorComments:
+    """Comments inside function bodies must stay in position, not move to footer."""
+
+    def test_comment_before_statement(self) -> None:
+        """A comment before a let statement stays before it."""
+        _fmt_check(
+            """
+            effect IO { op print(String -> Unit); }
+
+            public fn main(@Unit -> @Unit)
+              requires(true) ensures(true) effects(<IO>)
+            {
+              -- set up the value
+              let @Int = 42;
+              IO.print(int_to_string(@Int.0))
+            }
+            """,
+            """
+            effect IO {
+              op print(String -> Unit);
+            }
+
+            public fn main(@Unit -> @Unit)
+              requires(true)
+              ensures(true)
+              effects(<IO>)
+            {
+              -- set up the value
+              let @Int = 42;
+              IO.print(int_to_string(@Int.0))
+            }
+            """,
+        )
+
+    def test_comment_before_result_expr(self) -> None:
+        """A comment before the result expression stays before it."""
+        _fmt_check(
+            """
+            effect IO { op print(String -> Unit); }
+
+            public fn main(@Unit -> @Unit)
+              requires(true) ensures(true) effects(<IO>)
+            {
+              let @Int = 42;
+              -- now print it
+              IO.print(int_to_string(@Int.0))
+            }
+            """,
+            """
+            effect IO {
+              op print(String -> Unit);
+            }
+
+            public fn main(@Unit -> @Unit)
+              requires(true)
+              ensures(true)
+              effects(<IO>)
+            {
+              let @Int = 42;
+              -- now print it
+              IO.print(int_to_string(@Int.0))
+            }
+            """,
+        )
+
+    def test_multiple_interior_comments(self) -> None:
+        """Multiple comments inside a body each stay before their statement."""
+        _fmt_check(
+            """
+            effect IO { op print(String -> Unit); }
+
+            public fn main(@Unit -> @Unit)
+              requires(true) ensures(true) effects(<IO>)
+            {
+              -- first
+              let @Int = 1;
+              -- second
+              let @Int = 2;
+              -- result
+              IO.print(int_to_string(@Int.0))
+            }
+            """,
+            """
+            effect IO {
+              op print(String -> Unit);
+            }
+
+            public fn main(@Unit -> @Unit)
+              requires(true)
+              ensures(true)
+              effects(<IO>)
+            {
+              -- first
+              let @Int = 1;
+              -- second
+              let @Int = 2;
+              -- result
+              IO.print(int_to_string(@Int.0))
+            }
+            """,
+        )
+
+    def test_comment_inside_match_arm_block(self) -> None:
+        """Comments inside a match arm block body stay in position."""
+        _fmt_check(
+            """
+            effect IO { op print(String -> Unit); }
+
+            public fn f(@Int -> @Unit)
+              requires(true) ensures(true) effects(<IO>)
+            {
+              match @Int.0 {
+                0 -> {
+                  -- zero case
+                  let @String = "zero";
+                  IO.print(@String.0)
+                },
+                _ -> IO.print("other")
+              }
+            }
+            """,
+            """
+            effect IO {
+              op print(String -> Unit);
+            }
+
+            public fn f(@Int -> @Unit)
+              requires(true)
+              ensures(true)
+              effects(<IO>)
+            {
+              match @Int.0 {
+                0 -> {
+                  -- zero case
+                  let @String = "zero";
+                  IO.print(@String.0)
+                },
+                _ -> IO.print("other")
+              }
+            }
+            """,
+        )
+
+    def test_comment_not_moved_to_footer(self) -> None:
+        """Interior comments must NOT appear after the closing brace."""
+        src = _fmt("""
+            effect IO { op print(String -> Unit); }
+
+            public fn main(@Unit -> @Unit)
+              requires(true) ensures(true) effects(<IO>)
+            {
+              -- this stays inside
+              let @Int = 42;
+              IO.print(int_to_string(@Int.0))
+            }
+        """)
+        # The comment must appear before the let, not after the closing }
+        lines = src.strip().splitlines()
+        closing_brace_idx = None
+        for i, line in enumerate(lines):
+            if line.strip() == "}":
+                closing_brace_idx = i
+        assert closing_brace_idx is not None
+        # Nothing after closing brace except empty lines
+        after = [l for l in lines[closing_brace_idx + 1:] if l.strip()]
+        assert not after, f"Comment leaked to footer: {after}"
+        # Comment is inside the body
+        assert "-- this stays inside" in src
+        body_start = src.index("{", src.index("effects"))
+        body_end = src.rindex("}")
+        comment_pos = src.index("-- this stays inside")
+        assert body_start < comment_pos < body_end
+
+    def test_interior_comment_idempotent(self) -> None:
+        """Formatting a program with interior comments is idempotent."""
+        _fmt_roundtrip("""
+            effect IO { op print(String -> Unit); }
+
+            public fn main(@Unit -> @Unit)
+              requires(true) ensures(true) effects(<IO>)
+            {
+              -- first comment
+              let @Int = 1;
+              -- second comment
+              let @Int = 2;
+              -- before result
+              IO.print(int_to_string(@Int.0))
+            }
+        """)
+
+    def test_if_branch_interior_comment(self) -> None:
+        """Comments inside if/else branch blocks stay in position."""
+        _fmt_check(
+            """
+            effect IO { op print(String -> Unit); }
+
+            public fn f(@Bool -> @Unit)
+              requires(true) ensures(true) effects(<IO>)
+            {
+              if @Bool.0 then {
+                -- true branch
+                IO.print("yes")
+              } else {
+                -- false branch
+                IO.print("no")
+              }
+            }
+            """,
+            """
+            effect IO {
+              op print(String -> Unit);
+            }
+
+            public fn f(@Bool -> @Unit)
+              requires(true)
+              ensures(true)
+              effects(<IO>)
+            {
+              if @Bool.0 then {
+                -- true branch
+                IO.print("yes")
+              } else {
+                -- false branch
+                IO.print("no")
+              }
+            }
+            """,
+        )
+
+
+# =====================================================================
 # Idempotency — all examples
 # =====================================================================
 

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.87"
+__version__ = "0.0.88"

--- a/vera/formatter.py
+++ b/vera/formatter.py
@@ -245,6 +245,12 @@ def _attach_comments(
             anchors.append(tld.span.line)
             if tld.span.end_line > last_end:
                 last_end = tld.span.end_line
+        # Interior anchors let comments inside function bodies attach
+        # to the statement/expression they precede rather than falling
+        # to the footer.  last_end stays top-level-only so that the
+        # header/footer boundary is unaffected.
+        if isinstance(tld.decl, FnDecl):
+            _collect_interior_anchors(tld.decl, anchors)
 
     # Also consider module/import spans
     first_code_line = 0
@@ -288,6 +294,36 @@ def _attach_comments(
 
     return _Attached(before=before, inline=inline,
                      header=header, footer=footer)
+
+
+def _collect_interior_anchors(node: object, anchors: list[int]) -> None:
+    """Recursively collect span start lines from interior AST nodes.
+
+    Walks into blocks, if branches, match arm blocks, handler bodies,
+    and where functions to find every statement and result-expression
+    position that the formatter emits on its own line.
+    """
+    if isinstance(node, Block):
+        for stmt in node.statements:
+            if stmt.span:
+                anchors.append(stmt.span.line)
+        if node.expr.span:
+            anchors.append(node.expr.span.line)
+        # Recurse into the result expression for nested multi-line forms
+        _collect_interior_anchors(node.expr, anchors)
+    elif isinstance(node, IfExpr):
+        _collect_interior_anchors(node.then_branch, anchors)
+        _collect_interior_anchors(node.else_branch, anchors)
+    elif isinstance(node, MatchExpr):
+        for arm in node.arms:
+            _collect_interior_anchors(arm.body, anchors)
+    elif isinstance(node, HandleExpr):
+        _collect_interior_anchors(node.body, anchors)
+    elif isinstance(node, FnDecl):
+        _collect_interior_anchors(node.body, anchors)
+        if node.where_fns:
+            for wfn in node.where_fns:
+                _collect_interior_anchors(wfn, anchors)
 
 
 # =====================================================================
@@ -695,7 +731,11 @@ class Formatter:
     def _emit_block_body(self, block: Block) -> None:
         """Emit the interior of a block (statements then expression)."""
         for stmt in block.statements:
+            if stmt.span:
+                self._emit_comments(stmt.span.line)
             self._emit_stmt(stmt)
+        if block.expr.span:
+            self._emit_comments(block.expr.span.line)
         self._emit_block_expr(block.expr)
 
     def _emit_block_expr(self, expr: Expr) -> None:


### PR DESCRIPTION
## Summary

- **Fix comment repositioning bug** — comments inside function bodies were moved to the file footer during formatting. Extended the anchor system to collect interior AST spans (statements, result expressions) and emit comments at the correct positions within blocks, if/else branches, match arms, and handler bodies.
- **Add `_collect_interior_anchors` recursive walker** that descends through `Block`, `IfExpr`, `MatchExpr`, `HandleExpr`, and `FnDecl` nodes collecting span lines for the comment attachment algorithm.
- **7 new `TestInteriorComments` tests** — comment before statement, before result expression, multiple interior comments, inside match arm blocks, not-moved-to-footer assertion, idempotency, and if/else branch comments.
- **Reformat `examples/string_ops.vera`** to canonical form (15 interior comments now stay in position).
- **Known Bugs → "No open issues."** — both sub-issues of #274 are now resolved (block formatting in #286, comment positioning here).
- **Version 0.0.87 → 0.0.88**

Closes #274.

## Test plan

- [x] All 7 new `TestInteriorComments` tests pass
- [x] All 99 formatter tests pass
- [x] Full test suite: 2,313 tests pass
- [x] All 53 conformance programs pass
- [x] All 25 examples pass (`check` + `verify`)
- [x] `mypy vera/` clean
- [x] All 17 pre-commit hooks pass
- [x] `string_ops.vera` passes `vera fmt --check`
- [x] Version sync verified across 3 files
- [x] Doc counts consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)