### PR TITLE
Add "What's next" section to ROADMAP (Stage 11 implementation order)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,6 +14,44 @@ Significant progress has been made towards Vera being a viable agent target. [Ve
 
 ---
 
+## What's next — short-term priorities
+
+This section captures the concrete implementation order for Stage 11 work, ahead of the longer-term milestones below. The phase numbering in the milestones (Phase 4a/4b/4c etc.) reflects **strategic grouping** — what kind of feature it is and which broader goal it serves. It does **not** reflect implementation order. This section is where implementation order lives.
+
+### The ordering principle
+
+Early-stage Stage 11 issues fall into two categories:
+
+- **Capability-expansion** — unlocks *new kinds of programs that aren't possible today*. No hand-rolled workaround exists; the language literally can't do the thing. Examples: [#463](https://github.com/aallan/vera/issues/463) (`IO.sleep` / `IO.time` / `IO.stderr`), [#465](https://github.com/aallan/vera/issues/465) (Random effect), [#467](https://github.com/aallan/vera/issues/467) (log/sin/cos/constants).
+- **Error-reduction / ergonomic** — the program is already possible but verbose, bug-prone, or fragile. Hand-rolled recursive accumulators, manual ASCII range checks, nested Option/Json unwraps. Examples: [#466](https://github.com/aallan/vera/issues/466) (array utilities), [#470](https://github.com/aallan/vera/issues/470) / [#471](https://github.com/aallan/vera/issues/471) (string + char), [#366](https://github.com/aallan/vera/issues/366) (JSON accessors).
+
+Both matter, but they're asymmetric in timing: capability gaps are *blocking* (entire program categories don't exist), ergonomic gaps are *annoying* (programs compound verbosity). Blocking issues front-load more value per hour because they unlock whole genres of program. Early-stage: fix blockers first; later-stage: polish ergonomics.
+
+Empirical confirmation from a model writing Conway's Game of Life in Vera during Stage 11 planning:
+
+> "The bug fix plus `IO.sleep` and Random are transformative. With `IO.sleep` I can write a proper animation loop… With Random I can generate a random soup initial state instead of hardcoding a glider and blinker, which is dramatically more interesting to watch. The program goes from 'dump 20 static frames' to 'animated random cellular automaton that runs in your terminal.' From [#466](https://github.com/aallan/vera/issues/466), `array_any` is useful for detecting extinction, and `array_contains` could simplify some checks, but neither is essential. From [#470](https://github.com/aallan/vera/issues/470), `string_pad_start` would let me right-align the generation counter — minor polish."
+
+This reshaped the ordering: capability issues move up, ergonomic issues move down, and the prerequisite structural refactor [#480](https://github.com/aallan/vera/issues/480) stays at the top.
+
+### Implementation order
+
+| Order | Issue | Why now |
+|:---:|---|---|
+| 1 | [#480](https://github.com/aallan/vera/issues/480) — Reimplement higher-order array ops as iterative WASM | **Structural prerequisite.** If the new combinators in [#466](https://github.com/aallan/vera/issues/466) ship before this, they inherit recursive-Vera implementations that hit the same class of bugs as [#464](https://github.com/aallan/vera/issues/464) and have to be migrated later. Establishing the iterative pattern first means [#466](https://github.com/aallan/vera/issues/466)'s new combinators follow it from day one. |
+| 2 | [#463](https://github.com/aallan/vera/issues/463) — `IO.sleep` / `IO.time` / `IO.stderr` | **Capability unlock, smallest scope.** Three one-row additions to an existing effect. Enables animation loops, elapsed-time measurement, and stderr-separated CLI tools. Lowest risk, highest capability-per-hour of work. |
+| 3 | [#465](https://github.com/aallan/vera/issues/465) — Random effect | **Capability unlock, larger scope.** New effect (requires `EffectInfo` registration, grammar-level checks, handler plumbing, browser runtime). Unlocks non-determinism, simulation, randomised testing. |
+| 4 | [#467](https://github.com/aallan/vera/issues/467) — Math built-ins (log, sin, cos, …) | **Capability unlock, bulk addition.** ~14 pure host imports following the same pattern. Unlocks graphics, physics, statistics. |
+| 5 | [#466](https://github.com/aallan/vera/issues/466) — Array utilities (sort, mapi, reverse, …) | **Highest benchmark-score win.** Eliminates the recursive-accumulator-with-indexed-state pattern — the dominant LLM failure mode per VeraBench. Requires [#480](https://github.com/aallan/vera/issues/480) done first. |
+| 6 | [#470](https://github.com/aallan/vera/issues/470) — String utilities | `string_chars` is a bridge primitive (unlocks array-combinator approach to string processing). Rest is polish. |
+| 7 | [#471](https://github.com/aallan/vera/issues/471) — Character classification | Tiny, can ship alongside any of the above. Eliminates brittle ASCII range checks. |
+| 8 | [#366](https://github.com/aallan/vera/issues/366) — JSON typed accessors | Replaces nested Option/Json unwrap ceremony. Polish tier for the Inference/Http pipeline. |
+
+### What moves when
+
+Completed items get deleted from this table and noted in [HISTORY.md](HISTORY.md) as usual. When the Stage 11 primitives are mostly shipped and the table shrinks to ~3 items, this section should be re-evaluated — it's intended to be a rolling view of the next few weeks, not a permanent roadmap layer.
+
+---
+
 ## Milestone 1: Prove the thesis
 
 *Goal: answer the fundamental question — do LLMs write better code in Vera than in existing languages? Build the evidence base and fix the friction points that block honest evaluation.*

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,18 +16,18 @@ Significant progress has been made towards Vera being a viable agent target. [Ve
 
 ## What's next — short-term priorities
 
-This section captures the concrete implementation order for Stage 11 work, ahead of the longer-term milestones below. The phase numbering in the milestones (Phase 4a/4b/4c etc.) reflects **strategic grouping** — what kind of feature it is and which broader goal it serves. It does **not** reflect implementation order. This section is where implementation order lives.
+This section captures the concrete **implementation order** for the next few weeks of work. The phase numbering in the milestones below (Phase 4a/4b/4c etc.) reflects **strategic grouping** — what kind of feature it is and which broader goal it serves — and is stable across releases. Implementation order shifts as empirical evidence arrives, so it lives here rather than as a reordering of the milestones.
 
 ### The ordering principle
 
-Early-stage Stage 11 issues fall into two categories:
+The near-term queue mixes issues from two categories:
 
 - **Capability-expansion** — unlocks *new kinds of programs that aren't possible today*. No hand-rolled workaround exists; the language literally can't do the thing. Examples: [#463](https://github.com/aallan/vera/issues/463) (`IO.sleep` / `IO.time` / `IO.stderr`), [#465](https://github.com/aallan/vera/issues/465) (Random effect), [#467](https://github.com/aallan/vera/issues/467) (log/sin/cos/constants).
 - **Error-reduction / ergonomic** — the program is already possible but verbose, bug-prone, or fragile. Hand-rolled recursive accumulators, manual ASCII range checks, nested Option/Json unwraps. Examples: [#466](https://github.com/aallan/vera/issues/466) (array utilities), [#470](https://github.com/aallan/vera/issues/470) / [#471](https://github.com/aallan/vera/issues/471) (string + char), [#366](https://github.com/aallan/vera/issues/366) (JSON accessors).
 
-Both matter, but they're asymmetric in timing: capability gaps are *blocking* (entire program categories don't exist), ergonomic gaps are *annoying* (programs compound verbosity). Blocking issues front-load more value per hour because they unlock whole genres of program. Early-stage: fix blockers first; later-stage: polish ergonomics.
+Both matter, but they're asymmetric in timing: capability gaps are *blocking* (entire program categories don't exist), ergonomic gaps are *annoying* (programs compound verbosity). Blocking issues front-load more value per hour because they unlock whole genres of program. The current state of the language is "most programs possible, some categories blocked" — so capability-expansion goes first, ergonomic polish follows.
 
-Empirical confirmation from a model writing Conway's Game of Life in Vera during Stage 11 planning:
+Empirical confirmation from a model writing Conway's Game of Life in Vera while this queue was being planned:
 
 > "The bug fix plus `IO.sleep` and Random are transformative. With `IO.sleep` I can write a proper animation loop… With Random I can generate a random soup initial state instead of hardcoding a glider and blinker, which is dramatically more interesting to watch. The program goes from 'dump 20 static frames' to 'animated random cellular automaton that runs in your terminal.' From [#466](https://github.com/aallan/vera/issues/466), `array_any` is useful for detecting extinction, and `array_contains` could simplify some checks, but neither is essential. From [#470](https://github.com/aallan/vera/issues/470), `string_pad_start` would let me right-align the generation counter — minor polish."
 
@@ -48,7 +48,7 @@ This reshaped the ordering: capability issues move up, ergonomic issues move dow
 
 ### What moves when
 
-Completed items get deleted from this table and noted in [HISTORY.md](HISTORY.md) as usual. When the Stage 11 primitives are mostly shipped and the table shrinks to ~3 items, this section should be re-evaluated — it's intended to be a rolling view of the next few weeks, not a permanent roadmap layer.
+Completed items get deleted from this table and noted in [HISTORY.md](HISTORY.md) as usual. When the table shrinks to ~3 items the section should be re-evaluated and repopulated from the next batch of priorities — it's intended to be a rolling view of the next few weeks, not a permanent roadmap layer.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -190,7 +190,7 @@ These are not strictly required for the MCP demo but would make it more compelli
 - [#270](https://github.com/aallan/vera/issues/270) **`handle[Async]`** — custom scheduling strategies for async effect handlers.
 - [#228](https://github.com/aallan/vera/issues/228) **WebSocket/SSE** — streaming clients for real-time data feeds and LLM streaming responses.
 - [#227](https://github.com/aallan/vera/issues/227) **Timeout effect** — `<Timeout>` for cancellation and deadline management.
-- [#463](https://github.com/aallan/vera/issues/463) **`IO.sleep` operation** — millisecond delay via `IO.sleep(@Nat)`. Essential for animation loops, rate limiting, and polling. Discovered missing while writing Conway's Game of Life.
+- [#463](https://github.com/aallan/vera/issues/463) **`IO.sleep`, `IO.time`, `IO.stderr` operations** — millisecond delay (`IO.sleep(@Nat) -> Unit`), current time (`IO.time(@Unit) -> @Nat`), and stderr output (`IO.stderr(@String) -> Unit`). Three one-row additions to the `IO` effect. Enables animation loops, elapsed-time measurement, frame-budget computation, and stderr-separated CLI tools. Discovered missing while writing Conway's Game of Life.
 
 ### Phase 4b: Ecosystem
 

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,31 +2,31 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://veralang.dev/</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://veralang.dev/SKILL.md</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://veralang.dev/llms.txt</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://veralang.dev/llms-full.txt</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://veralang.dev/index.md</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>


### PR DESCRIPTION
Tiny docs-only PR that captures the Stage 11 implementation order ahead of the longer-term milestone structure.

The phase numbering in milestones (Phase 4a/4b/4c) reflects strategic grouping. It does not reflect the order we plan to tackle things in. This section is where implementation order lives — a rolling view of the next few weeks.

## Why add this now

While planning #480/#463/#465, a model writing Conway's Game of Life gave concrete feedback that reshaped the priority ordering: capability-expansion issues (IO.sleep, Random, math) move ahead of error-reduction issues (array/string utilities) because they unlock entire genres of program rather than just reducing error rate on existing programs. Worth writing down before it gets lost.

## What's in the section

- The capability-vs-ergonomics framing
- The empirical agent quote that motivated the reordering
- An 8-row implementation table from #480 (structural prerequisite) through #366 (polish)
- A note that this is meant to rotate out as items ship

## Verification

- [x] doc counts consistent (3,319 tests, 28 files, 73 conformance, 30 examples, 24 hooks, 7 CI jobs)
- [x] site assets up to date
- [x] all pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Roadmap updated with a new short-term priorities section that defines two issue categories (capability-expansion vs error-reduction/ergonomic), an ordering principle prioritising blocking capability gaps before ergonomic improvements, a fixed implementation-order table of upcoming items with guidance to refresh as work completes, and an expanded Milestone note clarifying planned IO-related operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->