### PR TITLE
Add run instruction for examples/http.vera in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ private fn fetch_title(@String -> @Result<String, String>)
 }
 ```
 
-> [`examples/http.vera`](examples/http.vera)
+> [`examples/http.vera`](examples/http.vera) — run with `vera run examples/http.vera` (requires network)
 
 ## Runs Everywhere
 


### PR DESCRIPTION
One-liner: adds `— run with `vera run examples/http.vera` (requires network)` to match the pattern used by all other example references in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the HTTP example documentation with clear instructions on how to run the example and a note about its network access requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->