### PR TITLE
docs: add safe_classify example with runtime-checked postcondition

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -13,7 +13,7 @@ This is the single source of truth for Vera's testing infrastructure, coverage d
 | **Spec code blocks** | 164 parseable blocks from 13 spec chapters: 86 parse, 72 type-check, 71 verify |
 | **README code blocks** | 13 Vera blocks (12 validated, 1 allowlisted future syntax) |
 | **FAQ code blocks** | 1 Vera block in FAQ.md (0 validated, 1 allowlisted snippet) |
-| **HTML code blocks** | 4 Vera blocks in docs/index.html (4 validated: parse + check + verify) |
+| **HTML code blocks** | 5 Vera blocks in docs/index.html (5 validated: parse + check + verify) |
 | **Contract verification** | 162 of 179 contracts (90.5%) verified statically (Tier 1) |
 | **CI matrix** | 6 combinations (Python 3.11/3.12/3.13 x Ubuntu/macOS) + browser parity (Node.js 22) |
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -817,7 +817,24 @@
       </div>
 
       <div class="code-subsection">
-        <p class="code-intro">Compose with <code>Http</code> to fetch, then reason. The <code>&lt;Http, Inference&gt;</code> annotation enforces the boundary: a caller that only permits <code>&lt;Http&gt;</code> cannot invoke this function. The postcondition can constrain the <em>shape</em> of the model&rsquo;s output at the type level.</p>
+        <p class="code-intro">Postconditions can constrain the model&rsquo;s output. Z3 cannot know what a model will return at compile time, so the contract is checked at runtime &mdash; if the model returns an empty string, the program traps with a contract violation rather than silently propagating garbage.</p>
+        <div class="code-block">
+<pre><span class="kw">public</span> <span class="kw">fn</span> safe_classify(<span class="sl">@String</span> -> <span class="sl">@String</span>)
+  <span class="ct">requires</span>(string_length(<span class="sl">@String.0</span>) > <span class="num">0</span>)
+  <span class="ct">ensures</span>(string_length(<span class="sl">@String.result</span>) > <span class="num">0</span>)
+  <span class="ct">effects</span>(&lt;Inference&gt;)
+{
+  <span class="kw">let</span> <span class="sl">@Result&lt;String, String&gt;</span> = classify_sentiment(<span class="sl">@String.0</span>);
+  <span class="kw">match</span> <span class="sl">@Result&lt;String, String&gt;.0</span> {
+    Ok(<span class="sl">@String</span>) -> <span class="sl">@String.0</span>,
+    Err(<span class="sl">@String</span>) -> <span class="str">"Neutral"</span>
+  }
+}</pre>
+        </div>
+      </div>
+
+      <div class="code-subsection">
+        <p class="code-intro">Compose with <code>Http</code> to fetch, then reason. The <code>&lt;Http, Inference&gt;</code> annotation enforces the boundary: a caller that only permits <code>&lt;Http&gt;</code> cannot invoke this function.</p>
         <div class="code-block">
 <pre><span class="kw">public</span> <span class="kw">fn</span> research_topic(<span class="sl">@String</span> -> <span class="sl">@Result&lt;String, String&gt;</span>)
   <span class="ct">requires</span>(string_length(<span class="sl">@String.0</span>) > <span class="num">0</span>)

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -158,7 +158,7 @@ class TestHtmlCodeSamples:
     def test_vera_block_count(self) -> None:
         """docs/index.html should have the expected number of Vera code blocks."""
         blocks = _extract_vera_blocks(INDEX_HTML)
-        # Currently: safe_divide, fizzbuzz, classify_sentiment, research_topic
-        assert len(blocks) == 4, (
-            f"Expected 4 Vera blocks in docs/index.html, found {len(blocks)}"
+        # Currently: safe_divide, fizzbuzz, classify_sentiment, safe_classify, research_topic
+        assert len(blocks) == 5, (
+            f"Expected 5 Vera blocks in docs/index.html, found {len(blocks)}"
         )


### PR DESCRIPTION
Adds a second Inference example to the LLM Integration section of `docs/index.html`.

The existing `classify_sentiment` (with `ensures(true)`) is unchanged. The new `safe_classify` demonstrates that postconditions can constrain model output — with honest prose explaining they are runtime-checked rather than Z3-static (since Z3 cannot know what an LLM will return at compile time). If the model returns an empty string, the program traps with a contract violation rather than silently propagating garbage.

The `safe_classify` block is now validated by `check_html_examples.py` (parse + check + verify). Block count updated 4 → 5 in `test_html.py` and `TESTING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated test coverage documentation reflecting an increase in validated code examples from 4 to 5, all passing parse, check, and verify validation stages.

* **Tests**
  * Updated test expectations to accommodate an additional code example validation in the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->