### PR TITLE
Release v0.0.94 — Map<K, V> collection type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.94] - 2026-03-23
+
+### Added
+- **Map\<K, V\> collection type** ([#62](https://github.com/aallan/vera/issues/62), PR 1/3) — eight built-in operations (`map_new`, `map_insert`, `map_get`, `map_contains`, `map_remove`, `map_size`, `map_keys`, `map_values`) with `Eq<K> + Hash<K>` ability constraints. Implemented via host imports (Python dicts / JS Maps behind opaque i32 handles). Pure functional semantics — `map_insert` and `map_remove` return new maps. New conformance test `ch09_map` (57 programs, was 56). 40 new unit tests. Browser runtime support.
+- **Decimal type issue** ([#333](https://github.com/aallan/vera/issues/333)) — split from #62 as independent future work.
+
+### Fixed
+- **Type inference for zero-argument generic functions** — `map_new()` and similar zero-arg generic calls now resolve type variables from expected type context (bidirectional coercion). Fixed unification to skip ADT args whose TypeVars match the callee's own forall vars.
+
 ## [0.0.93] - 2026-03-20
 
 ### Changed
@@ -1386,7 +1395,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Grammar: handler body simplified to avoid LALR reduce/reduce conflict
 - `pyproject.toml`: corrected build backend, package discovery, PEP 639 compliance
 
-[Unreleased]: https://github.com/aallan/vera/compare/v0.0.93...HEAD
+[Unreleased]: https://github.com/aallan/vera/compare/v0.0.94...HEAD
+[0.0.94]: https://github.com/aallan/vera/compare/v0.0.93...v0.0.94
 [0.0.93]: https://github.com/aallan/vera/compare/v0.0.92...v0.0.93
 [0.0.92]: https://github.com/aallan/vera/compare/v0.0.91...v0.0.92
 [0.0.91]: https://github.com/aallan/vera/compare/v0.0.90...v0.0.91

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,7 +18,7 @@ Development follows an **interleaved spiral** — each phase adds a complete com
 
 ## Where we are
 
-**v0.0.93** delivers a full compiler pipeline (parse → typecheck → verify → compile → run), 72 built-in functions plus 5 Option/Result combinators plus 4 higher-order array operations, a module system, algebraic effect handlers, constrained generics with four built-in abilities (Eq, Ord, Hash, Show), a 56-program conformance suite, a canonical formatter, and contract-driven testing. A standard prelude eliminates boilerplate — `Option<T>`, `Result<T, E>`, `Ordering`, and `UrlParts` are available in every program without explicit `data` declarations. An independent viability assessment rates Vera at **60–70% of the way to being a viable agent target**. The gap is standard library and data-format support, not the core language or verification system.
+**v0.0.94** delivers a full compiler pipeline (parse → typecheck → verify → compile → run), 80 built-in functions plus 5 Option/Result combinators plus 4 higher-order array operations, a module system, algebraic effect handlers, constrained generics with four built-in abilities (Eq, Ord, Hash, Show), a 57-program conformance suite, a canonical formatter, and contract-driven testing. `Map<K, V>` provides key-value collections with ability-constrained keys. A standard prelude eliminates boilerplate — `Option<T>`, `Result<T, E>`, `Ordering`, and `UrlParts` are available in every program without explicit `data` declarations. An independent viability assessment rates Vera at **60–70% of the way to being a viable agent target**. The gap is standard library and data-format support, not the core language or verification system.
 
 Most remaining features are gated by a single dependency chain:
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -546,7 +546,7 @@
         For Agents → SKILL.md
       </a>
     </div>
-    <p style="text-align: center; margin-top: 1rem; font-size: 0.9rem; color: var(--brown-400);">Current Version: <a href="https://github.com/aallan/vera/releases/tag/v0.0.93" style="color: var(--brown-500); font-weight: 500;">v0.0.93</a> <a href="https://github.com/aallan/vera/actions/workflows/ci.yml" style="vertical-align: middle; margin-left: 0.5rem;"><img src="https://github.com/aallan/vera/actions/workflows/ci.yml/badge.svg" alt="CI" style="vertical-align: middle; height: 20px;"></a></p>
+    <p style="text-align: center; margin-top: 1rem; font-size: 0.9rem; color: var(--brown-400);">Current Version: <a href="https://github.com/aallan/vera/releases/tag/v0.0.94" style="color: var(--brown-500); font-weight: 500;">v0.0.94</a> <a href="https://github.com/aallan/vera/actions/workflows/ci.yml" style="vertical-align: middle; margin-left: 0.5rem;"><img src="https://github.com/aallan/vera/actions/workflows/ci.yml/badge.svg" alt="CI" style="vertical-align: middle; height: 20px;"></a></p>
   </div>
 
   <!-- Why -->

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 > Vera is a statically typed, purely functional programming language designed for large language models to write. It uses typed slot references (`@T.n`) instead of variable names, requires contracts on every function, and compiles to WebAssembly.
 
-**Current version:** [0.0.93](https://github.com/aallan/vera/releases/tag/v0.0.93)
+**Current version:** [0.0.94](https://github.com/aallan/vera/releases/tag/v0.0.94)
 
 ## Why?
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2,7 +2,7 @@
 
 > Vera is a statically typed, purely functional programming language designed for large language models to write. It uses typed slot references (@T.n) instead of variable names, requires contracts on every function, and compiles to WebAssembly.
 
-This file contains the complete Vera documentation compiled into a single document. Version 0.0.93.
+This file contains the complete Vera documentation compiled into a single document. Version 0.0.94.
 
 
 ========================================================================

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -4,7 +4,7 @@
 
 Vera uses De Bruijn indexing for bindings: `@Int.0` is the most recent `Int` binding, `@Int.1` the one before. There are no variable names. Contracts are mandatory — every function must declare `requires(...)`, `ensures(...)`, and `effects(...)`. The Z3 SMT solver verifies contracts statically where possible; remaining contracts become runtime assertions. All side effects (IO, State, Exceptions, Async) are tracked in the type system via algebraic effects.
 
-Current version: 0.0.93. The reference compiler is written in Python. Install with `pip install -e .` from the repository.
+Current version: 0.0.94. The reference compiler is written in Python. Install with `pip install -e .` from the repository.
 
 ## Language Reference
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.93"
+version = "0.0.94"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,3 +1,3 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.93"
+__version__ = "0.0.94"


### PR DESCRIPTION
## Summary

Version bump and release metadata for v0.0.94.

- Bump version in `vera/__init__.py` and `pyproject.toml`
- CHANGELOG entry for Map collection, type inference fix, Decimal split
- ROADMAP: update "Where we are" section, add Decimal (#333) to Tier 2
- Website: update version to v0.0.94
- Regenerate site assets

## Test plan
- [x] All 21 pre-commit hooks pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.0.94

* **New Features**
  * Added `Map<K, V>` collection type supporting constraint-based keys and built-in operations with functional update semantics. Features browser runtime support, new conformance suite entries, and comprehensive unit tests.

* **Bug Fixes**
  * Fixed type inference for zero-argument generic functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->