### PR TITLE
Add license compliance checking to CI and pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,9 @@ jobs:
       - name: Check HTML code blocks parse, check, and verify
         run: python scripts/check_html_examples.py
 
+      - name: Check license compliance
+        run: python scripts/check_licenses.py
+
   browser-parity:
     runs-on: ubuntu-latest
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -91,6 +91,13 @@ repos:
         pass_filenames: false
         files: '(README\.md$|vera/README\.md$|spec/0[89]-.*\.md$|spec/1[12]-.*\.md$)'
 
+      - id: license-check
+        name: license check
+        entry: .venv/bin/python scripts/check_licenses.py
+        language: system
+        pass_filenames: false
+        files: 'pyproject\.toml$'
+
       - id: browser-parity
         name: browser parity
         entry: .venv/bin/pytest tests/test_browser.py -q

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,7 @@ python scripts/check_skill_examples.py # Verify SKILL.md code blocks parse
 python scripts/check_html_examples.py # Verify HTML code blocks parse + check + verify
 python scripts/check_version_sync.py  # Verify version consistency
 python scripts/check_doc_counts.py    # Verify documentation counts match codebase
+python scripts/check_licenses.py      # Verify all package licenses are MIT-compatible
 python scripts/check_limitations_sync.py              # Verify limitation tables are in sync
 python scripts/check_limitations_sync.py --check-states # Also verify issues are still open via GitHub API
 python scripts/fix_allowlists.py      # Preview stale allowlist line numbers

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ pre-commit install
 
 ### Pre-commit Hooks
 
-After running `pre-commit install`, every commit is automatically checked by 18 hooks including:
+After running `pre-commit install`, every commit is automatically checked by 19 hooks including:
 
 - Trailing whitespace and file endings
 - YAML/TOML validity
@@ -81,6 +81,7 @@ After running `pre-commit install`, every commit is automatically checked by 18 
 - All 25 `.vera` examples type-check and verify cleanly
 - README, SKILL.md, HTML, and spec code blocks parse correctly
 - Documentation counts match live codebase
+- License compliance (all dependencies MIT-compatible)
 - Browser parity (JS runtime matches Python runtime)
 
 ### Running Tests

--- a/README.md
+++ b/README.md
@@ -676,7 +676,13 @@ See [CHANGELOG.md](CHANGELOG.md) for a history of changes.
 
 ## Licence
 
