### PR TITLE
Add Option/Result combinators (#211)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.89] - 2026-03-12
+
+### Added
+- **Option/Result combinators** ([#211](https://github.com/aallan/vera/issues/211)) — five prelude functions that eliminate common match boilerplate: `option_unwrap_or`, `option_map`, `option_and_then`, `result_unwrap_or`, `result_map`. Implemented via source injection (parsed Vera AST, injected before codegen). Includes compiler fixes for generic type alias return type inference in closures, closure signature deduplication across functions, and AnonFn type variable inference in the monomorphizer. New conformance test, 12 unit tests, spec section 9.3.7.
+
+### Changed
+- **`map_option` renamed to `option_map`** — all references across spec, examples, and tests updated to follow the `domain_verb` naming convention ([#288](https://github.com/aallan/vera/issues/288)).
+
 ## [0.0.88] - 2026-03-12
 
 ### Fixed
@@ -1350,7 +1358,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Grammar: handler body simplified to avoid LALR reduce/reduce conflict
 - `pyproject.toml`: corrected build backend, package discovery, PEP 639 compliance
 
-[Unreleased]: https://github.com/aallan/vera/compare/v0.0.88...HEAD
+[Unreleased]: https://github.com/aallan/vera/compare/v0.0.89...HEAD
+[0.0.89]: https://github.com/aallan/vera/compare/v0.0.88...v0.0.89
 [0.0.88]: https://github.com/aallan/vera/compare/v0.0.87...v0.0.88
 [0.0.87]: https://github.com/aallan/vera/compare/v0.0.86...v0.0.87
 [0.0.86]: https://github.com/aallan/vera/compare/v0.0.85...v0.0.86

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ vera fmt --check file.vera        # Check if already canonical
 pytest tests/ -v                  # Run the test suite (see TESTING.md)
 mypy vera/                        # Type-check the compiler itself
 
-python scripts/check_conformance.py    # Verify all 53 conformance programs pass their declared level
+python scripts/check_conformance.py    # Verify all 54 conformance programs pass their declared level
 python scripts/check_examples.py      # Verify all 25 examples parse + check + verify
 python scripts/check_spec_examples.py # Verify spec code blocks parse
 python scripts/check_readme_examples.py # Verify README code blocks parse
@@ -59,7 +59,7 @@ python scripts/fix_allowlists.py --fix # Auto-fix stale allowlist line numbers
 - `vera/` — Reference compiler: grammar, parser, AST, transformer, type checker, verifier, codegen, CLI
 - `examples/` — 25 example Vera programs (all must pass `vera check` and `vera verify`)
 - `tests/` — Test suite (unit tests + conformance suite)
-- `tests/conformance/` — 53 conformance programs validating every language feature against the spec
+- `tests/conformance/` — 54 conformance programs validating every language feature against the spec
 - `scripts/` — CI and validation scripts
 
 ## Writing Vera code
@@ -86,7 +86,7 @@ Each stage is a module with a public API function and is independently testable.
 ## What not to break
 
 - Pre-commit hooks run mypy + pytest + conformance suite + example validation on every commit
-- All 53 conformance programs in `tests/conformance/` must pass their declared level
+- All 54 conformance programs in `tests/conformance/` must pass their declared level
 - All 25 examples in `examples/` must pass `vera check` and `vera verify`
 - Version must stay in sync across `vera/__init__.py`, `pyproject.toml`, and `CHANGELOG.md`
 - All tests must pass: `pytest tests/ -v`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ After running `pre-commit install`, every commit is automatically checked by 17 
 - Python debug statements
 - mypy type checking
 - pytest test suite
-- All 53 conformance programs pass their declared level
+- All 54 conformance programs pass their declared level
 - All 25 `.vera` examples type-check and verify cleanly
 - README, SKILL.md, HTML, and spec code blocks parse correctly
 - Documentation counts match live codebase
@@ -103,7 +103,7 @@ mypy vera/
 ### Validation Scripts
 
 ```bash
-python scripts/check_conformance.py      # verify all 53 conformance programs
+python scripts/check_conformance.py      # verify all 54 conformance programs
 python scripts/check_examples.py         # verify all 25 .vera examples
 python scripts/check_spec_examples.py    # verify spec code blocks parse
 python scripts/check_readme_examples.py  # verify README code blocks parse

--- a/README.md
+++ b/README.md
@@ -579,7 +579,7 @@ For compiler architecture, pipeline internals, and how to extend the compiler, s
 
 ### Testing
 
-Testing is organized in three layers: **unit tests** (2,313 tests across 23 files, testing compiler internals and browser parity), a **conformance suite** (53 programs across 9 spec chapters, systematically validating every language feature against the spec), and **example programs** (25 end-to-end demos). The compiler has 91% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations plus a dedicated browser parity job (Node.js 22). Every commit validates all conformance programs, example programs, and specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference.
+Testing is organized in three layers: **unit tests** (2,330 tests across 24 files, testing compiler internals and browser parity), a **conformance suite** (54 programs across 9 spec chapters, systematically validating every language feature against the spec), and **example programs** (25 end-to-end demos). The compiler has 91% code coverage, enforced by pre-commit hooks and [CI](.github/workflows/ci.yml) across 6 Python/OS combinations plus a dedicated browser parity job (Node.js 22). Every commit validates all conformance programs, example programs, and specification code blocks. See **[TESTING.md](TESTING.md)** for the full testing reference.
 
 ### Known Bugs
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Development follows an **interleaved spiral** — each phase adds a complete compiler layer with tests, docs, and working examples before moving to the next. The core language and compiler are complete through v0.0.88. What remains is standard library, effects, and ecosystem — the gap between a working language and a viable agent target.
+Development follows an **interleaved spiral** — each phase adds a complete compiler layer with tests, docs, and working examples before moving to the next. The core language and compiler are complete through v0.0.89. What remains is standard library, effects, and ecosystem — the gap between a working language and a viable agent target.
 
 | Phase | Version | Layer | Status |
 |-------|---------|-------|--------|
@@ -17,7 +17,7 @@ Development follows an **interleaved spiral** — each phase adds a complete com
 
 ## Where we are
 
-**v0.0.88** delivers a full compiler pipeline (parse → typecheck → verify → compile → run), 68 built-in functions, a module system, algebraic effect handlers, a 53-program conformance suite, a canonical formatter, and contract-driven testing. An independent viability assessment rates Vera at **60–70% of the way to being a viable agent target**. The gap is standard library and data-format support, not the core language or verification system.
+**v0.0.89** delivers a full compiler pipeline (parse → typecheck → verify → compile → run), 68 built-in functions plus 5 Option/Result combinators, a module system, algebraic effect handlers, a 54-program conformance suite, a canonical formatter, and contract-driven testing. An independent viability assessment rates Vera at **60–70% of the way to being a viable agent target**. The gap is standard library and data-format support, not the core language or verification system.
 
 Most remaining features are gated by a single dependency chain:
 
@@ -30,7 +30,7 @@ Abilities introduce type constraints (`Eq`, `Hash`, `Show`). Map needs abilities
 ```
 Tier 0 (unblocked)          Tier 1 (sequential)               Tier 2 (interleave)
 ─────────────────           ──────────────────                ──────────────────
-#211 Combinators            #60 Abilities ─┐                  #289 Prelude
+<del>#211 Combinators</del>    #60 Abilities ─┐                  #289 Prelude
 #133 Array slice            #133 map/fold ←┘─┐                #226 Typed holes
 #288 Naming audit                #62 Map ←───┘─┐              #233 DateTime
                                  #58 JSON ←────┘─┐            #235 Crypto
@@ -41,7 +41,7 @@ Tier 0 (unblocked)          Tier 1 (sequential)               Tier 2 (interleave
 
 No blocking dependencies. Highest value-per-effort.
 
-- [#211](https://github.com/aallan/vera/issues/211) **Option/Result combinators** — pure Vera functions, no compiler changes. Eliminates 5-line match blocks for every fallible operation. Fundamental enough for a standard prelude.
+- <del>[#211](https://github.com/aallan/vera/issues/211) **Option/Result combinators** — pure Vera functions, no compiler changes. Eliminates 5-line match blocks for every fallible operation. Fundamental enough for a standard prelude.</del> ([v0.0.89](https://github.com/aallan/vera/releases/tag/v0.0.89))
 - [#133](https://github.com/aallan/vera/issues/133) **Array `slice`** — the `slice` operation has no abilities dependency and can ship independently of `map`/`fold`/`filter`. Unblocks basic array manipulation.
 - [#288](https://github.com/aallan/vera/issues/288) **Built-in function naming audit** — four naming patterns where there should be one or two. Must happen before new functions ship to establish the convention they follow. Breaking change — do it early.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -435,6 +435,36 @@ For pure recursive functions that need termination proofs, add a `decreases` cla
 
 ## Built-in Functions
 
+### Option and Result Combinators
+
+When a program defines `Option<T>` or `Result<T, E>`, combinator functions are automatically available:
+
+```vera
+-- Option: unwrap with default
+option_unwrap_or(Some(42), 0)           -- returns 42
+option_unwrap_or(None, 0)               -- returns 0
+
+-- Option: transform the value inside Some
+option_map(Some(10), fn(@Int -> @Int) effects(pure) { @Int.0 + 1 })
+-- returns Some(11)
+
+-- Option: chain fallible operations (flatmap)
+option_and_then(Some(5), fn(@Int -> @Option<Int>) effects(pure) {
+  if @Int.0 > 0 then { Some(@Int.0 * 2) } else { None }
+})
+-- returns Some(10)
+
+-- Result: unwrap with default
+result_unwrap_or(Ok(42), 0)             -- returns 42
+result_unwrap_or(Err("oops"), 0)        -- returns 0
+
+-- Result: transform the Ok value
+result_map(Ok(10), fn(@Int -> @Int) effects(pure) { @Int.0 + 1 })
+-- returns Ok(11)
+```
+
+These are generic functions that follow the `domain_verb` naming convention. They are automatically injected and undergo normal monomorphization. If you define a function with the same name, your definition takes precedence.
+
 ### Array operations
 
 ```vera

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,9 +6,9 @@ This is the single source of truth for Vera's testing infrastructure, coverage d
 
 | Metric | Value |
 |--------|-------|
-| **Tests** | 2,313 across 23 files (~24,000 lines of test code) |
+| **Tests** | 2,330 across 24 files (~24,000 lines of test code) |
 | **Compiler code coverage** | 91% of 14,298 statements (CI minimum: 80%) |
-| **Conformance programs** | 53 programs across 9 spec chapters, validating every language feature |
+| **Conformance programs** | 54 programs across 9 spec chapters, validating every language feature |
 | **Example programs** | 25, all validated through `vera check` + `vera verify` |
 | **Spec code blocks** | 148 parseable blocks from 13 spec chapters: 81 parse, 67 type-check, 66 verify |
 | **README code blocks** | 9 Vera blocks (8 validated, 1 allowlisted future syntax) |
@@ -32,7 +32,7 @@ pytest tests/ --cov=vera --cov-report=term-missing   # with coverage
 mypy vera/                                           # strict mode
 
 # Validation scripts
-python scripts/check_conformance.py                  # conformance suite (53 programs)
+python scripts/check_conformance.py                  # conformance suite (54 programs)
 python scripts/check_examples.py                     # 25 example programs
 python scripts/check_spec_examples.py                # spec code blocks
 python scripts/check_readme_examples.py              # README code blocks
@@ -66,13 +66,14 @@ python scripts/fix_allowlists.py --fix               # auto-fix stale allowlists
 | `test_tester.py` | 13 | 345 | Contract-driven testing: tier classification, input generation, test execution |
 | `test_markdown.py` | 59 | 394 | Markdown parser: block/inline parsing, rendering, round-trips, edge cases |
 | `test_browser.py` | 58 | 706 | Browser parity: Python/wasmtime vs Node.js/JS-runtime output equivalence across IO, State, contracts, Markdown, Regex, and all compilable examples |
-| `test_conformance.py` | 265 | 102 | Parametrized conformance suite: parse, check, verify, run, format idempotency across 53 programs |
+| `test_conformance.py` | 270 | 102 | Parametrized conformance suite: parse, check, verify, run, format idempotency across 54 programs |
+| `test_prelude.py` | 12 | 218 | Prelude injection: Option/Result detection, combinator shadowing, type aliases, end-to-end compilation |
 | `test_readme.py` | 2 | 79 | README code sample parsing |
 | `test_html.py` | 4 | 164 | HTML landing page code samples: parse, check, verify |
 
 ## Conformance Suite
 
-The conformance suite is a collection of 52 small, focused programs in `tests/conformance/` that systematically validate every language feature against the spec. Each program is self-contained, imports nothing, and tests one feature or a small group of related features.
+The conformance suite is a collection of 54 small, focused programs in `tests/conformance/` that systematically validate every language feature against the spec. Each program is self-contained, imports nothing, and tests one feature or a small group of related features.
 
 Simon Willison [argues](https://simonwillison.net/tags/conformance-suites/) that conformance suites are a "huge unlock" for language projects — they transform development from trust-based to verification-based. The conformance suite serves as the definitive specification artifact that any implementation (or agent) can validate against.
 
@@ -97,7 +98,7 @@ Each conformance program declares the deepest pipeline stage it must pass:
 | `parse` | Source text is syntactically valid | 0 |
 | `check` | Parses and type-checks cleanly | 0 |
 | `verify` | Type-checks and all contracts verified by Z3 | 0 |
-| `run` | Compiles to WASM and executes correctly | 53 |
+| `run` | Compiles to WASM and executes correctly | 54 |
 
 All programs are at the `run` level — they compile and execute, producing correct results.
 
@@ -109,7 +110,7 @@ tests/conformance/
 ├── ch01_int_literals.vera     # Chapter 1: Integer literals
 ├── ch01_float_literals.vera   # Chapter 1: Float64 literals
 ├── ch01_string_escapes.vera   # Chapter 1: String escape sequences
-├── ...                        # 53 programs total, organized by spec chapter
+├── ...                        # 54 programs total, organized by spec chapter
 ├── ch07_state_handler.vera    # Chapter 7: State<T> effect handler
 ├── ch07_exn_handler.vera      # Chapter 7: Exn<E> effect handler
 ├── ch09_numeric_builtins.vera # Chapter 9: Numeric built-in functions
@@ -297,7 +298,7 @@ Nine scripts in `scripts/` validate cross-cutting concerns beyond unit tests:
 
 | Script | What it validates |
 |--------|-------------------|
-| `check_conformance.py` | All 52 conformance programs pass their declared level (parse/check/verify/run) |
+| `check_conformance.py` | All 54 conformance programs pass their declared level (parse/check/verify/run) |
 | `check_examples.py` | All 23 `.vera` examples pass `vera check` + `vera verify` |
 | `check_spec_examples.py` | 148 parseable code blocks from spec chapters: parse, type-check, and verify |
 | `check_readme_examples.py` | All Vera code blocks in README.md parse correctly |
@@ -336,7 +337,7 @@ After running `pre-commit install`, every commit is checked by 17 hooks:
 | `mypy vera/` | Type-check compiler in strict mode |
 | `pytest tests/ -q` | Run full test suite |
 | `fix_allowlists.py --fix` | Auto-fix stale allowlist line numbers |
-| `check_conformance.py` | All 52 conformance programs pass their declared level |
+| `check_conformance.py` | All 54 conformance programs pass their declared level |
 | `check_examples.py` | All 25 examples pass `vera check` + `vera verify` |
 | `check_readme_examples.py` | README code blocks parse correctly |
 | `check_skill_examples.py` | SKILL.md code blocks parse correctly |

--- a/docs/index.html
+++ b/docs/index.html
@@ -508,7 +508,7 @@
         For Agents → SKILL.md
       </a>
     </div>
-    <p style="text-align: center; margin-top: 1rem; font-size: 0.9rem; color: var(--brown-400);">Current Version: <a href="https://github.com/aallan/vera/releases/tag/v0.0.88" style="color: var(--brown-500); font-weight: 500;">v0.0.88</a></p>
+    <p style="text-align: center; margin-top: 1rem; font-size: 0.9rem; color: var(--brown-400);">Current Version: <a href="https://github.com/aallan/vera/releases/tag/v0.0.89" style="color: var(--brown-500); font-weight: 500;">v0.0.89</a></p>
   </div>
 
   <!-- Why -->

--- a/examples/closures.vera
+++ b/examples/closures.vera
@@ -28,7 +28,7 @@ private data Option<T> {
 
 type IntMapper = fn(Int -> Int) effects(pure);
 
-private fn map_option(@Option<Int>, @IntMapper -> @Option<Int>)
+private fn option_map(@Option<Int>, @IntMapper -> @Option<Int>)
   requires(true)
   ensures(true)
   effects(pure)
@@ -50,13 +50,13 @@ public fn test_closure(@Unit -> @Int)
 }
 
 -- Test: map a closure over an Option
-public fn test_map_option(@Unit -> @Int)
+public fn test_option_map(@Unit -> @Int)
   requires(true)
   ensures(true)
   effects(pure)
 {
   let @IntToInt = make_adder(100);
-  let @Option<Int> = map_option(Some(5), @IntToInt.0);
+  let @Option<Int> = option_map(Some(5), @IntToInt.0);
   match @Option<Int>.0 {
     None -> 0,
     Some(@Int) -> @Int.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.88"
+version = "0.0.89"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/scripts/check_skill_examples.py
+++ b/scripts/check_skill_examples.py
@@ -25,6 +25,9 @@ ALLOWLIST: dict[int, tuple[str, str]] = {
     # function declarations or programs.
     # =================================================================
 
+    # Option/Result combinator examples — bare function calls
+    442: ("FRAGMENT", "Option/Result combinator usage examples, bare calls"),
+
     # Types section — bare type expressions, not declarations
     304: ("FRAGMENT", "Composite type examples, bare expressions"),
     316: ("FRAGMENT", "Type alias examples"),
@@ -34,86 +37,86 @@ ALLOWLIST: dict[int, tuple[str, str]] = {
     400: ("FRAGMENT", "Block expression example"),
 
     # Array operations — bare function calls
-    440: ("FRAGMENT", "Array built-in examples, bare calls"),
+    470: ("FRAGMENT", "Array built-in examples, bare calls"),
 
     # String operations — bare function calls
-    449: ("FRAGMENT", "String built-in examples, bare calls"),
+    479: ("FRAGMENT", "String built-in examples, bare calls"),
 
     # Markdown operations — bare function calls
-    525: ("FRAGMENT", "Markdown built-in examples, bare calls"),
+    555: ("FRAGMENT", "Markdown built-in examples, bare calls"),
 
     # Regex operations — bare function calls
-    559: ("FRAGMENT", "Regex built-in examples, bare calls"),
-    570: ("FRAGMENT", "Regex Result matching example, bare expression"),
+    589: ("FRAGMENT", "Regex built-in examples, bare calls"),
+    600: ("FRAGMENT", "Regex Result matching example, bare expression"),
 
     # String interpolation — bare expressions
-    488: ("FRAGMENT", "String interpolation examples, bare expressions"),
+    518: ("FRAGMENT", "String interpolation examples, bare expressions"),
 
     # String search — bare function calls
-    500: ("FRAGMENT", "String search built-in examples, bare calls"),
+    530: ("FRAGMENT", "String search built-in examples, bare calls"),
 
     # String transformation — bare function calls
-    511: ("FRAGMENT", "String transformation built-in examples, bare calls"),
+    541: ("FRAGMENT", "String transformation built-in examples, bare calls"),
 
     # Numeric operations — bare function calls
-    582: ("FRAGMENT", "Numeric built-in examples, bare calls"),
+    612: ("FRAGMENT", "Numeric built-in examples, bare calls"),
 
     # Contracts section — requires/ensures fragments
-    639: ("FRAGMENT", "Requires clause example, not full function"),
-    648: ("FRAGMENT", "Ensures clause example, not full function"),
+    669: ("FRAGMENT", "Requires clause example, not full function"),
+    678: ("FRAGMENT", "Ensures clause example, not full function"),
 
     # Quantified expressions — bare forall/exists calls
-    675: ("FRAGMENT", "Quantified expression examples, bare calls"),
+    705: ("FRAGMENT", "Quantified expression examples, bare calls"),
 
     # Effects section — bare effect rows
     # (old entry at 580 removed — block shifted to 582 with Async addition)
 
     # Effect handler syntax template
-    858: ("FRAGMENT", "Handler syntax template, not real code"),
+    888: ("FRAGMENT", "Handler syntax template, not real code"),
 
     # Effect declarations — bare effects(...) clauses
-    693: ("FRAGMENT", "Effect declarations list"),
-    796: ("FRAGMENT", "Async effect declarations list"),
-    816: ("FRAGMENT", "Async effect declarations, bare clauses"),
+    723: ("FRAGMENT", "Effect declarations list"),
+    826: ("FRAGMENT", "Async effect declarations list"),
+    846: ("FRAGMENT", "Async effect declarations, bare clauses"),
 
     # Qualified calls and handler fragments — bare expressions
-    870: ("FRAGMENT", "Handler with clause, bare expression"),
-    880: ("FRAGMENT", "Qualified call examples, bare expressions"),
+    900: ("FRAGMENT", "Handler with clause, bare expression"),
+    910: ("FRAGMENT", "Qualified call examples, bare expressions"),
 
     # Module declaration and import syntax
-    918: ("FRAGMENT", "Module declaration and import example"),
+    948: ("FRAGMENT", "Module declaration and import example"),
 
     # Line comments — bare comments
-    969: ("FRAGMENT", "Comment syntax example"),
+    999: ("FRAGMENT", "Comment syntax example"),
 
     # Type conversions — bare function calls
-    597: ("FRAGMENT", "Type conversion examples, bare calls"),
+    627: ("FRAGMENT", "Type conversion examples, bare calls"),
 
     # Float64 predicates — bare function calls
-    610: ("FRAGMENT", "Float64 predicate examples, bare calls"),
+    640: ("FRAGMENT", "Float64 predicate examples, bare calls"),
 
     # Common mistakes section — intentionally wrong code
-    1032: ("FRAGMENT", "Wrong: missing contracts"),
-    1052: ("FRAGMENT", "Wrong: missing effects clause"),
-    1086: ("FRAGMENT", "Wrong: bare expression without indices"),
+    1062: ("FRAGMENT", "Wrong: missing contracts"),
+    1082: ("FRAGMENT", "Wrong: missing effects clause"),
+    1116: ("FRAGMENT", "Wrong: bare expression without indices"),
     1062: ("FRAGMENT", "Wrong: bare expression no indices"),
-    1099: ("FRAGMENT", "Wrong: missing index on slot reference"),
-    1104: ("FRAGMENT", "Correct: expression with indices (not full fn)"),
-    1170: ("FRAGMENT", "Wrong: match arm with incorrect return"),
-    1194: ("FRAGMENT", "Wrong: non-exhaustive match"),
+    1129: ("FRAGMENT", "Wrong: missing index on slot reference"),
+    1134: ("FRAGMENT", "Correct: expression with indices (not full fn)"),
+    1200: ("FRAGMENT", "Wrong: match arm with incorrect return"),
+    1224: ("FRAGMENT", "Wrong: non-exhaustive match"),
     1156: ("FRAGMENT", "Correct: match arm example"),
-    1201: ("FRAGMENT", "Correct: match expression (bare expression)"),
-    1211: ("FRAGMENT", "Wrong: if/else without braces (bare expression)"),
-    1216: ("FRAGMENT", "Correct: if/else with braces"),
+    1231: ("FRAGMENT", "Correct: match expression (bare expression)"),
+    1241: ("FRAGMENT", "Wrong: if/else without braces (bare expression)"),
+    1246: ("FRAGMENT", "Correct: if/else with braces"),
 
     # Import syntax — intentionally unsupported
-    1227: ("FRAGMENT", "Wrong: import aliasing not supported"),
-    1232: ("FRAGMENT", "Correct: import syntax example"),
-    1242: ("FRAGMENT", "Wrong: import hiding not supported"),
-    1227: ("FRAGMENT", "Correct: multi-import syntax"),
+    1257: ("FRAGMENT", "Wrong: import aliasing not supported"),
+    1262: ("FRAGMENT", "Correct: import syntax example"),
+    1272: ("FRAGMENT", "Wrong: import hiding not supported"),
+    1257: ("FRAGMENT", "Correct: multi-import syntax"),
 
     # String escapes — bare expression
-    1261: ("FRAGMENT", "String escape example"),
+    1291: ("FRAGMENT", "String escape example"),
 
     # =================================================================
     # MISMATCH — uses syntax the parser doesn't handle in isolation.

--- a/scripts/check_spec_examples.py
+++ b/scripts/check_spec_examples.py
@@ -57,25 +57,25 @@ ALLOWLIST: dict[tuple[str, int], str] = {
     ("02-types.md", 250): "FUTURE",          # forall<T where Ord<T>> fn sort
 
     # Chapter 9 — future stdlib features and signature-only blocks
-    ("09-standard-library.md", 396): "FUTURE",   # fn classify — uses ++ (string concat)
+    ("09-standard-library.md", 417): "FUTURE",   # fn classify — uses ++ (string concat)
 
     # Chapter 9 — Array builtin signatures (no body)
-    ("09-standard-library.md", 410): "FRAGMENT",  # array_length signature (no body)
-    ("09-standard-library.md", 430): "FRAGMENT",  # array_append signature (no body)
-    ("09-standard-library.md", 448): "FRAGMENT",  # array_range signature (no body)
-    ("09-standard-library.md", 466): "FRAGMENT",  # array_concat signature (no body)
+    ("09-standard-library.md", 431): "FRAGMENT",  # array_length signature (no body)
+    ("09-standard-library.md", 451): "FRAGMENT",  # array_append signature (no body)
+    ("09-standard-library.md", 469): "FRAGMENT",  # array_range signature (no body)
+    ("09-standard-library.md", 487): "FRAGMENT",  # array_concat signature (no body)
 
     # Chapter 9 — Numeric/string/encoding builtin signatures (no body)
-    ("09-standard-library.md", 573): "FRAGMENT",  # round signature (no body)
-    ("09-standard-library.md", 590): "FRAGMENT",  # sqrt signature (no body)
-    ("09-standard-library.md", 607): "FRAGMENT",  # pow signature (no body)
-    ("09-standard-library.md", 658): "FRAGMENT",  # byte_to_int signature (no body)
-    ("09-standard-library.md", 832): "FRAGMENT",  # ends_with signature (no body)
-    ("09-standard-library.md", 1095): "FRAGMENT",  # base64_decode signature (no body)
-    ("09-standard-library.md", 1224): "FRAGMENT",  # regex_match signature (no body)
-    ("09-standard-library.md", 1240): "FRAGMENT",  # regex_find signature (no body)
-    ("09-standard-library.md", 1256): "FRAGMENT",  # regex_find_all signature (no body)
-    ("09-standard-library.md", 1272): "FRAGMENT",  # regex_replace signature (no body)
+    ("09-standard-library.md", 594): "FRAGMENT",  # round signature (no body)
+    ("09-standard-library.md", 611): "FRAGMENT",  # sqrt signature (no body)
+    ("09-standard-library.md", 628): "FRAGMENT",  # pow signature (no body)
+    # (byte_to_int moved to line 679, now in the type conversion group below)
+    ("09-standard-library.md", 853): "FRAGMENT",  # ends_with signature (no body)
+    ("09-standard-library.md", 1116): "FRAGMENT",  # base64_decode signature (no body)
+    ("09-standard-library.md", 1245): "FRAGMENT",  # regex_match signature (no body)
+    ("09-standard-library.md", 1261): "FRAGMENT",  # regex_find signature (no body)
+    ("09-standard-library.md", 1277): "FRAGMENT",  # regex_find_all signature (no body)
+    ("09-standard-library.md", 1293): "FRAGMENT",  # regex_replace signature (no body)
 
     # =================================================================
     # FRAGMENT — heuristic false positives (look like declarations but
@@ -125,69 +125,70 @@ ALLOWLIST: dict[tuple[str, int], str] = {
     ("07-effects.md", 315): "FRAGMENT",     # effect Diverge {} — no operations
 
     # Chapter 9 — Async builtin signatures (no body)
-    ("09-standard-library.md", 346): "FRAGMENT",  # async/await signatures (no body)
+    ("09-standard-library.md", 367): "FRAGMENT",  # async/await signatures (no body)
 
     # Chapter 9 — Numeric builtin signatures (no body)
-    ("09-standard-library.md", 488): "FRAGMENT",  # abs signature (no body)
-    ("09-standard-library.md", 505): "FRAGMENT",  # min signature (no body)
-    ("09-standard-library.md", 522): "FRAGMENT",  # max signature (no body)
-    ("09-standard-library.md", 539): "FRAGMENT",  # floor signature (no body)
-    ("09-standard-library.md", 556): "FRAGMENT",  # ceil signature (no body)
+    ("09-standard-library.md", 509): "FRAGMENT",  # abs signature (no body)
+    ("09-standard-library.md", 526): "FRAGMENT",  # min signature (no body)
+    ("09-standard-library.md", 543): "FRAGMENT",  # max signature (no body)
+    ("09-standard-library.md", 560): "FRAGMENT",  # floor signature (no body)
+    ("09-standard-library.md", 577): "FRAGMENT",  # ceil signature (no body)
 
     # Chapter 9 — Numeric type conversion signatures (no body)
-    ("09-standard-library.md", 628): "FRAGMENT",  # to_float signature (no body)
-    ("09-standard-library.md", 643): "FRAGMENT",  # nat_to_int signature (no body)
-    ("09-standard-library.md", 673): "FRAGMENT",  # float_to_int signature (no body)
-    ("09-standard-library.md", 688): "FRAGMENT",  # int_to_nat signature (no body)
-    ("09-standard-library.md", 706): "FRAGMENT",  # int_to_byte signature (no body)
+    ("09-standard-library.md", 649): "FRAGMENT",  # to_float signature (no body)
+    ("09-standard-library.md", 664): "FRAGMENT",  # nat_to_int signature (no body)
+    ("09-standard-library.md", 679): "FRAGMENT",  # byte_to_int signature (no body)
+    ("09-standard-library.md", 694): "FRAGMENT",  # float_to_int signature (no body)
+    ("09-standard-library.md", 709): "FRAGMENT",  # int_to_nat signature (no body)
+    ("09-standard-library.md", 727): "FRAGMENT",  # int_to_byte signature (no body)
 
     # Chapter 9 — Float64 predicates (signatures, no body)
-    ("09-standard-library.md", 730): "FRAGMENT",  # is_nan signature (no body)
-    ("09-standard-library.md", 747): "FRAGMENT",  # is_infinite signature (no body)
-    ("09-standard-library.md", 766): "FRAGMENT",  # nan signature (no body)
-    ("09-standard-library.md", 781): "FRAGMENT",  # infinity signature (no body)
+    ("09-standard-library.md", 751): "FRAGMENT",  # is_nan signature (no body)
+    ("09-standard-library.md", 768): "FRAGMENT",  # is_infinite signature (no body)
+    ("09-standard-library.md", 787): "FRAGMENT",  # nan signature (no body)
+    ("09-standard-library.md", 802): "FRAGMENT",  # infinity signature (no body)
 
     # Chapter 9 — String search signatures (no body)
-    ("09-standard-library.md", 802): "FRAGMENT",  # string_contains signature (no body)
-    ("09-standard-library.md", 817): "FRAGMENT",  # starts_with signature (no body)
-    ("09-standard-library.md", 847): "FRAGMENT",  # index_of signature (no body)
+    ("09-standard-library.md", 823): "FRAGMENT",  # string_contains signature (no body)
+    ("09-standard-library.md", 838): "FRAGMENT",  # starts_with signature (no body)
+    ("09-standard-library.md", 868): "FRAGMENT",  # index_of signature (no body)
 
     # Chapter 9 — String transformation signatures (no body)
-    ("09-standard-library.md", 868): "FRAGMENT",  # to_upper signature (no body)
-    ("09-standard-library.md", 883): "FRAGMENT",  # to_lower signature (no body)
-    ("09-standard-library.md", 898): "FRAGMENT",  # replace signature (no body)
-    ("09-standard-library.md", 914): "FRAGMENT",  # split signature (no body)
-    ("09-standard-library.md", 929): "FRAGMENT",  # join signature (no body)
-    ("09-standard-library.md", 943): "FRAGMENT",  # from_char_code signature (no body)
-    ("09-standard-library.md", 958): "FRAGMENT",  # string_repeat signature (no body)
+    ("09-standard-library.md", 889): "FRAGMENT",  # to_upper signature (no body)
+    ("09-standard-library.md", 904): "FRAGMENT",  # to_lower signature (no body)
+    ("09-standard-library.md", 919): "FRAGMENT",  # replace signature (no body)
+    ("09-standard-library.md", 935): "FRAGMENT",  # split signature (no body)
+    ("09-standard-library.md", 950): "FRAGMENT",  # join signature (no body)
+    ("09-standard-library.md", 964): "FRAGMENT",  # from_char_code signature (no body)
+    ("09-standard-library.md", 979): "FRAGMENT",  # string_repeat signature (no body)
 
     # Chapter 9 — Parsing function signatures (no body)
-    ("09-standard-library.md", 986): "FRAGMENT",  # parse_nat signature (no body)
-    ("09-standard-library.md", 1008): "FRAGMENT",  # parse_int signature (no body)
-    ("09-standard-library.md", 1031): "FRAGMENT",  # parse_float64 signature (no body)
-    ("09-standard-library.md", 1053): "FRAGMENT",  # parse_bool signature (no body)
+    ("09-standard-library.md", 1007): "FRAGMENT",  # parse_nat signature (no body)
+    ("09-standard-library.md", 1029): "FRAGMENT",  # parse_int signature (no body)
+    ("09-standard-library.md", 1052): "FRAGMENT",  # parse_float64 signature (no body)
+    ("09-standard-library.md", 1074): "FRAGMENT",  # parse_bool signature (no body)
 
     # Chapter 9 — Base64 builtin signatures (no body)
-    ("09-standard-library.md", 1076): "FRAGMENT",  # base64_encode signature (no body)
+    ("09-standard-library.md", 1097): "FRAGMENT",  # base64_encode signature (no body)
 
     # Chapter 9 — URL encoding builtin signatures (no body)
-    ("09-standard-library.md", 1122): "FRAGMENT",  # url_encode signature (no body)
-    ("09-standard-library.md", 1141): "FRAGMENT",  # url_decode signature (no body)
+    ("09-standard-library.md", 1143): "FRAGMENT",  # url_encode signature (no body)
+    ("09-standard-library.md", 1162): "FRAGMENT",  # url_decode signature (no body)
 
     # Chapter 9 — URL parsing builtin signatures (no body)
-    ("09-standard-library.md", 1167): "FRAGMENT",  # url_parse signature (no body)
-    ("09-standard-library.md", 1187): "FRAGMENT",  # url_join signature (no body)
+    ("09-standard-library.md", 1188): "FRAGMENT",  # url_parse signature (no body)
+    ("09-standard-library.md", 1208): "FRAGMENT",  # url_join signature (no body)
 
     # Chapter 9 — ML/vector builtin signatures (no body)
-    ("09-standard-library.md", 1207): "FRAGMENT",  # similarity signature (no body)
+    ("09-standard-library.md", 1228): "FRAGMENT",  # similarity signature (no body)
 
     # Chapter 9 — Markdown stdlib type (future, uses MdBlock/MdInline types)
-    ("09-standard-library.md", 1379): "FUTURE",   # md_parse
-    ("09-standard-library.md", 1388): "FUTURE",   # md_render
-    ("09-standard-library.md", 1399): "FUTURE",   # md_has_heading
-    ("09-standard-library.md", 1408): "FUTURE",   # md_has_code_block
-    ("09-standard-library.md", 1417): "FUTURE",   # md_extract_code_blocks
-    ("09-standard-library.md", 1441): "FUTURE",   # convert_to_markdown
+    ("09-standard-library.md", 1400): "FUTURE",   # md_parse
+    ("09-standard-library.md", 1409): "FUTURE",   # md_render
+    ("09-standard-library.md", 1420): "FUTURE",   # md_has_heading
+    ("09-standard-library.md", 1429): "FUTURE",   # md_has_code_block
+    ("09-standard-library.md", 1438): "FUTURE",   # md_extract_code_blocks
+    ("09-standard-library.md", 1462): "FUTURE",   # convert_to_markdown
 }
 
 
@@ -238,7 +239,7 @@ CHECK_ALLOWLIST: dict[tuple[str, int], str] = {
     ("07-effects.md", 202): "INCOMPLETE",    # handle[Exn<String>] + parse_int
 
     # Chapter 9 — Http + Async composition example (Http not yet implemented)
-    ("09-standard-library.md", 326): "INCOMPLETE",  # fetch_both uses Http.get (future)
+    ("09-standard-library.md", 347): "INCOMPLETE",  # fetch_both uses Http.get (future)
 
     # Chapter 9 — Future<T> type definition (standalone, no visibility)
     ("09-standard-library.md", 103): "INCOMPLETE",  # data Future<T> (no visibility keyword)

--- a/spec/05-functions.md
+++ b/spec/05-functions.md
@@ -322,7 +322,7 @@ Type variables are introduced by `forall<...>` and are scoped to the entire func
 Functions can be polymorphic over effects:
 
 ```
-private forall<A, B> fn map_option(@Option<A>, fn(A -> B) effects(<E>) -> @Option<B>)
+private forall<A, B> fn option_map(@Option<A>, fn(A -> B) effects(<E>) -> @Option<B>)
   requires(true)
   ensures(true)
   effects(<E>)

--- a/spec/07-effects.md
+++ b/spec/07-effects.md
@@ -247,7 +247,7 @@ This demonstrates that `resume` is a first-class continuation: it can be called 
 Functions can be polymorphic over effects:
 
 ```
-private forall<A, B> fn map_option(@Option<A>, fn(A -> B) effects(<E>) -> @Option<B>)
+private forall<A, B> fn option_map(@Option<A>, fn(A -> B) effects(<E>) -> @Option<B>)
   requires(true)
   ensures(true)
   effects(<E>)
@@ -259,7 +259,7 @@ private forall<A, B> fn map_option(@Option<A>, fn(A -> B) effects(<E>) -> @Optio
 }
 ```
 
-The effect variable `E` is unified at each call site. If the passed function is `pure`, then `map_option` is `pure`. If it has `effects(<IO>)`, then `map_option` has `effects(<IO>)`.
+The effect variable `E` is unified at each call site. If the passed function is `pure`, then `option_map` is `pure`. If it has `effects(<IO>)`, then `option_map` has `effects(<IO>)`.
 
 ### 7.6.1 Effect Row Variables
 

--- a/spec/09-standard-library.md
+++ b/spec/09-standard-library.md
@@ -165,6 +165,27 @@ Constructors:
 
 See §9.7.3 for the Markdown function specifications.
 
+### 9.3.7 Option and Result Combinators
+
+The standard prelude provides combinator functions that eliminate common match boilerplate for `Option<T>` and `Result<T, E>`. These are automatically available when the corresponding ADT is defined.
+
+**Option combinators:**
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `option_unwrap_or` | `forall<T> (Option<T>, T) -> T` | Extract `Some` value or return default |
+| `option_map` | `forall<A, B> (Option<A>, fn(A -> B)) -> Option<B>` | Transform the value inside `Some` |
+| `option_and_then` | `forall<A, B> (Option<A>, fn(A -> Option<B>)) -> Option<B>` | Chain fallible operations |
+
+**Result combinators:**
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `result_unwrap_or` | `forall<T, E> (Result<T, E>, T) -> T` | Extract `Ok` value or return default |
+| `result_map` | `forall<A, B, E> (Result<A, E>, fn(A -> B)) -> Result<B, E>` | Transform the `Ok` value |
+
+Combinators follow the `domain_verb` naming convention (see §5). They are injected as private generic functions before compilation and undergo normal monomorphization. A combinator is not injected if the user defines a function with the same name.
+
 ## 9.4 Built-in Collections
 
 ### 9.4.1 Array\<T\>

--- a/tests/conformance/ch09_option_result_combinators.vera
+++ b/tests/conformance/ch09_option_result_combinators.vera
@@ -1,0 +1,65 @@
+-- Conformance: Option and Result Combinators (Chapter 9, Section 9.3.7)
+-- Tests: option_unwrap_or, option_map, option_and_then, result_unwrap_or, result_map
+public data Option<T> {
+  None,
+  Some(T)
+}
+
+public data Result<T, E> {
+  Ok(T),
+  Err(E)
+}
+
+-- option_unwrap_or: Some returns inner value
+public fn test_unwrap_some(@Unit -> @Int)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  option_unwrap_or(Some(42), 0)
+}
+
+-- option_map: transforms value inside Some
+public fn test_map_some(@Unit -> @Int)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  option_unwrap_or(option_map(Some(10), fn(@Int -> @Int) effects(pure) { @Int.0 + 1 }), 0)
+}
+
+-- option_and_then: chains fallible operations
+public fn test_and_then_some(@Unit -> @Int)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  option_unwrap_or(option_and_then(Some(5), fn(@Int -> @Option<Int>) effects(pure) { Some(@Int.0 * 2) }), 0)
+}
+
+-- result_unwrap_or: Ok returns inner value
+public fn test_result_ok(@Unit -> @Int)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  result_unwrap_or(Ok(77), 0)
+}
+
+-- result_map: transforms Ok value
+public fn test_result_map(@Unit -> @Int)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  result_unwrap_or(result_map(Ok(100), fn(@Int -> @Int) effects(pure) { @Int.0 - 1 }), 0)
+}
+
+-- Integration: all combinators compose
+public fn main(@Unit -> @Int)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  test_unwrap_some(()) + test_map_some(()) + test_and_then_some(()) + test_result_ok(()) + test_result_map(())
+}

--- a/tests/conformance/manifest.json
+++ b/tests/conformance/manifest.json
@@ -450,6 +450,15 @@
     "features": ["url_parse", "url_join", "urlparts", "result_type"]
   },
   {
+    "id": "ch09_option_result_combinators",
+    "file": "ch09_option_result_combinators.vera",
+    "chapter": 9,
+    "title": "Option and Result combinators",
+    "level": "run",
+    "spec_ref": "Section 9.3.7",
+    "features": ["option_unwrap_or", "option_map", "option_and_then", "result_unwrap_or", "result_map", "prelude_injection", "generic_closures"]
+  },
+  {
     "id": "ch09_async",
     "file": "ch09_async.vera",
     "chapter": 9,

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -225,7 +225,7 @@ FUNCTION_CALL_EXAMPLES = [
     ("safe_divide", "test_divide", [], []),
     ("increment", "increment", [], []),
     ("closures", "test_closure", [], []),
-    ("closures", "test_map_option", [], []),
+    ("closures", "test_option_map", [], []),
     ("generics", "test_generics", [], []),
     ("list_ops", "test_list", [], []),
     ("mutual_recursion", "is_even", ["4"], [4]),

--- a/tests/test_codegen_closures.py
+++ b/tests/test_codegen_closures.py
@@ -221,7 +221,7 @@ public fn test(@Unit -> @Int)
         src = """\
 private data Option<T> { None, Some(T) }
 type IntMapper = fn(Int -> Int) effects(pure);
-public fn map_option(@Option<Int>, @IntMapper -> @Option<Int>)
+public fn option_map(@Option<Int>, @IntMapper -> @Option<Int>)
   requires(true) ensures(true) effects(pure)
 {
   match @Option<Int>.0 {
@@ -238,7 +238,7 @@ public fn test(@Unit -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   let @IntMapper = make_adder(100);
-  let @Option<Int> = map_option(Some(5), @IntMapper.0);
+  let @Option<Int> = option_map(Some(5), @IntMapper.0);
   match @Option<Int>.0 {
     None -> 0,
     Some(@Int) -> @Int.0
@@ -248,11 +248,11 @@ public fn test(@Unit -> @Int)
         assert _run(src, "test") == 105
 
     def test_closure_in_match_none(self) -> None:
-        """map_option on None returns None."""
+        """option_map on None returns None."""
         src = """\
 private data Option<T> { None, Some(T) }
 type IntMapper = fn(Int -> Int) effects(pure);
-public fn map_option(@Option<Int>, @IntMapper -> @Option<Int>)
+public fn option_map(@Option<Int>, @IntMapper -> @Option<Int>)
   requires(true) ensures(true) effects(pure)
 {
   match @Option<Int>.0 {
@@ -269,7 +269,7 @@ public fn test(@Unit -> @Int)
   requires(true) ensures(true) effects(pure)
 {
   let @IntMapper = make_adder(100);
-  let @Option<Int> = map_option(None, @IntMapper.0);
+  let @Option<Int> = option_map(None, @IntMapper.0);
   match @Option<Int>.0 {
     None -> -1,
     Some(@Int) -> @Int.0
@@ -364,13 +364,13 @@ public fn make_fn(@Unit -> @IntToInt)
         exec_result = execute(result, fn_name="test_closure")
         assert exec_result.value == 15
 
-    def test_closures_example_test_map_option(self) -> None:
-        """examples/closures.vera test_map_option returns 105."""
+    def test_closures_example_test_option_map(self) -> None:
+        """examples/closures.vera test_option_map returns 105."""
         from pathlib import Path
         path = Path(__file__).parent.parent / "examples" / "closures.vera"
         source = path.read_text()
         result = _compile_ok(source)
-        exec_result = execute(result, fn_name="test_map_option")
+        exec_result = execute(result, fn_name="test_option_map")
         assert exec_result.value == 105
 
     def test_multiple_closures(self) -> None:

--- a/tests/test_prelude.py
+++ b/tests/test_prelude.py
@@ -1,0 +1,218 @@
+"""Tests for vera.prelude — Option/Result combinator injection."""
+
+from __future__ import annotations
+
+from vera import ast
+from vera.parser import parse
+from vera.transform import transform
+from vera.prelude import inject_prelude
+
+
+def _make_program(src: str) -> ast.Program:
+    tree = parse(src)
+    return transform(tree)
+
+
+class TestPreludeDetection:
+    """Tests for ADT detection and conditional injection."""
+
+    def test_option_detected(self) -> None:
+        """Option combinators injected when Option<T> defined."""
+        prog = _make_program(
+            "public data Option<T> { None, Some(T) }\n"
+            "public fn main(@Unit -> @Int)\n"
+            "  requires(true) ensures(true) effects(pure)\n"
+            "{ 0 }\n"
+        )
+        inject_prelude(prog)
+        fn_names = {
+            tld.decl.name
+            for tld in prog.declarations
+            if isinstance(tld.decl, ast.FnDecl)
+        }
+        assert "option_unwrap_or" in fn_names
+        assert "option_map" in fn_names
+        assert "option_and_then" in fn_names
+
+    def test_result_detected(self) -> None:
+        """Result combinators injected when Result<T, E> defined."""
+        prog = _make_program(
+            "public data Result<T, E> { Ok(T), Err(E) }\n"
+            "public fn main(@Unit -> @Int)\n"
+            "  requires(true) ensures(true) effects(pure)\n"
+            "{ 0 }\n"
+        )
+        inject_prelude(prog)
+        fn_names = {
+            tld.decl.name
+            for tld in prog.declarations
+            if isinstance(tld.decl, ast.FnDecl)
+        }
+        assert "result_unwrap_or" in fn_names
+        assert "result_map" in fn_names
+        # Option combinators not injected (no Option defined)
+        assert "option_map" not in fn_names
+
+    def test_no_injection_without_adt(self) -> None:
+        """No injection when neither Option nor Result defined."""
+        prog = _make_program(
+            "public fn main(@Unit -> @Int)\n"
+            "  requires(true) ensures(true) effects(pure)\n"
+            "{ 0 }\n"
+        )
+        orig_len = len(prog.declarations)
+        inject_prelude(prog)
+        assert len(prog.declarations) == orig_len
+
+    def test_non_standard_option_ignored(self) -> None:
+        """Non-standard Option (missing Some) not detected."""
+        prog = _make_program(
+            "public data Option<T> { None, Just(T) }\n"
+            "public fn main(@Unit -> @Int)\n"
+            "  requires(true) ensures(true) effects(pure)\n"
+            "{ 0 }\n"
+        )
+        orig_len = len(prog.declarations)
+        inject_prelude(prog)
+        assert len(prog.declarations) == orig_len
+
+
+class TestPreludeShadowing:
+    """Tests for user-defined function shadowing."""
+
+    def test_user_fn_shadows_combinator(self) -> None:
+        """User-defined option_map is not overwritten."""
+        prog = _make_program(
+            "public data Option<T> { None, Some(T) }\n"
+            "public fn option_map(@Unit -> @Int)\n"
+            "  requires(true) ensures(true) effects(pure)\n"
+            "{ 0 }\n"
+        )
+        inject_prelude(prog)
+        # The user's option_map should still be there, unmodified
+        user_fns = [
+            tld.decl
+            for tld in prog.declarations
+            if isinstance(tld.decl, ast.FnDecl)
+            and tld.decl.name == "option_map"
+        ]
+        assert len(user_fns) >= 1
+        # The user-defined one has no forall_vars
+        assert any(fn.forall_vars is None for fn in user_fns)
+
+
+class TestPreludeTypeAliases:
+    """Tests for type alias injection."""
+
+    def test_type_aliases_injected(self) -> None:
+        """OptionMapFn and OptionBindFn injected with Option."""
+        prog = _make_program(
+            "public data Option<T> { None, Some(T) }\n"
+            "public fn main(@Unit -> @Int)\n"
+            "  requires(true) ensures(true) effects(pure)\n"
+            "{ 0 }\n"
+        )
+        inject_prelude(prog)
+        alias_names = {
+            tld.decl.name
+            for tld in prog.declarations
+            if isinstance(tld.decl, ast.TypeAliasDecl)
+        }
+        assert "OptionMapFn" in alias_names
+        assert "OptionBindFn" in alias_names
+
+    def test_result_alias_injected(self) -> None:
+        """ResultMapFn injected with Result."""
+        prog = _make_program(
+            "public data Result<T, E> { Ok(T), Err(E) }\n"
+            "public fn main(@Unit -> @Int)\n"
+            "  requires(true) ensures(true) effects(pure)\n"
+            "{ 0 }\n"
+        )
+        inject_prelude(prog)
+        alias_names = {
+            tld.decl.name
+            for tld in prog.declarations
+            if isinstance(tld.decl, ast.TypeAliasDecl)
+        }
+        assert "ResultMapFn" in alias_names
+
+
+class TestPreludeEndToEnd:
+    """End-to-end tests verifying combinators compile and run."""
+
+    def test_option_unwrap_or_some(self) -> None:
+        """option_unwrap_or(Some(42), 0) returns 42."""
+        from tests.test_codegen_closures import _run
+        src = """\
+public data Option<T> { None, Some(T) }
+public fn test(@Unit -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  option_unwrap_or(Some(42), 0)
+}
+"""
+        assert _run(src, "test") == 42
+
+    def test_option_map_some(self) -> None:
+        """option_map(Some(10), +1) returns Some(11)."""
+        from tests.test_codegen_closures import _run
+        src = """\
+public data Option<T> { None, Some(T) }
+public fn test(@Unit -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  option_unwrap_or(
+    option_map(Some(10), fn(@Int -> @Int) effects(pure) { @Int.0 + 1 }),
+    0
+  )
+}
+"""
+        assert _run(src, "test") == 11
+
+    def test_option_and_then_some(self) -> None:
+        """option_and_then(Some(5), *2) returns Some(10)."""
+        from tests.test_codegen_closures import _run
+        src = """\
+public data Option<T> { None, Some(T) }
+public fn test(@Unit -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  option_unwrap_or(
+    option_and_then(Some(5), fn(@Int -> @Option<Int>) effects(pure) {
+      Some(@Int.0 * 2)
+    }),
+    0
+  )
+}
+"""
+        assert _run(src, "test") == 10
+
+    def test_result_unwrap_or_ok(self) -> None:
+        """result_unwrap_or(Ok(77), 0) returns 77."""
+        from tests.test_codegen_closures import _run
+        src = """\
+public data Result<T, E> { Ok(T), Err(E) }
+public fn test(@Unit -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  result_unwrap_or(Ok(77), 0)
+}
+"""
+        assert _run(src, "test") == 77
+
+    def test_result_map_ok(self) -> None:
+        """result_map(Ok(100), -1) returns Ok(99)."""
+        from tests.test_codegen_closures import _run
+        src = """\
+public data Result<T, E> { Ok(T), Err(E) }
+public fn test(@Unit -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  result_unwrap_or(
+    result_map(Ok(100), fn(@Int -> @Int) effects(pure) { @Int.0 - 1 }),
+    0
+  )
+}
+"""
+        assert _run(src, "test") == 99

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.88"
+__version__ = "0.0.89"

--- a/vera/cli.py
+++ b/vera/cli.py
@@ -70,6 +70,7 @@ def cmd_check(path: str, as_json: bool = False) -> int:
         tree = parse_file(path)
         ast = transform(tree)
 
+
         # Resolve imports (C7a)
         resolver = ModuleResolver(_root=p.parent)
         resolved = resolver.resolve_imports(ast, p)
@@ -133,6 +134,7 @@ def cmd_verify(path: str, as_json: bool = False) -> int:
         source = p.read_text(encoding="utf-8")
         tree = parse_file(path)
         ast = transform(tree)
+
 
         # Resolve imports (C7a)
         resolver = ModuleResolver(_root=p.parent)
@@ -241,6 +243,7 @@ def cmd_compile(
         source = p.read_text(encoding="utf-8")
         tree = parse_file(path)
         ast = transform(tree)
+
 
         # Resolve imports (C7a)
         resolver = ModuleResolver(_root=p.parent)
@@ -368,6 +371,7 @@ def cmd_run(
         source = p.read_text(encoding="utf-8")
         tree = parse_file(path)
         ast = transform(tree)
+
 
         # Resolve imports (C7a)
         resolver = ModuleResolver(_root=p.parent)
@@ -614,6 +618,7 @@ def cmd_test(
         source = p.read_text(encoding="utf-8")
         tree = parse_file(path)
         ast = transform(tree)
+
 
         # Resolve imports (C7a)
         resolver = ModuleResolver(_root=p.parent)

--- a/vera/codegen/closures.py
+++ b/vera/codegen/closures.py
@@ -98,6 +98,7 @@ class ClosureLiftingMixin:
                 fn_ret_types[fn_name] = ret_wt
         ctx.set_fn_ret_types(fn_ret_types)
         ctx.set_type_aliases(self._type_aliases)
+        ctx.set_type_alias_params(self._type_alias_params)
         env = WasmSlotEnv()
 
         # Parameter 0: $env (i32 — closure environment pointer)

--- a/vera/codegen/core.py
+++ b/vera/codegen/core.py
@@ -83,6 +83,9 @@ class CodeGenerator(
         # Type aliases (populated during registration)
         # Maps alias name -> TypeExpr (for resolving function type aliases)
         self._type_aliases: dict[str, ast.TypeExpr] = {}
+        # Type alias parameters: alias name -> param names
+        # Needed for generic type alias resolution in closure codegen
+        self._type_alias_params: dict[str, tuple[str, ...]] = {}
 
         # Closure compilation state
         self._closure_table: list[str] = []  # lifted fn names for table
@@ -142,6 +145,24 @@ class CodeGenerator(
 
         # Pass 1: register local function signatures (shadows imports)
         self._register_all(program)
+
+        # Pass 1.2: inject prelude combinator implementations
+        # Prelude functions are registered as builtins in the type checker
+        # (environment.py) but need compilable AST bodies for codegen.
+        # inject_prelude prepends FnDecl + TypeAliasDecl nodes to
+        # program.declarations; we register them here.
+        existing_fns = set(self._fn_sigs.keys())
+        from vera.prelude import inject_prelude
+        inject_prelude(program)
+        for tld in program.declarations:
+            decl = tld.decl
+            if isinstance(decl, ast.FnDecl) and decl.name not in existing_fns:
+                self._register_fn(decl)
+            elif isinstance(decl, ast.TypeAliasDecl):
+                if decl.name not in self._type_aliases:
+                    self._type_aliases[decl.name] = decl.type_expr
+                    if decl.type_params:
+                        self._type_alias_params[decl.name] = decl.type_params
 
         # Pass 1.5: monomorphize generic functions
         mono_decls = self._monomorphize(program)

--- a/vera/codegen/functions.py
+++ b/vera/codegen/functions.py
@@ -77,7 +77,9 @@ class FunctionCompilationMixin:
         ctx.set_fn_ret_types(fn_ret_types)
         # Provide type aliases so closures can resolve FnType return types
         ctx.set_type_aliases(self._type_aliases)
+        ctx.set_type_alias_params(self._type_alias_params)
         ctx.set_closure_id_start(self._next_closure_id)
+        ctx.set_closure_sigs(self._closure_sigs)
         env = WasmSlotEnv()
 
         # Allocate parameters and track pointer params for GC prologue

--- a/vera/codegen/monomorphize.py
+++ b/vera/codegen/monomorphize.py
@@ -138,6 +138,11 @@ class MonomorphizationMixin:
                 self._collect_calls_in_expr(
                     arm.body, generic_decls, ctor_to_adt, instances,
                 )
+        elif isinstance(expr, ast.AnonFn):
+            # Recurse into closure bodies for generic call collection
+            self._collect_calls_in_expr(
+                expr.body, generic_decls, ctor_to_adt, instances,
+            )
         elif isinstance(expr, ast.ModuleCall):
             # C7e: recurse into ModuleCall args for generic call collection
             for arg in expr.args:
@@ -166,11 +171,15 @@ class MonomorphizationMixin:
             self._unify_param_arg(param_te, arg, forall_vars, ctor_to_adt,
                                   mapping, generic_decls)
 
-        # Check all type vars are resolved
+        # Check all type vars are resolved; default phantom vars to Unit
         result = []
         for tv in forall_vars:
             if tv not in mapping:
-                return None
+                # Phantom type variable (e.g. E in result_unwrap_or(Ok(x), d))
+                # — the generated WASM is identical regardless of this type.
+                # Use Bool (i32) rather than Unit (no WASM repr) so the
+                # monomorphized body can still compile unused branches.
+                mapping[tv] = "Bool"
             result.append(mapping[tv])
         return tuple(result)
 
@@ -204,6 +213,21 @@ class MonomorphizationMixin:
 
         # Parameterized type like Option<T> — match type args
         if param_te.type_args:
+            # Handle type alias for FnType matched against AnonFn arg
+            if isinstance(arg, ast.AnonFn):
+                alias_concrete = self._infer_fn_alias_type_args(
+                    param_te, arg,
+                )
+                if alias_concrete is not None:
+                    for param_ta, concrete_name in zip(
+                        param_te.type_args, alias_concrete,
+                    ):
+                        if (isinstance(param_ta, ast.NamedType)
+                                and param_ta.name in forall_vars
+                                and param_ta.name not in mapping):
+                            mapping[param_ta.name] = concrete_name
+                    return
+
             arg_info = self._get_arg_type_info(arg, ctor_to_adt)
             if arg_info and arg_info[0] == param_te.name:
                 for param_ta, arg_ta_name in zip(
@@ -324,6 +348,94 @@ class MonomorphizationMixin:
                         return None
                 return (adt_name, tuple(arg_types))
         return None
+
+    def _infer_fn_alias_type_args(
+        self,
+        param_te: ast.NamedType,
+        anon_fn: ast.AnonFn,
+    ) -> tuple[str, ...] | None:
+        """Infer concrete types for a type alias's params from an AnonFn.
+
+        When ``param_te`` is e.g. ``NamedType("OptionMapFn", [A, B])``
+        which aliases ``fn(A -> B)``, and the argument is an AnonFn
+        with concrete param/return types, infer one concrete type name
+        per alias type parameter.
+
+        Returns a tuple of concrete type names aligned to the alias's
+        type parameters, or None if inference fails.
+        """
+        type_aliases: dict[str, ast.TypeExpr] = getattr(
+            self, "_type_aliases", {},
+        )
+        type_alias_params: dict[str, tuple[str, ...]] = getattr(
+            self, "_type_alias_params", {},
+        )
+
+        alias_te = type_aliases.get(param_te.name)
+        if not isinstance(alias_te, ast.FnType):
+            return None
+
+        alias_params = type_alias_params.get(param_te.name)
+        if (
+            not alias_params
+            or not param_te.type_args
+            or len(alias_params) != len(param_te.type_args)
+        ):
+            return None
+
+        # Match the FnType body against the AnonFn to build an
+        # alias-local mapping:  alias_param_name -> concrete_type_name
+        alias_mapping: dict[str, str] = {}
+
+        # Match parameter types positionally
+        for fn_param_te, anon_param_te in zip(
+            alias_te.params, anon_fn.params,
+        ):
+            if (
+                isinstance(fn_param_te, ast.NamedType)
+                and fn_param_te.name in alias_params
+                and isinstance(anon_param_te, ast.NamedType)
+            ):
+                alias_mapping[fn_param_te.name] = anon_param_te.name
+
+        # Match return type
+        ret = alias_te.return_type
+        if isinstance(ret, ast.NamedType) and ret.name in alias_params:
+            if isinstance(anon_fn.return_type, ast.NamedType):
+                alias_mapping[ret.name] = anon_fn.return_type.name
+            elif isinstance(anon_fn.return_type, ast.FnType):
+                # Return type is itself a FnType — map to "Fn"
+                alias_mapping[ret.name] = "Fn"
+        # Handle ADT return types like Option<B> where B is an alias param
+        if isinstance(ret, ast.NamedType) and ret.type_args:
+            for ret_ta in ret.type_args:
+                if (
+                    isinstance(ret_ta, ast.NamedType)
+                    and ret_ta.name in alias_params
+                    and isinstance(anon_fn.return_type, ast.NamedType)
+                ):
+                    # For Option<B> matched against Option<Int>, extract
+                    # B from the AnonFn's return type args
+                    if anon_fn.return_type.type_args:
+                        idx = [
+                            i for i, rta in enumerate(ret.type_args)
+                            if (isinstance(rta, ast.NamedType)
+                                and rta.name == ret_ta.name)
+                        ]
+                        if idx:
+                            pos = idx[0]
+                            if pos < len(anon_fn.return_type.type_args):
+                                art = anon_fn.return_type.type_args[pos]
+                                if isinstance(art, ast.NamedType):
+                                    alias_mapping[ret_ta.name] = art.name
+
+        # Produce result in alias param order
+        result: list[str] = []
+        for ap in alias_params:
+            if ap not in alias_mapping:
+                return None
+            result.append(alias_mapping[ap])
+        return tuple(result)
 
     @staticmethod
     def _mangle_fn_name(name: str, concrete_types: tuple[str, ...]) -> str:

--- a/vera/codegen/registration.py
+++ b/vera/codegen/registration.py
@@ -24,6 +24,8 @@ class RegistrationMixin:
                 self._register_data(decl)
             elif isinstance(decl, ast.TypeAliasDecl):
                 self._type_aliases[decl.name] = decl.type_expr
+                if decl.type_params:
+                    self._type_alias_params[decl.name] = decl.type_params
 
     def _register_fn(self, decl: ast.FnDecl) -> None:
         """Register a function's WASM signature."""

--- a/vera/environment.py
+++ b/vera/environment.py
@@ -370,6 +370,72 @@ class TypeEnv:
             effect=PureEffectRow(),
         )
 
+        # Option / Result combinators
+        # Implementations are injected as Vera source AST during codegen
+        # (see vera.prelude); these signatures enable type checking.
+        self.functions["option_unwrap_or"] = FunctionInfo(
+            name="option_unwrap_or",
+            forall_vars=("T",),
+            param_types=(
+                AdtType("Option", (TypeVar("T"),)),
+                TypeVar("T"),
+            ),
+            return_type=TypeVar("T"),
+            effect=PureEffectRow(),
+        )
+        self.functions["option_map"] = FunctionInfo(
+            name="option_map",
+            forall_vars=("A", "B"),
+            param_types=(
+                AdtType("Option", (TypeVar("A"),)),
+                FunctionType(
+                    params=(TypeVar("A"),),
+                    return_type=TypeVar("B"),
+                    effect=PureEffectRow(),
+                ),
+            ),
+            return_type=AdtType("Option", (TypeVar("B"),)),
+            effect=PureEffectRow(),
+        )
+        self.functions["option_and_then"] = FunctionInfo(
+            name="option_and_then",
+            forall_vars=("A", "B"),
+            param_types=(
+                AdtType("Option", (TypeVar("A"),)),
+                FunctionType(
+                    params=(TypeVar("A"),),
+                    return_type=AdtType("Option", (TypeVar("B"),)),
+                    effect=PureEffectRow(),
+                ),
+            ),
+            return_type=AdtType("Option", (TypeVar("B"),)),
+            effect=PureEffectRow(),
+        )
+        self.functions["result_unwrap_or"] = FunctionInfo(
+            name="result_unwrap_or",
+            forall_vars=("T", "E"),
+            param_types=(
+                AdtType("Result", (TypeVar("T"), TypeVar("E"))),
+                TypeVar("T"),
+            ),
+            return_type=TypeVar("T"),
+            effect=PureEffectRow(),
+        )
+        self.functions["result_map"] = FunctionInfo(
+            name="result_map",
+            forall_vars=("A", "B", "E"),
+            param_types=(
+                AdtType("Result", (TypeVar("A"), TypeVar("E"))),
+                FunctionType(
+                    params=(TypeVar("A"),),
+                    return_type=TypeVar("B"),
+                    effect=PureEffectRow(),
+                ),
+            ),
+            return_type=AdtType("Result", (TypeVar("B"), TypeVar("E"))),
+            effect=PureEffectRow(),
+        )
+
         # Built-in string operations
         self.functions["string_length"] = FunctionInfo(
             name="string_length",

--- a/vera/prelude.py
+++ b/vera/prelude.py
@@ -1,0 +1,234 @@
+"""Prelude injection for Option/Result combinators.
+
+Defines combinator functions as Vera source text, parses them into
+AST nodes, and injects them into a program's declarations before
+type checking.  The normal pipeline (type checking, monomorphization,
+codegen) then handles them like any user-defined function.
+
+Injection is conditional:
+- Option combinators require ``data Option<T> { None, Some(T) }``
+  (or equivalent with swapped constructor order).
+- Result combinators require ``data Result<T, E> { Ok(T), Err(E) }``
+  (or equivalent with swapped constructor order).
+- A combinator is skipped if the user already defined a function
+  with the same name.
+"""
+
+from __future__ import annotations
+
+from vera import ast
+
+
+# =====================================================================
+# Combinator Vera source
+# =====================================================================
+
+# Type aliases needed by closure-taking combinators.
+# These are injected alongside the functions that reference them.
+_OPTION_TYPE_ALIASES = """\
+type OptionMapFn<A, B> = fn(A -> B) effects(pure);
+type OptionBindFn<A, B> = fn(A -> Option<B>) effects(pure);
+"""
+
+_RESULT_TYPE_ALIASES = """\
+type ResultMapFn<A, B> = fn(A -> B) effects(pure);
+"""
+
+_OPTION_COMBINATORS = """\
+private forall<T> fn option_unwrap_or(@Option<T>, @T -> @T)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  match @Option<T>.0 {
+    None -> @T.0,
+    Some(@T) -> @T.0
+  }
+}
+
+private forall<A, B> fn option_map(@Option<A>, @OptionMapFn<A, B> -> @Option<B>)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  match @Option<A>.0 {
+    None -> None,
+    Some(@A) -> Some(apply_fn(@OptionMapFn<A, B>.0, @A.0))
+  }
+}
+
+private forall<A, B> fn option_and_then(@Option<A>, @OptionBindFn<A, B> -> @Option<B>)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  match @Option<A>.0 {
+    None -> None,
+    Some(@A) -> apply_fn(@OptionBindFn<A, B>.0, @A.0)
+  }
+}
+"""
+
+_RESULT_COMBINATORS = """\
+private forall<T, E> fn result_unwrap_or(@Result<T, E>, @T -> @T)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  match @Result<T, E>.0 {
+    Ok(@T) -> @T.0,
+    Err(@E) -> @T.0
+  }
+}
+
+private forall<A, B, E> fn result_map(@Result<A, E>, @ResultMapFn<A, B> -> @Result<B, E>)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  match @Result<A, E>.0 {
+    Ok(@A) -> Ok(apply_fn(@ResultMapFn<A, B>.0, @A.0)),
+    Err(@E) -> Err(@E.0)
+  }
+}
+"""
+
+
+# =====================================================================
+# Detection helpers
+# =====================================================================
+
+def _has_standard_option(program: ast.Program) -> bool:
+    """Check if the program defines Option<T> with None and Some(T)."""
+    for tld in program.declarations:
+        decl = tld.decl
+        if isinstance(decl, ast.DataDecl) and decl.name == "Option":
+            if decl.type_params and len(decl.type_params) == 1:
+                ctor_names = {c.name for c in decl.constructors}
+                if "None" in ctor_names and "Some" in ctor_names:
+                    return True
+    return False
+
+
+def _has_standard_result(program: ast.Program) -> bool:
+    """Check if the program defines Result<T, E> with Ok(T) and Err(E)."""
+    for tld in program.declarations:
+        decl = tld.decl
+        if isinstance(decl, ast.DataDecl) and decl.name == "Result":
+            if decl.type_params and len(decl.type_params) == 2:
+                ctor_names = {c.name for c in decl.constructors}
+                if "Ok" in ctor_names and "Err" in ctor_names:
+                    return True
+    return False
+
+
+def _user_defined_names(program: ast.Program) -> set[str]:
+    """Collect all user-defined function and type alias names."""
+    names: set[str] = set()
+    for tld in program.declarations:
+        decl = tld.decl
+        if isinstance(decl, ast.FnDecl):
+            names.add(decl.name)
+        elif isinstance(decl, ast.TypeAliasDecl):
+            names.add(decl.name)
+    return names
+
+
+# =====================================================================
+# Parsing helpers
+# =====================================================================
+
+def _parse_source(source: str) -> ast.Program:
+    """Parse and transform Vera source into an AST Program."""
+    from vera.parser import parse
+    from vera.transform import transform
+
+    tree = parse(source)
+    return transform(tree)
+
+
+# =====================================================================
+# Public API
+# =====================================================================
+
+def inject_prelude(program: ast.Program) -> None:
+    """Inject Option/Result combinator declarations into a program.
+
+    Mutates ``program.declarations`` by prepending combinator
+    function declarations and their type aliases.  Only injects
+    combinators whose ADT prerequisites are met and whose names
+    don't collide with user definitions.
+    """
+    user_names = _user_defined_names(program)
+    inject_option = _has_standard_option(program)
+    inject_result = _has_standard_result(program)
+
+    if not inject_option and not inject_result:
+        return
+
+    # Build source for what we need to inject
+    source_parts: list[str] = []
+
+    option_fn_names = {"option_unwrap_or", "option_map", "option_and_then"}
+    option_alias_names = {"OptionMapFn", "OptionBindFn"}
+    result_fn_names = {"result_unwrap_or", "result_map"}
+    result_alias_names = {"ResultMapFn"}
+
+    if inject_option and not option_fn_names.issubset(user_names):
+        # Check which aliases are needed (only if closure fns are not shadowed)
+        need_aliases = not (
+            {"option_map", "option_and_then"}.issubset(user_names)
+        )
+        if need_aliases and not option_alias_names.issubset(user_names):
+            source_parts.append(_OPTION_TYPE_ALIASES)
+        source_parts.append(_OPTION_COMBINATORS)
+
+    if inject_result and not result_fn_names.issubset(user_names):
+        need_aliases = "result_map" not in user_names
+        if need_aliases and not result_alias_names.issubset(user_names):
+            source_parts.append(_RESULT_TYPE_ALIASES)
+        source_parts.append(_RESULT_COMBINATORS)
+
+    if not source_parts:
+        return
+
+    # We need a minimal program wrapper with the data declarations
+    # so the parser can resolve constructor references in the combinator
+    # source.  Build a full source with data defs + combinators.
+    data_defs: list[str] = []
+    if inject_option:
+        data_defs.append("data Option<T> { None, Some(T) }")
+    if inject_result:
+        data_defs.append("data Result<T, E> { Ok(T), Err(E) }")
+
+    full_source = "\n".join(data_defs) + "\n" + "\n".join(source_parts)
+    parsed = _parse_source(full_source)
+
+    # Extract the FnDecl and TypeAliasDecl nodes (skip the data defs
+    # since those are already in the user's program)
+    new_decls: list[ast.TopLevelDecl] = []
+    for tld in parsed.declarations:
+        decl = tld.decl
+        if isinstance(decl, ast.DataDecl):
+            continue  # Skip — user already has these
+        if isinstance(decl, ast.FnDecl) and decl.name in user_names:
+            continue  # User shadowed this function
+        if isinstance(decl, ast.TypeAliasDecl) and decl.name in user_names:
+            continue  # User shadowed this type alias
+        # Mark as private (defensive — source already says private)
+        new_decls.append(ast.TopLevelDecl(
+            visibility="private",
+            decl=decl,
+            span=None,
+        ))
+
+    if not new_decls:
+        return
+
+    # Prepend to declarations so user defs shadow during registration.
+    # Program is a frozen dataclass, so we use object.__setattr__.
+    object.__setattr__(
+        program,
+        "declarations",
+        tuple(new_decls) + program.declarations,
+    )

--- a/vera/wasm/calls.py
+++ b/vera/wasm/calls.py
@@ -288,11 +288,11 @@ class CallsMixin:
         for param_te, arg in zip(param_types, call.args):
             self._unify_param_arg_wasm(param_te, arg, forall_vars, mapping)
 
-        # Build mangled name
+        # Build mangled name; default phantom vars to Unit
         parts = []
         for tv in forall_vars:
             if tv not in mapping:
-                return None
+                mapping[tv] = "Bool"
             parts.append(mapping[tv])
         return f"{call.name}${'_'.join(parts)}"
 
@@ -325,6 +325,21 @@ class CallsMixin:
 
         # Parameterized type like Option<T>
         if param_te.type_args:
+            # Handle type alias for FnType matched against AnonFn arg
+            if isinstance(arg, ast.AnonFn):
+                alias_concrete = self._infer_fn_alias_type_args_wasm(
+                    param_te, arg,
+                )
+                if alias_concrete is not None:
+                    for param_ta, concrete_name in zip(
+                        param_te.type_args, alias_concrete,
+                    ):
+                        if (isinstance(param_ta, ast.NamedType)
+                                and param_ta.name in forall_vars
+                                and param_ta.name not in mapping):
+                            mapping[param_ta.name] = concrete_name
+                    return
+
             arg_info = self._get_arg_type_info_wasm(arg)
             if arg_info and arg_info[0] == param_te.name:
                 for param_ta, arg_ta_name in zip(
@@ -334,6 +349,74 @@ class CallsMixin:
                             and param_ta.name in forall_vars
                             and param_ta.name not in mapping):
                         mapping[param_ta.name] = arg_ta_name
+
+    def _infer_fn_alias_type_args_wasm(
+        self,
+        param_te: ast.NamedType,
+        anon_fn: ast.AnonFn,
+    ) -> tuple[str, ...] | None:
+        """Infer concrete types for a type alias's params from an AnonFn.
+
+        Mirrors MonomorphizationMixin._infer_fn_alias_type_args for use
+        during WASM call-site rewriting.
+        """
+        alias_te = self._type_aliases.get(param_te.name)
+        if not isinstance(alias_te, ast.FnType):
+            return None
+
+        alias_params = self._type_alias_params.get(param_te.name)
+        if (
+            not alias_params
+            or not param_te.type_args
+            or len(alias_params) != len(param_te.type_args)
+        ):
+            return None
+
+        alias_mapping: dict[str, str] = {}
+
+        # Match parameter types positionally
+        for fn_param_te, anon_param_te in zip(
+            alias_te.params, anon_fn.params,
+        ):
+            if (
+                isinstance(fn_param_te, ast.NamedType)
+                and fn_param_te.name in alias_params
+                and isinstance(anon_param_te, ast.NamedType)
+            ):
+                alias_mapping[fn_param_te.name] = anon_param_te.name
+
+        # Match return type
+        ret = alias_te.return_type
+        if isinstance(ret, ast.NamedType) and ret.name in alias_params:
+            if isinstance(anon_fn.return_type, ast.NamedType):
+                alias_mapping[ret.name] = anon_fn.return_type.name
+        # Handle ADT return types like Option<B>
+        if isinstance(ret, ast.NamedType) and ret.type_args:
+            for ret_ta in ret.type_args:
+                if (
+                    isinstance(ret_ta, ast.NamedType)
+                    and ret_ta.name in alias_params
+                    and isinstance(anon_fn.return_type, ast.NamedType)
+                    and anon_fn.return_type.type_args
+                ):
+                    idx = [
+                        i for i, rta in enumerate(ret.type_args)
+                        if (isinstance(rta, ast.NamedType)
+                            and rta.name == ret_ta.name)
+                    ]
+                    if idx:
+                        pos = idx[0]
+                        if pos < len(anon_fn.return_type.type_args):
+                            art = anon_fn.return_type.type_args[pos]
+                            if isinstance(art, ast.NamedType):
+                                alias_mapping[ret_ta.name] = art.name
+
+        result: list[str] = []
+        for ap in alias_params:
+            if ap not in alias_mapping:
+                return None
+            result.append(alias_mapping[ap])
+        return tuple(result)
 
     def _translate_array_length(
         self, arg: ast.Expr, env: WasmSlotEnv,

--- a/vera/wasm/context.py
+++ b/vera/wasm/context.py
@@ -104,6 +104,8 @@ class WasmContext(
         ] = []
         # Type aliases: alias_name -> TypeExpr (for FnType resolution)
         self._type_aliases: dict[str, ast.TypeExpr] = {}
+        # Type alias parameters: alias_name -> param names (for generic aliases)
+        self._type_alias_params: dict[str, tuple[str, ...]] = {}
         # Closure signature registry: sig_key -> (type_name, param/result WAT)
         self._closure_sigs: dict[str, str] = {}
         # Flags for resource requirements detected during translation
@@ -129,9 +131,26 @@ class WasmContext(
         """Set type alias mappings for FnType resolution."""
         self._type_aliases = aliases
 
+    def set_type_alias_params(
+        self, params: dict[str, tuple[str, ...]],
+    ) -> None:
+        """Set type alias parameter names for generic alias resolution."""
+        self._type_alias_params = params
+
     def set_closure_id_start(self, start: int) -> None:
         """Set the starting closure ID for this context."""
         self._next_closure_id = start
+
+    def set_closure_sigs(self, sigs: dict[str, str]) -> None:
+        """Seed with accumulated module-level closure signatures.
+
+        Each context independently numbers ``$closure_sig_N`` from zero.
+        When multiple functions use closures with different signatures,
+        the names collide after module-level merge.  By seeding the
+        context with signatures already registered at module level, new
+        signatures get unique numbers and existing ones reuse their names.
+        """
+        self._closure_sigs = dict(sigs)
 
     def set_result_local(self, local_idx: int) -> None:
         """Set the local index used for @T.result in postconditions."""

--- a/vera/wasm/inference.py
+++ b/vera/wasm/inference.py
@@ -601,29 +601,72 @@ class InferenceMixin:
 
         Looks at the closure argument's type (via slot ref type name
         and type alias resolution) to determine the return type.
+
+        For generic type aliases like ``OptionMapFn<Int, String>``
+        (defined as ``fn(A -> B) effects(pure)``), the slot ref
+        carries type_args that must be substituted into the alias
+        body before inferring the WASM return type.
         """
         if isinstance(closure_arg, ast.SlotRef):
             type_name = closure_arg.type_name
             # Check if this is a type alias for a function type
             alias_te = self._type_aliases.get(type_name)
             if isinstance(alias_te, ast.FnType):
+                # Handle generic type aliases: substitute type_args
+                alias_params = self._type_alias_params.get(type_name)
+                if (
+                    alias_params
+                    and closure_arg.type_args
+                    and len(alias_params) == len(closure_arg.type_args)
+                ):
+                    return self._resolve_generic_fn_return(
+                        alias_te, alias_params, closure_arg.type_args,
+                    )
                 return self._fn_type_return_wasm(alias_te)
         return "i64"  # safe default for most cases
+
+    def _resolve_generic_fn_return(
+        self,
+        fn_type: ast.FnType,
+        alias_params: tuple[str, ...],
+        type_args: tuple[ast.TypeExpr, ...],
+    ) -> str | None:
+        """Resolve the return type of a generic FnType alias.
+
+        Builds a substitution map from alias type params to concrete
+        type args, then resolves the return type to a WASM type.
+        """
+        # Build substitution: param_name -> concrete NamedType name
+        subst: dict[str, str] = {}
+        for param, arg in zip(alias_params, type_args):
+            if isinstance(arg, ast.NamedType):
+                subst[param] = arg.name
+
+        ret = fn_type.return_type
+        if isinstance(ret, ast.NamedType):
+            # If the return type is a type variable, substitute it
+            name = subst.get(ret.name, ret.name)
+            return self._named_type_to_wasm(name)
+        return "i64"  # default
+
+    @staticmethod
+    def _named_type_to_wasm(name: str) -> str | None:
+        """Map a concrete type name to its WASM representation."""
+        if name in ("Int", "Nat"):
+            return "i64"
+        if name == "Float64":
+            return "f64"
+        if name == "Bool":
+            return "i32"
+        if name == "Unit":
+            return None
+        return "i32"  # ADT or other pointer type
 
     def _fn_type_return_wasm(self, fn_type: ast.FnType) -> str | None:
         """Get the WASM return type from a FnType AST node."""
         ret = fn_type.return_type
         if isinstance(ret, ast.NamedType):
-            name = ret.name
-            if name in ("Int", "Nat"):
-                return "i64"
-            if name == "Float64":
-                return "f64"
-            if name == "Bool":
-                return "i32"
-            if name == "Unit":
-                return None
-            return "i32"  # ADT or other pointer type
+            return self._named_type_to_wasm(ret.name)
         return "i64"  # default
 
     def _fn_type_param_wasm_types(


### PR DESCRIPTION
## Summary

- Ships 5 combinator functions: `option_unwrap_or`, `option_map`, `option_and_then`, `result_unwrap_or`, `result_map`
- Eliminates 5-line match blocks for every fallible operation — the highest-value Tier 0 roadmap item
- Implements via source injection: combinators defined as Vera source, parsed to AST, injected into the program before compilation
- Fixes generic type alias return type inference, AnonFn type variable inference in the monomorphizer, closure signature deduplication
- Renames `map_option` to `option_map` across entire codebase per #288 naming convention
- Adds spec section 9.3.7, SKILL.md docs, conformance test, 12 unit tests
- Version bump to v0.0.89

Closes #211

## Test plan

- [x] All 2,330 tests pass (`pytest tests/ -v`)
- [x] mypy clean (`mypy vera/`)
- [x] All 54 conformance programs pass (`check_conformance.py`)
- [x] All 25 examples pass (`check_examples.py`)
- [x] Spec, SKILL.md, README, HTML code blocks validate
- [x] Doc counts consistent
- [x] Version sync clean
- [x] Pre-commit hooks pass (17/17)

Generated with [Claude Code](https://claude.com/claude-code)