### PR TITLE
Emit iterative WASM for array_filter (#480 PR 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Changed
+- **Iterative WASM `array_filter`** ([#480](https://github.com/aallan/vera/issues/480) PR 2) — `array_filter<T>(arr, pred)` is now emitted as a single WAT `loop` with a separate `write_idx`, replacing the recursive prelude (`array_filter` / `array_filter_go`). Worst-case over-allocates `len * sizeof(T)` bytes and returns `(dst, write_idx)`; the unused tail is unreachable via the returned pair and gets reclaimed by the sweeper. Single-pass by design — the predicate is invoked exactly once per element. Shadow-stack usage is now O(1). Follows the same pattern as PR 1 (`array_map`); `array_fold` to follow in PR 3.
 - **Iterative WASM `array_map`** ([#480](https://github.com/aallan/vera/issues/480) PR 1) — `array_map<A, B>(arr, fn)` is now emitted as a single WAT `loop` driven by a `call_indirect` on the closure, replacing the recursive prelude implementation (`array_map_go`). Shadow-stack usage is now O(1) regardless of input length — the old recursive version hit the 16K shadow-stack ceiling (post-[#464](https://github.com/aallan/vera/issues/464)) around 4K elements. The generic higher-order signature (`forall<A, B>`) is preserved via a `FunctionInfo` built-in registration, so source code is unchanged. Also discovered and filed [#484](https://github.com/aallan/vera/issues/484) — a pre-existing 16-bit GC-header size-field limits allocations to 65535 bytes; the stress test caps at 8K Int elements (64,000 bytes) until that's fixed.
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@ See [HISTORY.md](HISTORY.md) for a narrative account of how the compiler was bui
 
 ## Where we are
 
-The compiler is complete end-to-end: parse, type-check, verify contracts via Z3, compile to WebAssembly, and run — at the command line and in the browser. The language has 122 built-in functions, algebraic effects (IO, Http, State, Exceptions, Async, Inference), constrained generics, a module system, contract-driven testing, and a canonical formatter. Type inference for bare constructors (`None`, `Err`, `Ok`) now works correctly across all call sites. The compiler has 3,324 tests, 73 conformance programs, 30 examples, and a 13-chapter specification.
+The compiler is complete end-to-end: parse, type-check, verify contracts via Z3, compile to WebAssembly, and run — at the command line and in the browser. The language has 122 built-in functions, algebraic effects (IO, Http, State, Exceptions, Async, Inference), constrained generics, a module system, contract-driven testing, and a canonical formatter. Type inference for bare constructors (`None`, `Err`, `Ok`) now works correctly across all call sites. The compiler has 3,330 tests, 73 conformance programs, 30 examples, and a 13-chapter specification.
 
 Significant progress has been made towards Vera being a viable agent target. [VeraBench](https://github.com/aallan/vera-bench) — a 50-problem benchmark across 5 difficulty tiers — now covers 6 models across 3 providers (v0.0.7). The headline result: Kimi K2.5 achieves 100% run_correct on Vera, beating both Python (86%) and TypeScript (91%). Three models beat TypeScript on Vera. The flagship tier averages 93% Vera run_correct vs 93% Python — essentially parity. These are single-run results with high variance; stable rates will require pass@k evaluation. The remaining gaps are empirical breadth (repeated trials, more models), standard library depth (HTTP hardening, server effects), and tooling integration (LSP).
 
@@ -223,7 +223,7 @@ These are not milestone-gated — they should be addressed continuously alongsid
 | Item | Issue | Effort | Impact |
 |------|-------|--------|--------|
 | Add property-based testing with Hypothesis | [#386](https://github.com/aallan/vera/issues/386) | 2–4 hours | Catches parser/formatter edge cases via round-trip properties |
-| Add mutation testing with mutmut (detection only) | [#387](https://github.com/aallan/vera/issues/387) | 2–4 hours | Measures whether 3,324 tests catch real bugs, not just execute paths |
+| Add mutation testing with mutmut (detection only) | [#387](https://github.com/aallan/vera/issues/387) | 2–4 hours | Measures whether 3,330 tests catch real bugs, not just execute paths |
 | Investigate parser fuzzing with Atheris | [#402](https://github.com/aallan/vera/issues/402) | 4–8 hours | Crash-inducing inputs for parser and type checker |
 | Improve browser runtime test coverage to >80% | [#349](https://github.com/aallan/vera/issues/349) | 2–4 hours | Parity with Python-side coverage gate |
 | Add `check_changelog_updated.py` pre-push hook + CI check | [#478](https://github.com/aallan/vera/issues/478) | 30–60 min | Fails PRs that touch `vera/`/`spec/`/`SKILL.md` without a CHANGELOG entry; prevents the #474 miss from recurring |
@@ -268,4 +268,4 @@ The compiler was built through ten development phases from February to March 202
 | C8.5 | v0.0.66–v0.0.88 | **Completeness** — builtins, IO runtime, types, effects, browser target | Done |
 | C9 | v0.0.89–v0.0.101 | **Abilities, standard library, data types, effects** — Eq/Ord/Hash/Show, Map/Set, JSON, HTML, Markdown, Http, Decimal, Inference, standard prelude, combinators, higher-order array ops | Done |
 
-**810+ commits, 113 tagged releases, 3,324 tests, 96% coverage, 73 conformance programs, 30 examples, 13 spec chapters.** See [HISTORY.md](HISTORY.md) for the full narrative of how the compiler was built.
+**810+ commits, 113 tagged releases, 3,330 tests, 96% coverage, 73 conformance programs, 30 examples, 13 spec chapters.** See [HISTORY.md](HISTORY.md) for the full narrative of how the compiler was built.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@ See [HISTORY.md](HISTORY.md) for a narrative account of how the compiler was bui
 
 ## Where we are
 
-The compiler is complete end-to-end: parse, type-check, verify contracts via Z3, compile to WebAssembly, and run — at the command line and in the browser. The language has 122 built-in functions, algebraic effects (IO, Http, State, Exceptions, Async, Inference), constrained generics, a module system, contract-driven testing, and a canonical formatter. Type inference for bare constructors (`None`, `Err`, `Ok`) now works correctly across all call sites. The compiler has 3,330 tests, 73 conformance programs, 30 examples, and a 13-chapter specification.
+The compiler is complete end-to-end: parse, type-check, verify contracts via Z3, compile to WebAssembly, and run — at the command line and in the browser. The language has 122 built-in functions, algebraic effects (IO, Http, State, Exceptions, Async, Inference), constrained generics, a module system, contract-driven testing, and a canonical formatter. Type inference for bare constructors (`None`, `Err`, `Ok`) now works correctly across all call sites. The compiler has 3,332 tests, 73 conformance programs, 30 examples, and a 13-chapter specification.
 
 Significant progress has been made towards Vera being a viable agent target. [VeraBench](https://github.com/aallan/vera-bench) — a 50-problem benchmark across 5 difficulty tiers — now covers 6 models across 3 providers (v0.0.7). The headline result: Kimi K2.5 achieves 100% run_correct on Vera, beating both Python (86%) and TypeScript (91%). Three models beat TypeScript on Vera. The flagship tier averages 93% Vera run_correct vs 93% Python — essentially parity. These are single-run results with high variance; stable rates will require pass@k evaluation. The remaining gaps are empirical breadth (repeated trials, more models), standard library depth (HTTP hardening, server effects), and tooling integration (LSP).
 
@@ -223,7 +223,7 @@ These are not milestone-gated — they should be addressed continuously alongsid
 | Item | Issue | Effort | Impact |
 |------|-------|--------|--------|
 | Add property-based testing with Hypothesis | [#386](https://github.com/aallan/vera/issues/386) | 2–4 hours | Catches parser/formatter edge cases via round-trip properties |
-| Add mutation testing with mutmut (detection only) | [#387](https://github.com/aallan/vera/issues/387) | 2–4 hours | Measures whether 3,330 tests catch real bugs, not just execute paths |
+| Add mutation testing with mutmut (detection only) | [#387](https://github.com/aallan/vera/issues/387) | 2–4 hours | Measures whether 3,332 tests catch real bugs, not just execute paths |
 | Investigate parser fuzzing with Atheris | [#402](https://github.com/aallan/vera/issues/402) | 4–8 hours | Crash-inducing inputs for parser and type checker |
 | Improve browser runtime test coverage to >80% | [#349](https://github.com/aallan/vera/issues/349) | 2–4 hours | Parity with Python-side coverage gate |
 | Add `check_changelog_updated.py` pre-push hook + CI check | [#478](https://github.com/aallan/vera/issues/478) | 30–60 min | Fails PRs that touch `vera/`/`spec/`/`SKILL.md` without a CHANGELOG entry; prevents the #474 miss from recurring |
@@ -268,4 +268,4 @@ The compiler was built through ten development phases from February to March 202
 | C8.5 | v0.0.66–v0.0.88 | **Completeness** — builtins, IO runtime, types, effects, browser target | Done |
 | C9 | v0.0.89–v0.0.101 | **Abilities, standard library, data types, effects** — Eq/Ord/Hash/Show, Map/Set, JSON, HTML, Markdown, Http, Decimal, Inference, standard prelude, combinators, higher-order array ops | Done |
 
-**810+ commits, 113 tagged releases, 3,330 tests, 96% coverage, 73 conformance programs, 30 examples, 13 spec chapters.** See [HISTORY.md](HISTORY.md) for the full narrative of how the compiler was built.
+**810+ commits, 113 tagged releases, 3,332 tests, 96% coverage, 73 conformance programs, 30 examples, 13 spec chapters.** See [HISTORY.md](HISTORY.md) for the full narrative of how the compiler was built.

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,7 +6,7 @@ This is the single source of truth for Vera's testing infrastructure, coverage d
 
 | Metric | Value |
 |--------|-------|
-| **Tests** | 3,324 across 28 files (~34,000 lines of test code; 3,313 passed, 11 skipped) |
+| **Tests** | 3,330 across 28 files (~34,000 lines of test code; 3,319 passed, 11 skipped) |
 | **Compiler code coverage** | 96% of 15,149 statements (CI minimum: 80%) |
 | **Conformance programs** | 73 programs across 9 spec chapters, validating every language feature |
 | **Example programs** | 30, all validated through `vera check` + `vera verify` |
@@ -57,7 +57,7 @@ python scripts/fix_allowlists.py --fix               # auto-fix stale allowlists
 | `test_verifier.py` | 132 | 1,886 | Z3 verification, counterexamples, tier classification, call-site preconditions, branch-aware preconditions, pipe operator, cross-module contracts, match/ADT verification, decreases verification, mutual recursion, refined Bool/String/Float64 param sorts |
 | `test_codegen.py` | 862 | 10,563 | WASM compilation, arithmetic, Float64, Byte, arrays (incl. compound element types), ADTs, match (incl. nested patterns), generics, State\<T\>, Exn\<E\> handlers, control flow, strings, string escape sequences, IO (read\_line, read\_file, write\_file, args, exit, get\_env), bounds checking, quantifiers, assert/assume, refinement type aliases, pipe operator, string built-ins, built-in shadowing, parse\_nat Result, GC, Markdown host bindings, Regex host bindings, Map collection, Set collection, Decimal type, Json type, Html type, Http effect, Inference effect, example round-trips, GC shadow stack overflow |
 | `test_codegen_contracts.py` | 32 | 576 | Runtime pre/postconditions, contract fail messages, old/new state postconditions |
-| `test_codegen_monomorphize.py` | 57 | 1,013 | Generic instantiation, type inference, monomorphization edge cases, ability constraint satisfaction (Eq/Ord/Hash/Show), operation rewriting (eq/compare), show/hash dispatch, ADT auto-derivation, array operations (slice/map/filter/fold) |
+| `test_codegen_monomorphize.py` | 63 | 1,134 | Generic instantiation, type inference, monomorphization edge cases, ability constraint satisfaction (Eq/Ord/Hash/Show), operation rewriting (eq/compare), show/hash dispatch, ADT auto-derivation, array operations (slice/map/filter/fold) |
 | `test_codegen_closures.py` | 19 | 473 | Closure lifting, captured variables, higher-order functions |
 | `test_codegen_modules.py` | 19 | 565 | Cross-module guard rail, cross-module codegen, name collision detection (E608/E609/E610) |
 | `test_codegen_coverage.py` | 5 | 250 | Defensive error paths: E600, E601, E605, E606, unknown module calls  |
@@ -74,7 +74,7 @@ python scripts/fix_allowlists.py --fix               # auto-fix stale allowlists
 | `test_markdown.py` | 59 | 394 | Markdown parser: block/inline parsing, rendering, round-trips, edge cases |
 | `test_browser.py` | 61 | 749 | Browser parity: Python/wasmtime vs Node.js/JS-runtime output equivalence across IO, State, contracts, Markdown, Regex, and all compilable examples |
 | `test_conformance.py` | 365 | 102 | Parametrized conformance suite: parse, check, verify, run, format idempotency across 73 programs |
-| `test_prelude.py` | 24 | 419 | Prelude injection: Option/Result/array operation detection, combinator shadowing, type aliases, end-to-end compilation |
+| `test_prelude.py` | 24 | 421 | Prelude injection: Option/Result/array operation detection, combinator shadowing, type aliases, end-to-end compilation |
 | `test_readme.py` | 2 | 79 | README code sample parsing |
 | `test_html.py` | 4 | 164 | HTML landing page code samples: parse, check, verify |
 | `test_build_site.py` | 17 | 213 | `_abs_links` unit tests: relative link rewriting, fenced block immunity (backtick and tilde fences, inline backticks inside fences), http/https/fragment pass-through, Vera effect syntax not mis-parsed |

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,7 +6,7 @@ This is the single source of truth for Vera's testing infrastructure, coverage d
 
 | Metric | Value |
 |--------|-------|
-| **Tests** | 3,330 across 28 files (~34,000 lines of test code; 3,319 passed, 11 skipped) |
+| **Tests** | 3,332 across 28 files (~34,000 lines of test code; 3,321 passed, 11 skipped) |
 | **Compiler code coverage** | 96% of 15,149 statements (CI minimum: 80%) |
 | **Conformance programs** | 73 programs across 9 spec chapters, validating every language feature |
 | **Example programs** | 30, all validated through `vera check` + `vera verify` |
@@ -57,7 +57,7 @@ python scripts/fix_allowlists.py --fix               # auto-fix stale allowlists
 | `test_verifier.py` | 132 | 1,886 | Z3 verification, counterexamples, tier classification, call-site preconditions, branch-aware preconditions, pipe operator, cross-module contracts, match/ADT verification, decreases verification, mutual recursion, refined Bool/String/Float64 param sorts |
 | `test_codegen.py` | 862 | 10,563 | WASM compilation, arithmetic, Float64, Byte, arrays (incl. compound element types), ADTs, match (incl. nested patterns), generics, State\<T\>, Exn\<E\> handlers, control flow, strings, string escape sequences, IO (read\_line, read\_file, write\_file, args, exit, get\_env), bounds checking, quantifiers, assert/assume, refinement type aliases, pipe operator, string built-ins, built-in shadowing, parse\_nat Result, GC, Markdown host bindings, Regex host bindings, Map collection, Set collection, Decimal type, Json type, Html type, Http effect, Inference effect, example round-trips, GC shadow stack overflow |
 | `test_codegen_contracts.py` | 32 | 576 | Runtime pre/postconditions, contract fail messages, old/new state postconditions |
-| `test_codegen_monomorphize.py` | 63 | 1,134 | Generic instantiation, type inference, monomorphization edge cases, ability constraint satisfaction (Eq/Ord/Hash/Show), operation rewriting (eq/compare), show/hash dispatch, ADT auto-derivation, array operations (slice/map/filter/fold) |
+| `test_codegen_monomorphize.py` | 65 | 1,180 | Generic instantiation, type inference, monomorphization edge cases, ability constraint satisfaction (Eq/Ord/Hash/Show), operation rewriting (eq/compare), show/hash dispatch, ADT auto-derivation, array operations (slice/map/filter/fold) |
 | `test_codegen_closures.py` | 19 | 473 | Closure lifting, captured variables, higher-order functions |
 | `test_codegen_modules.py` | 19 | 565 | Cross-module guard rail, cross-module codegen, name collision detection (E608/E609/E610) |
 | `test_codegen_coverage.py` | 5 | 250 | Defensive error paths: E600, E601, E605, E606, unknown module calls  |

--- a/tests/test_codegen_monomorphize.py
+++ b/tests/test_codegen_monomorphize.py
@@ -1132,3 +1132,49 @@ public fn main(-> @Nat)
 """
         # Elements with length > 1: ["bb", "ccc"] — lengths 2 and 3; sum = 5.
         assert _run(source, fn="main") == 5
+
+    def test_array_filter_of_array_map(self) -> None:
+        """Nested ``array_filter(array_map(...), pred)`` — output-type inference.
+
+        Regression for a latent bug exposed during PR 2 review:
+        ``_infer_concat_elem_type`` didn't handle ``array_map``
+        calls, so its output-type (the closure's return type) was
+        invisible to the enclosing filter.  The filter would bail
+        out silently and the whole module would fail to compile.
+        Now the helper consults the inner map's closure return type
+        to size the filter correctly.
+        """
+        source = """\
+public fn main(-> @Nat)
+  requires(true) ensures(true) effects(pure)
+{
+  let @Array<Bool> = array_filter(
+    array_map([1, 2, 3, 4, 5], fn(@Int -> @Bool) effects(pure) { @Int.0 > 2 }),
+    fn(@Bool -> @Bool) effects(pure) { @Bool.0 }
+  );
+  array_length(@Array<Bool>.0)
+}
+"""
+        # map → [false, false, true, true, true]; filter trues → [true, true, true]; len 3.
+        assert _run(source, fn="main") == 3
+
+    def test_array_map_of_array_map(self) -> None:
+        """Nested ``array_map(array_map(...), fn)`` — output-type inference.
+
+        Sibling to the filter-of-map test: the outer map must see
+        the inner map's output element type (the inner closure's
+        return type), not the original array's element type.
+        """
+        source = """\
+public fn main(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  let @Array<Int> = array_map(
+    array_map([1, 2, 3], fn(@Int -> @Int) effects(pure) { @Int.0 * 2 }),
+    fn(@Int -> @Int) effects(pure) { @Int.0 + 1 }
+  );
+  @Array<Int>.0[2]
+}
+"""
+        # [1,2,3] → [2,4,6] → [3,5,7]; [2] = 7.
+        assert _run(source, fn="main") == 7

--- a/tests/test_codegen_monomorphize.py
+++ b/tests/test_codegen_monomorphize.py
@@ -1011,3 +1011,124 @@ public fn main(-> @Nat)
 }
 """
         assert _run(source, fn="main") == 0
+
+    # ----------------------------------------------------------------
+    # array_filter — regression tests for the iterative implementation
+    # (#480 PR 2).  The iterative filter over-allocates
+    # ``len * sizeof(T)`` (worst case, every element passes) and
+    # returns ``(dst, write_idx)``.  Focus: boundary cases and
+    # write-index correctness (separate from read-index).
+    # ----------------------------------------------------------------
+
+    def test_array_filter_large_input_no_stack_overflow(self) -> None:
+        """8,000-element filter without blowing the shadow stack.
+
+        Under the old recursive prelude each element pushed a stack
+        frame and hit the 16K ceiling (#464) around 4K elements.
+        The iterative loop is O(1) in shadow-stack depth.  Capped at
+        8K (64,000 bytes worst-case allocation) until #484 widens the
+        GC-header size field.
+        """
+        source = """\
+public fn main(-> @Nat)
+  requires(true) ensures(true) effects(pure)
+{
+  let @Array<Int> = array_range(0, 8000);
+  let @Array<Int> = array_filter(@Array<Int>.0, fn(@Int -> @Bool) effects(pure) { @Int.0 < 100 });
+  array_length(@Array<Int>.0)
+}
+"""
+        # Elements 0..99 pass, rest rejected → length 100.
+        assert _run(source, fn="main") == 100
+
+    def test_array_filter_empty_input(self) -> None:
+        """Empty input → empty output; loop init/term exercised at n=0.
+
+        The loop's ``idx >= arr_len`` guard must fire on the very
+        first iteration; the predicate is never invoked; the
+        returned ``(dst, write_idx)`` has ``write_idx = 0``.
+        """
+        source = """\
+public fn main(-> @Nat)
+  requires(true) ensures(true) effects(pure)
+{
+  let @Array<Int> = array_range(0, 0);
+  let @Array<Int> = array_filter(@Array<Int>.0, fn(@Int -> @Bool) effects(pure) { @Int.0 > 0 });
+  array_length(@Array<Int>.0)
+}
+"""
+        assert _run(source, fn="main") == 0
+
+    def test_array_filter_all_pass(self) -> None:
+        """Every element passes → ``write_idx == arr_len``.
+
+        Exercises the "no wasted tail" happy path: the dst buffer
+        is fully used and the returned length equals the input
+        length.  Reads several elements to confirm the write path
+        copied values correctly, not just that the count is right.
+        """
+        source = """\
+public fn main(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  let @Array<Int> = array_filter([10, 20, 30, 40, 50], fn(@Int -> @Bool) effects(pure) { true });
+  @Array<Int>.0[0] + @Array<Int>.0[2] + @Array<Int>.0[4]
+}
+"""
+        # 10 + 30 + 50 = 90; confirms elements at idx 0, 2, 4 were copied intact.
+        assert _run(source, fn="main") == 90
+
+    def test_array_filter_none_pass(self) -> None:
+        """Predicate always false → empty output despite non-empty input.
+
+        The dst buffer is allocated at worst-case size but
+        ``write_idx`` never advances, so the returned length is 0.
+        """
+        source = """\
+public fn main(-> @Nat)
+  requires(true) ensures(true) effects(pure)
+{
+  let @Array<Int> = array_filter([1, 2, 3, 4, 5], fn(@Int -> @Bool) effects(pure) { false });
+  array_length(@Array<Int>.0)
+}
+"""
+        assert _run(source, fn="main") == 0
+
+    def test_array_filter_closure_captures_outer_variable(self) -> None:
+        """Predicate closure captures an outer binding.
+
+        Ensures the closure-env lifting path works for filter the
+        same way it does for map — the captured threshold must be
+        visible inside the predicate body.
+        """
+        source = """\
+public fn main(-> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  let @Int = 3;
+  let @Array<Int> = array_filter([1, 2, 3, 4, 5], fn(@Int -> @Bool) effects(pure) { @Int.0 > @Int.1 });
+  @Array<Int>.0[0] + @Array<Int>.0[1]
+}
+"""
+        # Captured threshold = 3; elements > 3 → [4, 5]; sum = 9.
+        assert _run(source, fn="main") == 9
+
+    def test_array_filter_pair_element(self) -> None:
+        """Filter Array<String> — output is pair-typed (i32_pair).
+
+        Exercises the pair-element copy path: both i32 words (ptr
+        at offset 0, len at offset 4) must be loaded from src[idx]
+        into temp locals, fed to the predicate, AND stored into
+        dst[write_idx] if the predicate passed — without re-reading
+        src.
+        """
+        source = """\
+public fn main(-> @Nat)
+  requires(true) ensures(true) effects(pure)
+{
+  let @Array<String> = array_filter(["a", "bb", "ccc", "d"], fn(@String -> @Bool) effects(pure) { string_length(@String.0) > 1 });
+  string_length(@Array<String>.0[0]) + string_length(@Array<String>.0[1])
+}
+"""
+        # Elements with length > 1: ["bb", "ccc"] — lengths 2 and 3; sum = 5.
+        assert _run(source, fn="main") == 5

--- a/tests/test_prelude.py
+++ b/tests/test_prelude.py
@@ -43,12 +43,11 @@ _PRELUDE_DATA_NAMES = {"Option", "Result", "Ordering", "UrlParts"}
 # Prelude combinator function names
 _OPTION_FN_NAMES = {"option_unwrap_or", "option_map", "option_and_then"}
 _RESULT_FN_NAMES = {"result_unwrap_or", "result_map"}
-# ``array_map`` is emitted as iterative WASM by codegen (#480);
-# it no longer has a prelude-injected recursive implementation.
-# ``array_filter`` / ``array_fold`` remain recursive prelude functions
-# until their own iterative migration lands.
+# ``array_map`` and ``array_filter`` are emitted as iterative WASM
+# by codegen (#480); they no longer have prelude-injected recursive
+# implementations.  ``array_fold`` remains a recursive prelude
+# function until its own iterative migration lands.
 _ARRAY_FN_NAMES = {
-    "array_filter", "array_filter_go",
     "array_fold", "array_fold_go",
 }
 
@@ -113,13 +112,14 @@ class TestPreludeCombinators:
         assert _RESULT_FN_NAMES.issubset(names)
 
     def test_array_operations_injected(self) -> None:
-        """Array operations always injected — except array_map.
+        """Array operations injected — except array_map and array_filter.
 
-        ``array_map`` / ``array_map_go`` are emitted as iterative WASM
-        by codegen (#480) and must NOT appear in the prelude-injected
-        function set.  The explicit negative assertion guards against
-        accidental re-injection if someone widens ``_ARRAY_FN_NAMES``
-        without updating the prelude.
+        ``array_map`` / ``array_map_go`` and ``array_filter`` /
+        ``array_filter_go`` are emitted as iterative WASM by codegen
+        (#480) and must NOT appear in the prelude-injected function
+        set.  The explicit negative assertions guard against
+        accidental re-injection if someone widens
+        ``_ARRAY_FN_NAMES`` without updating the prelude.
         """
         prog = _make_program(
             "public fn main(@Unit -> @Int)\n"
@@ -129,9 +129,11 @@ class TestPreludeCombinators:
         inject_prelude(prog)
         names = _fn_names(prog)
         assert _ARRAY_FN_NAMES.issubset(names)
-        # Regression: array_map is a built-in, not a prelude function.
+        # Regression: these are built-ins, not prelude functions.
         assert "array_map" not in names
         assert "array_map_go" not in names
+        assert "array_filter" not in names
+        assert "array_filter_go" not in names
 
     def test_combinators_with_user_option(self) -> None:
         """Option combinators still injected when user defines standard Option."""

--- a/vera/codegen/modules.py
+++ b/vera/codegen/modules.py
@@ -253,9 +253,9 @@ class CrossModuleMixin:
             "array_length", "array_append", "array_range", "array_concat",
             "array_slice",
             # Higher-order combinators — iterative WASM (#480).
-            # array_filter / array_fold still use the recursive prelude
-            # form until their own iterative migration lands.
-            "array_map",
+            # array_fold still uses the recursive prelude form until
+            # its own iterative migration lands.
+            "array_map", "array_filter",
             "apply_fn", "get", "put", "throw", "resume",
             "string_length", "string_concat", "string_slice",
             "string_char_code", "string_from_char_code", "string_repeat",

--- a/vera/prelude.py
+++ b/vera/prelude.py
@@ -70,50 +70,12 @@ type ArrayFoldFn<T, U> = fn(U, T -> U) effects(pure);
 """
 
 # Array higher-order operations.
-# array_map is emitted as an iterative WASM loop by codegen (#480) —
-# removed from this prelude injection.  array_filter and array_fold
-# still use recursive helpers with an index parameter to walk the
-# array; they will migrate to iterative implementations in follow-up
-# PRs.  De Bruijn slot references are commented for clarity.
+# array_map and array_filter are emitted as iterative WASM loops by
+# codegen (#480) — removed from this prelude injection.  array_fold
+# still uses a recursive helper with an index parameter; it will
+# migrate to an iterative implementation in the next follow-up PR.
+# De Bruijn slot references are commented for clarity.
 _ARRAY_COMBINATORS = """\
-private forall<T> fn array_filter_go(@Array<T>, @ArrayFilterFn<T>, @Int, @Array<T> -> @Array<T>)
-  requires(true)
-  ensures(true)
-  decreases(array_length(@Array<T>.1) - @Int.0)
-  effects(pure)
-{
-  -- @Array<T>.0 = acc (most recent), @Int.0 = index,
-  -- @ArrayFilterFn<T>.0 = predicate, @Array<T>.1 = input
-  if @Int.0 >= array_length(@Array<T>.1) then {
-    @Array<T>.0
-  } else {
-    if apply_fn(@ArrayFilterFn<T>.0, @Array<T>.1[@Int.0]) then {
-      array_filter_go(
-        @Array<T>.1,
-        @ArrayFilterFn<T>.0,
-        @Int.0 + 1,
-        array_append(@Array<T>.0, @Array<T>.1[@Int.0])
-      )
-    } else {
-      array_filter_go(
-        @Array<T>.1,
-        @ArrayFilterFn<T>.0,
-        @Int.0 + 1,
-        @Array<T>.0
-      )
-    }
-  }
-}
-
-private forall<T> fn array_filter(@Array<T>, @ArrayFilterFn<T> -> @Array<T>)
-  requires(true)
-  ensures(true)
-  effects(pure)
-{
-  -- @ArrayFilterFn<T>.0 = predicate (most recent), @Array<T>.0 = input
-  array_filter_go(@Array<T>.0, @ArrayFilterFn<T>.0, 0, [])
-}
-
 private forall<T, U> fn array_fold_go(@Array<T>, @U, @ArrayFoldFn<T, U>, @Int -> @U)
   requires(true)
   ensures(true)
@@ -534,10 +496,10 @@ def inject_prelude(program: ast.Program) -> None:
     - Result combinators (``result_unwrap_or``, ``result_map``) —
       injected unless the user defines a non-standard ``Result<T, E>``
       or shadows the function names.
-    - Array operations (``array_filter``, ``array_fold``) — always
-      injected as recursive helpers until their own iterative
-      migration lands.  ``array_map`` is emitted as iterative WASM
-      by codegen (#480) and has no prelude body.
+    - Array operations (``array_fold``) — injected as a recursive
+      helper until its own iterative migration lands.  ``array_map``
+      and ``array_filter`` are emitted as iterative WASM by codegen
+      (#480) and have no prelude body.
     """
     user_names = _user_defined_names(program)
     user_data_names = _user_defined_data_names(program)
@@ -562,12 +524,11 @@ def inject_prelude(program: ast.Program) -> None:
     option_alias_names = {"OptionMapFn", "OptionBindFn"}
     result_fn_names = {"result_unwrap_or", "result_map"}
     result_alias_names = {"ResultMapFn"}
-    # array_map is a built-in emitted as iterative WASM (#480); it has
-    # no prelude body any more.  array_filter / array_fold are still
-    # injected as recursive helpers until their own iterative migration
-    # lands.
+    # array_map and array_filter are built-ins emitted as iterative
+    # WASM (#480); they have no prelude body any more.  array_fold is
+    # still injected as a recursive helper until its own iterative
+    # migration lands in the next #480 follow-up.
     array_fn_names = {
-        "array_filter", "array_filter_go",
         "array_fold", "array_fold_go",
     }
     array_alias_names = {"ArrayMapFn", "ArrayFilterFn", "ArrayFoldFn"}

--- a/vera/wasm/calls.py
+++ b/vera/wasm/calls.py
@@ -207,6 +207,10 @@ class CallsMixin:
                 return self._translate_array_map(
                     call.args[0], call.args[1], env,
                 )
+            if call.name == "array_filter" and len(call.args) == 2:
+                return self._translate_array_filter(
+                    call.args[0], call.args[1], env,
+                )
             # Numeric math builtins
             if call.name == "abs" and len(call.args) == 1:
                 return self._translate_abs(call.args[0], env)

--- a/vera/wasm/calls.py
+++ b/vera/wasm/calls.py
@@ -577,6 +577,11 @@ class CallsMixin:
         if isinstance(expr, ast.FnCall):
             if expr.name == "array_range":
                 return "Int"
+            # array_map output element type = closure's return type.
+            # Not the input array's element type (that's the *input*
+            # of the map, not what we hand to the next combinator).
+            if expr.name == "array_map" and len(expr.args) == 2:
+                return self._infer_closure_return_vera_type(expr.args[1])
             if expr.name in (
                 "array_concat", "array_append", "array_slice",
                 "array_filter",

--- a/vera/wasm/calls_arrays.py
+++ b/vera/wasm/calls_arrays.py
@@ -781,3 +781,207 @@ class CallsArraysMixin:
         instructions.append(f"local.get {dst}")
         instructions.append(f"local.get {arr_len}")
         return instructions
+
+    def _translate_array_filter(
+        self,
+        arr_arg: ast.Expr,
+        fn_arg: ast.Expr,
+        env: WasmSlotEnv,
+    ) -> list[str] | None:
+        """Translate ``array_filter<T>(arr, pred) -> Array<T>`` iteratively.
+
+        The output length is not known up-front, so we over-allocate
+        ``len * sizeof(T)`` bytes (worst case — every element passes),
+        walk the input once invoking the predicate, copy passing
+        elements into ``dst[write_idx]``, and return ``(dst,
+        write_idx)``.  The unused tail is unreachable via the
+        returned pair and gets reclaimed by the sweeper.
+
+        Single-pass deliberately: calling the predicate twice (once
+        to count, once to copy) would double cost and, more
+        importantly, assume purity at evaluation granularity.  A
+        single pass is also closer to what a programmer would write
+        by hand.
+
+        WAT shape::
+
+            ;; evaluate arr → (ptr, len), save + GC-root arr_ptr
+            ;; evaluate fn → i32 handle, save + GC-root fn_tmp
+            ;; call $alloc(len * sizeof(T)), save as dst, GC-root dst
+            ;; write_idx = 0
+            ;; loop idx in [0, len):
+            ;;   push fn (env); load src[idx]; push fn_idx;
+            ;;   call_indirect → i32 (Bool)
+            ;;   if result != 0:
+            ;;     compute dst_slot = dst + write_idx * sizeof(T)
+            ;;     copy src[idx] to dst[write_idx] (1 or 2 loads+stores)
+            ;;     write_idx++
+            ;; push (dst, write_idx)
+
+        Size note: subject to the pre-existing 16-bit GC-header
+        limit ([#484](https://github.com/aallan/vera/issues/484)) —
+        worst-case allocations over 65535 bytes silently corrupt.
+        The iterative codegen itself is correct; callers just need
+        to keep inputs under the ceiling until the header is widened.
+        """
+        arr_instrs = self.translate_expr(arr_arg, env)
+        fn_instrs = self.translate_expr(fn_arg, env)
+        if arr_instrs is None or fn_instrs is None:
+            return None
+
+        t_type = self._infer_concat_elem_type(arr_arg)
+        if t_type is None:
+            return None
+        t_size = _element_mem_size(t_type)
+        if t_size is None:
+            return None
+        t_is_pair = _is_pair_element_type(t_type)
+        t_wasm = _element_wasm_type(t_type)
+        if t_wasm is None:
+            return None
+
+        self.needs_alloc = True
+
+        arr_ptr = self.alloc_local("i32")
+        arr_len = self.alloc_local("i32")
+        fn_tmp = self.alloc_local("i32")
+        dst = self.alloc_local("i32")
+        idx = self.alloc_local("i32")
+        write_idx = self.alloc_local("i32")
+        src_slot = self.alloc_local("i32")
+        dst_slot = self.alloc_local("i32")
+        # Temp for the loaded source element (so we can reload it into
+        # both the call_indirect arg and the dst store without a
+        # second memory read).
+        if t_is_pair:
+            src_ptr = self.alloc_local("i32")
+            src_len = self.alloc_local("i32")
+        else:
+            src_val = self.alloc_local(t_wasm)
+
+        instructions: list[str] = []
+
+        # Evaluate arr → (ptr, len), save, shadow-push.
+        instructions.extend(arr_instrs)
+        instructions.append(f"local.set {arr_len}")
+        instructions.append(f"local.set {arr_ptr}")
+        instructions.extend(gc_shadow_push(arr_ptr))
+
+        # Evaluate fn → closure handle, save, shadow-push.
+        instructions.extend(fn_instrs)
+        instructions.append(f"local.set {fn_tmp}")
+        instructions.extend(gc_shadow_push(fn_tmp))
+
+        # Worst-case allocation: every element passes the predicate.
+        instructions.append(f"local.get {arr_len}")
+        instructions.append(f"i32.const {t_size}")
+        instructions.append("i32.mul")
+        instructions.append("call $alloc")
+        instructions.append(f"local.set {dst}")
+        instructions.extend(gc_shadow_push(dst))
+
+        # Predicate closure sig: (env:i32, T-expanded) -> Bool (i32).
+        t_param_types = ["i32", "i32"] if t_is_pair else [t_wasm]
+        param_parts = " ".join(
+            f"(param {wt})" for wt in ["i32"] + t_param_types
+        )
+        sig_key = f"{param_parts} (result i32)"
+        if sig_key not in self._closure_sigs:
+            sig_name = f"$closure_sig_{len(self._closure_sigs)}"
+            self._closure_sigs[sig_key] = sig_name
+        sig_name = self._closure_sigs[sig_key]
+
+        # write_idx = 0; loop idx in [0, arr_len).
+        instructions.append("i32.const 0")
+        instructions.append(f"local.set {write_idx}")
+        instructions.append("i32.const 0")
+        instructions.append(f"local.set {idx}")
+        instructions.append("block $brk_flt")
+        instructions.append("  loop $lp_flt")
+        instructions.append(f"    local.get {idx}")
+        instructions.append(f"    local.get {arr_len}")
+        instructions.append("    i32.ge_u")
+        instructions.append("    br_if $brk_flt")
+
+        # src_slot = arr_ptr + idx * sizeof(T).
+        instructions.append(f"    local.get {arr_ptr}")
+        instructions.append(f"    local.get {idx}")
+        instructions.append(f"    i32.const {t_size}")
+        instructions.append("    i32.mul")
+        instructions.append("    i32.add")
+        instructions.append(f"    local.set {src_slot}")
+
+        # Load src[idx] into temp local(s) — reused for the predicate
+        # call below AND the conditional store further down.
+        if t_is_pair:
+            instructions.append(f"    local.get {src_slot}")
+            instructions.append("    i32.load offset=0")
+            instructions.append(f"    local.set {src_ptr}")
+            instructions.append(f"    local.get {src_slot}")
+            instructions.append("    i32.load offset=4")
+            instructions.append(f"    local.set {src_len}")
+        else:
+            t_load = _element_load_op(t_type)
+            if t_load is None:
+                return None
+            instructions.append(f"    local.get {src_slot}")
+            instructions.append(f"    {t_load} offset=0")
+            instructions.append(f"    local.set {src_val}")
+
+        # Invoke predicate: push env, push element, push fn_idx,
+        # call_indirect → i32 (Bool).
+        instructions.append(f"    local.get {fn_tmp}")
+        if t_is_pair:
+            instructions.append(f"    local.get {src_ptr}")
+            instructions.append(f"    local.get {src_len}")
+        else:
+            instructions.append(f"    local.get {src_val}")
+        instructions.append(f"    local.get {fn_tmp}")
+        instructions.append("    i32.load offset=0")
+        instructions.append(f"    call_indirect (type {sig_name})")
+
+        # if predicate returned true: copy element, bump write_idx.
+        instructions.append("    if")
+        # dst_slot = dst + write_idx * sizeof(T).
+        instructions.append(f"      local.get {dst}")
+        instructions.append(f"      local.get {write_idx}")
+        instructions.append(f"      i32.const {t_size}")
+        instructions.append("      i32.mul")
+        instructions.append("      i32.add")
+        instructions.append(f"      local.set {dst_slot}")
+        if t_is_pair:
+            instructions.append(f"      local.get {dst_slot}")
+            instructions.append(f"      local.get {src_ptr}")
+            instructions.append("      i32.store offset=0")
+            instructions.append(f"      local.get {dst_slot}")
+            instructions.append(f"      local.get {src_len}")
+            instructions.append("      i32.store offset=4")
+        else:
+            t_store = _element_store_op(t_type)
+            if t_store is None:
+                return None
+            instructions.append(f"      local.get {dst_slot}")
+            instructions.append(f"      local.get {src_val}")
+            instructions.append(f"      {t_store} offset=0")
+        # write_idx++.
+        instructions.append(f"      local.get {write_idx}")
+        instructions.append("      i32.const 1")
+        instructions.append("      i32.add")
+        instructions.append(f"      local.set {write_idx}")
+        instructions.append("    end")
+
+        # idx++, loop.
+        instructions.append(f"    local.get {idx}")
+        instructions.append("    i32.const 1")
+        instructions.append("    i32.add")
+        instructions.append(f"    local.set {idx}")
+        instructions.append("    br $lp_flt")
+        instructions.append("  end")
+        instructions.append("end")
+
+        # Result: (dst, write_idx).  Tail past write_idx is unused
+        # but still inside the allocated block; sweeper reclaims it
+        # when dst itself becomes unreachable.
+        instructions.append(f"local.get {dst}")
+        instructions.append(f"local.get {write_idx}")
+        return instructions


### PR DESCRIPTION
## Summary

- Replace the recursive prelude `array_filter` / `array_filter_go` with a single iterative WAT `loop`. Worst-case over-allocates `len * sizeof(T)` bytes, walks input once, copies passing elements to `dst[write_idx]`, returns `(dst, write_idx)` — unused tail is unreachable via the returned pair and the sweeper reclaims it.
- Single-pass by design: counting matches first would double closure invocations and assume purity at evaluation granularity. Over-allocating is the cleaner trade.
- Preserves the generic `forall<T>` signature through the existing `FunctionInfo` built-in; source programs unchanged.
- Six new regression tests: empty input, all-pass, none-pass, closure-capture, pair-element (`Array<String>`), and an 8K stress (capped by #484 until the 16-bit header lands).

Mirrors [#485](https://github.com/aallan/vera/pull/485) (PR 1) in structure. `array_fold` migration follows as PR 3.

## Test plan
- [x] `mypy vera/` clean (57 files)
- [x] `pytest tests/ -q` — 3,319 passed, 11 skipped (6 new tests)
- [x] 25 `TestArrayOperations` tests pass including the 6 new filter regressions + the 4 pre-existing `array_filter` basic tests now exercising the iterative path
- [x] Pre-commit hooks green (doc counts, CHANGELOG, allowlists, conformance, examples)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Array filter rewritten to an iterative implementation: lower stack usage, single predicate call per element, predictable allocation behaviour, improved handling of pair/complex elements and nested map/filter patterns.

* **Tests**
  * Added eight regression tests covering large inputs, empty/all/none-pass cases, closure captures, pair elements, and nested map/filter scenarios.

* **Documentation**
  * Updated changelog, roadmap and testing docs to reflect the implementation and test-count changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->