### PR TITLE
fix: include grammar.lark in wheel package data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ vera = "vera.cli:main"
 include = ["vera*"]
 
 [tool.setuptools.package-data]
+"vera" = ["*.lark"]
 "vera.browser" = ["*.mjs"]
 
 [build-system]


### PR DESCRIPTION
## Summary

- `grammar.lark` was missing from `[tool.setuptools.package-data]`, so `pip install git+https://github.com/aallan/vera` silently omitted it from the wheel, causing an immediate crash on import
- Editable installs (`pip install -e .`) worked fine because they read from the source tree directly — which is why this went unnoticed until an external consumer tried a non-editable install

## Fix

Add `"vera" = ["*.lark"]` to `[tool.setuptools.package-data]` alongside the existing `"vera.browser" = ["*.mjs"]` entry.

## Verification

Built a wheel locally and confirmed `vera/grammar.lark` is present in the archive alongside the `.mjs` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package configuration to ensure all required grammar files are properly included in distributions. This guarantees the package functions correctly when installed from standard package repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->