### PR TITLE
Add Gitleaks secret scanning to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,18 @@ jobs:
       - name: Check license compliance
         run: python scripts/check_licenses.py
 
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   browser-parity:
     runs-on: ubuntu-latest
     steps:

--- a/TESTING.md
+++ b/TESTING.md
@@ -361,7 +361,7 @@ The validation hooks are smart about triggers -- they only run when relevant fil
 
 ## CI Pipeline
 
-GitHub Actions ([`.github/workflows/ci.yml`](.github/workflows/ci.yml)) runs four parallel jobs on every push and pull request to `main`:
+GitHub Actions ([`.github/workflows/ci.yml`](.github/workflows/ci.yml)) runs five parallel jobs on every push and pull request to `main`:
 
 | Job | Matrix / Runner | What it checks |
 |-----|----------------|---------------|
@@ -369,6 +369,7 @@ GitHub Actions ([`.github/workflows/ci.yml`](.github/workflows/ci.yml)) runs fou
 | **test** (coverage) | Python 3.12 x Ubuntu only | `pytest --cov=vera --cov-fail-under=80` |
 | **typecheck** | Python 3.12 x Ubuntu | `mypy vera/` clean in strict mode |
 | **lint** | Python 3.12 x Ubuntu | `check_conformance.py`, `check_examples.py`, `check_version_sync.py`, `check_spec_examples.py`, `check_readme_examples.py`, `check_skill_examples.py`, `check_faq_examples.py`, `check_html_examples.py`, `check_site_assets.py`, `check_licenses.py` |
+| **security** | Ubuntu | [Gitleaks](https://github.com/gitleaks/gitleaks-action) secret scanning on full history |
 | **browser-parity** | Python 3.12 + Node.js 22 x Ubuntu | `pytest tests/test_browser.py -v` — verifies JS runtime matches Python runtime |
 
 The coverage threshold of **80%** is enforced in CI. Current coverage is 96%.


### PR DESCRIPTION
## Summary

- Add a **security** job to CI that runs [Gitleaks](https://github.com/gitleaks/gitleaks-action) on every push and PR to `main`
- Scans full git history (`fetch-depth: 0`) for accidentally committed secrets, API keys, and credentials
- Free for personal (non-organisation) accounts — no `GITLEAKS_LICENSE` secret required
- Update TESTING.md: four → five CI jobs, add security row to job table

## Test plan
- [x] All pre-commit hooks pass (including doc counts: 5 CI jobs)
- [ ] CI passes — first run will also confirm Gitleaks finds no existing secrets in repo history

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the CI/CD pipeline with additional automated security scanning during continuous integration.

* **Documentation**
  * Updated testing documentation to reflect current pipeline configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->