### PR TITLE
Add #490 to KNOWN_ISSUES.md (missed at v0.0.113)

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -11,6 +11,7 @@ Bugs and limitations tracked against the [issue tracker](https://github.com/aall
 | GC worklist overflow for deeply nested object graphs | [#348](https://github.com/aallan/vera/issues/348) |
 | WASM call translators: 10 pre-existing bugs (INT64_MIN to_string, string/array slice i64→i32 narrowing, char_code no bounds check, expression-bodied Exn handler result type, Map<K, Array<T>> lowering, url_parse/url_join round-trip, base64 `=` validation, parse_nat/int embedded spaces, float fractional carry) | [#475](https://github.com/aallan/vera/issues/475) |
 | GC `$alloc` grows memory by only 1 page — single allocations more than ~64 KB larger than free heap space trap (out-of-bounds memory access) | [#487](https://github.com/aallan/vera/issues/487) |
+| `array_fold` heuristic over-roots host-managed opaque handles (Map, Set, Regex, Decimal) as if they were Vera heap pointers — safe (conservative GC rejects out-of-range values) but wastes work and can cause spurious mark retention | [#490](https://github.com/aallan/vera/issues/490) |
 
 ## Limitations
 


### PR DESCRIPTION
## Summary
- #490 (array_fold over-rooting of host-managed opaque handles) was filed during the #489 CodeRabbit review but never added to `KNOWN_ISSUES.md` when that PR landed in v0.0.113
- Adds a one-liner in the Bugs section alongside the existing GC-opaque-handle cluster (#346 / #347 / #348)

## Process note
Per the repo rule: new issues generated during a PR review must be added to `ROADMAP.md` or `KNOWN_ISSUES.md` as part of that same PR — main being protected means we can't drive-by-fix later, and leaving issues un-listed creates a gap between the tracker and the curated docs. This PR retroactively closes that gap for #490.

## Test plan
- [x] `python scripts/check_limitations_sync.py` — still consistent (28 entries)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated known issues documentation to record an identified garbage collection optimisation behaviour that may inadvertently affect certain opaque handle types. Whilst this behaviour is confirmed safe through conservative validation mechanisms deployed in the collection process, it may increase processing overhead and potentially lead to spurious mark retention during memory management operations in certain scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->