### PR TITLE
Add check_changelog_updated.py: pre-push + CI CHANGELOG enforcement (Closes #478)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          # Full history so check_changelog_updated.py can diff against
+          # origin/main.  Other lint checks work fine without it.
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Set up Python
@@ -83,6 +86,14 @@ jobs:
 
       - name: Install dependencies
         run: pip install -e ".[dev]"
+
+      - name: Check CHANGELOG updated for substantive changes
+        # PR-level escape hatch: adding the "skip-changelog" label
+        # skips this step for PRs that legitimately don't need an entry
+        # (e.g., a typo fix in a code comment).  The step always runs
+        # for push events on main.
+        if: github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'skip-changelog')
+        run: python scripts/check_changelog_updated.py
 
       - name: Check conformance suite
         run: python scripts/check_conformance.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -132,3 +132,17 @@ repos:
         language: system
         pass_filenames: false
         files: '(vera/browser/.*|vera/codegen/api\.py$|vera/wasm/markdown\.py$|vera/markdown\.py$)'
+
+      # Pre-push stage: runs once before `git push`, not per-commit.
+      # Checks that PRs touching substantive code (vera/, spec/, SKILL.md)
+      # also include a new CHANGELOG entry.  Escape hatches: a
+      # "Skip-changelog: <reason>" trailer in any commit on the branch,
+      # or SKIP_CHANGELOG_LABEL=1 in the environment (used by CI when a
+      # skip-changelog PR label has been detected).
+      - id: check-changelog-updated
+        name: check CHANGELOG updated for substantive changes
+        entry: .venv/bin/python scripts/check_changelog_updated.py
+        language: system
+        pass_filenames: false
+        stages: [pre-push]
+        always_run: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- **CHANGELOG enforcement at pre-push and CI** ([#478](https://github.com/aallan/vera/issues/478)) — new `scripts/check_changelog_updated.py` fails a PR if any substantive file (`vera/`, `spec/`, `SKILL.md`) is changed without a matching new entry in `CHANGELOG.md`. Runs at the `pre-push` hook stage locally (opt in with `pre-commit install --hook-type pre-push`) and in the CI `lint` job. Escape hatches: a `Skip-changelog: <reason>` commit trailer (Git-native) or a `skip-changelog` PR label (CI-only). Prevents the kind of missed release-prep that happened on [#474](https://github.com/aallan/vera/pull/474).
+
 ## [0.0.113] - 2026-04-16
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,9 @@ dependencies. CI enforces that `uv.lock` stays current.
 
 ### Pre-commit Hooks
 
-After running `pre-commit install` (and `pre-commit install --hook-type pre-push` for pre-push hooks), every commit is automatically checked by 24 hooks including:
+Every push is checked by 24 hooks across two stages: 23 run on every commit after `pre-commit install`, and 1 (`check-changelog-updated`, described below) runs only at push time after `pre-commit install --hook-type pre-push`.
+
+The **commit-time** hooks (23) include:
 
 - Trailing whitespace and file endings
 - YAML/TOML validity

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,7 @@ python -m venv .venv
 source .venv/bin/activate
 pip install -e ".[dev]"
 pre-commit install
+pre-commit install --hook-type pre-push
 ```
 
 For reproducible installs with hash-pinned versions, use `uv` instead (recommended):
@@ -75,6 +76,7 @@ For reproducible installs with hash-pinned versions, use `uv` instead (recommend
 pip install uv
 uv sync
 pre-commit install
+pre-commit install --hook-type pre-push
 ```
 
 `uv.lock` is checked in and tracks exact versions with hashes. Run `uv lock --check` to verify
@@ -83,7 +85,7 @@ dependencies. CI enforces that `uv.lock` stays current.
 
 ### Pre-commit Hooks
 
-After running `pre-commit install`, every commit is automatically checked by 23 hooks including:
+After running `pre-commit install` (and `pre-commit install --hook-type pre-push` for pre-push hooks), every commit is automatically checked by 24 hooks including:
 
 - Trailing whitespace and file endings
 - YAML/TOML validity
@@ -100,6 +102,19 @@ After running `pre-commit install`, every commit is automatically checked by 23 
 - Browser parity (JS runtime matches Python runtime)
 
 If you modify documentation sources (SKILL.md, AGENTS.md, FAQ.md, `vera/errors.py`, `vera/grammar.lark`, or `docs/index.html`), the `site-assets` hook will regenerate `docs/` files via `scripts/build_site.py`. The CI also runs `scripts/check_site_assets.py` to verify freshness.
+
+### Pre-push hook: CHANGELOG enforcement
+
+A separate `pre-push` hook runs once before each `git push` (not per-commit — which would be too noisy on feature branches). It verifies that any PR touching substantive code (`vera/`, `spec/`, `SKILL.md`) also adds a new entry to `CHANGELOG.md`. The same check also runs in CI, so pushes without the local hook installed are still caught before merge.
+
+**To enable locally:** `pre-commit install --hook-type pre-push` (part of the install instructions above).
+
+**Escape hatches** for PRs that genuinely don't need a CHANGELOG entry (e.g. fixing a typo in a code comment):
+
+- Include a `Skip-changelog: <reason>` trailer in any commit message on the branch (Git-native — works locally and in CI), or
+- Add the `skip-changelog` label to the PR on GitHub (CI-only).
+
+**Configuration:** Override the base ref with `CHANGELOG_CHECK_BASE=<ref>` if you're working on a non-`main` release branch.
 
 ### Running Tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,9 @@ If you modify documentation sources (SKILL.md, AGENTS.md, FAQ.md, `vera/errors.p
 
 ### Pre-push hook: CHANGELOG enforcement
 
-A separate `pre-push` hook runs once before each `git push` (not per-commit — which would be too noisy on feature branches). It verifies that any PR touching substantive code (`vera/`, `spec/`, `SKILL.md`) also adds a new entry to `CHANGELOG.md`. The same check also runs in CI, so pushes without the local hook installed are still caught before merge.
+A separate `pre-push` hook runs once before each `git push` (not per-commit — which would be too noisy on feature branches). It verifies that any PR touching a non-exempt top-level path adds a new entry to `CHANGELOG.md`. The same check also runs in CI, so pushes without the local hook installed are still caught before merge.
+
+**Classification.** The check is exempt-list based: changes confined to `tests/`, `scripts/`, `.github/`, `docs/`, `examples/`, `editors/`, `assets/`; to any of the root-level doc files (`README.md`, `HISTORY.md`, `ROADMAP.md`, `KNOWN_ISSUES.md`, `FAQ.md`, `CONTRIBUTING.md`, `TESTING.md`, `AGENTS.md`, `CLAUDE.md`, `DE_BRUIJN.md`, `EXAMPLES.md`, `CHANGELOG.md`, `LICENSE`); or to `pyproject.toml`, `uv.lock`, `.pre-commit-config.yaml`, `.coderabbit.yaml`, `.gitignore` skip the requirement. Everything else — `vera/**`, `spec/**`, `SKILL.md`, and any new top-level directory you haven't explicitly added to the exempt list in `scripts/check_changelog_updated.py` — is treated as substantive and needs an entry. The conservative default means contributors get a clear failure rather than a silent bypass when adding a new top-level folder (e.g. `stdlib/` or `runtime/`).
 
 **To enable locally:** `pre-commit install --hook-type pre-push` (part of the install instructions above).
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -244,6 +244,7 @@ Stage 11 shifts focus from evaluation infrastructure to the standard library and
 |---------|------|-------------|
 | v0.0.112 | 16 Apr | **Fix GC shadow stack overflow** ([#464](https://github.com/aallan/vera/issues/464)) — 4K shadow stack overflowed into the GC worklist during deep recursive array accumulation (450+ frames), causing silent corruption of the first array elements. Shadow stack increased to 16K with overflow guard trap. |
 | v0.0.113 | 16 Apr | **Decompose `calls.py` into 8 subsystem mixins** ([#418](https://github.com/aallan/vera/issues/418)) — split the 8,390-line `vera/wasm/calls.py` monolith into a 572-line core dispatcher plus domain mixins (math, markup, arrays, handlers, containers, parsing, encoding, strings). Pure code motion — no behavioral changes. Prepares the codebase for Stage 11's ~40 new built-in primitives (#463, #366, #466, #467, #470, #471). Review surfaced 10 pre-existing bugs tracked in [#475](https://github.com/aallan/vera/issues/475). |
+| — | 16 Apr | **CHANGELOG enforcement at pre-push and CI** ([#478](https://github.com/aallan/vera/issues/478)) — new `scripts/check_changelog_updated.py` fails a PR if any substantive file (`vera/`, `spec/`, `SKILL.md`) is changed without a matching new entry in `CHANGELOG.md`. Runs at the `pre-push` hook stage locally and in the CI `lint` job. Escape hatches: `Skip-changelog:` commit trailer (Git-native) or `skip-changelog` PR label (CI-only). Prevents the #474 release-prep miss from recurring. |
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@ See [HISTORY.md](HISTORY.md) for a narrative account of how the compiler was bui
 
 ## Where we are
 
-The compiler is complete end-to-end: parse, type-check, verify contracts via Z3, compile to WebAssembly, and run — at the command line and in the browser. The language has 122 built-in functions, algebraic effects (IO, Http, State, Exceptions, Async, Inference), constrained generics, a module system, contract-driven testing, and a canonical formatter. Type inference for bare constructors (`None`, `Err`, `Ok`) now works correctly across all call sites. The compiler has 3,316 tests, 73 conformance programs, 30 examples, and a 13-chapter specification.
+The compiler is complete end-to-end: parse, type-check, verify contracts via Z3, compile to WebAssembly, and run — at the command line and in the browser. The language has 122 built-in functions, algebraic effects (IO, Http, State, Exceptions, Async, Inference), constrained generics, a module system, contract-driven testing, and a canonical formatter. Type inference for bare constructors (`None`, `Err`, `Ok`) now works correctly across all call sites. The compiler has 3,318 tests, 73 conformance programs, 30 examples, and a 13-chapter specification.
 
 Significant progress has been made towards Vera being a viable agent target. [VeraBench](https://github.com/aallan/vera-bench) — a 50-problem benchmark across 5 difficulty tiers — now covers 6 models across 3 providers (v0.0.7). The headline result: Kimi K2.5 achieves 100% run_correct on Vera, beating both Python (86%) and TypeScript (91%). Three models beat TypeScript on Vera. The flagship tier averages 93% Vera run_correct vs 93% Python — essentially parity. These are single-run results with high variance; stable rates will require pass@k evaluation. The remaining gaps are empirical breadth (repeated trials, more models), standard library depth (HTTP hardening, server effects), and tooling integration (LSP).
 
@@ -184,7 +184,7 @@ These are not milestone-gated — they should be addressed continuously alongsid
 | Item | Issue | Effort | Impact |
 |------|-------|--------|--------|
 | Add property-based testing with Hypothesis | [#386](https://github.com/aallan/vera/issues/386) | 2–4 hours | Catches parser/formatter edge cases via round-trip properties |
-| Add mutation testing with mutmut (detection only) | [#387](https://github.com/aallan/vera/issues/387) | 2–4 hours | Measures whether 3,316 tests catch real bugs, not just execute paths |
+| Add mutation testing with mutmut (detection only) | [#387](https://github.com/aallan/vera/issues/387) | 2–4 hours | Measures whether 3,318 tests catch real bugs, not just execute paths |
 | Investigate parser fuzzing with Atheris | [#402](https://github.com/aallan/vera/issues/402) | 4–8 hours | Crash-inducing inputs for parser and type checker |
 | Improve browser runtime test coverage to >80% | [#349](https://github.com/aallan/vera/issues/349) | 2–4 hours | Parity with Python-side coverage gate |
 | Add `check_changelog_updated.py` pre-push hook + CI check | [#478](https://github.com/aallan/vera/issues/478) | 30–60 min | Fails PRs that touch `vera/`/`spec/`/`SKILL.md` without a CHANGELOG entry; prevents the #474 miss from recurring |
@@ -227,4 +227,4 @@ The compiler was built through ten development phases from February to March 202
 | C8.5 | v0.0.66–v0.0.88 | **Completeness** — builtins, IO runtime, types, effects, browser target | Done |
 | C9 | v0.0.89–v0.0.101 | **Abilities, standard library, data types, effects** — Eq/Ord/Hash/Show, Map/Set, JSON, HTML, Markdown, Http, Decimal, Inference, standard prelude, combinators, higher-order array ops | Done |
 
-**810+ commits, 113 tagged releases, 3,316 tests, 96% coverage, 73 conformance programs, 30 examples, 13 spec chapters.** See [HISTORY.md](HISTORY.md) for the full narrative of how the compiler was built.
+**810+ commits, 113 tagged releases, 3,318 tests, 96% coverage, 73 conformance programs, 30 examples, 13 spec chapters.** See [HISTORY.md](HISTORY.md) for the full narrative of how the compiler was built.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@ See [HISTORY.md](HISTORY.md) for a narrative account of how the compiler was bui
 
 ## Where we are
 
-The compiler is complete end-to-end: parse, type-check, verify contracts via Z3, compile to WebAssembly, and run — at the command line and in the browser. The language has 122 built-in functions, algebraic effects (IO, Http, State, Exceptions, Async, Inference), constrained generics, a module system, contract-driven testing, and a canonical formatter. Type inference for bare constructors (`None`, `Err`, `Ok`) now works correctly across all call sites. The compiler has 3,253 tests, 73 conformance programs, 30 examples, and a 13-chapter specification.
+The compiler is complete end-to-end: parse, type-check, verify contracts via Z3, compile to WebAssembly, and run — at the command line and in the browser. The language has 122 built-in functions, algebraic effects (IO, Http, State, Exceptions, Async, Inference), constrained generics, a module system, contract-driven testing, and a canonical formatter. Type inference for bare constructors (`None`, `Err`, `Ok`) now works correctly across all call sites. The compiler has 3,307 tests, 73 conformance programs, 30 examples, and a 13-chapter specification.
 
 Significant progress has been made towards Vera being a viable agent target. [VeraBench](https://github.com/aallan/vera-bench) — a 50-problem benchmark across 5 difficulty tiers — now covers 6 models across 3 providers (v0.0.7). The headline result: Kimi K2.5 achieves 100% run_correct on Vera, beating both Python (86%) and TypeScript (91%). Three models beat TypeScript on Vera. The flagship tier averages 93% Vera run_correct vs 93% Python — essentially parity. These are single-run results with high variance; stable rates will require pass@k evaluation. The remaining gaps are empirical breadth (repeated trials, more models), standard library depth (HTTP hardening, server effects), and tooling integration (LSP).
 
@@ -184,7 +184,7 @@ These are not milestone-gated — they should be addressed continuously alongsid
 | Item | Issue | Effort | Impact |
 |------|-------|--------|--------|
 | Add property-based testing with Hypothesis | [#386](https://github.com/aallan/vera/issues/386) | 2–4 hours | Catches parser/formatter edge cases via round-trip properties |
-| Add mutation testing with mutmut (detection only) | [#387](https://github.com/aallan/vera/issues/387) | 2–4 hours | Measures whether 3,253 tests catch real bugs, not just execute paths |
+| Add mutation testing with mutmut (detection only) | [#387](https://github.com/aallan/vera/issues/387) | 2–4 hours | Measures whether 3,307 tests catch real bugs, not just execute paths |
 | Investigate parser fuzzing with Atheris | [#402](https://github.com/aallan/vera/issues/402) | 4–8 hours | Crash-inducing inputs for parser and type checker |
 | Improve browser runtime test coverage to >80% | [#349](https://github.com/aallan/vera/issues/349) | 2–4 hours | Parity with Python-side coverage gate |
 | Add `check_changelog_updated.py` pre-push hook + CI check | [#478](https://github.com/aallan/vera/issues/478) | 30–60 min | Fails PRs that touch `vera/`/`spec/`/`SKILL.md` without a CHANGELOG entry; prevents the #474 miss from recurring |
@@ -227,4 +227,4 @@ The compiler was built through ten development phases from February to March 202
 | C8.5 | v0.0.66–v0.0.88 | **Completeness** — builtins, IO runtime, types, effects, browser target | Done |
 | C9 | v0.0.89–v0.0.101 | **Abilities, standard library, data types, effects** — Eq/Ord/Hash/Show, Map/Set, JSON, HTML, Markdown, Http, Decimal, Inference, standard prelude, combinators, higher-order array ops | Done |
 
-**800+ commits, 112 tagged releases, 3,253 tests, 96% coverage, 73 conformance programs, 30 examples, 13 spec chapters.** See [HISTORY.md](HISTORY.md) for the full narrative of how the compiler was built.
+**810+ commits, 113 tagged releases, 3,307 tests, 96% coverage, 73 conformance programs, 30 examples, 13 spec chapters.** See [HISTORY.md](HISTORY.md) for the full narrative of how the compiler was built.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@ See [HISTORY.md](HISTORY.md) for a narrative account of how the compiler was bui
 
 ## Where we are
 
-The compiler is complete end-to-end: parse, type-check, verify contracts via Z3, compile to WebAssembly, and run — at the command line and in the browser. The language has 122 built-in functions, algebraic effects (IO, Http, State, Exceptions, Async, Inference), constrained generics, a module system, contract-driven testing, and a canonical formatter. Type inference for bare constructors (`None`, `Err`, `Ok`) now works correctly across all call sites. The compiler has 3,307 tests, 73 conformance programs, 30 examples, and a 13-chapter specification.
+The compiler is complete end-to-end: parse, type-check, verify contracts via Z3, compile to WebAssembly, and run — at the command line and in the browser. The language has 122 built-in functions, algebraic effects (IO, Http, State, Exceptions, Async, Inference), constrained generics, a module system, contract-driven testing, and a canonical formatter. Type inference for bare constructors (`None`, `Err`, `Ok`) now works correctly across all call sites. The compiler has 3,316 tests, 73 conformance programs, 30 examples, and a 13-chapter specification.
 
 Significant progress has been made towards Vera being a viable agent target. [VeraBench](https://github.com/aallan/vera-bench) — a 50-problem benchmark across 5 difficulty tiers — now covers 6 models across 3 providers (v0.0.7). The headline result: Kimi K2.5 achieves 100% run_correct on Vera, beating both Python (86%) and TypeScript (91%). Three models beat TypeScript on Vera. The flagship tier averages 93% Vera run_correct vs 93% Python — essentially parity. These are single-run results with high variance; stable rates will require pass@k evaluation. The remaining gaps are empirical breadth (repeated trials, more models), standard library depth (HTTP hardening, server effects), and tooling integration (LSP).
 
@@ -184,7 +184,7 @@ These are not milestone-gated — they should be addressed continuously alongsid
 | Item | Issue | Effort | Impact |
 |------|-------|--------|--------|
 | Add property-based testing with Hypothesis | [#386](https://github.com/aallan/vera/issues/386) | 2–4 hours | Catches parser/formatter edge cases via round-trip properties |
-| Add mutation testing with mutmut (detection only) | [#387](https://github.com/aallan/vera/issues/387) | 2–4 hours | Measures whether 3,307 tests catch real bugs, not just execute paths |
+| Add mutation testing with mutmut (detection only) | [#387](https://github.com/aallan/vera/issues/387) | 2–4 hours | Measures whether 3,316 tests catch real bugs, not just execute paths |
 | Investigate parser fuzzing with Atheris | [#402](https://github.com/aallan/vera/issues/402) | 4–8 hours | Crash-inducing inputs for parser and type checker |
 | Improve browser runtime test coverage to >80% | [#349](https://github.com/aallan/vera/issues/349) | 2–4 hours | Parity with Python-side coverage gate |
 | Add `check_changelog_updated.py` pre-push hook + CI check | [#478](https://github.com/aallan/vera/issues/478) | 30–60 min | Fails PRs that touch `vera/`/`spec/`/`SKILL.md` without a CHANGELOG entry; prevents the #474 miss from recurring |
@@ -227,4 +227,4 @@ The compiler was built through ten development phases from February to March 202
 | C8.5 | v0.0.66–v0.0.88 | **Completeness** — builtins, IO runtime, types, effects, browser target | Done |
 | C9 | v0.0.89–v0.0.101 | **Abilities, standard library, data types, effects** — Eq/Ord/Hash/Show, Map/Set, JSON, HTML, Markdown, Http, Decimal, Inference, standard prelude, combinators, higher-order array ops | Done |
 
-**810+ commits, 113 tagged releases, 3,307 tests, 96% coverage, 73 conformance programs, 30 examples, 13 spec chapters.** See [HISTORY.md](HISTORY.md) for the full narrative of how the compiler was built.
+**810+ commits, 113 tagged releases, 3,316 tests, 96% coverage, 73 conformance programs, 30 examples, 13 spec chapters.** See [HISTORY.md](HISTORY.md) for the full narrative of how the compiler was built.

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,7 +6,7 @@ This is the single source of truth for Vera's testing infrastructure, coverage d
 
 | Metric | Value |
 |--------|-------|
-| **Tests** | 3,316 across 28 files (~34,000 lines of test code; 3,305 passed, 11 skipped) |
+| **Tests** | 3,318 across 28 files (~34,000 lines of test code; 3,307 passed, 11 skipped) |
 | **Compiler code coverage** | 96% of 15,149 statements (CI minimum: 80%) |
 | **Conformance programs** | 73 programs across 9 spec chapters, validating every language feature |
 | **Example programs** | 30, all validated through `vera check` + `vera verify` |
@@ -78,7 +78,7 @@ python scripts/fix_allowlists.py --fix               # auto-fix stale allowlists
 | `test_readme.py` | 2 | 79 | README code sample parsing |
 | `test_html.py` | 4 | 164 | HTML landing page code samples: parse, check, verify |
 | `test_build_site.py` | 17 | 213 | `_abs_links` unit tests: relative link rewriting, fenced block immunity (backtick and tilde fences, inline backticks inside fences), http/https/fragment pass-through, Vera effect syntax not mis-parsed |
-| `test_check_changelog_updated.py` | 63 | 526 | `check_changelog_updated.py` unit + end-to-end tests: file classification (incl. file-style exact-match vs directory-style prefix-match), CHANGELOG diff parsing with `[Unreleased]` section tracking, `Skip-changelog:` trailer detection, temp-repo integration covering substantive/exempt/label/trailer paths |
+| `test_check_changelog_updated.py` | 65 | 572 | `check_changelog_updated.py` unit + end-to-end tests: file classification (incl. file-style exact-match vs directory-style prefix-match), CHANGELOG diff parsing with `[Unreleased]` section tracking and bare-heading rejection, `Skip-changelog:` trailer detection, temp-repo integration covering substantive/exempt/label/trailer paths |
 
 ## Conformance Suite
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,7 +6,7 @@ This is the single source of truth for Vera's testing infrastructure, coverage d
 
 | Metric | Value |
 |--------|-------|
-| **Tests** | 3,253 across 27 files (~34,000 lines of test code; 3,242 passed, 11 skipped) |
+| **Tests** | 3,307 across 28 files (~34,000 lines of test code; 3,296 passed, 11 skipped) |
 | **Compiler code coverage** | 96% of 15,149 statements (CI minimum: 80%) |
 | **Conformance programs** | 73 programs across 9 spec chapters, validating every language feature |
 | **Example programs** | 30, all validated through `vera check` + `vera verify` |
@@ -78,6 +78,7 @@ python scripts/fix_allowlists.py --fix               # auto-fix stale allowlists
 | `test_readme.py` | 2 | 79 | README code sample parsing |
 | `test_html.py` | 4 | 164 | HTML landing page code samples: parse, check, verify |
 | `test_build_site.py` | 17 | 213 | `_abs_links` unit tests: relative link rewriting, fenced block immunity (backtick and tilde fences, inline backticks inside fences), http/https/fragment pass-through, Vera effect syntax not mis-parsed |
+| `test_check_changelog_updated.py` | 54 | 433 | `check_changelog_updated.py` unit + end-to-end tests: file classification, CHANGELOG diff parsing, `Skip-changelog:` trailer detection, temp-repo integration covering substantive/exempt/label/trailer paths |
 
 ## Conformance Suite
 
@@ -373,7 +374,7 @@ Allowlisted entries have stale-detection: when a feature lands or a spec edit sh
 
 ## Pre-commit Hooks
 
-After running `pre-commit install`, every commit is checked by 23 hooks:
+After running `pre-commit install`, every commit is checked by 24 hooks:
 
 | Hook | What it does |
 |------|-------------|

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,7 +6,7 @@ This is the single source of truth for Vera's testing infrastructure, coverage d
 
 | Metric | Value |
 |--------|-------|
-| **Tests** | 3,307 across 28 files (~34,000 lines of test code; 3,296 passed, 11 skipped) |
+| **Tests** | 3,316 across 28 files (~34,000 lines of test code; 3,305 passed, 11 skipped) |
 | **Compiler code coverage** | 96% of 15,149 statements (CI minimum: 80%) |
 | **Conformance programs** | 73 programs across 9 spec chapters, validating every language feature |
 | **Example programs** | 30, all validated through `vera check` + `vera verify` |
@@ -78,7 +78,7 @@ python scripts/fix_allowlists.py --fix               # auto-fix stale allowlists
 | `test_readme.py` | 2 | 79 | README code sample parsing |
 | `test_html.py` | 4 | 164 | HTML landing page code samples: parse, check, verify |
 | `test_build_site.py` | 17 | 213 | `_abs_links` unit tests: relative link rewriting, fenced block immunity (backtick and tilde fences, inline backticks inside fences), http/https/fragment pass-through, Vera effect syntax not mis-parsed |
-| `test_check_changelog_updated.py` | 54 | 433 | `check_changelog_updated.py` unit + end-to-end tests: file classification, CHANGELOG diff parsing, `Skip-changelog:` trailer detection, temp-repo integration covering substantive/exempt/label/trailer paths |
+| `test_check_changelog_updated.py` | 63 | 526 | `check_changelog_updated.py` unit + end-to-end tests: file classification (incl. file-style exact-match vs directory-style prefix-match), CHANGELOG diff parsing with `[Unreleased]` section tracking, `Skip-changelog:` trailer detection, temp-repo integration covering substantive/exempt/label/trailer paths |
 
 ## Conformance Suite
 
@@ -374,7 +374,7 @@ Allowlisted entries have stale-detection: when a feature lands or a spec edit sh
 
 ## Pre-commit Hooks
 
-After running `pre-commit install`, every commit is checked by 24 hooks:
+Every push is checked by 24 hooks across two stages: 23 run on every commit after `pre-commit install`, and 1 (`check-changelog-updated`) runs only at push time after `pre-commit install --hook-type pre-push`. Full list:
 
 | Hook | What it does |
 |------|-------------|

--- a/scripts/check_changelog_updated.py
+++ b/scripts/check_changelog_updated.py
@@ -136,6 +136,25 @@ def _changed_files(base: str) -> list[str]:
     return [line for line in stdout.strip().split("\n") if line]
 
 
+def _is_exempt(path: str) -> bool:
+    """Return True iff ``path`` matches any entry in ``EXEMPT_PREFIXES``.
+
+    Entries ending in ``/`` are treated as directory prefixes (matched
+    with ``startswith``).  Entries without a trailing slash are treated
+    as exact file paths (matched with equality).  This prevents
+    accidental overmatching — e.g. ``README.md`` is exempt but
+    ``README.md.bak`` is still treated as substantive.
+    """
+    for entry in EXEMPT_PREFIXES:
+        if entry.endswith("/"):
+            if path.startswith(entry):
+                return True
+        else:
+            if path == entry:
+                return True
+    return False
+
+
 def is_substantive(path: str) -> bool:
     """Return True iff ``path`` is substantive and needs a CHANGELOG entry.
 
@@ -147,28 +166,68 @@ def is_substantive(path: str) -> bool:
     path = path.strip()
     if not path:
         return False
-    return not any(path == p or path.startswith(p) for p in EXEMPT_PREFIXES)
+    return not _is_exempt(path)
 
 
 def _changelog_has_new_entry(base: str) -> bool:
     """Return True if the CHANGELOG.md diff adds a new entry.
 
-    Looks for at least one added line whose content starts with either
-    a bullet (``- ``) or a version heading (``## [``).  This catches
-    the two legitimate ways of adding entries; pure whitespace or
-    cosmetic changes to CHANGELOG.md don't count.
+    A "new entry" is either:
+
+    1. An added line introducing a new version heading (``+## [X.Y.Z]``
+       or ``+## [Unreleased]``).
+    2. An added bullet (``+- ...``) that appears *inside* the
+       ``[Unreleased]`` section.
+
+    Section-tracking is necessary because CHANGELOG.md commonly has
+    prose edits (typo fixes, wording tweaks) inside released-version
+    entries.  Those edits sometimes add bulleted lines, but they
+    shouldn't count as "adding a new entry" for the purposes of this
+    check — only bullets under ``[Unreleased]`` do.
+
+    Pure whitespace or cosmetic changes to CHANGELOG.md don't count.
     """
     diff = _run(["git", "diff", base, "HEAD", "--", "CHANGELOG.md"])
     if not diff:
         return False
+
+    # Track which section header we're currently inside.  The diff
+    # includes both context lines (prefixed with a space) and added
+    # lines (prefixed with ``+``); we update current_section on both
+    # so the tracker reflects the post-diff state of the file.
+    current_section: str | None = None
     for line in diff.splitlines():
-        # ``+++`` is the file header; actual added lines start with a
-        # single ``+`` followed by the content.
-        if not line.startswith("+") or line.startswith("+++"):
+        if line.startswith("+++") or line.startswith("---"):
+            # File headers — ignore entirely.
             continue
-        content = line[1:].lstrip()
-        if content.startswith("- ") or content.startswith("## ["):
-            return True
+
+        # Extract the line content regardless of diff marker.
+        if line.startswith("+") or line.startswith(" "):
+            content = line[1:].lstrip() if len(line) > 1 else ""
+        elif line.startswith("-"):
+            # Removed context — doesn't tell us about the post-diff
+            # section layout.
+            continue
+        else:
+            # Hunk headers (``@@ ... @@``) and other metadata.
+            continue
+
+        if content.startswith("## ["):
+            # Update section tracker — skip past ``## [`` (4 chars) to
+            # the name, up to the closing ``]``.
+            end = content.find("]", 4)
+            if end > 4:
+                current_section = content[4:end]
+            # An *added* version heading is itself a new entry.
+            if line.startswith("+"):
+                return True
+            continue
+
+        # Added bullets only count inside the [Unreleased] section.
+        if line.startswith("+") and content.startswith("- "):
+            if current_section == "Unreleased":
+                return True
+
     return False
 
 

--- a/scripts/check_changelog_updated.py
+++ b/scripts/check_changelog_updated.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python
+"""Verify that substantive PRs update CHANGELOG.md.
+
+Runs at pre-push stage (locally) and in CI.  Compares the current
+branch against the base ref (default ``origin/main``); if any
+"substantive" files changed, requires ``CHANGELOG.md`` to also be
+in the diff with a new entry.
+
+File classification
+-------------------
+
+Substantive (requires a CHANGELOG entry when changed):
+
+- ``vera/**``       compiler source
+- ``spec/**``       language specification
+- ``SKILL.md``      user-facing agent guide
+
+Exempt (changing only these never triggers the check):
+
+- ``tests/``, ``scripts/``, ``.github/``, ``docs/``, ``examples/``
+- ``CHANGELOG.md``, ``HISTORY.md``, ``README.md``, ``ROADMAP.md``,
+  ``KNOWN_ISSUES.md``, ``FAQ.md``, ``CONTRIBUTING.md``, ``TESTING.md``,
+  ``AGENTS.md``, ``CLAUDE.md``, ``DE_BRUIJN.md``, ``EXAMPLES.md``,
+  ``LICENSE``
+- ``pyproject.toml``, ``uv.lock``
+- ``.pre-commit-config.yaml``, ``.coderabbit.yaml``, ``.gitignore``
+
+Any other path is treated as substantive (conservative default so a
+new top-level directory doesn't accidentally bypass the check).
+
+Escape hatches
+--------------
+
+- Commit trailer ``Skip-changelog: <reason>`` in any commit on the
+  branch (git-native — works locally and in CI).
+- Environment variable ``SKIP_CHANGELOG_LABEL=1`` (intended for CI
+  runs where a ``skip-changelog`` PR label has been detected by an
+  earlier workflow step).
+
+Configuration
+-------------
+
+- ``CHANGELOG_CHECK_BASE`` — override the base ref (default
+  ``origin/main``).  Mainly useful for release branches.
+
+Exit codes
+----------
+
+- ``0`` — check passed, skipped, or not applicable (e.g. no diff).
+- ``1`` — substantive changes detected without a matching CHANGELOG
+  update and no escape hatch engaged.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+# Prefixes / exact paths whose changes require a CHANGELOG entry.
+# Anything not exempt is treated as substantive by default, but these
+# are the "obviously substantive" paths used in error messages.
+SUBSTANTIVE_PREFIXES: tuple[str, ...] = (
+    "vera/",
+    "spec/",
+    "SKILL.md",
+)
+
+# Paths that are always exempt from the check.  Changing only files
+# in this list never requires a CHANGELOG entry.
+EXEMPT_PREFIXES: tuple[str, ...] = (
+    # Directories (trailing slash intentional)
+    "tests/",
+    "scripts/",
+    ".github/",
+    "docs/",
+    "examples/",
+    "editors/",
+    "assets/",
+    # Root-level docs
+    "CHANGELOG.md",
+    "HISTORY.md",
+    "README.md",
+    "ROADMAP.md",
+    "KNOWN_ISSUES.md",
+    "FAQ.md",
+    "CONTRIBUTING.md",
+    "TESTING.md",
+    "AGENTS.md",
+    "CLAUDE.md",
+    "DE_BRUIJN.md",
+    "EXAMPLES.md",
+    "LICENSE",
+    # Build + config
+    "pyproject.toml",
+    "uv.lock",
+    ".pre-commit-config.yaml",
+    ".coderabbit.yaml",
+    ".gitignore",
+)
+
+DEFAULT_BASE_REF = "origin/main"
+
+
+def _run(cmd: list[str]) -> str | None:
+    """Run a git command, returning stdout or ``None`` on failure."""
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+    return result.stdout
+
+
+def _resolve_base_ref() -> str | None:
+    """Pick a base ref that actually exists in the local git repo.
+
+    Falls back through ``origin/main``, ``main``, and any explicit
+    override from ``$CHANGELOG_CHECK_BASE``.  Returns ``None`` if
+    nothing usable exists (e.g. running outside a git worktree).
+    """
+    override = os.environ.get("CHANGELOG_CHECK_BASE")
+    candidates = [c for c in (override, DEFAULT_BASE_REF, "main") if c]
+    for ref in candidates:
+        if _run(["git", "rev-parse", "--verify", ref]) is not None:
+            return ref
+    return None
+
+
+def _changed_files(base: str) -> list[str]:
+    """Files changed between ``base`` and ``HEAD``."""
+    stdout = _run(["git", "diff", "--name-only", base, "HEAD"])
+    if stdout is None:
+        return []
+    return [line for line in stdout.strip().split("\n") if line]
+
+
+def is_substantive(path: str) -> bool:
+    """Return True iff ``path`` is substantive and needs a CHANGELOG entry.
+
+    A path is substantive if it does NOT match any ``EXEMPT_PREFIXES``
+    entry.  This is deliberately conservative — a brand-new top-level
+    directory is treated as substantive until explicitly exempted.
+    """
+    # Normalise for robustness (no leading ``./`` etc).
+    path = path.strip()
+    if not path:
+        return False
+    return not any(path == p or path.startswith(p) for p in EXEMPT_PREFIXES)
+
+
+def _changelog_has_new_entry(base: str) -> bool:
+    """Return True if the CHANGELOG.md diff adds a new entry.
+
+    Looks for at least one added line whose content starts with either
+    a bullet (``- ``) or a version heading (``## [``).  This catches
+    the two legitimate ways of adding entries; pure whitespace or
+    cosmetic changes to CHANGELOG.md don't count.
+    """
+    diff = _run(["git", "diff", base, "HEAD", "--", "CHANGELOG.md"])
+    if not diff:
+        return False
+    for line in diff.splitlines():
+        # ``+++`` is the file header; actual added lines start with a
+        # single ``+`` followed by the content.
+        if not line.startswith("+") or line.startswith("+++"):
+            continue
+        content = line[1:].lstrip()
+        if content.startswith("- ") or content.startswith("## ["):
+            return True
+    return False
+
+
+def _has_skip_trailer(base: str) -> bool:
+    """Return True if any commit on the branch has a ``Skip-changelog:`` trailer."""
+    log = _run(["git", "log", f"{base}..HEAD", "--format=%B"])
+    if not log:
+        return False
+    for line in log.splitlines():
+        # Trailers appear at the start of a line, case-sensitive.
+        if line.startswith("Skip-changelog:"):
+            return True
+    return False
+
+
+def main() -> int:
+    base = _resolve_base_ref()
+    if base is None:
+        # No base to diff against — likely running outside a git
+        # worktree (e.g. inside a tarball) or during the very first
+        # commit of a repo.  Skip without failing.
+        print(
+            "check_changelog_updated: no base ref found; skipping.",
+            file=sys.stderr,
+        )
+        return 0
+
+    changed = _changed_files(base)
+    if not changed:
+        return 0
+
+    substantive = [f for f in changed if is_substantive(f)]
+    if not substantive:
+        return 0
+
+    if _changelog_has_new_entry(base):
+        return 0
+
+    if _has_skip_trailer(base):
+        return 0
+
+    if os.environ.get("SKIP_CHANGELOG_LABEL") == "1":
+        return 0
+
+    print(
+        "ERROR: Substantive changes detected but CHANGELOG.md "
+        "is missing a new entry.",
+        file=sys.stderr,
+    )
+    print("", file=sys.stderr)
+    print("Files changed that require a CHANGELOG entry:", file=sys.stderr)
+    for path in substantive[:10]:
+        print(f"  {path}", file=sys.stderr)
+    if len(substantive) > 10:
+        print(f"  ... and {len(substantive) - 10} more", file=sys.stderr)
+    print("", file=sys.stderr)
+    print(
+        "Add a bullet under [Unreleased] in CHANGELOG.md, or include",
+        file=sys.stderr,
+    )
+    print(
+        "'Skip-changelog: <reason>' in a commit message trailer.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_changelog_updated.py
+++ b/scripts/check_changelog_updated.py
@@ -218,8 +218,13 @@ def _changelog_has_new_entry(base: str) -> bool:
             end = content.find("]", 4)
             if end > 4:
                 current_section = content[4:end]
-            # An *added* version heading is itself a new entry.
-            if line.startswith("+"):
+            # An *added* versioned heading (e.g. ``+## [0.0.114]``) is
+            # itself a new entry — that's the release-cutting pattern.
+            # But a bare ``+## [Unreleased]`` heading is just structural
+            # scaffolding; don't short-circuit on it, let the loop
+            # continue so the bullet-under-section check below can
+            # decide whether there's any actual content.
+            if line.startswith("+") and current_section != "Unreleased":
                 return True
             continue
 

--- a/tests/test_check_changelog_updated.py
+++ b/tests/test_check_changelog_updated.py
@@ -125,6 +125,32 @@ class TestIsSubstantive:
         # "testing.md" is not "tests/" either
         assert _mod.is_substantive("testing.md") is True
 
+    @pytest.mark.parametrize("path", [
+        "README.md.bak",
+        "README.md.orig",
+        "CHANGELOG.md.old",
+        "pyproject.toml.backup",
+        ".gitignore.sample",
+    ])
+    def test_file_style_exemptions_require_exact_match(
+        self, path: str,
+    ) -> None:
+        """File-style exempt entries (no trailing slash) must match
+        exactly — a file whose name *starts with* an exempt filename
+        is still substantive.
+
+        Regression test: prior to the fix, ``path.startswith("README.md")``
+        returned True for ``"README.md.bak"``, silently exempting a
+        file that isn't actually README.md.
+        """
+        assert _mod.is_substantive(path) is True
+
+    def test_directory_style_exemptions_match_prefix(self) -> None:
+        """Directory-style entries (trailing slash) still match via prefix."""
+        # tests/ matches anything under the tests/ directory
+        assert _mod.is_substantive("tests/deeply/nested/test_foo.py") is False
+        assert _mod.is_substantive("tests/conformance/manifest.json") is False
+
 
 # ---------------------------------------------------------------------------
 # _changelog_has_new_entry — diff parsing
@@ -197,6 +223,73 @@ class TestChangelogHasNewEntry:
             """)
         monkeypatch.setattr(_mod, "_run", lambda cmd: diff)
         assert _mod._changelog_has_new_entry("origin/main") is False
+
+    def test_bullet_outside_unreleased_does_not_count(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Added bullets inside a *released* version entry are not new entries.
+
+        A prose fix that inserts a bullet into an existing version's
+        description isn't "adding a new entry" — only bullets under the
+        [Unreleased] section (or a new ``## [X.Y.Z]`` heading) count.
+
+        Regression test: prior to the fix, any added ``+- `` line
+        counted, so editing v0.0.111's description would have satisfied
+        the check for any substantive change on the branch.
+        """
+        diff = textwrap.dedent("""\
+            diff --git a/CHANGELOG.md b/CHANGELOG.md
+            @@ -5,7 +5,10 @@
+             ## [Unreleased]
+
+             ## [0.0.111] - 2026-04-10
+
+             ### Fixed
+            +
+            +- Additional clarification bullet on an existing fix.
+             - **SMT translator: String/Float64 parameters**...
+            """)
+        monkeypatch.setattr(_mod, "_run", lambda cmd: diff)
+        assert _mod._changelog_has_new_entry("origin/main") is False
+
+    def test_bullet_under_unreleased_counts(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Added bullet inside [Unreleased] section counts as a new entry."""
+        diff = textwrap.dedent("""\
+            diff --git a/CHANGELOG.md b/CHANGELOG.md
+            @@ -5,6 +5,9 @@
+             ## [Unreleased]
+
+            +### Added
+            +- **New feature** — shipped the thing.
+            +
+             ## [0.0.111] - 2026-04-10
+            """)
+        monkeypatch.setattr(_mod, "_run", lambda cmd: diff)
+        assert _mod._changelog_has_new_entry("origin/main") is True
+
+    def test_unreleased_section_tracking_survives_context(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Section tracker must use context lines, not only added lines.
+
+        If the ``## [Unreleased]`` heading is a context line (pre-existing)
+        and a ``+- `` is added immediately under it, the tracker should
+        have recorded ``Unreleased`` from the context line.
+        """
+        diff = textwrap.dedent("""\
+            diff --git a/CHANGELOG.md b/CHANGELOG.md
+            @@ -6,6 +6,8 @@
+             ## [Unreleased]
+
+            +### Fixed
+            +- Fixed a thing that was broken.
+
+             ## [0.0.111] - 2026-04-10
+            """)
+        monkeypatch.setattr(_mod, "_run", lambda cmd: diff)
+        assert _mod._changelog_has_new_entry("origin/main") is True
 
     def test_no_diff_means_no_entry(
         self, monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_check_changelog_updated.py
+++ b/tests/test_check_changelog_updated.py
@@ -190,6 +190,52 @@ class TestChangelogHasNewEntry:
         monkeypatch.setattr(_mod, "_run", lambda cmd: diff)
         assert _mod._changelog_has_new_entry("origin/main") is True
 
+    def test_bare_unreleased_heading_alone_does_not_count(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An added ``+## [Unreleased]`` alone is structural scaffolding,
+        not a new entry — require a bullet under it to count.
+
+        Regression test: prior to the fix, the heading branch short-
+        circuited on *any* added ``## [`` heading including
+        ``[Unreleased]``, so reorganising a CHANGELOG to add the
+        Unreleased section without any entries would have satisfied
+        the check for any substantive change on the branch.
+        """
+        diff = textwrap.dedent("""\
+            diff --git a/CHANGELOG.md b/CHANGELOG.md
+            @@ -5,6 +5,8 @@
+             The format is based on [Keep a Changelog]...
+
+            +## [Unreleased]
+            +
+             ## [0.0.111] - 2026-04-10
+            """)
+        monkeypatch.setattr(_mod, "_run", lambda cmd: diff)
+        assert _mod._changelog_has_new_entry("origin/main") is False
+
+    def test_added_unreleased_heading_with_bullet_counts(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``+## [Unreleased]`` plus a ``+- `` bullet underneath counts.
+
+        The bullet-under-section branch must pick up the added bullet
+        once the section tracker has recorded ``Unreleased``.
+        """
+        diff = textwrap.dedent("""\
+            diff --git a/CHANGELOG.md b/CHANGELOG.md
+            @@ -5,6 +5,10 @@
+             The format is based on [Keep a Changelog]...
+
+            +## [Unreleased]
+            +### Added
+            +- **Something new** — actually shipped.
+            +
+             ## [0.0.111] - 2026-04-10
+            """)
+        monkeypatch.setattr(_mod, "_run", lambda cmd: diff)
+        assert _mod._changelog_has_new_entry("origin/main") is True
+
     def test_ignores_file_header_lines(
         self, monkeypatch: pytest.MonkeyPatch,
     ) -> None:

--- a/tests/test_check_changelog_updated.py
+++ b/tests/test_check_changelog_updated.py
@@ -1,0 +1,433 @@
+"""Tests for scripts/check_changelog_updated.py.
+
+Covers:
+- ``is_substantive`` classification of file paths (pure function)
+- ``_changelog_has_new_entry`` diff parsing (direct tests with stubbed
+  subprocess calls)
+- ``_has_skip_trailer`` commit-message parsing (direct tests with
+  stubbed subprocess calls)
+- End-to-end behaviour against a temporary git repository that
+  actually exercises the script's subprocess-driven git commands.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Load the script as a module (it's in scripts/, not a package).
+# ---------------------------------------------------------------------------
+
+_SCRIPT = Path(__file__).parent.parent / "scripts" / "check_changelog_updated.py"
+
+
+def _load() -> Any:
+    spec = importlib.util.spec_from_file_location(
+        "check_changelog_updated", _SCRIPT,
+    )
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+_mod = _load()
+
+
+# ---------------------------------------------------------------------------
+# is_substantive — pure classification logic
+# ---------------------------------------------------------------------------
+
+
+class TestIsSubstantive:
+    """Classification of file paths."""
+
+    @pytest.mark.parametrize("path", [
+        "vera/cli.py",
+        "vera/wasm/calls.py",
+        "vera/codegen/api.py",
+        "spec/06-contracts.md",
+        "SKILL.md",
+    ])
+    def test_substantive_paths(self, path: str) -> None:
+        """Files under vera/, spec/, or SKILL.md are substantive."""
+        assert _mod.is_substantive(path) is True
+
+    @pytest.mark.parametrize("path", [
+        # Test files
+        "tests/test_codegen.py",
+        "tests/conformance/ch03_slot_indexing.vera",
+        # Scripts and CI
+        "scripts/check_examples.py",
+        ".github/workflows/ci.yml",
+        # Docs
+        "docs/index.html",
+        "docs/llms.txt",
+        # Examples
+        "examples/hello_world.vera",
+        # Root-level docs
+        "CHANGELOG.md",
+        "HISTORY.md",
+        "README.md",
+        "ROADMAP.md",
+        "KNOWN_ISSUES.md",
+        "FAQ.md",
+        "CONTRIBUTING.md",
+        "TESTING.md",
+        "AGENTS.md",
+        "CLAUDE.md",
+        "DE_BRUIJN.md",
+        "EXAMPLES.md",
+        "LICENSE",
+        # Build + config
+        "pyproject.toml",
+        "uv.lock",
+        ".pre-commit-config.yaml",
+        ".coderabbit.yaml",
+        ".gitignore",
+        # Editors + assets
+        "editors/vscode/package.json",
+        "assets/vera-social-preview.jpg",
+    ])
+    def test_exempt_paths(self, path: str) -> None:
+        """Known exempt paths are not substantive."""
+        assert _mod.is_substantive(path) is False
+
+    @pytest.mark.parametrize("path", [
+        "",
+        "   ",
+    ])
+    def test_empty_paths(self, path: str) -> None:
+        """Empty / whitespace paths are not substantive (can't be classified)."""
+        assert _mod.is_substantive(path) is False
+
+    def test_unknown_toplevel_is_substantive(self) -> None:
+        """Conservative default: unknown top-level dirs trigger the check."""
+        # A hypothetical future directory that we forgot to classify
+        # should be treated as substantive, not silently skipped.
+        assert _mod.is_substantive("stdlib/something.py") is True
+        assert _mod.is_substantive("runtime/init.c") is True
+
+    def test_path_prefix_matching_is_boundary_aware(self) -> None:
+        """A file starting with the same letters as an exempt prefix is
+        not automatically exempt (prefix must include the boundary)."""
+        # "testsuite/" is not "tests/", so it should be substantive
+        assert _mod.is_substantive("testsuite/foo.py") is True
+        # "testing.md" is not "tests/" either
+        assert _mod.is_substantive("testing.md") is True
+
+
+# ---------------------------------------------------------------------------
+# _changelog_has_new_entry — diff parsing
+# ---------------------------------------------------------------------------
+
+
+class TestChangelogHasNewEntry:
+    """Diff-parsing logic for CHANGELOG.md."""
+
+    def test_detects_new_bullet(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An added bullet line counts as a new entry."""
+        diff = textwrap.dedent("""\
+            diff --git a/CHANGELOG.md b/CHANGELOG.md
+            @@ -7,6 +7,7 @@
+             ## [Unreleased]
+            +
+            +- **New feature** — added the thing ([#999](https://...)).
+
+             ## [0.0.111] - 2026-04-10
+            """)
+        monkeypatch.setattr(_mod, "_run", lambda cmd: diff)
+        assert _mod._changelog_has_new_entry("origin/main") is True
+
+    def test_detects_new_version_heading(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An added ``## [X.Y.Z]`` heading counts as a new entry."""
+        diff = textwrap.dedent("""\
+            diff --git a/CHANGELOG.md b/CHANGELOG.md
+            @@ -7,6 +7,8 @@
+             ## [Unreleased]
+
+            +## [0.0.200] - 2026-05-01
+            +
+             ## [0.0.111] - 2026-04-10
+            """)
+        monkeypatch.setattr(_mod, "_run", lambda cmd: diff)
+        assert _mod._changelog_has_new_entry("origin/main") is True
+
+    def test_ignores_file_header_lines(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``+++`` (file header) must not be confused with ``+`` (added line)."""
+        diff = textwrap.dedent("""\
+            diff --git a/CHANGELOG.md b/CHANGELOG.md
+            --- a/CHANGELOG.md
+            +++ b/CHANGELOG.md
+            @@ -7,6 +7,6 @@
+             ## [Unreleased]
+
+             ## [0.0.111] - 2026-04-10
+            """)
+        monkeypatch.setattr(_mod, "_run", lambda cmd: diff)
+        # Only the +++ line was "added" — no real entry.
+        assert _mod._changelog_has_new_entry("origin/main") is False
+
+    def test_ignores_cosmetic_changes(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Whitespace-only or prose-only changes do not count as entries."""
+        diff = textwrap.dedent("""\
+            diff --git a/CHANGELOG.md b/CHANGELOG.md
+            @@ -1,5 +1,5 @@
+             # Changelog
+
+            -All notable changes to this project will be documented in this file.
+            +All notable changes to this project are documented in this file.
+
+             The format is based on...
+            """)
+        monkeypatch.setattr(_mod, "_run", lambda cmd: diff)
+        assert _mod._changelog_has_new_entry("origin/main") is False
+
+    def test_no_diff_means_no_entry(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Empty diff (file untouched) returns False."""
+        monkeypatch.setattr(_mod, "_run", lambda cmd: "")
+        assert _mod._changelog_has_new_entry("origin/main") is False
+
+    def test_git_failure_returns_false(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """If git fails (``_run`` returns None) we treat CHANGELOG as unchanged."""
+        monkeypatch.setattr(_mod, "_run", lambda cmd: None)
+        assert _mod._changelog_has_new_entry("origin/main") is False
+
+
+# ---------------------------------------------------------------------------
+# _has_skip_trailer — commit-message parsing
+# ---------------------------------------------------------------------------
+
+
+class TestHasSkipTrailer:
+    """Detection of the ``Skip-changelog:`` trailer in commit messages."""
+
+    def test_detects_trailer(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        log = textwrap.dedent("""\
+            Fix some internal typo
+
+            Skip-changelog: cosmetic comment update only
+
+            Co-Authored-By: Claude <noreply@anthropic.invalid>
+            """)
+        monkeypatch.setattr(_mod, "_run", lambda cmd: log)
+        assert _mod._has_skip_trailer("origin/main") is True
+
+    def test_absent_trailer(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        log = textwrap.dedent("""\
+            Add feature X
+
+            This does a thing.
+
+            Co-Authored-By: Claude <noreply@anthropic.invalid>
+            """)
+        monkeypatch.setattr(_mod, "_run", lambda cmd: log)
+        assert _mod._has_skip_trailer("origin/main") is False
+
+    def test_must_be_line_start(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Mention of 'Skip-changelog:' in prose does not count."""
+        log = (
+            "Some commit\n"
+            "\n"
+            "I considered using Skip-changelog: but decided not to.\n"
+        )
+        monkeypatch.setattr(_mod, "_run", lambda cmd: log)
+        assert _mod._has_skip_trailer("origin/main") is False
+
+    def test_empty_log(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(_mod, "_run", lambda cmd: "")
+        assert _mod._has_skip_trailer("origin/main") is False
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: run the script against a real temporary git repo.
+# ---------------------------------------------------------------------------
+
+
+def _git(cwd: Path, *args: str) -> None:
+    """Run ``git <args>`` in ``cwd``; raise if it fails."""
+    subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+    )
+
+
+def _setup_repo(tmp_path: Path) -> Path:
+    """Create a tiny git repo with one commit on ``main`` mirroring the
+    project layout (so file classification works).
+
+    The repo has:
+
+    - ``CHANGELOG.md``  — minimal valid structure with ``[Unreleased]``
+    - ``vera/cli.py``    — a substantive file
+    - ``tests/t.py``     — an exempt file
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.invalid")
+    _git(repo, "config", "user.name", "Test User")
+    _git(repo, "config", "commit.gpgsign", "false")
+
+    (repo / "CHANGELOG.md").write_text(
+        "# Changelog\n\n## [Unreleased]\n\n## [0.0.1] - 2026-01-01\n",
+    )
+    (repo / "vera").mkdir()
+    (repo / "vera" / "cli.py").write_text("# placeholder\n")
+    (repo / "tests").mkdir()
+    (repo / "tests" / "t.py").write_text("# placeholder\n")
+
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "Initial")
+    return repo
+
+
+def _run_script(repo: Path, **env_overrides: str) -> subprocess.CompletedProcess[str]:
+    """Run the check script inside ``repo``, diffing against local ``main``."""
+    env = os.environ.copy()
+    # Use local ``main`` instead of ``origin/main`` (no remote in the temp repo).
+    env["CHANGELOG_CHECK_BASE"] = "main"
+    # Strip out the repo-level env vars inherited from pre-commit, if any.
+    for key in ("SKIP_CHANGELOG_LABEL",):
+        env.pop(key, None)
+    env.update(env_overrides)
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT)],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+class TestEndToEnd:
+    """Run the script against temporary git repos."""
+
+    def test_passes_when_no_changes(self, tmp_path: Path) -> None:
+        """No diff vs base → pass."""
+        repo = _setup_repo(tmp_path)
+        result = _run_script(repo)
+        assert result.returncode == 0, result.stderr
+
+    def test_passes_with_only_exempt_changes(self, tmp_path: Path) -> None:
+        """Touching only exempt files doesn't require a CHANGELOG entry."""
+        repo = _setup_repo(tmp_path)
+        _git(repo, "checkout", "-b", "feature")
+        (repo / "tests" / "t.py").write_text("# modified\n")
+        _git(repo, "commit", "-am", "Tweak test")
+        result = _run_script(repo)
+        assert result.returncode == 0, result.stderr
+
+    def test_fails_when_substantive_without_changelog(
+        self, tmp_path: Path,
+    ) -> None:
+        """Touching vera/ without CHANGELOG → fail with helpful message."""
+        repo = _setup_repo(tmp_path)
+        _git(repo, "checkout", "-b", "feature")
+        (repo / "vera" / "cli.py").write_text("# modified\n")
+        _git(repo, "commit", "-am", "Tweak cli")
+        result = _run_script(repo)
+        assert result.returncode == 1
+        assert "CHANGELOG.md" in result.stderr
+        assert "vera/cli.py" in result.stderr
+
+    def test_passes_when_substantive_with_changelog(
+        self, tmp_path: Path,
+    ) -> None:
+        """Touching vera/ AND adding a CHANGELOG bullet → pass."""
+        repo = _setup_repo(tmp_path)
+        _git(repo, "checkout", "-b", "feature")
+        (repo / "vera" / "cli.py").write_text("# modified\n")
+        (repo / "CHANGELOG.md").write_text(
+            "# Changelog\n\n"
+            "## [Unreleased]\n\n"
+            "- **Tweaked the CLI** — did a thing.\n\n"
+            "## [0.0.1] - 2026-01-01\n",
+        )
+        _git(repo, "commit", "-am", "Tweak cli")
+        result = _run_script(repo)
+        assert result.returncode == 0, result.stderr
+
+    def test_skip_trailer_bypasses_check(self, tmp_path: Path) -> None:
+        """``Skip-changelog:`` trailer lets substantive changes pass."""
+        repo = _setup_repo(tmp_path)
+        _git(repo, "checkout", "-b", "feature")
+        (repo / "vera" / "cli.py").write_text("# cosmetic\n")
+        _git(
+            repo, "commit", "-am",
+            "Fix typo in comment\n\nSkip-changelog: cosmetic only",
+        )
+        result = _run_script(repo)
+        assert result.returncode == 0, result.stderr
+
+    def test_skip_label_env_var_bypasses_check(
+        self, tmp_path: Path,
+    ) -> None:
+        """``SKIP_CHANGELOG_LABEL=1`` lets substantive changes pass."""
+        repo = _setup_repo(tmp_path)
+        _git(repo, "checkout", "-b", "feature")
+        (repo / "vera" / "cli.py").write_text("# cosmetic\n")
+        _git(repo, "commit", "-am", "Fix typo")
+        result = _run_script(repo, SKIP_CHANGELOG_LABEL="1")
+        assert result.returncode == 0, result.stderr
+
+    def test_explicit_override_falls_back_to_main(
+        self, tmp_path: Path,
+    ) -> None:
+        """An invalid ``CHANGELOG_CHECK_BASE`` falls through to ``main``.
+
+        The fallback chain is ``$CHANGELOG_CHECK_BASE → origin/main → main``,
+        so setting an invalid override doesn't break the check as long as
+        ``main`` (or ``origin/main``) exists.
+        """
+        repo = _setup_repo(tmp_path)
+        result = _run_script(repo, CHANGELOG_CHECK_BASE="nonexistent-ref")
+        # Same behaviour as passing no override — no changes vs main → pass.
+        assert result.returncode == 0
+
+    def test_no_base_ref_at_all_skips_gracefully(
+        self, tmp_path: Path,
+    ) -> None:
+        """No ``main``, no ``origin/main``, no override → skip with warning.
+
+        This covers the edge case of running inside a repo that has
+        neither ``main`` nor ``origin/main`` available (tarball extract,
+        detached HEAD with no branch history fetched, etc.).  The script
+        must exit 0 rather than crashing.
+        """
+        repo = tmp_path / "emptyrepo"
+        repo.mkdir()
+        _git(repo, "init", "-b", "feature")  # no ``main`` branch
+        _git(repo, "config", "user.email", "t@e.invalid")
+        _git(repo, "config", "user.name", "T")
+        _git(repo, "config", "commit.gpgsign", "false")
+        (repo / "f.txt").write_text("x\n")
+        _git(repo, "add", "f.txt")
+        _git(repo, "commit", "-m", "init on feature")
+
+        result = _run_script(repo)
+        assert result.returncode == 0
+        assert "no base ref found" in result.stderr


### PR DESCRIPTION
Closes #478.

## Summary

Adds `scripts/check_changelog_updated.py`, which diffs the current branch against `origin/main` and fails if any substantive file (`vera/`, `spec/`, `SKILL.md`) was changed without a matching new entry in `CHANGELOG.md`. Wired into the pre-commit chain at the `pre-push` stage and into the CI `lint` job.

Catches the kind of missed release-prep that happened on #474 (calls.py decomposition merged without a CHANGELOG entry).

## Files

| File | Kind |
|---|---|
| `scripts/check_changelog_updated.py` | New — ~180 lines |
| `tests/test_check_changelog_updated.py` | New — 54 unit + end-to-end tests |
| `.pre-commit-config.yaml` | New hook at `pre-push` stage |
| `.github/workflows/ci.yml` | New step in `lint` job + `fetch-depth: 0` |
| `CONTRIBUTING.md` | New "Pre-push hook: CHANGELOG enforcement" subsection |
| `TESTING.md` | Hook count 23 → 24, test count 3,253 → 3,307, new row |
| `ROADMAP.md` | Test count + totals line |
| `CHANGELOG.md` | New `[Unreleased] Added` entry |

## Classification

**Substantive** (requires a CHANGELOG entry): `vera/`, `spec/`, `SKILL.md`.

**Exempt**: `tests/`, `scripts/`, `.github/`, `docs/`, `examples/`, `editors/`, `assets/`; all root-level docs (`README.md`, `HISTORY.md`, `ROADMAP.md`, `KNOWN_ISSUES.md`, `FAQ.md`, `CONTRIBUTING.md`, `TESTING.md`, `AGENTS.md`, `CLAUDE.md`, `DE_BRUIJN.md`, `EXAMPLES.md`, `CHANGELOG.md`, `LICENSE`); `pyproject.toml`, `uv.lock`, `.pre-commit-config.yaml`, `.coderabbit.yaml`, `.gitignore`.

**Unknown paths** default to substantive (conservative — a hypothetical new `stdlib/` or `runtime/` folder won't accidentally bypass the check).

## Escape hatches

- **Git-native**: a `Skip-changelog: <reason>` trailer in any commit message on the branch (works locally and in CI).
- **GitHub-native**: add the `skip-changelog` label to the PR (CI-only; the `if:` condition on the step skips it when the label is present).

## Why pre-push, not pre-commit

Feature branches typically have 5–20 commits. Running the check per-commit would block every intermediate commit with "no CHANGELOG entry" — pure friction. Pre-push gives the whole branch's worth of commits before checking. Enable locally with `pre-commit install --hook-type pre-push` (CONTRIBUTING.md updated).

## Self-test

Running the script on this PR exits 0 — all files touched are exempt. The CHANGELOG entry added here is a bonus (following project convention for CI tooling, mirroring the v0.0.107 pattern), not a requirement. The substantive-without-CHANGELOG path is covered by the end-to-end pytest suite against temp git repos.

## Verification

- [x] `check_changelog_updated.py` self-test (exit 0)
- [x] mypy clean
- [x] 3,296 tests pass (54 new), 11 skipped
- [x] doc counts consistent (3,307 tests, 24 hooks)
- [x] version sync + site assets clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated CHANGELOG enforcement running in CI and as an optional local pre-push check.

* **Chores**
  * Enforced CHANGELOG updates for substantive repository changes; opt-out via a commit trailer or PR label.

* **Tests**
  * Added comprehensive unit and end-to-end tests covering changelog-check logic and real git scenarios.

* **Documentation**
  * Updated CONTRIBUTING, CHANGELOG, TESTING, ROADMAP and HISTORY to document the checks, setup and escape hatches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->