### PR TITLE
Fix GC shadow stack overflow causing silent array corruption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.112] - 2026-04-16
+
+### Fixed
+- **GC shadow stack overflow causing silent array corruption** ([#464](https://github.com/aallan/vera/issues/464)) — the GC shadow stack was 4K (4096 bytes). Recursive functions with multiple `Array` parameters push ~12 bytes per frame (2 pointer params + 1 `array_append` destination), overflowing at ~341 frames into the adjacent GC worklist region. When GC triggered during deep recursion, the worklist corruption caused intermediate arrays to be incorrectly freed, silently overwriting the first bytes of Bool arrays with free-list pointers. Shadow stack increased from 4K to 16K; worklist increased from 4K to 16K; overflow guard added to `gc_shadow_push` (traps instead of silent corruption). Closes [#464](https://github.com/aallan/vera/issues/464).
+
 ## [0.0.111] - 2026-04-10
 
 ### Fixed
@@ -1549,7 +1554,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Grammar: handler body simplified to avoid LALR reduce/reduce conflict
 - `pyproject.toml`: corrected build backend, package discovery, PEP 639 compliance
 
-[Unreleased]: https://github.com/aallan/vera/compare/v0.0.111...HEAD
+[Unreleased]: https://github.com/aallan/vera/compare/v0.0.112...HEAD
+[0.0.112]: https://github.com/aallan/vera/compare/v0.0.111...v0.0.112
 [0.0.111]: https://github.com/aallan/vera/compare/v0.0.110...v0.0.111
 [0.0.110]: https://github.com/aallan/vera/compare/v0.0.109...v0.0.110
 [0.0.109]: https://github.com/aallan/vera/compare/v0.0.108...v0.0.109

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
 # History
 
-How the Vera compiler was built, from initial commit through Stage 10, across 32 active development days.
+How the Vera compiler was built, from initial commit through Stage 11, across 40 active development days.
 
 Vera was developed in an interleaved spiral — each phase added a complete compiler layer with tests, documentation, and working examples before moving to the next. The compiler was built by a single developer working with Claude Code, with CodeRabbit providing AI code review on pull requests from v0.0.80 onwards. The entire project — language design, specification, compiler, test suite, documentation, website — was built from scratch starting 22 February 2026.
 
@@ -220,7 +220,7 @@ With the core language complete, Stage 9 focused on friction removal and polish 
 | v0.0.105 | 30 Mar | **Typed holes** — `?` placeholder for partial programs; `vera check` reports W001 with expected type and slot bindings; holes block compilation (E614). |
 | v0.0.106 | 31 Mar | **`vera test` String & Float64 input generation** — Z3 testing extended to String (sequence sort, ≤50 chars) and Float64 (real sort, boundary seeding) (#169). |
 
-## Stage 10: Evaluation and CI quality (7 April onwards)
+## Stage 10: Evaluation and CI quality (7–11 April)
 
 *After a week working in parallel on [VeraBench](https://github.com/aallan/vera-bench) evaluation, Stage 10 returns to the compiler with benchmark results informing priorities.*
 
@@ -233,6 +233,16 @@ With the core language complete, Stage 9 focused on friction removal and polish 
 | v0.0.109 | 10 Apr | **Fix closure `i32_pair` param/return types** (#359) — `String`/`Array` params and return types in closures now emit correct two-slot WAT signatures; host imports used inside closures now propagated to module-level tracker; `_infer_fncall_vera_type` fixed for parameterised accumulator types like `Map<String, Int>`. |
 | v0.0.110 | 10 Apr | **Mistral AI provider + provider registry refactor** (#413) — `Inference.complete` supports Mistral (`VERA_MISTRAL_API_KEY`, default `mistral-small-latest`). `_call_inference_provider` refactored to `_ProviderConfig` dataclass + `_PROVIDERS` registry dict; adding further providers is now a one-row change. |
 | v0.0.111 | 10 Apr | **SMT translator: String/Float64 parameter sorts + string predicates** — `String` and `Float64` function parameters now declared with correct Z3 sorts (SeqSort/RealSort) rather than falling back to IntSort. `StringLit` translates to `z3.StringVal()`. `string_length` uses `z3.Length()` for SeqSort args so call-site preconditions on string literals verify Tier 1. `string_contains`, `string_starts_with`, `string_ends_with` now Tier 1 via Z3 native string theory. `float_is_nan`/`float_is_infinite` explicitly Tier 3 (encoding as False would drop the runtime guard). |
+
+## Stage 11: Real-world programming (16 April onwards)
+
+*Bug fixes and standard library depth — closing the gaps that trip up models and human programmers alike.*
+
+Stage 11 shifts focus from evaluation infrastructure to the standard library and runtime correctness. The benchmark results from Stage 10 identified missing primitives as the dominant friction source: models reaching for `array_sort` or `string_reverse` and finding nothing, then writing fragile hand-rolled implementations. This stage adds the utility functions that any real program needs, alongside critical bug fixes.
+
+| Version | Date | What shipped |
+|---------|------|-------------|
+| — | 16 Apr | **Fix GC shadow stack overflow** (#464) — 4K shadow stack overflowed into the GC worklist during deep recursive array accumulation (450+ frames), causing silent corruption of the first array elements. Shadow stack increased to 16K with overflow guard trap. |
 
 ---
 
@@ -259,14 +269,14 @@ Alongside the compiler, editor support and AI discoverability infrastructure wer
 
 ## By the numbers
 
-| Metric | v0.0.1 (23 Feb) | v0.0.9 (23 Feb) | v0.0.39 (27 Feb) | v0.0.65 (4 Mar) | v0.0.88 (12 Mar) | v0.0.101 (27 Mar) | v0.0.102 (28 Mar) | v0.0.103 (29 Mar) |
-|--------|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-| Compiler layers | Parser | 5 (full pipeline) | 5 + modules | 5 + modules + GC | 5 + modules + GC + browser | 5 + modules + GC + browser | 5 + modules + GC + browser | 5 + modules + GC + browser |
-| Tests | ~50 | ~300 | ~600 | ~1,400 | ~2,300 | 3,095 | 3,121 | 3,184 |
-| Examples | 13 | 15 | 16 | 18 | 24 | 30 | 30 | 30 |
-| Built-in functions | 0 | 0 | ~5 | ~30 | ~80 | 122 | 122 | 122 |
-| Conformance programs | 0 | 0 | 0 | 0 | ~50 | 64 | 65 | 71 |
-| Spec chapters | 7 | 10 | 11 | 12 | 13 | 13 | 13 | 13 |
-| Code coverage | — | — | — | 90% | 91% | 96% | 96% | 96% |
+| Metric | v0.0.1 (23 Feb) | v0.0.9 (23 Feb) | v0.0.39 (27 Feb) | v0.0.65 (4 Mar) | v0.0.88 (12 Mar) | v0.0.101 (27 Mar) | v0.0.111 (11 Apr) |
+|--------|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| Compiler layers | Parser | 5 (full pipeline) | 5 + modules | 5 + modules + GC | 5 + modules + GC + browser | 5 + modules + GC + browser | 5 + modules + GC + browser |
+| Tests | ~50 | ~300 | ~600 | ~1,400 | ~2,300 | 3,095 | 3,253 |
+| Examples | 13 | 15 | 16 | 18 | 24 | 30 | 30 |
+| Built-in functions | 0 | 0 | ~5 | ~30 | ~80 | 122 | 122 |
+| Conformance programs | 0 | 0 | 0 | 0 | ~50 | 64 | 73 |
+| Spec chapters | 7 | 10 | 11 | 12 | 13 | 13 | 13 |
+| Code coverage | — | — | — | 90% | 91% | 96% | 96% |
 
-Total: **630+ commits, 110 tagged releases, 32 active development days.**
+Total: **800+ commits, 112 tagged releases, 40 active development days.**

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -6,11 +6,9 @@ Bugs and limitations tracked against the [issue tracker](https://github.com/aall
 
 | Bug | Issue |
 |-----|-------|
-| Closure parameter with pair-ABI type emits invalid WAT | [#359](https://github.com/aallan/vera/issues/359) |
 | Opaque handle memory leak in host stores | [#346](https://github.com/aallan/vera/issues/346) |
 | GC shadow stack pollution from opaque handle parameters | [#347](https://github.com/aallan/vera/issues/347) |
 | GC worklist overflow for deeply nested object graphs | [#348](https://github.com/aallan/vera/issues/348) |
-| Type-checked pure program produces incorrect runtime output that isolated probes cannot reproduce (suspected GC/array interaction on long accumulators) | [#464](https://github.com/aallan/vera/issues/464) |
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ cp /path/to/vera/SKILL.md ~/.claude/skills/vera-language/SKILL.md
 
 ## Project status
 
-Vera is in **active development** at v0.0.111 — 630+ commits, 111 releases, 3,250 tests, 96% code coverage, 73 conformance programs, 30 examples, and a 13-chapter specification. See **[HISTORY.md](HISTORY.md)** for how the compiler was built.
+Vera is in **active development** at v0.0.112 — 800+ commits, 112 releases, 3,253 tests, 96% code coverage, 73 conformance programs, 30 examples, and a 13-chapter specification. See **[HISTORY.md](HISTORY.md)** for how the compiler was built.
 
 The reference compiler — parser, AST, type checker, contract verifier (Z3), WASM code generator, module system, browser runtime, and runtime contract insertion — is working. The language specification is in draft across [13 chapters](spec/).
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@ See [HISTORY.md](HISTORY.md) for a narrative account of how the compiler was bui
 
 ## Where we are
 
-The compiler is complete end-to-end: parse, type-check, verify contracts via Z3, compile to WebAssembly, and run — at the command line and in the browser. The language has 122 built-in functions, algebraic effects (IO, Http, State, Exceptions, Async, Inference), constrained generics, a module system, contract-driven testing, and a canonical formatter. Type inference for bare constructors (`None`, `Err`, `Ok`) now works correctly across all call sites. The compiler has 3,250 tests, 73 conformance programs, 30 examples, and a 13-chapter specification.
+The compiler is complete end-to-end: parse, type-check, verify contracts via Z3, compile to WebAssembly, and run — at the command line and in the browser. The language has 122 built-in functions, algebraic effects (IO, Http, State, Exceptions, Async, Inference), constrained generics, a module system, contract-driven testing, and a canonical formatter. Type inference for bare constructors (`None`, `Err`, `Ok`) now works correctly across all call sites. The compiler has 3,252 tests, 73 conformance programs, 30 examples, and a 13-chapter specification.
 
 Significant progress has been made towards Vera being a viable agent target. [VeraBench](https://github.com/aallan/vera-bench) — a 50-problem benchmark across 5 difficulty tiers — now covers 6 models across 3 providers (v0.0.7). The headline result: Kimi K2.5 achieves 100% run_correct on Vera, beating both Python (86%) and TypeScript (91%). Three models beat TypeScript on Vera. The flagship tier averages 93% Vera run_correct vs 93% Python — essentially parity. These are single-run results with high variance; stable rates will require pass@k evaluation. The remaining gaps are empirical breadth (repeated trials, more models), standard library depth (HTTP hardening, server effects), and tooling integration (LSP).
 
@@ -184,7 +184,7 @@ These are not milestone-gated — they should be addressed continuously alongsid
 | Item | Issue | Effort | Impact |
 |------|-------|--------|--------|
 | Add property-based testing with Hypothesis | [#386](https://github.com/aallan/vera/issues/386) | 2–4 hours | Catches parser/formatter edge cases via round-trip properties |
-| Add mutation testing with mutmut (detection only) | [#387](https://github.com/aallan/vera/issues/387) | 2–4 hours | Measures whether 3,250 tests catch real bugs, not just execute paths |
+| Add mutation testing with mutmut (detection only) | [#387](https://github.com/aallan/vera/issues/387) | 2–4 hours | Measures whether 3,252 tests catch real bugs, not just execute paths |
 | Investigate parser fuzzing with Atheris | [#402](https://github.com/aallan/vera/issues/402) | 4–8 hours | Crash-inducing inputs for parser and type checker |
 | Improve browser runtime test coverage to >80% | [#349](https://github.com/aallan/vera/issues/349) | 2–4 hours | Parity with Python-side coverage gate |
 
@@ -226,4 +226,4 @@ The compiler was built through ten development phases from February to March 202
 | C8.5 | v0.0.66–v0.0.88 | **Completeness** — builtins, IO runtime, types, effects, browser target | Done |
 | C9 | v0.0.89–v0.0.101 | **Abilities, standard library, data types, effects** — Eq/Ord/Hash/Show, Map/Set, JSON, HTML, Markdown, Http, Decimal, Inference, standard prelude, combinators, higher-order array ops | Done |
 
-**630+ commits, 111 tagged releases, 3,250 tests, 96% coverage, 73 conformance programs, 30 examples, 13 spec chapters.** See [HISTORY.md](HISTORY.md) for the full narrative of how the compiler was built.
+**630+ commits, 111 tagged releases, 3,252 tests, 96% coverage, 73 conformance programs, 30 examples, 13 spec chapters.** See [HISTORY.md](HISTORY.md) for the full narrative of how the compiler was built.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -226,4 +226,4 @@ The compiler was built through ten development phases from February to March 202
 | C8.5 | v0.0.66–v0.0.88 | **Completeness** — builtins, IO runtime, types, effects, browser target | Done |
 | C9 | v0.0.89–v0.0.101 | **Abilities, standard library, data types, effects** — Eq/Ord/Hash/Show, Map/Set, JSON, HTML, Markdown, Http, Decimal, Inference, standard prelude, combinators, higher-order array ops | Done |
 
-**630+ commits, 111 tagged releases, 3,253 tests, 96% coverage, 73 conformance programs, 30 examples, 13 spec chapters.** See [HISTORY.md](HISTORY.md) for the full narrative of how the compiler was built.
+**800+ commits, 112 tagged releases, 3,253 tests, 96% coverage, 73 conformance programs, 30 examples, 13 spec chapters.** See [HISTORY.md](HISTORY.md) for the full narrative of how the compiler was built.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@ See [HISTORY.md](HISTORY.md) for a narrative account of how the compiler was bui
 
 ## Where we are
 
-The compiler is complete end-to-end: parse, type-check, verify contracts via Z3, compile to WebAssembly, and run — at the command line and in the browser. The language has 122 built-in functions, algebraic effects (IO, Http, State, Exceptions, Async, Inference), constrained generics, a module system, contract-driven testing, and a canonical formatter. Type inference for bare constructors (`None`, `Err`, `Ok`) now works correctly across all call sites. The compiler has 3,252 tests, 73 conformance programs, 30 examples, and a 13-chapter specification.
+The compiler is complete end-to-end: parse, type-check, verify contracts via Z3, compile to WebAssembly, and run — at the command line and in the browser. The language has 122 built-in functions, algebraic effects (IO, Http, State, Exceptions, Async, Inference), constrained generics, a module system, contract-driven testing, and a canonical formatter. Type inference for bare constructors (`None`, `Err`, `Ok`) now works correctly across all call sites. The compiler has 3,253 tests, 73 conformance programs, 30 examples, and a 13-chapter specification.
 
 Significant progress has been made towards Vera being a viable agent target. [VeraBench](https://github.com/aallan/vera-bench) — a 50-problem benchmark across 5 difficulty tiers — now covers 6 models across 3 providers (v0.0.7). The headline result: Kimi K2.5 achieves 100% run_correct on Vera, beating both Python (86%) and TypeScript (91%). Three models beat TypeScript on Vera. The flagship tier averages 93% Vera run_correct vs 93% Python — essentially parity. These are single-run results with high variance; stable rates will require pass@k evaluation. The remaining gaps are empirical breadth (repeated trials, more models), standard library depth (HTTP hardening, server effects), and tooling integration (LSP).
 
@@ -184,7 +184,7 @@ These are not milestone-gated — they should be addressed continuously alongsid
 | Item | Issue | Effort | Impact |
 |------|-------|--------|--------|
 | Add property-based testing with Hypothesis | [#386](https://github.com/aallan/vera/issues/386) | 2–4 hours | Catches parser/formatter edge cases via round-trip properties |
-| Add mutation testing with mutmut (detection only) | [#387](https://github.com/aallan/vera/issues/387) | 2–4 hours | Measures whether 3,252 tests catch real bugs, not just execute paths |
+| Add mutation testing with mutmut (detection only) | [#387](https://github.com/aallan/vera/issues/387) | 2–4 hours | Measures whether 3,253 tests catch real bugs, not just execute paths |
 | Investigate parser fuzzing with Atheris | [#402](https://github.com/aallan/vera/issues/402) | 4–8 hours | Crash-inducing inputs for parser and type checker |
 | Improve browser runtime test coverage to >80% | [#349](https://github.com/aallan/vera/issues/349) | 2–4 hours | Parity with Python-side coverage gate |
 
@@ -226,4 +226,4 @@ The compiler was built through ten development phases from February to March 202
 | C8.5 | v0.0.66–v0.0.88 | **Completeness** — builtins, IO runtime, types, effects, browser target | Done |
 | C9 | v0.0.89–v0.0.101 | **Abilities, standard library, data types, effects** — Eq/Ord/Hash/Show, Map/Set, JSON, HTML, Markdown, Http, Decimal, Inference, standard prelude, combinators, higher-order array ops | Done |
 
-**630+ commits, 111 tagged releases, 3,252 tests, 96% coverage, 73 conformance programs, 30 examples, 13 spec chapters.** See [HISTORY.md](HISTORY.md) for the full narrative of how the compiler was built.
+**630+ commits, 111 tagged releases, 3,253 tests, 96% coverage, 73 conformance programs, 30 examples, 13 spec chapters.** See [HISTORY.md](HISTORY.md) for the full narrative of how the compiler was built.

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,7 +6,7 @@ This is the single source of truth for Vera's testing infrastructure, coverage d
 
 | Metric | Value |
 |--------|-------|
-| **Tests** | 3,250 across 27 files (~34,000 lines of test code; 3,239 passed, 11 skipped) |
+| **Tests** | 3,252 across 27 files (~34,000 lines of test code; 3,241 passed, 11 skipped) |
 | **Compiler code coverage** | 96% of 15,149 statements (CI minimum: 80%) |
 | **Conformance programs** | 73 programs across 9 spec chapters, validating every language feature |
 | **Example programs** | 30, all validated through `vera check` + `vera verify` |
@@ -55,7 +55,7 @@ python scripts/fix_allowlists.py --fix               # auto-fix stale allowlists
 | `test_ast.py` | 123 | 1,130 | AST transformation, node structure, serialisation, string escape sequences, ability declarations |
 | `test_checker.py` | 508 | 5,656 | Type synthesis, slot resolution, effects, effect subtyping, contracts, exhaustiveness, cross-module typing, visibility, error codes, string built-ins, generic rejection, IO operation types, Markdown types, Regex types, abilities, Map collection, Set collection, Decimal type, Json type, Html type, Http effect, Inference effect, removed legacy name regression |
 | `test_verifier.py` | 132 | 1,886 | Z3 verification, counterexamples, tier classification, call-site preconditions, branch-aware preconditions, pipe operator, cross-module contracts, match/ADT verification, decreases verification, mutual recursion, refined Bool/String/Float64 param sorts |
-| `test_codegen.py` | 859 | 10,465 | WASM compilation, arithmetic, Float64, Byte, arrays (incl. compound element types), ADTs, match (incl. nested patterns), generics, State\<T\>, Exn\<E\> handlers, control flow, strings, string escape sequences, IO (read\_line, read\_file, write\_file, args, exit, get\_env), bounds checking, quantifiers, assert/assume, refinement type aliases, pipe operator, string built-ins, built-in shadowing, parse\_nat Result, GC, Markdown host bindings, Regex host bindings, Map collection, Set collection, Decimal type, Json type, Html type, Http effect, Inference effect, example round-trips |
+| `test_codegen.py` | 861 | 10,536 | WASM compilation, arithmetic, Float64, Byte, arrays (incl. compound element types), ADTs, match (incl. nested patterns), generics, State\<T\>, Exn\<E\> handlers, control flow, strings, string escape sequences, IO (read\_line, read\_file, write\_file, args, exit, get\_env), bounds checking, quantifiers, assert/assume, refinement type aliases, pipe operator, string built-ins, built-in shadowing, parse\_nat Result, GC, Markdown host bindings, Regex host bindings, Map collection, Set collection, Decimal type, Json type, Html type, Http effect, Inference effect, example round-trips, GC shadow stack overflow |
 | `test_codegen_contracts.py` | 32 | 576 | Runtime pre/postconditions, contract fail messages, old/new state postconditions |
 | `test_codegen_monomorphize.py` | 52 | 897 | Generic instantiation, type inference, monomorphization edge cases, ability constraint satisfaction (Eq/Ord/Hash/Show), operation rewriting (eq/compare), show/hash dispatch, ADT auto-derivation, array operations (slice/map/filter/fold) |
 | `test_codegen_closures.py` | 19 | 473 | Closure lifting, captured variables, higher-order functions |

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,7 +6,7 @@ This is the single source of truth for Vera's testing infrastructure, coverage d
 
 | Metric | Value |
 |--------|-------|
-| **Tests** | 3,252 across 27 files (~34,000 lines of test code; 3,241 passed, 11 skipped) |
+| **Tests** | 3,253 across 27 files (~34,000 lines of test code; 3,242 passed, 11 skipped) |
 | **Compiler code coverage** | 96% of 15,149 statements (CI minimum: 80%) |
 | **Conformance programs** | 73 programs across 9 spec chapters, validating every language feature |
 | **Example programs** | 30, all validated through `vera check` + `vera verify` |
@@ -55,7 +55,7 @@ python scripts/fix_allowlists.py --fix               # auto-fix stale allowlists
 | `test_ast.py` | 123 | 1,130 | AST transformation, node structure, serialisation, string escape sequences, ability declarations |
 | `test_checker.py` | 508 | 5,656 | Type synthesis, slot resolution, effects, effect subtyping, contracts, exhaustiveness, cross-module typing, visibility, error codes, string built-ins, generic rejection, IO operation types, Markdown types, Regex types, abilities, Map collection, Set collection, Decimal type, Json type, Html type, Http effect, Inference effect, removed legacy name regression |
 | `test_verifier.py` | 132 | 1,886 | Z3 verification, counterexamples, tier classification, call-site preconditions, branch-aware preconditions, pipe operator, cross-module contracts, match/ADT verification, decreases verification, mutual recursion, refined Bool/String/Float64 param sorts |
-| `test_codegen.py` | 861 | 10,536 | WASM compilation, arithmetic, Float64, Byte, arrays (incl. compound element types), ADTs, match (incl. nested patterns), generics, State\<T\>, Exn\<E\> handlers, control flow, strings, string escape sequences, IO (read\_line, read\_file, write\_file, args, exit, get\_env), bounds checking, quantifiers, assert/assume, refinement type aliases, pipe operator, string built-ins, built-in shadowing, parse\_nat Result, GC, Markdown host bindings, Regex host bindings, Map collection, Set collection, Decimal type, Json type, Html type, Http effect, Inference effect, example round-trips, GC shadow stack overflow |
+| `test_codegen.py` | 862 | 10,563 | WASM compilation, arithmetic, Float64, Byte, arrays (incl. compound element types), ADTs, match (incl. nested patterns), generics, State\<T\>, Exn\<E\> handlers, control flow, strings, string escape sequences, IO (read\_line, read\_file, write\_file, args, exit, get\_env), bounds checking, quantifiers, assert/assume, refinement type aliases, pipe operator, string built-ins, built-in shadowing, parse\_nat Result, GC, Markdown host bindings, Regex host bindings, Map collection, Set collection, Decimal type, Json type, Html type, Http effect, Inference effect, example round-trips, GC shadow stack overflow |
 | `test_codegen_contracts.py` | 32 | 576 | Runtime pre/postconditions, contract fail messages, old/new state postconditions |
 | `test_codegen_monomorphize.py` | 52 | 897 | Generic instantiation, type inference, monomorphization edge cases, ability constraint satisfaction (Eq/Ord/Hash/Show), operation rewriting (eq/compare), show/hash dispatch, ADT auto-derivation, array operations (slice/map/filter/fold) |
 | `test_codegen_closures.py` | 19 | 473 | Closure lifting, captured variables, higher-order functions |

--- a/docs/index.html
+++ b/docs/index.html
@@ -730,7 +730,7 @@
         For Agents → SKILL.md
       </a>
     </div>
-    <p style="display: flex; justify-content: center; align-items: center; gap: 0.5rem; margin-top: 1rem; font-size: 0.9rem; color: var(--brown-400);">Current Version: <a href="https://github.com/aallan/vera/releases/tag/v0.0.111" style="color: var(--brown-500); font-weight: 500;">v0.0.111</a> <a href="https://github.com/aallan/vera/actions/workflows/ci.yml" style="display: flex;"><img src="https://github.com/aallan/vera/actions/workflows/ci.yml/badge.svg" alt="CI" style="height: 20px;"></a></p>
+    <p style="display: flex; justify-content: center; align-items: center; gap: 0.5rem; margin-top: 1rem; font-size: 0.9rem; color: var(--brown-400);">Current Version: <a href="https://github.com/aallan/vera/releases/tag/v0.0.112" style="color: var(--brown-500); font-weight: 500;">v0.0.112</a> <a href="https://github.com/aallan/vera/actions/workflows/ci.yml" style="display: flex;"><img src="https://github.com/aallan/vera/actions/workflows/ci.yml/badge.svg" alt="CI" style="height: 20px;"></a></p>
   </div>
 
   <!-- Why -->

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 > Vera is a statically typed, purely functional programming language designed for large language models to write. It uses typed slot references (`@T.n`) instead of variable names, requires contracts on every function, and compiles to WebAssembly.
 
-**Current version:** [0.0.111](https://github.com/aallan/vera/releases/tag/v0.0.111)
+**Current version:** [0.0.112](https://github.com/aallan/vera/releases/tag/v0.0.112)
 
 ## Why?
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2,7 +2,7 @@
 
 > Vera is a statically typed, purely functional programming language designed for large language models to write. It uses typed slot references (@T.n) instead of variable names, requires contracts on every function, and compiles to WebAssembly.
 
-This file contains the core Vera language documentation — language reference, agent instructions, FAQ, error codes, and formal grammar — compiled into a single document. Version 0.0.111. For the full documentation index including the 13-chapter specification and supplementary docs, see llms.txt.
+This file contains the core Vera language documentation — language reference, agent instructions, FAQ, error codes, and formal grammar — compiled into a single document. Version 0.0.112. For the full documentation index including the 13-chapter specification and supplementary docs, see llms.txt.
 
 
 ========================================================================

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -4,7 +4,7 @@
 
 Vera uses De Bruijn indexing for bindings: `@Int.0` is the most recent `Int` binding, `@Int.1` the one before. There are no variable names. Contracts are mandatory — every function must declare `requires(...)`, `ensures(...)`, and `effects(...)`. The Z3 SMT solver verifies contracts statically where possible; remaining contracts become runtime assertions. All side effects (IO, Http, State, Exceptions, Async, Inference) are tracked in the type system via algebraic effects.
 
-Current version: 0.0.111. The reference compiler is written in Python. Install with `pip install -e .` from the repository.
+Current version: 0.0.112. The reference compiler is written in Python. Install with `pip install -e .` from the repository.
 
 ## Language Reference
 

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,31 +2,31 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://veralang.dev/</loc>
-    <lastmod>2026-04-10</lastmod>
+    <lastmod>2026-04-16</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://veralang.dev/SKILL.md</loc>
-    <lastmod>2026-04-10</lastmod>
+    <lastmod>2026-04-16</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://veralang.dev/llms.txt</loc>
-    <lastmod>2026-04-10</lastmod>
+    <lastmod>2026-04-16</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://veralang.dev/llms-full.txt</loc>
-    <lastmod>2026-04-10</lastmod>
+    <lastmod>2026-04-16</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://veralang.dev/index.md</loc>
-    <lastmod>2026-04-10</lastmod>
+    <lastmod>2026-04-16</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.111"
+version = "0.0.112"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -10512,6 +10512,33 @@ public fn main(@Unit -> @Int)
 """
         assert _run(src) == 0  # first element must be false
 
+    def test_shadow_stack_overflow_traps(self) -> None:
+        """Overflow guard traps instead of silently corrupting memory."""
+        src = """
+private fn overflow(@Array<Bool>, @Array<Bool>, @Int -> @Array<Bool>)
+  requires(@Int.0 >= 0)
+  ensures(true)
+  decreases(@Int.0)
+  effects(pure)
+{
+  if @Int.0 <= 0 then { @Array<Bool>.0 }
+  else {
+    overflow(
+      @Array<Bool>.1,
+      array_append(@Array<Bool>.0, false),
+      @Int.0 - 1
+    )
+  }
+}
+
+public fn main(@Unit -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  array_length(overflow([false], [false], 2000))
+}
+"""
+        _run_trap(src)
+
     def test_deep_array_accumulation_preserves_content(self) -> None:
         """Verify array content is fully preserved after deep accumulation."""
         src = """

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -10539,8 +10539,8 @@ public fn main(@Unit -> @Int)
 """
         _run_trap(src)
 
-    def test_deep_array_accumulation_preserves_content(self) -> None:
-        """Verify array content is fully preserved after deep accumulation."""
+    def test_deep_array_accumulation_preserves_length(self) -> None:
+        """Verify array length is correct after deep single-param accumulation."""
         src = """
 private fn build_acc(@Array<Bool>, @Int -> @Array<Bool>)
   requires(@Int.0 >= 0)

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -1652,13 +1652,13 @@ public fn main(@Unit -> @Unit)
 { IO.print("hello") }
 """
         result = _compile_ok(source)
-        # "hello" is 5 bytes; GC adds 8192 (4K shadow stack + 4K worklist)
-        # so heap_ptr should start at 5 + 8192 = 8197
+        # "hello" is 5 bytes; GC adds 32768 (16K shadow stack + 16K worklist)
+        # so heap_ptr should start at 5 + 32768 = 32773
         assert "global $heap_ptr" in result.wat
-        assert "i32.const 8197" in result.wat
+        assert "i32.const 32773" in result.wat
 
     def test_heap_ptr_zero_without_strings(self) -> None:
-        """Without strings, heap starts at GC offset 8192."""
+        """Without strings, heap starts at GC offset 32768."""
         source = """\
 private data Flag { On, Off }
 
@@ -1667,7 +1667,7 @@ public fn f(-> @Int)
 { 42 }
 """
         result = _compile_ok(source)
-        assert "i32.const 8192)" in result.wat  # heap_ptr init
+        assert "i32.const 32768)" in result.wat  # heap_ptr init
 
     def test_alloc_alignment_logic(self) -> None:
         """Alloc function contains 8-byte alignment rounding."""
@@ -10463,3 +10463,74 @@ public fn main(-> @Int)
 }
 """
         assert _run(src) == 3  # 3 + 0
+
+
+class TestGCShadowStackOverflow:
+    """Regression tests for #464: deep recursive array accumulation
+    overflowing the GC shadow stack into the worklist region.
+
+    With a 4K shadow stack, build_acc (2 Array<Bool> params + 1 array_append
+    dst = 12 bytes/frame) overflows at ~341 frames.  The overflow corrupted
+    the GC worklist, causing incorrect mark/sweep and silent data corruption
+    in the first few array elements.
+
+    Fixed by increasing the shadow stack to 16K and adding an overflow guard.
+    """
+
+    def test_deep_array_accumulation_bool(self) -> None:
+        """450-deep recursion with Array<Bool> accumulator."""
+        src = """
+private fn build_acc(@Array<Bool>, @Array<Bool>, @Int -> @Array<Bool>)
+  requires(@Int.0 >= 0)
+  ensures(true)
+  decreases(@Int.0)
+  effects(pure)
+{
+  if @Int.0 <= 0 then { @Array<Bool>.0 }
+  else {
+    build_acc(
+      @Array<Bool>.1,
+      array_append(@Array<Bool>.0, false),
+      @Int.0 - 1
+    )
+  }
+}
+
+private fn first_bool(@Array<Bool> -> @Int)
+  requires(array_length(@Array<Bool>.0) > 0)
+  ensures(true)
+  effects(pure)
+{
+  if @Array<Bool>.0[0] then { 1 } else { 0 }
+}
+
+public fn main(@Unit -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  first_bool(build_acc([false], [false, false, false], 450))
+}
+"""
+        assert _run(src) == 0  # first element must be false
+
+    def test_deep_array_accumulation_preserves_content(self) -> None:
+        """Verify array content is fully preserved after deep accumulation."""
+        src = """
+private fn build_acc(@Array<Bool>, @Int -> @Array<Bool>)
+  requires(@Int.0 >= 0)
+  ensures(true)
+  decreases(@Int.0)
+  effects(pure)
+{
+  if @Int.0 <= 0 then { @Array<Bool>.0 }
+  else {
+    build_acc(array_append(@Array<Bool>.0, false), @Int.0 - 1)
+  }
+}
+
+public fn main(@Unit -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  array_length(build_acc([], 500))
+}
+"""
+        assert _run(src) == 500

--- a/uv.lock
+++ b/uv.lock
@@ -559,7 +559,7 @@ wheels = [
 
 [[package]]
 name = "vera"
-version = "0.0.111"
+version = "0.0.112"
 source = { editable = "." }
 dependencies = [
     { name = "lark" },

--- a/vera/README.md
+++ b/vera/README.md
@@ -538,9 +538,9 @@ Memory is managed automatically. The allocator and garbage collector are impleme
 
 ```
 [0, data_end)            String constants (data section)
-[data_end, +4096)        GC shadow stack (1024 root slots)
-[data_end+4096, +8192)   GC mark worklist (1024 entries)
-[data_end+8192, ...)     Heap (objects with 4-byte headers)
+[data_end, +16K)         GC shadow stack (4096 root slots)
+[data_end+16K, +32K)     GC mark worklist (4096 entries)
+[data_end+32K, ...)      Heap (objects with 4-byte headers)
 ```
 
 **Allocator** (`$alloc` in `assembly.py`): Bump allocator with free-list overlay. Each allocation prepends a 4-byte header (`mark_bit | size << 1`). Allocation tries free-list first-fit, then bump, triggers GC on OOM, falls back to `memory.grow`.
@@ -550,7 +550,7 @@ Memory is managed automatically. The allocator and garbage collector are impleme
 2. **Mark** — seed worklist from shadow stack roots, drain iteratively; any i32 word that looks like a valid heap pointer is treated as one (no type descriptors needed)
 3. **Sweep** — walk heap, link unmarked objects into free list
 
-**Shadow stack** (`gc_shadow_push` in `helpers.py`): WASM has no stack scanning, so the compiler pushes live heap pointers explicitly. `_compile_fn` in `functions.py` emits a prologue (save `$gc_sp`, push pointer params) and epilogue (save return, restore `$gc_sp`, push return back). Allocation sites in `data.py`, `closures.py`, and `calls.py` push newly allocated pointers after each `call $alloc`.
+**Shadow stack** (`gc_shadow_push` in `helpers.py`): WASM has no stack scanning, so the compiler pushes live heap pointers explicitly. `_compile_fn` in `functions.py` emits a prologue (save `$gc_sp`, push pointer params) and epilogue (save return, restore `$gc_sp`, push return back). Allocation sites in `data.py`, `closures.py`, and `calls.py` push newly allocated pointers after each `call $alloc`. An overflow guard (`$gc_sp >= $gc_stack_limit`) traps if the shadow stack would overflow into the worklist region — this prevents silent GC corruption during deep recursion (#464).
 
 **Zero overhead:** The GC infrastructure (globals, shadow stack, worklist, `$gc_collect`) is only emitted when `needs_alloc` is True. Programs that perform no heap allocation have no GC overhead.
 

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,4 +1,4 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.111"
-version = "0.0.111"
+__version__ = "0.0.112"
+version = "0.0.112"

--- a/vera/codegen/assembly.py
+++ b/vera/codegen/assembly.py
@@ -216,7 +216,9 @@ class AssemblyMixin:
         if self._needs_alloc:
             data_end = self.string_pool.heap_offset
             gc_stack_base = data_end
-            gc_heap_start = data_end + 8192  # 4K shadow stack + 4K worklist
+            gc_stack_size = 16384  # 16K shadow stack
+            gc_worklist_size = 16384  # 16K worklist (4096 entries)
+            gc_heap_start = data_end + gc_stack_size + gc_worklist_size
             parts.append(
                 f"  (global $heap_ptr (export \"heap_ptr\") "
                 f"(mut i32) (i32.const {gc_heap_start}))"
@@ -228,6 +230,11 @@ class AssemblyMixin:
             parts.append(
                 f"  (global $gc_stack_base i32 "
                 f"(i32.const {gc_stack_base}))"
+            )
+            gc_stack_limit = gc_stack_base + gc_stack_size
+            parts.append(
+                f"  (global $gc_stack_limit i32 "
+                f"(i32.const {gc_stack_limit}))"
             )
             parts.append(
                 f"  (global $gc_heap_start i32 "
@@ -484,7 +491,7 @@ class AssemblyMixin:
           2. Mark from shadow-stack roots (iterative, conservative).
           3. Sweep: link unmarked objects into the free list.
         """
-        # Worklist region sits at gc_stack_base + 4096, size 4096 (1024 entries)
+        # Worklist region sits right after shadow stack, sized to match
         return (
             "  (func $gc_collect\n"
             "    (local $ptr i32)\n"
@@ -498,16 +505,12 @@ class AssemblyMixin:
             "    (local $obj_ptr i32)\n"
             "    (local $free_head i32)\n"
             "\n"
-            "    ;; Worklist region: gc_stack_base + 4096 .. +8192\n"
-            "    global.get $gc_stack_base\n"
-            "    i32.const 4096\n"
-            "    i32.add\n"
+            "    ;; Worklist region: gc_stack_limit .. gc_heap_start\n"
+            "    global.get $gc_stack_limit\n"
             "    local.set $wl_base\n"
             "    local.get $wl_base\n"
             "    local.set $wl_ptr\n"
-            "    local.get $wl_base\n"
-            "    i32.const 4096\n"
-            "    i32.add\n"
+            "    global.get $gc_heap_start\n"
             "    local.set $wl_end\n"
             "\n"
             "    ;; === Phase 1: Clear all mark bits ===\n"

--- a/vera/wasm/helpers.py
+++ b/vera/wasm/helpers.py
@@ -114,11 +114,17 @@ def gc_shadow_push(local_idx: int) -> list[str]:
     """Generate WAT instructions to push an i32 value onto the GC shadow stack.
 
     Stores the value from ``local_idx`` at the current shadow-stack
-    pointer (``$gc_sp``) and advances ``$gc_sp`` by 4 bytes.  These
-    instructions are stack-neutral (consume nothing, produce nothing)
-    and can be inserted at any point in the instruction stream.
+    pointer (``$gc_sp``) and advances ``$gc_sp`` by 4 bytes.  Traps
+    if the push would overflow the shadow stack into the GC worklist
+    region.
     """
     return [
+        "global.get $gc_sp",
+        "global.get $gc_stack_limit",
+        "i32.ge_u",
+        "if",
+        "  unreachable",  # shadow stack overflow
+        "end",
         "global.get $gc_sp",
         f"local.get {local_idx}",
         "i32.store",


### PR DESCRIPTION
## Summary
- Fix #464: recursive functions with multiple `Array` parameters overflowed the 4K GC shadow stack into the adjacent worklist region, causing silent data corruption in array elements 0-3
- Increase shadow stack from 4K to 16K (handles ~1,365 frames at 12 bytes each)
- Increase GC worklist from 4K to 16K (proportional)
- Add overflow guard in `gc_shadow_push` — traps with `unreachable` instead of silently corrupting memory
- Add 2 regression tests for deep array accumulation (3,250 → 3,252 tests)

## Root cause

The GC shadow stack and worklist are adjacent regions in linear memory. Each recursive frame of a function with 2 `Array<Bool>` parameters pushes 12 bytes (2 pointer params + 1 `array_append` destination). At 450 recursion depth (e.g. Conway's Game of Life on a 30x15 grid), the shadow stack overflowed at frame ~341 into the worklist region.

When GC triggered during the deep recursion, Phase 2's root scan and worklist push operated on the same memory — a concurrent read-write corruption. Intermediate arrays from deep frames weren't marked as roots, were swept (freed), and their first bytes were overwritten with free-list pointers.

## Files changed
- `vera/codegen/assembly.py` — shadow stack size, `$gc_stack_limit` global, worklist offset
- `vera/wasm/helpers.py` — overflow guard in `gc_shadow_push`
- `tests/test_codegen.py` — 2 regression tests + updated heap offset assertions
- `TESTING.md`, `ROADMAP.md` — doc count updates

## Test plan
- [x] Full Game of Life reproduction program now produces correct output
- [x] Glider-only variant also correct
- [x] 2 new regression tests pass
- [x] Full test suite: 3,241 passed, 11 skipped
- [x] mypy clean
- [x] All 23 pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented silent corruption by adding a guard that traps on GC shadow‑stack overflow and adjusted GC memory layout to avoid overlap.

* **Tests**
  * Added regression tests for deep recursion and shadow‑stack overflow.
  * Updated total test count to 3,253 (passed tests 3,242).

* **Documentation**
  * Bumped project to v0.0.112 and updated ROADMAP, TESTING, CHANGELOG, HISTORY and README metrics and GC memory‑layout docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->