### PR TITLE
ci: switch dependabot to uv ecosystem so uv.lock stays in sync

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,13 @@
 version: 2
 
 updates:
-  # Python pip dependencies (pyproject.toml)
-  - package-ecosystem: "pip"
+  # Python dependencies — managed via uv.
+  # The "uv" ecosystem updates pyproject.toml AND regenerates uv.lock
+  # in the same PR so the lockfile stays in sync with manifest bumps.
+  # Using "pip" leaves uv.lock stale and breaks the `uv lock --check`
+  # step in CI lint (see PR #493 for the failure mode).
+  # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## Summary

Switches `.github/dependabot.yml` from `package-ecosystem: "pip"` to `package-ecosystem: "uv"` so dependabot regenerates `uv.lock` in the same PR as `pyproject.toml` bumps.

## Why

PR #493 (and the four other dependabot PRs filed 2026-04-20 — #494, #495, #496, #497) all fail CI lint with:

```
The lockfile at `uv.lock` needs to be updated, but `--check` was provided.
To update the lockfile, run `uv lock`.
##[error]Process completed with exit code 1.
```

Root cause is structural: dependabot's `pip` ecosystem updates `pyproject.toml` (which it understands) but does not touch `uv.lock` (which it doesn't understand under that ecosystem). The CI lint job runs `uv lock --check`, detects the drift, and fails — every time, for every Python dependency PR.

GitHub added `package-ecosystem: "uv"` in February 2025 specifically to handle `pyproject.toml` and `uv.lock` together when uv is the project's package manager. This change is one keyword.

## What this does NOT fix

The five existing dependabot PRs (#493–#497) were filed under the old `pip` ecosystem. They do not get retroactively re-resolved when the config changes. Each will need either:

- `@dependabot recreate` comment on the PR, which refiles it under the new ecosystem with the lockfile included, OR
- A manual `uv lock` commit pushed to each branch before merging.

`recreate` is preferred — one command, no local checkout needed.

## Test plan

- [x] YAML parses cleanly (`python -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"`)
- [x] Both ecosystem entries (`uv`, `github-actions`) preserved
- [ ] After merge: trigger a manual dependabot run from the GitHub UI (Insights → Dependency graph → Dependabot → Last checked → Check for updates) to verify the new ecosystem produces a lockfile-inclusive PR shape
- [ ] After merge: `@dependabot recreate` on each of #493–#497 and confirm they all pass CI lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Python dependency management configuration to optimise the synchronisation of dependency declarations with lock files during automated updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->