### PR TITLE
Release v0.0.113: docs updates for calls.py decomposition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.113] - 2026-04-16
+
+### Changed
+- **Decompose `vera/wasm/calls.py` into 8 subsystem mixins** ([#418](https://github.com/aallan/vera/issues/418)) — the 8,390-line `calls.py` monolith is split into a small core dispatcher (572 lines) plus 8 domain-focused mixins: `calls_math.py` (numeric + conversions), `calls_markup.py` (JSON/HTML/Markdown/Regex/async), `calls_arrays.py`, `calls_handlers.py` (Show/Hash/handle), `calls_containers.py` (Map/Set/Decimal), `calls_parsing.py`, `calls_encoding.py` (base64/URL), `calls_strings.py`. Pure code motion — `WasmContext` continues to compose all mixins via Python MRO; no behavioral changes, runtime output identical. Makes `calls.py` 93% smaller and prepares ground for Stage 11 primitives additions. Closes [#418](https://github.com/aallan/vera/issues/418).
+
+### Known issues
+- **10 pre-existing bugs in WASM call translators** surfaced during review of [#474](https://github.com/aallan/vera/pull/474) — all predate this release; tracked in [#475](https://github.com/aallan/vera/issues/475). See `KNOWN_ISSUES.md` for the summary; the issue lists each bug with severity, location, and description.
+
 ## [0.0.112] - 2026-04-16
 
 ### Fixed
@@ -1554,7 +1562,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Grammar: handler body simplified to avoid LALR reduce/reduce conflict
 - `pyproject.toml`: corrected build backend, package discovery, PEP 639 compliance
 
-[Unreleased]: https://github.com/aallan/vera/compare/v0.0.112...HEAD
+[Unreleased]: https://github.com/aallan/vera/compare/v0.0.113...HEAD
+[0.0.113]: https://github.com/aallan/vera/compare/v0.0.112...v0.0.113
 [0.0.112]: https://github.com/aallan/vera/compare/v0.0.111...v0.0.112
 [0.0.111]: https://github.com/aallan/vera/compare/v0.0.110...v0.0.111
 [0.0.110]: https://github.com/aallan/vera/compare/v0.0.109...v0.0.110

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -242,7 +242,8 @@ Stage 11 shifts focus from evaluation infrastructure to the standard library and
 
 | Version | Date | What shipped |
 |---------|------|-------------|
-| — | 16 Apr | **Fix GC shadow stack overflow** (#464) — 4K shadow stack overflowed into the GC worklist during deep recursive array accumulation (450+ frames), causing silent corruption of the first array elements. Shadow stack increased to 16K with overflow guard trap. |
+| v0.0.112 | 16 Apr | **Fix GC shadow stack overflow** ([#464](https://github.com/aallan/vera/issues/464)) — 4K shadow stack overflowed into the GC worklist during deep recursive array accumulation (450+ frames), causing silent corruption of the first array elements. Shadow stack increased to 16K with overflow guard trap. |
+| v0.0.113 | 16 Apr | **Decompose `calls.py` into 8 subsystem mixins** ([#418](https://github.com/aallan/vera/issues/418)) — split the 8,390-line `vera/wasm/calls.py` monolith into a 572-line core dispatcher plus domain mixins (math, markup, arrays, handlers, containers, parsing, encoding, strings). Pure code motion — no behavioral changes. Prepares the codebase for Stage 11's ~40 new built-in primitives (#463, #366, #466, #467, #470, #471). Review surfaced 10 pre-existing bugs tracked in [#475](https://github.com/aallan/vera/issues/475). |
 
 ---
 
@@ -269,7 +270,7 @@ Alongside the compiler, editor support and AI discoverability infrastructure wer
 
 ## By the numbers
 
-| Metric | v0.0.1 (23 Feb) | v0.0.9 (23 Feb) | v0.0.39 (27 Feb) | v0.0.65 (4 Mar) | v0.0.88 (12 Mar) | v0.0.101 (27 Mar) | v0.0.111 (11 Apr) |
+| Metric | v0.0.1 (23 Feb) | v0.0.9 (23 Feb) | v0.0.39 (27 Feb) | v0.0.65 (4 Mar) | v0.0.88 (12 Mar) | v0.0.101 (27 Mar) | v0.0.113 (16 Apr) |
 |--------|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
 | Compiler layers | Parser | 5 (full pipeline) | 5 + modules | 5 + modules + GC | 5 + modules + GC + browser | 5 + modules + GC + browser | 5 + modules + GC + browser |
 | Tests | ~50 | ~300 | ~600 | ~1,400 | ~2,300 | 3,095 | 3,253 |
@@ -279,4 +280,4 @@ Alongside the compiler, editor support and AI discoverability infrastructure wer
 | Spec chapters | 7 | 10 | 11 | 12 | 13 | 13 | 13 |
 | Code coverage | — | — | — | 90% | 91% | 96% | 96% |
 
-Total: **800+ commits, 112 tagged releases, 40 active development days.**
+Total: **810+ commits, 113 tagged releases, 40 active development days.**

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -44,7 +44,6 @@ Files that have grown beyond a comfortable size and need decomposition. None of 
 
 | File | Lines | Refactoring | Issue |
 |------|-------|-------------|-------|
-| `vera/wasm/calls.py` | 8,337 | Split into subsystem mixins: strings, arrays, containers, encoding, parsing, conversions, math, markup, decimal | [#418](https://github.com/aallan/vera/issues/418) |
 | `tests/test_codegen.py` | 10,019 | Split into feature-focused test files (literals, arithmetic, control flow, strings, arrays, collections, effects, data types) | [#419](https://github.com/aallan/vera/issues/419) |
 | `tests/test_checker.py` | 5,522 | Split into phase-focused test files (types, functions, effects, contracts, modules, errors) | [#420](https://github.com/aallan/vera/issues/420) |
 | `vera/codegen/api.py` | 2,228 | Extract memory layout utilities → `memory.py`; extract host runtime → `runtime.py` | [#421](https://github.com/aallan/vera/issues/421) |

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ cp /path/to/vera/SKILL.md ~/.claude/skills/vera-language/SKILL.md
 
 ## Project status
 
-Vera is in **active development** at v0.0.112 — 800+ commits, 112 releases, 3,253 tests, 96% code coverage, 73 conformance programs, 30 examples, and a 13-chapter specification. See **[HISTORY.md](HISTORY.md)** for how the compiler was built.
+Vera is in **active development** at v0.0.113 — 810+ commits, 113 releases, 3,253 tests, 96% code coverage, 73 conformance programs, 30 examples, and a 13-chapter specification. See **[HISTORY.md](HISTORY.md)** for how the compiler was built.
 
 The reference compiler — parser, AST, type checker, contract verifier (Z3), WASM code generator, module system, browser runtime, and runtime contract insertion — is working. The language specification is in draft across [13 chapters](spec/).
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -187,6 +187,7 @@ These are not milestone-gated — they should be addressed continuously alongsid
 | Add mutation testing with mutmut (detection only) | [#387](https://github.com/aallan/vera/issues/387) | 2–4 hours | Measures whether 3,253 tests catch real bugs, not just execute paths |
 | Investigate parser fuzzing with Atheris | [#402](https://github.com/aallan/vera/issues/402) | 4–8 hours | Crash-inducing inputs for parser and type checker |
 | Improve browser runtime test coverage to >80% | [#349](https://github.com/aallan/vera/issues/349) | 2–4 hours | Parity with Python-side coverage gate |
+| Add `check_changelog_updated.py` pre-push hook + CI check | [#478](https://github.com/aallan/vera/issues/478) | 30–60 min | Fails PRs that touch `vera/`/`spec/`/`SKILL.md` without a CHANGELOG entry; prevents the #474 miss from recurring |
 
 
 ### Verification depth

--- a/docs/index.html
+++ b/docs/index.html
@@ -730,7 +730,7 @@
         For Agents → SKILL.md
       </a>
     </div>
-    <p style="display: flex; justify-content: center; align-items: center; gap: 0.5rem; margin-top: 1rem; font-size: 0.9rem; color: var(--brown-400);">Current Version: <a href="https://github.com/aallan/vera/releases/tag/v0.0.112" style="color: var(--brown-500); font-weight: 500;">v0.0.112</a> <a href="https://github.com/aallan/vera/actions/workflows/ci.yml" style="display: flex;"><img src="https://github.com/aallan/vera/actions/workflows/ci.yml/badge.svg" alt="CI" style="height: 20px;"></a></p>
+    <p style="display: flex; justify-content: center; align-items: center; gap: 0.5rem; margin-top: 1rem; font-size: 0.9rem; color: var(--brown-400);">Current Version: <a href="https://github.com/aallan/vera/releases/tag/v0.0.113" style="color: var(--brown-500); font-weight: 500;">v0.0.113</a> <a href="https://github.com/aallan/vera/actions/workflows/ci.yml" style="display: flex;"><img src="https://github.com/aallan/vera/actions/workflows/ci.yml/badge.svg" alt="CI" style="height: 20px;"></a></p>
   </div>
 
   <!-- Why -->

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 > Vera is a statically typed, purely functional programming language designed for large language models to write. It uses typed slot references (`@T.n`) instead of variable names, requires contracts on every function, and compiles to WebAssembly.
 
-**Current version:** [0.0.112](https://github.com/aallan/vera/releases/tag/v0.0.112)
+**Current version:** [0.0.113](https://github.com/aallan/vera/releases/tag/v0.0.113)
 
 ## Why?
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2,7 +2,7 @@
 
 > Vera is a statically typed, purely functional programming language designed for large language models to write. It uses typed slot references (@T.n) instead of variable names, requires contracts on every function, and compiles to WebAssembly.
 
-This file contains the core Vera language documentation — language reference, agent instructions, FAQ, error codes, and formal grammar — compiled into a single document. Version 0.0.112. For the full documentation index including the 13-chapter specification and supplementary docs, see llms.txt.
+This file contains the core Vera language documentation — language reference, agent instructions, FAQ, error codes, and formal grammar — compiled into a single document. Version 0.0.113. For the full documentation index including the 13-chapter specification and supplementary docs, see llms.txt.
 
 
 ========================================================================

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -4,7 +4,7 @@
 
 Vera uses De Bruijn indexing for bindings: `@Int.0` is the most recent `Int` binding, `@Int.1` the one before. There are no variable names. Contracts are mandatory — every function must declare `requires(...)`, `ensures(...)`, and `effects(...)`. The Z3 SMT solver verifies contracts statically where possible; remaining contracts become runtime assertions. All side effects (IO, Http, State, Exceptions, Async, Inference) are tracked in the type system via algebraic effects.
 
-Current version: 0.0.112. The reference compiler is written in Python. Install with `pip install -e .` from the repository.
+Current version: 0.0.113. The reference compiler is written in Python. Install with `pip install -e .` from the repository.
 
 ## Language Reference
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.112"
+version = "0.0.113"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -559,7 +559,7 @@ wheels = [
 
 [[package]]
 name = "vera"
-version = "0.0.112"
+version = "0.0.113"
 source = { editable = "." }
 dependencies = [
     { name = "lark" },

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,4 +1,4 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.112"
-version = "0.0.112"
+__version__ = "0.0.113"
+version = "0.0.113"


### PR DESCRIPTION
## Summary

Documentation updates that **should have been included in #474**. I skipped the release prep on the refactor PR — this catches it up.

- **Version bump** to 0.0.113 across `__init__.py`, `pyproject.toml`, `docs/index.html`, `README.md`
- **CHANGELOG.md**: add v0.0.113 entry for the refactor + note about #475 (pre-existing bugs surfaced in review)
- **HISTORY.md**: add v0.0.113 row to Stage 11 table; update by-the-numbers header to v0.0.113; bump commit and release totals
- **KNOWN_ISSUES.md**: remove the #418 "Refactoring needed" row (now done)
- **README.md**: update version and release count (810+ commits, 113 releases)
- **Site assets**: regenerated
- **uv.lock**: regenerated for v0.0.113

## Verification

- [x] `check_version_sync.py`: Version 0.0.113 is consistent across 4 files
- [x] `check_site_assets.py`: Site assets are up-to-date
- [x] `check_doc_counts.py`: Documentation counts are consistent
- [x] mypy clean
- [x] 3,242 tests pass, 11 skipped
- [x] All 23 pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Version bumped to v0.0.113 and package metadata updated.
  * Added a pre-push/CI check to require changelog updates for certain project changes.

* **Documentation**
  * Added a v0.0.113 release entry and updated changelog compare links.
  * Updated project status and release/commit counts in README and history.
  * Cleared a previously listed refactoring item from the known-issues list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->