### PR TITLE
Add SKILL.md best practices and IO effect clarification

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -718,7 +718,9 @@ The IO effect is built-in — no declaration is needed. It provides seven operat
 | `IO.exit` | `Int -> Never` | Exit with status code |
 | `IO.get_env` | `String -> Option<String>` | Read environment variable |
 
-If you declare `effect IO { op print(String -> Unit); }` explicitly, that overrides the built-in and only the declared operations are available.
+If you declare `effect IO { op print(String -> Unit); }` explicitly, that overrides the built-in and only the declared operations are available. Most examples do this — declaring only `print` — because it follows the principle of least privilege: a program that only declares `op print` cannot accidentally perform file I/O or call `exit`.
+
+**Why IO works differently from State and Async:** IO has 7 operations and programs choose which ones they need. State and Async have fixed, minimal operation sets (State: `get`/`put`; Async: no operations, it is a marker effect), so there is nothing to restrict.
 
 ### Performing effects
 
@@ -986,6 +988,41 @@ See: spec Chapter 8 for the full module system specification.
 | 8 | `*` `/` `%` | left |
 | 9 | `!` `-` (unary) | prefix |
 | 10 | `[]` (index) `()` (call) | postfix |
+
+## Best Practices
+
+### Keep functions small
+
+Vera's De Bruijn slot references (`@T.n`) are clear when functions have 2–3 parameters of different types. They become harder to track with 4+ parameters of the same type or long let-chains where indices shift with each binding.
+
+**Guidelines:**
+- Keep functions under ~5 parameters total
+- When multiple parameters share a type, prefer breaking into smaller helper functions or where-functions
+- Break long let-chains (4+ bindings of the same type) into where-functions — they create fresh scopes with reset slot indices
+- Commutative operations (`+`, `*`) mask index errors; be especially careful with non-commutative operations (`-`, `/`, `<`, `>`) and recursive calls
+
+### Use where-functions for complex logic
+
+Where-functions are private helpers scoped to their parent function. They reset the slot index namespace, making code easier to reason about:
+
+```vera
+public fn process(@Int, @Int, @String -> @Int)
+  requires(@Int.1 > 0)
+  ensures(true)
+  effects(pure)
+{
+  compute(@Int.1, @Int.0, string_length(@String.0))
+}
+where {
+  fn compute(@Int, @Int, @Int -> @Int)
+    requires(true)
+    ensures(true)
+    effects(pure)
+  {
+    (@Int.2 + @Int.1) * @Int.0
+  }
+}
+```
 
 ## Common Mistakes
 