-Vera is licensed under the [MIT License](LICENSE).
+Vera is licensed under the [MIT License](LICENSE). All dependencies (direct and transitive) are MIT-compatible — licence compliance is enforced by CI and pre-commit hooks via `scripts/check_licenses.py`.
+
+| Dependency | Licence | Role |
+|-----------|---------|------|
+| [Lark](https://github.com/lark-parser/lark) | MIT | LALR(1) parser generator |
+| [z3-solver](https://github.com/Z3Prover/z3) | MIT | SMT solver for contract verification |
+| [wasmtime](https://github.com/bytecodealliance/wasmtime) | Apache-2.0 | WebAssembly runtime |
 
 Copyright &copy; 2026 Alasdair Allan
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -294,7 +294,7 @@ When extending the compiler, add tests following the existing patterns:
 
 ## Validation Scripts
 
-Nine scripts in `scripts/` validate cross-cutting concerns beyond unit tests:
+Ten scripts in `scripts/` validate cross-cutting concerns beyond unit tests:
 
 | Script | What it validates |
 |--------|-------------------|
@@ -306,6 +306,7 @@ Nine scripts in `scripts/` validate cross-cutting concerns beyond unit tests:
 | `check_html_examples.py` | All Vera code blocks in docs/index.html pass parse + check + verify |
 | `check_version_sync.py` | `pyproject.toml` and `vera/__init__.py` versions match |
 | `check_doc_counts.py` | Counts cited in TESTING.md, CONTRIBUTING.md, and CLAUDE.md match live codebase |
+| `check_licenses.py` | All installed packages have MIT-compatible licenses |
 | `fix_allowlists.py` | Auto-fix stale allowlist line numbers after Markdown edits |
 
 These run in both pre-commit hooks and CI, so issues are caught locally before they reach the remote.
@@ -324,7 +325,7 @@ Allowlisted entries have stale-detection: when a feature lands or a spec edit sh
 
 ## Pre-commit Hooks
 
-After running `pre-commit install`, every commit is checked by 18 hooks:
+After running `pre-commit install`, every commit is checked by 19 hooks:
 
 | Hook | What it does |
 |------|-------------|
@@ -344,6 +345,7 @@ After running `pre-commit install`, every commit is checked by 18 hooks:
 | `check_html_examples.py` | HTML landing page code blocks pass parse + check + verify |
 | `check_doc_counts.py` | Counts in docs match live codebase |
 | `check_limitations_sync.py` | Limitation tables consistent across README, vera/README, and spec |
+| `check_licenses.py` | All package licenses are MIT-compatible |
 | `browser parity` | Browser runtime produces identical output to Python runtime |
 
 The validation hooks are smart about triggers -- they only run when relevant files change (`.vera`, `vera/**/*.py`, `grammar.lark`, the corresponding Markdown file, or `vera/browser/*` for browser parity).
@@ -357,7 +359,7 @@ GitHub Actions ([`.github/workflows/ci.yml`](.github/workflows/ci.yml)) runs fou
 | **test** | Python 3.11, 3.12, 3.13 x Ubuntu, macOS (6 combos) | `pytest -v` passes on all combinations |
 | **test** (coverage) | Python 3.12 x Ubuntu only | `pytest --cov=vera --cov-fail-under=80` |
 | **typecheck** | Python 3.12 x Ubuntu | `mypy vera/` clean in strict mode |
-| **lint** | Python 3.12 x Ubuntu | `check_conformance.py`, `check_examples.py`, `check_version_sync.py`, `check_spec_examples.py`, `check_readme_examples.py`, `check_skill_examples.py`, `check_html_examples.py` |
+| **lint** | Python 3.12 x Ubuntu | `check_conformance.py`, `check_examples.py`, `check_version_sync.py`, `check_spec_examples.py`, `check_readme_examples.py`, `check_skill_examples.py`, `check_html_examples.py`, `check_licenses.py` |
 | **browser-parity** | Python 3.12 + Node.js 22 x Ubuntu | `pytest tests/test_browser.py -v` — verifies JS runtime matches Python runtime |
 
 The coverage threshold of **80%** is enforced in CI. Current coverage is 91%.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dev = [
     "pytest-cov>=4.0",
     "mypy>=1.0",
     "pre-commit>=3.0",
+    "pip-licenses>=5.0",
 ]
 
 [project.scripts]

--- a/scripts/check_licenses.py
+++ b/scripts/check_licenses.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+"""Verify all installed packages have MIT-compatible licenses.
+
+Vera is MIT-licensed.  This script ensures no dependency (direct or
+transitive) introduces a license that is incompatible with MIT
+redistribution.  It uses ``pip-licenses`` to enumerate packages and
+checks each license string against a set of known-compatible patterns.
+
+Runs in under 1 second — fast enough for a pre-commit hook.
+"""
+
+import json
+import subprocess
+import sys
+
+# ---------------------------------------------------------------------------
+# Compatible license patterns (case-insensitive substring match)
+# ---------------------------------------------------------------------------
+# All of these are permissive licenses compatible with MIT redistribution.
+# MPL-2.0 is included because it allows larger works under any license —
+# only the MPL-covered source files themselves must remain under MPL.
+
+_COMPATIBLE_PATTERNS: list[str] = [
+    "mit",
+    "bsd",
+    "apache",
+    "psf",
+    "python software foundation",
+    "isc",
+    "mpl",
+    "unlicense",
+    "cc0",
+    "public domain",
+    "0bsd",
+]
+
+# Packages to exclude from checking (this project itself).
+_SELF_PACKAGES: set[str] = {"vera"}
+
+
+def _is_compatible(license_str: str) -> bool:
+    """Return True if *license_str* matches a known-compatible pattern."""
+    normalised = license_str.strip().lower()
+    return any(pattern in normalised for pattern in _COMPATIBLE_PATTERNS)
+
+
+def main() -> int:
+    # Run pip-licenses as a subprocess (module name is ``piplicenses``).
+    try:
+        result = subprocess.run(
+            [sys.executable, "-m", "piplicenses", "--format=json"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except FileNotFoundError:
+        print(
+            "ERROR: pip-licenses is not installed."
+            "  Run: pip install -e '.[dev]'",
+            file=sys.stderr,
+        )
+        return 1
+
+    if result.returncode != 0:
+        print(
+            f"ERROR: pip-licenses failed:\n{result.stderr}",
+            file=sys.stderr,
+        )
+        return 1
+
+    packages: list[dict[str, str]] = json.loads(result.stdout)
+
+    violations: list[tuple[str, str, str]] = []
+    checked = 0
+
+    for pkg in packages:
+        name = pkg["Name"]
+        if name.lower() in _SELF_PACKAGES:
+            continue
+
+        license_str = pkg.get("License", "UNKNOWN")
+        checked += 1
+
+        if license_str in ("UNKNOWN", "") or not _is_compatible(license_str):
+            violations.append((name, pkg.get("Version", "?"), license_str))
+
+    if violations:
+        print(
+            f"ERROR: {len(violations)} package(s) with incompatible or"
+            " unknown licenses:",
+            file=sys.stderr,
+        )
+        for name, version, lic in violations:
+            print(f"  {name} {version}: {lic!r}", file=sys.stderr)
+        return 1
+
+    print(f"All {checked} packages have compatible licenses.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- **New `scripts/check_licenses.py`** — uses `pip-licenses` to verify all installed packages have MIT-compatible licenses (substring match on normalised license strings)
- **Pre-commit hook** — triggers only on `pyproject.toml` changes, so it runs when dependencies change
- **CI lint step** — runs unconditionally on every PR as a safety net
- **README Licence section** — dependency table listing the three runtime dependencies and their licenses, with a note that compliance is CI-enforced

## How it works

The script runs `pip-licenses --format=json`, then checks each package license string against a set of known-compatible patterns: MIT, BSD, Apache, PSF, ISC, MPL, Unlicense, CC0, Public Domain. Packages with `UNKNOWN` or unrecognised licenses fail the check. The project itself (`vera`) is excluded.

Current status: all 26 packages pass.

## Test plan

- [x] `python scripts/check_licenses.py` — all 26 packages compatible
- [x] `python scripts/check_doc_counts.py` — counts consistent (19 hooks, 4 CI jobs)
- [x] `pytest tests/ -v` — 2,375 tests pass
- [x] `mypy vera/` — clean
- [x] All 19 pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)