### PR TITLE
docs: add State handler + where block example to SKILL.md

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1258,7 +1258,7 @@ Key points:
 - The `where` block helper `sum_loop` has `effects(<State<Int>>)` — it uses `get`/`put` directly
 - Functions inside `where` blocks do NOT take `public`/`private` visibility
 - The `with @Int = @Int.0` clause updates the handler state when `put` resumes
-- Pure helper functions (like `add_value`) can be called from within the handler body
+- Pure helper functions (like `add_value`) can be called from the `where` block helper (`sum_loop`)
 - The `decreases` clause on the loop helper ensures termination
 
 ## Where Blocks (Mutual Recursion)

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -1210,6 +1210,57 @@ State.put(42);
 Logger.put("message");
 ```
 
+### State handler with a loop helper
+
+The most common State pattern uses a `where` block to define a loop helper with `effects(<State<Int>>)`. The handler wraps the entire computation; the helper calls `get` and `put` directly.
+
+```vera
+-- Sum 1..n using State<Int>
+private fn add_value(@Int, @Int -> @Int)
+  requires(true)
+  ensures(@Int.result == @Int.1 + @Int.0)
+  effects(pure)
+{
+  @Int.1 + @Int.0
+}
+
+public fn sum_with_state(@Nat -> @Int)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  handle[State<Int>](@Int = 0) {
+    get(@Unit) -> { resume(@Int.0) },
+    put(@Int) -> { resume(()) } with @Int = @Int.0
+  } in {
+    sum_loop(@Nat.0, 1)
+  }
+}
+where {
+  fn sum_loop(@Nat, @Nat -> @Int)
+    requires(true)
+    ensures(true)
+    decreases(@Nat.1 - @Nat.0 + 1)
+    effects(<State<Int>>)
+  {
+    if @Nat.0 > @Nat.1 then {
+      get(())
+    } else {
+      put(add_value(get(()), @Nat.0));
+      sum_loop(@Nat.1, @Nat.0 + 1)
+    }
+  }
+}
+```
+
+Key points:
+- The outer function `sum_with_state` is **pure** — the handler discharges the State effect
+- The `where` block helper `sum_loop` has `effects(<State<Int>>)` — it uses `get`/`put` directly
+- Functions inside `where` blocks do NOT take `public`/`private` visibility
+- The `with @Int = @Int.0` clause updates the handler state when `put` resumes
+- Pure helper functions (like `add_value`) can be called from the `where` block helper (`sum_loop`)
+- The `decreases` clause on the loop helper ensures termination
+
 ## Where Blocks (Mutual Recursion)
 
 ```vera

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1216,6 +1216,57 @@ State.put(42);
 Logger.put("message");
 ```
 
+### State handler with a loop helper
+
+The most common State pattern uses a `where` block to define a loop helper with `effects(<State<Int>>)`. The handler wraps the entire computation; the helper calls `get` and `put` directly.
+
+```vera
+-- Sum 1..n using State<Int>
+private fn add_value(@Int, @Int -> @Int)
+  requires(true)
+  ensures(@Int.result == @Int.1 + @Int.0)
+  effects(pure)
+{
+  @Int.1 + @Int.0
+}
+
+public fn sum_with_state(@Nat -> @Int)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  handle[State<Int>](@Int = 0) {
+    get(@Unit) -> { resume(@Int.0) },
+    put(@Int) -> { resume(()) } with @Int = @Int.0
+  } in {
+    sum_loop(@Nat.0, 1)
+  }
+}
+where {
+  fn sum_loop(@Nat, @Nat -> @Int)
+    requires(true)
+    ensures(true)
+    decreases(@Nat.1 - @Nat.0 + 1)
+    effects(<State<Int>>)
+  {
+    if @Nat.0 > @Nat.1 then {
+      get(())
+    } else {
+      put(add_value(get(()), @Nat.0));
+      sum_loop(@Nat.1, @Nat.0 + 1)
+    }
+  }
+}
+```
+
+Key points:
+- The outer function `sum_with_state` is **pure** — the handler discharges the State effect
+- The `where` block helper `sum_loop` has `effects(<State<Int>>)` — it uses `get`/`put` directly
+- Functions inside `where` blocks do NOT take `public`/`private` visibility
+- The `with @Int = @Int.0` clause updates the handler state when `put` resumes
+- Pure helper functions (like `add_value`) can be called from the `where` block helper (`sum_loop`)
+- The `decreases` clause on the loop helper ensures termination
+
 ## Where Blocks (Mutual Recursion)
 
 ```vera

