### PR TITLE
docs: note uv sync vs pip install -e '.[dev]' in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,8 @@ If the venv does not exist, create it first:
 python -m venv .venv && source .venv/bin/activate && pip install -e ".[dev]"
 ```
 
+If you prefer `uv`, use `uv sync --extra dev` (not plain `uv sync`). The `[dev]` extras group holds pytest, mypy, ruff, pre-commit, and pip-licenses; `uv sync` without `--extra dev` will quietly uninstall those and make `pytest` fall through to a non-venv copy that can't import `vera`.
+
 ## Key commands
 
 ```bash


### PR DESCRIPTION
## Summary

Adds a one-line note under CLAUDE.md's `Virtual environment` section warning that `uv sync` (alone) is not equivalent to `pip install -e ".[dev]"` — the uv form needs `--extra dev` (or `--all-extras`) to include dev tooling.

## Why

Encountered during today's dependabot cleanup session. Ran plain `uv sync` during a local verification sweep; it silently uninstalled pytest, mypy, ruff, pre-commit, and pip-licenses from the venv. Shell `pytest` then fell through PATH to a Homebrew copy running under a non-venv Python without `vera` installed, and two subprocess tests in `tests/test_cli.py::TestStdinInput` failed with:

```
/opt/homebrew/opt/python@3.14/bin/python3.14: Error while finding module specification for 'vera.cli' (ModuleNotFoundError: No module named 'vera')
```

That error traces back through multiple indirections before landing on "oh, your venv is missing its dev deps." A one-line note in CLAUDE.md under the venv setup preempts the confusion for future uv users (human or agent).

## Test plan
- [x] CLAUDE.md parses as markdown
- [x] After merge, next session pulling the repo with uv will see the note in its project orientation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced setup documentation with clearer guidance on virtual environment dependency synchronisation, including details on development tooling packages and the importance of proper configuration during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->