### PR TITLE
docs: surface VeraBench across README, ROADMAP, and website

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ The reference compiler — parser, AST, type checker, contract verifier (Z3), WA
 
 **Key features delivered:** [typed De Bruijn indices](DE_BRUIJN.md) (`@T.n`), mandatory contracts, algebraic effects (IO, Http, State, Exceptions, Async, Inference), refinement types, constrained generics (Eq, Ord, Hash, Show), algebraic data types, pattern matching, modules, 122 built-in functions (strings, arrays, maps, sets, decimals, JSON, HTML, Markdown, regex, base64, URL), contract-driven testing, canonical formatter, browser runtime, and three-tier verification (Z3 static, guided, runtime fallback).
 
-**What's next:** the path from "working language" to "the language agents actually use" — see **[ROADMAP.md](ROADMAP.md)** for the four strategic milestones. The flagship goal is a verified MCP tool server where contracts guarantee tool schemas at compile time.
+**What's next:** the path from "working language" to "the language agents actually use" — see **[ROADMAP.md](ROADMAP.md)** for the four strategic milestones. The flagship goal is a verified MCP tool server where contracts guarantee tool schemas at compile time. Empirical evaluation is underway via **[VeraBench](https://github.com/aallan/vera-bench)**, a HumanEval-style benchmark suite being built in a separate repository.
 
 Known bugs and open issues are tracked on the **[issue tracker](https://github.com/aallan/vera/issues)**. See **[KNOWN_ISSUES.md](KNOWN_ISSUES.md)** for a consolidated list.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,9 +24,11 @@ Phase 1a (evaluation friction removal) is complete — see [HISTORY.md](HISTORY.
 
 ### Phase 1b: Build the benchmark suite
 
-- [#225](https://github.com/aallan/vera/issues/225) **Benchmark suite** — design a HumanEval/MBPP-style benchmark adapted for Vera. This is the single highest-value work item for the project's scientific credibility.
+**[VeraBench](https://github.com/aallan/vera-bench) is under active development** in a separate repository. The benchmark is being built out now; contributions and feedback welcome.
 
-  The benchmark should cover five difficulty tiers:
+- [#225](https://github.com/aallan/vera/issues/225) **Benchmark suite** — a HumanEval/MBPP-style benchmark adapted for Vera. This is the single highest-value work item for the project's scientific credibility.
+
+  The benchmark covers five difficulty tiers:
   1. **Pure arithmetic** — functions with 1–2 parameters, simple contracts (the easy case for `@T.n`)
   2. **String and array manipulation** — functions using built-ins, testing whether agents find the right `domain_verb` names
   3. **ADTs and pattern matching** — custom data types, exhaustive match, testing De Bruijn indices in match arms

--- a/docs/index.html
+++ b/docs/index.html
@@ -993,13 +993,15 @@ cp /path/to/vera/SKILL.md ~/.claude/skills/vera-language/SKILL.md</pre>
       </div>
       <p class="status-text">
         A complete compiler with 122 built-in functions, algebraic effects (IO, Http, State, Inference), contract-driven testing, and a 13-chapter specification.
+        Empirical evaluation is underway via <a href="https://github.com/aallan/vera-bench" class="status-link">VeraBench</a>, a HumanEval-style benchmark suite being built in a separate repository.
         <br>
         <a href="https://github.com/aallan/vera/blob/main/README.md">README</a> ·
         <a href="https://github.com/aallan/vera/blob/main/ROADMAP.md">Roadmap</a> ·
         <a href="https://github.com/aallan/vera/blob/main/HISTORY.md">History</a> ·
         <a href="https://github.com/aallan/vera/blob/main/CHANGELOG.md">Changelog</a> ·
         <a href="https://github.com/aallan/vera/blob/main/CONTRIBUTING.md">Contributing</a> ·
-        <a href="https://github.com/aallan/vera/issues">Issues</a>
+        <a href="https://github.com/aallan/vera/issues">Issues</a> ·
+        <a href="https://github.com/aallan/vera-bench">VeraBench</a>
       </p>
     </div>
   </section>


### PR DESCRIPTION
## Summary

- **ROADMAP.md Phase 1b**: notes that VeraBench is under active development in a separate repository, with a direct link; rewords from future-tense design spec to present-tense active project
- **README.md**: adds VeraBench mention to the "What's next" paragraph
- **docs/index.html**: adds a VeraBench sentence to the status banner and a link in the footer row

VeraBench: https://github.com/aallan/vera-bench

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README and roadmap to reflect that the HumanEval/MBPP-style benchmark suite is now being actively developed in a separate external repository named VeraBench, covering five difficulty tiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->