--- a/scripts/check_skill_examples.py
+++ b/scripts/check_skill_examples.py
@@ -45,9 +45,6 @@ ALLOWLIST: dict[int, tuple[str, str]] = {
     # Handler syntax — pseudocode template
     1186: ("FRAGMENT", "Effect handler syntax template"),
 
-    # Common mistake: bare if/else expression
-    1609: ("FRAGMENT", "Common mistake example, bare if/else"),
-
     # String operations — bare function calls
     660: ("FRAGMENT", "String built-in examples, bare calls"),
 
@@ -107,11 +104,8 @@ ALLOWLIST: dict[int, tuple[str, str]] = {
     # Qualified calls and handler fragments — bare expressions
     1136: ("FRAGMENT", "Handler with clause, bare expression"),
 
-    # Module declaration and import syntax
-    1246: ("FRAGMENT", "Module declaration and import example"),
-
     # Line comments — bare comments
-    1351: ("FRAGMENT", "Comment syntax example"),
+    1402: ("FRAGMENT", "Comment syntax example"),
 
     # Type conversions — bare function calls
     859: ("FRAGMENT", "Float64 predicate and constant examples, bare calls"),
@@ -120,33 +114,29 @@ ALLOWLIST: dict[int, tuple[str, str]] = {
     846: ("FRAGMENT", "Float64 predicate examples, bare calls"),
 
     # Common mistakes section — intentionally wrong code
-    1430: ("FRAGMENT", "Wrong: missing contracts"),
-    1437: ("FRAGMENT", "Wrong: missing effects clause"),
-    1450: ("FRAGMENT", "Wrong: missing effects clause (with contracts)"),
-    1460: ("FRAGMENT", "Wrong: bare expression without indices"),
-    1497: ("FRAGMENT", "Wrong: missing index on slot reference"),
-    1502: ("FRAGMENT", "Correct: expression with indices (not full fn)"),
-    1509: ("FRAGMENT", "Wrong: match arm with incorrect return"),
-    1579: ("FRAGMENT", "Wrong: non-exhaustive match (missing None)"),
-    1592: ("FRAGMENT", "Wrong: non-exhaustive match (missing arm)"),
+    1481: ("FRAGMENT", "Wrong: missing contracts"),
+    1501: ("FRAGMENT", "Wrong: missing effects clause (with contracts)"),
+    1548: ("FRAGMENT", "Wrong: missing index on slot reference"),
+    1553: ("FRAGMENT", "Correct: expression with indices (not full fn)"),
+    1630: ("FRAGMENT", "Wrong: non-exhaustive match (missing None)"),
+    1643: ("FRAGMENT", "Wrong: non-exhaustive match (missing arm)"),
 
     # Import syntax — intentionally unsupported
-    1625: ("FRAGMENT", "Wrong: import aliasing not supported"),
-    1630: ("FRAGMENT", "Correct: import syntax example"),
-    1640: ("FRAGMENT", "Wrong: import hiding not supported"),
-    1645: ("FRAGMENT", "Correct: multi-import syntax"),
+    1676: ("FRAGMENT", "Wrong: import aliasing not supported"),
+    1681: ("FRAGMENT", "Correct: import syntax example"),
+    1691: ("FRAGMENT", "Wrong: import hiding not supported"),
 
     # Match arm fragment — bare match body
-    1554: ("FRAGMENT", "Match arm bare expression"),
-    1599: ("FRAGMENT", "Correct: match expression example (bare)"),
-    1614: ("FRAGMENT", "Correct: if/else with braces (common mistakes)"),
+    1650: ("FRAGMENT", "Correct: match expression example (bare)"),
+    1660: ("FRAGMENT", "Common mistake example, bare if/else"),
+    1665: ("FRAGMENT", "Correct: if/else with braces (common mistakes)"),
 
     # String escapes — bare expression
-    1659: ("FRAGMENT", "Correct escape sequence examples, bare strings"),
+    1710: ("FRAGMENT", "Correct escape sequence examples, bare strings"),
 
     # Map/Set common mistakes — bare let bindings
-    1667: ("FRAGMENT", "Wrong: standalone map_new/set_new without type context"),
-    1673: ("FRAGMENT", "Correct: map_new/set_new with type context"),
+    1718: ("FRAGMENT", "Wrong: standalone map_new/set_new without type context"),
+    1724: ("FRAGMENT", "Correct: map_new/set_new with type context"),
 
     # Effect disambiguation — qualified calls
     1208: ("FRAGMENT", "Qualified effect calls (State.put, Logger.put)"),


### PR DESCRIPTION
## Summary

Add a "State handler with a loop helper" subsection to SKILL.md showing the most common State effect pattern: `handle[State<Int>]` wrapping a `where`-block helper that has `effects(<State<Int>>)`.

## Why this matters

SKILL.md is the sole source of Vera knowledge provided to LLMs during evaluation. This pattern — combining a State handler with a where-block effectful helper — was completely undocumented. The existing where-block examples only show pure functions (is_even/is_odd), and the existing State examples only show inline get/put without helper functions.

## Evidence from VeraBench

We A/B tested the improved SKILL.md against the original on two problems that use this pattern:

Problem | Original SKILL.md | Improved SKILL.md
-- | -- | --
VB-T5-004 (State accumulator) | ❌ check fail | ✅ check pass
VB-T5-008 (IO print loop) | ❌ check fail | ✅ check pass

Both problems went from "can't produce valid Vera syntax at all" to "compiles successfully" with the documentation improvement. The model (Claude Sonnet 4) had no other changes — same prompt, same problem description, only the SKILL.md content differed.

De Bruijn slot ordering is the dominant failure mode in VeraBench (see [vera-bench issue 6](https://github.com/aallan/vera-bench/issues/6)), but the where-block + effects syntax gap was the top *syntax* failure — the model couldn't even produce code that parses.

## What the example covers

- Pure outer function with `handle[State<Int>]` that discharges the effect
- Where-block helper with `effects(<State<Int>>)` that calls `get`/`put` directly
- `with @Int = @Int.0` clause for updating handler state
- `decreases` clause on the loop helper for termination
- Pure helper function called from within the handler body
- Visibility rules (no `public`/`private` on where-block functions)

## Relates to

- [vera-bench issue 15](https://github.com/aallan/vera-bench/issues/15) — Improve SKILL.md coverage of where blocks and State handler patterns

## Test plan

- [ ] The example code passes `vera check` and `vera verify`
- [ ] `scripts/check_skill_examples.py` passes
- [ ] `docs/SKILL.md` regenerated via `scripts/build_site.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new “State handler with a loop helper” section with examples showing a public-facing state-eliminating function, a where-scoped recursive loop helper that performs get/put and uses resumptions, and a termination hint for the recursive helper.
* **Chores**
  * Adjusted example-validation allowlisting and fragment mappings to reflect relocated examples and to change which example blocks are treated as intentionally unparseable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->