--- a/scripts/check_skill_examples.py
+++ b/scripts/check_skill_examples.py
@@ -69,22 +69,22 @@ ALLOWLIST: dict[int, tuple[str, str]] = {
     # (old entry at 580 removed — block shifted to 582 with Async addition)
 
     # Effect handler syntax template
-    856: ("FRAGMENT", "Handler syntax template, not real code"),
+    858: ("FRAGMENT", "Handler syntax template, not real code"),
 
     # Effect declarations — bare effects(...) clauses
     693: ("FRAGMENT", "Effect declarations list"),
-    794: ("FRAGMENT", "Async effect declarations list"),
-    814: ("FRAGMENT", "Async effect declarations, bare clauses"),
+    796: ("FRAGMENT", "Async effect declarations list"),
+    816: ("FRAGMENT", "Async effect declarations, bare clauses"),
 
     # Qualified calls and handler fragments — bare expressions
-    868: ("FRAGMENT", "Handler with clause, bare expression"),
-    878: ("FRAGMENT", "Qualified call examples, bare expressions"),
+    870: ("FRAGMENT", "Handler with clause, bare expression"),
+    880: ("FRAGMENT", "Qualified call examples, bare expressions"),
 
     # Module declaration and import syntax
-    916: ("FRAGMENT", "Module declaration and import example"),
+    918: ("FRAGMENT", "Module declaration and import example"),
 
     # Line comments — bare comments
-    967: ("FRAGMENT", "Comment syntax example"),
+    969: ("FRAGMENT", "Comment syntax example"),
 
     # Type conversions — bare function calls
     597: ("FRAGMENT", "Type conversion examples, bare calls"),
@@ -93,26 +93,27 @@ ALLOWLIST: dict[int, tuple[str, str]] = {
     610: ("FRAGMENT", "Float64 predicate examples, bare calls"),
 
     # Common mistakes section — intentionally wrong code
-    995: ("FRAGMENT", "Wrong: missing contracts"),
-    1015: ("FRAGMENT", "Wrong: missing effects clause"),
-    1049: ("FRAGMENT", "Wrong: bare expression without indices"),
+    1032: ("FRAGMENT", "Wrong: missing contracts"),
+    1052: ("FRAGMENT", "Wrong: missing effects clause"),
+    1086: ("FRAGMENT", "Wrong: bare expression without indices"),
     1062: ("FRAGMENT", "Wrong: bare expression no indices"),
-    1067: ("FRAGMENT", "Correct: expression with indices (not full fn)"),
-    1133: ("FRAGMENT", "Wrong: match arm with incorrect return"),
-    1157: ("FRAGMENT", "Wrong: non-exhaustive match"),
-    1119: ("FRAGMENT", "Correct: match arm example"),
-    1164: ("FRAGMENT", "Correct: match expression (bare expression)"),
-    1174: ("FRAGMENT", "Wrong: if/else without braces (bare expression)"),
-    1179: ("FRAGMENT", "Correct: if/else with braces"),
+    1099: ("FRAGMENT", "Wrong: missing index on slot reference"),
+    1104: ("FRAGMENT", "Correct: expression with indices (not full fn)"),
+    1170: ("FRAGMENT", "Wrong: match arm with incorrect return"),
+    1194: ("FRAGMENT", "Wrong: non-exhaustive match"),
+    1156: ("FRAGMENT", "Correct: match arm example"),
+    1201: ("FRAGMENT", "Correct: match expression (bare expression)"),
+    1211: ("FRAGMENT", "Wrong: if/else without braces (bare expression)"),
+    1216: ("FRAGMENT", "Correct: if/else with braces"),
 
     # Import syntax — intentionally unsupported
-    1190: ("FRAGMENT", "Wrong: import aliasing not supported"),
-    1195: ("FRAGMENT", "Correct: import syntax example"),
-    1205: ("FRAGMENT", "Wrong: import hiding not supported"),
-    1190: ("FRAGMENT", "Correct: multi-import syntax"),
+    1227: ("FRAGMENT", "Wrong: import aliasing not supported"),
+    1232: ("FRAGMENT", "Correct: import syntax example"),
+    1242: ("FRAGMENT", "Wrong: import hiding not supported"),
+    1227: ("FRAGMENT", "Correct: multi-import syntax"),
 
     # String escapes — bare expression
-    1224: ("FRAGMENT", "String escape example"),
+    1261: ("FRAGMENT", "String escape example"),
 
     # =================================================================
     # MISMATCH — uses syntax the parser doesn't handle in isolation.


### PR DESCRIPTION
## Summary

Response to the v0.0.88 viability assessment. Alongside this PR, design direction comments were added to 8 existing issues and 2 new issues were opened.

- **SKILL.md Best Practices section** — guidance on keeping functions under ~5 parameters, breaking long let-chains into where-functions, and being careful with non-commutative operations where De Bruijn indices matter most. Includes a working where-function example.
- **SKILL.md IO effect clarification** — explains the least-privilege pattern: IO has 7 operations and programs choose which ones they need via local `effect IO { ... }` override, while State/Async have fixed minimal operation sets that need no restriction.
- **Allowlist fix** — adds entry for the new "missing index" fragment and fixes stale line numbers shifted by the new content.

### Issue tracker work (done separately, not in this PR)

**Comments added to:** #133, #211, #60, #225, #61, #183, #222, #58

**New issues opened:**
- #288 — Built-in function naming consistency audit
- #289 — Standard prelude for Result, Option, and common ADT constructors

## Test plan

- [x] All 2,313 tests pass
- [x] All SKILL.md code blocks parse (79 Vera blocks: 36 parsed, 43 allowlisted, 0 failed)
- [x] All validation scripts pass (conformance, examples, README, HTML, doc counts)
- [x] `mypy vera/` clean
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)