### PR TITLE
v0.0.136: fix #586 (apply_fn(closure, ()) on Unit-arg closure trips WASM validation)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Read `SKILL.md` for the full language reference. It covers syntax, slot referenc
 
 ### Conformance programs as reference
 
-The conformance suite in `tests/conformance/` contains 84 small, self-contained programs — one per language feature — that serve as minimal working examples. Each program must pass its declared verification level (see `manifest.json` for mappings: `parse`, `check`, `verify`, or `run`). When you need to see how a specific construct works (e.g. effect handlers, match expressions, closures), check the corresponding conformance program before reading the spec.
+The conformance suite in `tests/conformance/` contains 85 small, self-contained programs — one per language feature — that serve as minimal working examples. Each program must pass its declared verification level (see `manifest.json` for mappings: `parse`, `check`, `verify`, or `run`). When you need to see how a specific construct works (e.g. effect handlers, match expressions, closures), check the corresponding conformance program before reading the spec.
 
 ### Workflow
 
@@ -161,7 +161,7 @@ Each stage is a module with a single public API function (`parse_file`, `transfo
 pytest tests/ -v                       # Run all tests (see TESTING.md)
 pytest tests/test_conformance.py -v    # Conformance suite only
 mypy vera/                             # Type-check the compiler
-python scripts/check_conformance.py    # All 84 conformance programs must pass
+python scripts/check_conformance.py    # All 85 conformance programs must pass
 python scripts/check_examples.py       # All 33 examples must pass
 ```
 
@@ -171,7 +171,7 @@ When implementing a new language feature, write the conformance program *first* 
 
 ### Invariants
 
-- All 84 conformance programs in `tests/conformance/` must pass their declared level
+- All 85 conformance programs in `tests/conformance/` must pass their declared level
 - All 33 examples in `examples/` must pass `vera check` and `vera verify`
 - `mypy vera/` must be clean
 - `pytest tests/ -v` must pass

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.136] - 2026-05-06
+
 ### Fixed
+- **[#586](https://github.com/aallan/vera/issues/586)** — `apply_fn(closure, ())` on a `(Unit -> X)` closure no longer trips a WASM type mismatch.  Pre-fix, `_translate_apply_fn` in `vera/wasm/closures.py` defaulted the value-arg's WASM type to `i64` whenever `_infer_expr_wasm_type` returned `None` — but it returns `None` for both "couldn't infer" and "Unit has no representation", conflating the two cases.  A `UnitLit` arg pushed nothing onto the stack but registered a phantom `i64` param in the call_indirect signature.  The closure-lift side correctly skips Unit params, so the two ends disagreed and validation rejected the call with `expected i64, found i32` (the `func_table_idx` landing where the phantom value-arg was expected).  Fix is three lines: change `arg_wasm_types.append(wt or "i64")` to `elif wt is not None: arg_wasm_types.append(wt)` so Unit args contribute zero entries to the sig.  Same falsy-pitfall pattern as #584's `_fn_ret_types` filter.  New conformance test `ch05_unit_arg_closure.vera` covers no-capture, Int-capture, and Array-capture variants.
 - **[#589](https://github.com/aallan/vera/issues/589)** — `host_print` / `host_stderr` / `host_contract_fail` / `_read_wasm_string` / `vera/wasm/markdown.py::_read_string` no longer crash with a raw Python `UnicodeDecodeError` when an upstream codegen bug produces a corrupt String `(ptr, len)` pair pointing at non-UTF-8 bytes.  Pre-fix, the unhandled exception escaped through wasmtime's trampoline as a "python exception" cause and the user's CLI saw a 30+ line Python traceback ending in `UnicodeDecodeError: 'utf-8' codec can't decode byte 0xc1`.  A user-level program must never produce a Python traceback regardless of what the program does — this is the WasmTrapError contract from #516 / #522 / #547 applied to the UTF-8-decode paths.  Fix is per-site `errors="replace"` so invalid bytes surface as U+FFFD replacement characters in the user's output instead.  The String-return decoder in `execute()` (added by v0.0.135) was previously try/except → pointer fallback, which silently mutated the return type from `str` to `int` when bytes weren't valid UTF-8 — that fallback was a worse silent failure than visible U+FFFD chars (downstream consumers printed an integer where a string was expected) and is now also `errors="replace"`.  Surfaced by [#588](https://github.com/aallan/vera/issues/588) (captured-Array-indexing in closure produces corrupt String pointers); fixing #588 removes the most common trigger but the defensive-coding hygiene applies regardless of source.  New `TestHostPrintInvalidUtf8589` test class in `tests/test_runtime_traps.py` covers all six affected sites with structural assertions plus an end-to-end wasmtime-trampoline contract test using a synthetic WAT module that imports `vera.print` and calls it with raw invalid UTF-8 bytes.
 
 ## [0.0.135] - 2026-05-06
@@ -1945,7 +1948,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Grammar: handler body simplified to avoid LALR reduce/reduce conflict
 - `pyproject.toml`: corrected build backend, package discovery, PEP 639 compliance
 
-[Unreleased]: https://github.com/aallan/vera/compare/v0.0.135...HEAD
+[Unreleased]: https://github.com/aallan/vera/compare/v0.0.136...HEAD
+[0.0.136]: https://github.com/aallan/vera/compare/v0.0.135...v0.0.136
 [0.0.135]: https://github.com/aallan/vera/compare/v0.0.134...v0.0.135
 [0.0.134]: https://github.com/aallan/vera/compare/v0.0.133...v0.0.134
 [0.0.133]: https://github.com/aallan/vera/compare/v0.0.132...v0.0.133

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ pytest tests/ -v                  # Run the test suite (see TESTING.md)
 VERA_JS_COVERAGE=1 pytest tests/test_browser.py -v  # Browser tests with JS coverage
 mypy vera/                        # Type-check the compiler itself
 
-python scripts/check_conformance.py    # Verify all 84 conformance programs pass their declared level
+python scripts/check_conformance.py    # Verify all 85 conformance programs pass their declared level
 python scripts/check_examples.py      # Verify all 33 examples parse + check + verify
 python scripts/check_examples_readme.py # Verify vera run commands in examples/README.md
 python scripts/check_spec_examples.py # Verify spec code blocks parse
@@ -74,7 +74,7 @@ python scripts/fix_allowlists.py --fix # Auto-fix stale allowlist line numbers
 - `vera/` — Reference compiler: grammar, parser, AST, transformer, type checker, verifier, codegen, CLI
 - `examples/` — 33 example Vera programs (all must pass `vera check` and `vera verify`)
 - `tests/` — Test suite (unit tests + conformance suite)
-- `tests/conformance/` — 84 conformance programs validating every language feature against the spec
+- `tests/conformance/` — 85 conformance programs validating every language feature against the spec
 - `scripts/` — CI and validation scripts
 
 ## Writing Vera code
@@ -101,7 +101,7 @@ Each stage is a module with a public API function and is independently testable.
 ## What not to break
 
 - Pre-commit hooks run mypy + pytest + conformance suite + example validation on every commit
-- All 84 conformance programs in `tests/conformance/` must pass their declared level
+- All 85 conformance programs in `tests/conformance/` must pass their declared level
 - All 33 examples in `examples/` must pass `vera check` and `vera verify`
 - Version must stay in sync across `vera/__init__.py`, `pyproject.toml`, and `CHANGELOG.md`
 - All tests must pass: `pytest tests/ -v`

--- a/FAQ.md
+++ b/FAQ.md
@@ -162,7 +162,7 @@ None of this is Vera-specific, but it validates the design choices. The thesis i
 
 This is a real concern. LLMs are trained on trillions of tokens of Python, TypeScript, and JavaScript. A MojoBench study (NAACL 2025) found that even fine-tuned models achieved only 30–35% improvement over base models on Mojo code generation, illustrating the cold-start problem for new languages.
 
-Vera's approach has three parts. First, the agent-facing documentation (SKILL.md) is designed to be dropped into a model's context window, so the model works from the language specification rather than training data recall. Second, Vera's syntax is deliberately simple and regular — fewer constructs, each with exactly one canonical form — which reduces the surface area a model needs to learn. Third, the conformance test suite (84 programs covering every language feature) gives models concrete examples to learn from and conform to. Simon Willison argued in December 2025 that a language-agnostic conformance suite is the single most important tool for LLM adoption of a new language — LLMs can learn new languages remarkably well when given tests to conform to.
+Vera's approach has three parts. First, the agent-facing documentation (SKILL.md) is designed to be dropped into a model's context window, so the model works from the language specification rather than training data recall. Second, Vera's syntax is deliberately simple and regular — fewer constructs, each with exactly one canonical form — which reduces the surface area a model needs to learn. Third, the conformance test suite (85 programs covering every language feature) gives models concrete examples to learn from and conform to. Simon Willison argued in December 2025 that a language-agnostic conformance suite is the single most important tool for LLM adoption of a new language — LLMs can learn new languages remarkably well when given tests to conform to.
 
 
 ## How does Vera compare to Dafny / Lean / Koka / F*?
@@ -203,7 +203,7 @@ The reference compiler is under active development. The current release includes
 
 - A seven-stage pipeline: parse, transform, resolve, typecheck, verify, compile, execute
 - A 13-chapter formal specification
-- Over 3,000 unit tests plus an 84-program conformance suite
+- Over 3,000 unit tests plus an 85-program conformance suite
 - 33 working example programs
 - 164 built-in functions covering strings, arrays, math, parsing, and data types
 - Four built-in abilities (Eq, Ord, Hash, Show) with constrained generics and ADT auto-derivation

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -270,6 +270,7 @@ Stage 11 shifts focus from evaluation infrastructure to the standard library and
 | v0.0.133 | 5 May | **Iterative array builders no longer leak closure return-value root — closes [#570](https://github.com/aallan/vera/issues/570)** (`array_map` / `_mapi` / `_fold` / `_sort_by`). |
 | v0.0.134 | 6 May | **Active reclamation of host-store handles via heap-wrap-as-ADT — closes [#573](https://github.com/aallan/vera/issues/573), [#575](https://github.com/aallan/vera/issues/575), [#576](https://github.com/aallan/vera/issues/576), [#579](https://github.com/aallan/vera/issues/579)** (Map / Set / Decimal). |
 | v0.0.135 | 6 May | **Three codegen bug fixes — closes [#584](https://github.com/aallan/vera/issues/584), [#583](https://github.com/aallan/vera/issues/583), [#568](https://github.com/aallan/vera/issues/568)** (user `@Unit` fn in non-tail position; `Array<T>` type aliases in param/let/index/element positions; `url_parse(":foo")` → `Err` per RFC 3986 §3.1). |
+| v0.0.136 | 6 May | **Two host-runtime hygiene fixes — closes [#586](https://github.com/aallan/vera/issues/586) and [#589](https://github.com/aallan/vera/issues/589)** (`apply_fn(closure, ())` on a `(Unit -> X)` closure no longer registers a phantom `i64` param in the call_indirect signature; `host_print` / `host_stderr` / `host_contract_fail` / `_read_wasm_string` / `markdown::_read_string` / String-return decoder all use `errors="replace"` so corrupt String pointers from upstream codegen bugs surface as U+FFFD chars in user output rather than escape as Python tracebacks through wasmtime's trampoline). |
 
 ---
 
@@ -309,4 +310,4 @@ Alongside the compiler, editor support and AI discoverability infrastructure wer
 | Spec chapters | 7 | 10 | 11 | 12 | 13 | 13 | 13 |
 | Code coverage | — | — | — | 90% | 91% | 96% | 96% |
 
-Total: **810+ commits, 135 tagged releases, 54 active development days.**
+Total: **810+ commits, 136 tagged releases, 54 active development days.**

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ cp /path/to/vera/SKILL.md ~/.claude/skills/vera-language/SKILL.md
 
 ## Project status
 
-Vera is in **active development** at v0.0.136 — 810+ commits, 136 releases, 3,729 tests, 96% code coverage, 85 conformance programs, 33 examples, and a 13-chapter specification. See **[HISTORY.md](HISTORY.md)** for how the compiler was built.
+Vera is in **active development** at v0.0.136 — 810+ commits, 136 releases, 3,740 tests, 96% code coverage, 85 conformance programs, 33 examples, and a 13-chapter specification. See **[HISTORY.md](HISTORY.md)** for how the compiler was built.
 
 The reference compiler — parser, AST, type checker, contract verifier (Z3), WASM code generator, module system, browser runtime, and runtime contract insertion — is working. The language specification is in draft across [13 chapters](spec/).
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ cp /path/to/vera/SKILL.md ~/.claude/skills/vera-language/SKILL.md
 
 ## Project status
 
-Vera is in **active development** at v0.0.135 — 810+ commits, 135 releases, 3,726 tests, 96% code coverage, 84 conformance programs, 33 examples, and a 13-chapter specification. See **[HISTORY.md](HISTORY.md)** for how the compiler was built.
+Vera is in **active development** at v0.0.136 — 810+ commits, 136 releases, 3,729 tests, 96% code coverage, 85 conformance programs, 33 examples, and a 13-chapter specification. See **[HISTORY.md](HISTORY.md)** for how the compiler was built.
 
 The reference compiler — parser, AST, type checker, contract verifier (Z3), WASM code generator, module system, browser runtime, and runtime contract insertion — is working. The language specification is in draft across [13 chapters](spec/).
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@ See [HISTORY.md](HISTORY.md) for a narrative account of how the compiler was bui
 
 ## Where we are
 
-The compiler is complete end-to-end: parse, type-check, verify contracts via Z3, compile to WebAssembly, and run — at the command line and in the browser. The language has 164 built-in functions, algebraic effects (IO, Http, State, Exceptions, Async, Inference, Random), constrained generics, a module system, contract-driven testing, and a canonical formatter. Type inference for bare constructors (`None`, `Err`, `Ok`) now works correctly across all call sites. The compiler has 3,735 tests, 84 conformance programs, 33 examples, and a 13-chapter specification.
+The compiler is complete end-to-end: parse, type-check, verify contracts via Z3, compile to WebAssembly, and run — at the command line and in the browser. The language has 164 built-in functions, algebraic effects (IO, Http, State, Exceptions, Async, Inference, Random), constrained generics, a module system, contract-driven testing, and a canonical formatter. Type inference for bare constructors (`None`, `Err`, `Ok`) now works correctly across all call sites. The compiler has 3,740 tests, 85 conformance programs, 33 examples, and a 13-chapter specification.
 
 Significant progress has been made towards Vera being a viable agent target. [VeraBench](https://github.com/aallan/vera-bench) — a 50-problem benchmark across 5 difficulty tiers — now covers 6 models across 3 providers (v0.0.7). The headline result: Kimi K2.5 achieves 100% run_correct on Vera, beating both Python (86%) and TypeScript (91%). Three models beat TypeScript on Vera. The flagship tier averages 93% Vera run_correct vs 93% Python — essentially parity. These are single-run results with high variance; stable rates will require pass@k evaluation. The remaining gaps are empirical breadth (repeated trials, more models), standard library depth (HTTP hardening, server effects), and tooling integration (LSP).
 
@@ -250,4 +250,4 @@ Items here are **deferred decisions**, not scheduled work. Each captures the des
 
 ## Completed phases
 
-The compiler was built through eleven stages from February 2026 onwards. **810+ commits, 135 tagged releases (as of v0.0.135), 3,735 tests, 96% coverage, 84 conformance programs, 33 examples, 13 spec chapters.** See [HISTORY.md](HISTORY.md) for the per-stage narrative and per-release table.
+The compiler was built through eleven stages from February 2026 onwards. **810+ commits, 136 tagged releases (as of v0.0.136), 3,740 tests, 96% coverage, 85 conformance programs, 33 examples, 13 spec chapters.** See [HISTORY.md](HISTORY.md) for the per-stage narrative and per-release table.

--- a/SKILL.md
+++ b/SKILL.md
@@ -2230,7 +2230,7 @@ public fn main(@Unit -> @Unit)
 
 ## Conformance Suite
 
-The `tests/conformance/` directory contains 84 small, self-contained programs that validate every language feature against the spec — one program per feature. These are the best minimal working examples of Vera syntax and semantics.
+The `tests/conformance/` directory contains 85 small, self-contained programs that validate every language feature against the spec — one program per feature. These are the best minimal working examples of Vera syntax and semantics.
 
 Each program is organized by spec chapter (`ch01_int_literals.vera`, `ch04_match_basic.vera`, `ch07_state_handler.vera`, etc.) and the `manifest.json` file maps features to programs. When you need to see how a specific construct works, check the conformance program before reading the spec.
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,9 +6,9 @@ This is the single source of truth for Vera's testing infrastructure, coverage d
 
 | Metric | Value |
 |--------|-------|
-| **Tests** | 3,735 across 29 files (~34,800 lines of test code; 3,721 passed, 14 skipped) |
+| **Tests** | 3,740 across 29 files (~34,800 lines of test code; 3,726 passed, 14 skipped) |
 | **Compiler code coverage** | 96% of 15,149 statements (CI minimum: 80%) |
-| **Conformance programs** | 84 programs across 9 spec chapters, validating every language feature |
+| **Conformance programs** | 85 programs across 9 spec chapters, validating every language feature |
 | **Example programs** | 33, all validated through `vera check` + `vera verify` |
 | **Spec code blocks** | 164 parseable blocks from 13 spec chapters: 86 parse, 72 type-check, 71 verify |
 | **README code blocks** | 13 Vera blocks (12 validated, 1 allowlisted future syntax) |
@@ -36,7 +36,7 @@ VERA_JS_COVERAGE=1 pytest tests/test_browser.py -v  # V8 coverage via c8
 mypy vera/                                           # strict mode
 
 # Validation scripts
-python scripts/check_conformance.py                  # conformance suite (84 programs, see manifest.json)
+python scripts/check_conformance.py                  # conformance suite (85 programs, see manifest.json)
 python scripts/check_examples.py                     # 33 example programs
 python scripts/check_spec_examples.py                # spec code blocks
 python scripts/check_readme_examples.py              # README code blocks
@@ -73,7 +73,7 @@ python scripts/fix_allowlists.py --fix               # auto-fix stale allowlists
 | `test_tester_coverage.py` | 34 | 901 | Tester coverage gaps: String/Float64/ADT parameter input generation, Bool/Byte parameters, unsatisfiable preconditions, type expression edge cases |
 | `test_markdown.py` | 59 | 394 | Markdown parser: block/inline parsing, rendering, round-trips, edge cases |
 | `test_browser.py` | 99 | 1,821 | Browser parity: Python/wasmtime vs Node.js/JS-runtime output equivalence across IO, State, contracts, Markdown, Regex, and all compilable examples |
-| `test_conformance.py` | 420 | 102 | Parametrized conformance suite: parse, check, verify, run, format idempotency across 84 programs |
+| `test_conformance.py` | 425 | 102 | Parametrized conformance suite: parse, check, verify, run, format idempotency across 85 programs |
 | `test_prelude.py` | 24 | 422 | Prelude injection: Option/Result/array operation detection, combinator shadowing, type aliases, end-to-end compilation |
 | `test_readme.py` | 2 | 79 | README code sample parsing |
 | `test_html.py` | 4 | 166 | HTML landing page code samples: parse, check, verify |
@@ -108,7 +108,7 @@ Each conformance program declares the deepest pipeline stage it must pass:
 | `parse` | Source text is syntactically valid | 0 |
 | `check` | Parses and type-checks cleanly | 4 |
 | `verify` | Type-checks and all contracts verified by Z3 | 6 |
-| `run` | Compiles to WASM and executes correctly | 74 |
+| `run` | Compiles to WASM and executes correctly | 75 |
 
 Almost all programs are at the `run` level — they compile and execute, producing correct results. Four programs (`ch07_cross_module_contracts_lib`, `ch09_http`, `ch09_inference`, `ch03_typed_holes`) are at the `check` level. Six programs (`ch03_slot_let_chains`, `ch03_slot_noncommutative`, `ch07_cross_module_contracts`, `ch07_io_sleep`, `ch07_random_effect`, `ch09_math_builtins`) are at the `verify` level, using Z3-provable contracts.
 
@@ -150,7 +150,7 @@ tests/conformance/
 ├── ch01_int_literals.vera     # Chapter 1: Integer literals
 ├── ch01_float_literals.vera   # Chapter 1: Float64 literals
 ├── ch01_string_escapes.vera   # Chapter 1: String escape sequences
-├── ...                        # 84 programs total, organized by spec chapter
+├── ...                        # 85 programs total, organized by spec chapter
 ├── ch07_state_handler.vera    # Chapter 7: State<T> effect handler
 ├── ch07_exn_handler.vera      # Chapter 7: Exn<E> effect handler
 ├── ch09_numeric_builtins.vera # Chapter 9: Numeric built-in functions
@@ -349,7 +349,7 @@ Twelve scripts in `scripts/` validate cross-cutting concerns beyond unit tests:
 
 | Script | What it validates |
 |--------|-------------------|
-| `check_conformance.py` | All 84 conformance programs pass their declared level (parse/check/verify/run) |
+| `check_conformance.py` | All 85 conformance programs pass their declared level (parse/check/verify/run) |
 | `check_examples.py` | All 33 `.vera` examples pass `vera check` + `vera verify` |
 | `check_spec_examples.py` | 148 parseable code blocks from spec chapters: parse, type-check, and verify |
 | `check_readme_examples.py` | All Vera code blocks in README.md parse correctly |
@@ -391,7 +391,7 @@ Every push is checked by 25 configured hooks across two stages: 23 are configure
 | `mypy vera/` | Type-check compiler in strict mode |
 | `pytest tests/ -q` | Run full test suite |
 | `fix_allowlists.py --fix` | Auto-fix stale allowlist line numbers |
-| `check_conformance.py` | All 84 conformance programs pass their declared level |
+| `check_conformance.py` | All 85 conformance programs pass their declared level |
 | `check_examples.py` | All 33 examples pass `vera check` + `vera verify` |
 | `check_examples_readme.py` | `vera run` commands in `examples/README.md` reference existing files and exported functions |
 | `check_readme_examples.py` | README code blocks parse correctly |

--- a/TESTING.md
+++ b/TESTING.md
@@ -83,7 +83,7 @@ python scripts/fix_allowlists.py --fix               # auto-fix stale allowlists
 
 ## Conformance Suite
 
-The conformance suite is a collection of 84 small, focused programs in `tests/conformance/` that systematically validate every language feature against the spec. Each program is self-contained and imports nothing, with the single exception of `ch07_cross_module_contracts.vera` which depends on `ch07_cross_module_contracts_lib.vera`. Each program tests one feature or a small group of related features.
+The conformance suite is a collection of 85 small, focused programs in `tests/conformance/` that systematically validate every language feature against the spec. Each program is self-contained and imports nothing, with the single exception of `ch07_cross_module_contracts.vera` which depends on `ch07_cross_module_contracts_lib.vera`. Each program tests one feature or a small group of related features.
 
 Simon Willison [argues](https://simonwillison.net/tags/conformance-suites/) that conformance suites are a "huge unlock" for language projects — they transform development from trust-based to verification-based. The conformance suite serves as the definitive specification artifact that any implementation (or agent) can validate against.
 
@@ -184,7 +184,7 @@ The manifest is the machine-readable feature inventory — agents can query it t
 ### Running the conformance suite
 
 ```bash
-# Via pytest (parametrized — 410 tests)
+# Via pytest (parametrized — 425 tests)
 pytest tests/test_conformance.py -v
 
 # Via standalone script (used in CI and pre-commit)

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -2230,7 +2230,7 @@ public fn main(@Unit -> @Unit)
 
 ## Conformance Suite
 
-The `tests/conformance/` directory contains 84 small, self-contained programs that validate every language feature against the spec — one program per feature. These are the best minimal working examples of Vera syntax and semantics.
+The `tests/conformance/` directory contains 85 small, self-contained programs that validate every language feature against the spec — one program per feature. These are the best minimal working examples of Vera syntax and semantics.
 
 Each program is organized by spec chapter (`ch01_int_literals.vera`, `ch04_match_basic.vera`, `ch07_state_handler.vera`, etc.) and the `manifest.json` file maps features to programs. When you need to see how a specific construct works, check the conformance program before reading the spec.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -265,7 +265,7 @@
         <a href="/SKILL.md" rel="agent-instructions" type="text/markdown" class="btn btn-ghost">For Agents → SKILL.md</a>
       </div>
       <p class="version">
-        <span>v<a href="https://github.com/aallan/vera/releases/tag/v0.0.135">0.0.135</a></span>
+        <span>v<a href="https://github.com/aallan/vera/releases/tag/v0.0.136">0.0.136</a></span>
         <a href="https://github.com/aallan/vera/actions/workflows/ci.yml" aria-label="CI status"><img src="https://github.com/aallan/vera/actions/workflows/ci.yml/badge.svg" alt="CI" style="height:18px"></a>
       </p>
     </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@
 
 From the Latin *veritas* — truth. In Vera, verification is a first-class citizen.
 
-**Current version:** [0.0.135](https://github.com/aallan/vera/releases/tag/v0.0.135)  ·  [GitHub](https://github.com/aallan/vera)  ·  [SKILL.md](https://veralang.dev/SKILL.md) (agent language reference)
+**Current version:** [0.0.136](https://github.com/aallan/vera/releases/tag/v0.0.136)  ·  [GitHub](https://github.com/aallan/vera)  ·  [SKILL.md](https://veralang.dev/SKILL.md) (agent language reference)
 
 ## Why?
 
@@ -229,7 +229,7 @@ For other models: point them at [`SKILL.md`](https://veralang.dev/SKILL.md) via 
 
 ## Status
 
-Vera is under [active development](https://raw.githubusercontent.com/aallan/vera/main/ROADMAP.md). A complete compiler with 164 built-in functions, seven algebraic effects (IO, Http, State, Exceptions, Async, Inference, Random), contract-driven testing via [Z3](https://www.microsoft.com/en-us/research/project/z3-3/), and a 13-chapter specification. An 84-program conformance suite and 33 worked examples are validated against the spec on every pull request. All of it is developed openly on [GitHub](https://github.com/aallan/vera) and released under the MIT licence.
+Vera is under [active development](https://raw.githubusercontent.com/aallan/vera/main/ROADMAP.md). A complete compiler with 164 built-in functions, seven algebraic effects (IO, Http, State, Exceptions, Async, Inference, Random), contract-driven testing via [Z3](https://www.microsoft.com/en-us/research/project/z3-3/), and a 13-chapter specification. An 85-program conformance suite and 33 worked examples are validated against the spec on every pull request. All of it is developed openly on [GitHub](https://github.com/aallan/vera) and released under the MIT licence.
 
 ## Links
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2,7 +2,7 @@
 
 > Vera is a statically typed, purely functional programming language designed for large language models to write. It uses typed slot references (@T.n) instead of variable names, requires contracts on every function, and compiles to WebAssembly.
 
-This file contains the core Vera language documentation — language reference, agent instructions, FAQ, error codes, and formal grammar — compiled into a single document. Version 0.0.135. For the full documentation index including the 13-chapter specification and supplementary docs, see llms.txt.
+This file contains the core Vera language documentation — language reference, agent instructions, FAQ, error codes, and formal grammar — compiled into a single document. Version 0.0.136. For the full documentation index including the 13-chapter specification and supplementary docs, see llms.txt.
 
 
 ========================================================================
@@ -2236,7 +2236,7 @@ public fn main(@Unit -> @Unit)
 
 ## Conformance Suite
 
-The `tests/conformance/` directory contains 84 small, self-contained programs that validate every language feature against the spec — one program per feature. These are the best minimal working examples of Vera syntax and semantics.
+The `tests/conformance/` directory contains 85 small, self-contained programs that validate every language feature against the spec — one program per feature. These are the best minimal working examples of Vera syntax and semantics.
 
 Each program is organized by spec chapter (`ch01_int_literals.vera`, `ch04_match_basic.vera`, `ch07_state_handler.vera`, etc.) and the `manifest.json` file maps features to programs. When you need to see how a specific construct works, check the conformance program before reading the spec.
 
@@ -2308,7 +2308,7 @@ Read `SKILL.md` for the full language reference. It covers syntax, slot referenc
 
 ### Conformance programs as reference
 
-The conformance suite in `tests/conformance/` contains 84 small, self-contained programs — one per language feature — that serve as minimal working examples. Each program must pass its declared verification level (see `manifest.json` for mappings: `parse`, `check`, `verify`, or `run`). When you need to see how a specific construct works (e.g. effect handlers, match expressions, closures), check the corresponding conformance program before reading the spec.
+The conformance suite in `tests/conformance/` contains 85 small, self-contained programs — one per language feature — that serve as minimal working examples. Each program must pass its declared verification level (see `manifest.json` for mappings: `parse`, `check`, `verify`, or `run`). When you need to see how a specific construct works (e.g. effect handlers, match expressions, closures), check the corresponding conformance program before reading the spec.
 
 ### Workflow
 
@@ -2461,7 +2461,7 @@ Each stage is a module with a single public API function (`parse_file`, `transfo
 pytest tests/ -v                       # Run all tests (see TESTING.md)
 pytest tests/test_conformance.py -v    # Conformance suite only
 mypy vera/                             # Type-check the compiler
-python scripts/check_conformance.py    # All 84 conformance programs must pass
+python scripts/check_conformance.py    # All 85 conformance programs must pass
 python scripts/check_examples.py       # All 33 examples must pass
 ```
 
@@ -2471,7 +2471,7 @@ When implementing a new language feature, write the conformance program *first* 
 
 ### Invariants
 
-- All 84 conformance programs in `tests/conformance/` must pass their declared level
+- All 85 conformance programs in `tests/conformance/` must pass their declared level
 - All 33 examples in `examples/` must pass `vera check` and `vera verify`
 - `mypy vera/` must be clean
 - `pytest tests/ -v` must pass
@@ -2650,7 +2650,7 @@ None of this is Vera-specific, but it validates the design choices. The thesis i
 
 This is a real concern. LLMs are trained on trillions of tokens of Python, TypeScript, and JavaScript. A MojoBench study (NAACL 2025) found that even fine-tuned models achieved only 30–35% improvement over base models on Mojo code generation, illustrating the cold-start problem for new languages.
 
-Vera's approach has three parts. First, the agent-facing documentation (SKILL.md) is designed to be dropped into a model's context window, so the model works from the language specification rather than training data recall. Second, Vera's syntax is deliberately simple and regular — fewer constructs, each with exactly one canonical form — which reduces the surface area a model needs to learn. Third, the conformance test suite (84 programs covering every language feature) gives models concrete examples to learn from and conform to. Simon Willison argued in December 2025 that a language-agnostic conformance suite is the single most important tool for LLM adoption of a new language — LLMs can learn new languages remarkably well when given tests to conform to.
+Vera's approach has three parts. First, the agent-facing documentation (SKILL.md) is designed to be dropped into a model's context window, so the model works from the language specification rather than training data recall. Second, Vera's syntax is deliberately simple and regular — fewer constructs, each with exactly one canonical form — which reduces the surface area a model needs to learn. Third, the conformance test suite (85 programs covering every language feature) gives models concrete examples to learn from and conform to. Simon Willison argued in December 2025 that a language-agnostic conformance suite is the single most important tool for LLM adoption of a new language — LLMs can learn new languages remarkably well when given tests to conform to.
 
 
 ## How does Vera compare to Dafny / Lean / Koka / F*?
@@ -2691,7 +2691,7 @@ The reference compiler is under active development. The current release includes
 
 - A seven-stage pipeline: parse, transform, resolve, typecheck, verify, compile, execute
 - A 13-chapter formal specification
-- Over 3,000 unit tests plus an 84-program conformance suite
+- Over 3,000 unit tests plus an 85-program conformance suite
 - 33 working example programs
 - 164 built-in functions covering strings, arrays, math, parsing, and data types
 - Four built-in abilities (Eq, Ord, Hash, Show) with constrained generics and ADT auto-derivation

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -4,7 +4,7 @@
 
 Vera uses De Bruijn indexing for bindings: `@Int.0` is the most recent `Int` binding, `@Int.1` the one before. There are no variable names. Contracts are mandatory — every function must declare `requires(...)`, `ensures(...)`, and `effects(...)`. The Z3 SMT solver verifies contracts statically where possible; remaining contracts become runtime assertions. All side effects (IO, Http, State, Exceptions, Async, Inference, Random) are tracked in the type system via algebraic effects.
 
-Current version: 0.0.135. The reference compiler is written in Python. Install with `pip install -e .` from the repository.
+Current version: 0.0.136. The reference compiler is written in Python. Install with `pip install -e .` from the repository.
 
 ## Homepage
 
@@ -54,4 +54,4 @@ Current version: 0.0.135. The reference compiler is written in Python. Install w
 - [TESTING.md](https://raw.githubusercontent.com/aallan/vera/main/TESTING.md): Test suite architecture, coverage data, and test conventions.
 - [KNOWN_ISSUES.md](https://raw.githubusercontent.com/aallan/vera/main/KNOWN_ISSUES.md): Known bugs and limitations.
 - [CONTRIBUTING.md](https://raw.githubusercontent.com/aallan/vera/main/CONTRIBUTING.md): Contribution guidelines.
-- [Conformance Suite](https://github.com/aallan/vera/tree/main/tests/conformance): 84 programs validating every language feature against the spec.
+- [Conformance Suite](https://github.com/aallan/vera/tree/main/tests/conformance): 85 programs validating every language feature against the spec.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.135"
+version = "0.0.136"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/tests/conformance/ch05_unit_arg_closure.vera
+++ b/tests/conformance/ch05_unit_arg_closure.vera
@@ -1,0 +1,59 @@
+-- Conformance: apply_fn with Unit-arg closures (Chapter 5, #586)
+-- Tests: closure, unit_arg, apply_fn — exercises the _translate_apply_fn
+-- path that previously generated a phantom i64 param for None (Unit) args.
+-- Three positions: no-capture, Int-capture, Array<Bool>-capture.
+type UnitToInt = fn(Unit -> Int) effects(pure);
+
+type UnitToBool = fn(Unit -> Bool) effects(pure);
+
+-- Position 1: no capture, closure returns a constant.
+private fn make_const(@Unit -> @UnitToInt)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  fn(@Unit -> @Int) effects(pure) { 42 }
+}
+
+-- Position 2: capture an Int from the outer scope.
+private fn make_int_capture(@Int -> @UnitToInt)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  fn(@Unit -> @Int) effects(pure) { @Int.0 }
+}
+
+-- Position 3: capture an Array<Bool> and check it is non-empty.
+private fn make_array_capture(@Array<Bool> -> @UnitToBool)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  fn(@Unit -> @Bool) effects(pure) { nat_to_int(array_length(@Array<Bool>.0)) > 0 }
+}
+
+public fn main(@Unit -> @Int)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  -- Position 1: no capture, expect 42.
+  let @UnitToInt = make_const(());
+  let @Int = apply_fn(@UnitToInt.0, ());
+  -- Position 2: capture 7, expect 7.
+  let @UnitToInt = make_int_capture(7);
+  let @Int = apply_fn(@UnitToInt.0, ());
+  -- Position 3: non-empty array is truthy → encode as 1.
+  let @Array<Bool> = [true, false];
+  let @UnitToBool = make_array_capture(@Array<Bool>.0);
+  let @Bool = apply_fn(@UnitToBool.0, ());
+  let @Int = if @Bool.0 then { 1 } else { 0 };
+  -- Sum: 42 + 7 + 1 = 50. Return 0 on success.
+  let @Int = @Int.2 + @Int.1 + @Int.0;
+  if @Int.0 == 50 then {
+    0
+  } else {
+    1
+  }
+}

--- a/tests/conformance/manifest.json
+++ b/tests/conformance/manifest.json
@@ -508,6 +508,19 @@
     ]
   },
   {
+    "id": "ch05_unit_arg_closure",
+    "file": "ch05_unit_arg_closure.vera",
+    "chapter": 5,
+    "title": "apply_fn with Unit-arg closures (#586)",
+    "level": "run",
+    "spec_ref": "Section 5.4",
+    "features": [
+      "closure",
+      "unit_arg",
+      "apply_fn"
+    ]
+  },
+  {
     "id": "ch05_visibility",
     "file": "ch05_visibility.vera",
     "chapter": 5,

--- a/uv.lock
+++ b/uv.lock
@@ -574,7 +574,7 @@ wheels = [
 
 [[package]]
 name = "vera"
-version = "0.0.135"
+version = "0.0.136"
 source = { editable = "." }
 dependencies = [
     { name = "lark" },

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,4 +1,4 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.135"
-version = "0.0.135"
+__version__ = "0.0.136"
+version = "0.0.136"

--- a/vera/wasm/closures.py
+++ b/vera/wasm/closures.py
@@ -141,11 +141,19 @@ class ClosuresMixin:
             instructions.extend(arg_instrs)
             # Infer WASM type for call_indirect type signature.
             # Pair types (String, Array) push two i32 values onto the stack.
+            # Unit args push nothing — `_infer_expr_wasm_type` returns None
+            # for them — so they must NOT contribute a phantom param to
+            # the call_indirect sig.  The closure-lift side already
+            # skips Unit params (vera/codegen/closures.py:85), and a
+            # mismatch here makes WASM validation reject the call with
+            # "type mismatch: expected i64, found i32" because the
+            # closure's func_table_idx ends up where the phantom value
+            # arg was expected.
             wt = self._infer_expr_wasm_type(arg)
             if wt == "i32_pair":
                 arg_wasm_types.extend(["i32", "i32"])
-            else:
-                arg_wasm_types.append(wt or "i64")  # default to i64
+            elif wt is not None:
+                arg_wasm_types.append(wt)
 
         # Load func_table_idx from closure struct
         instructions.append(f"local.get {tmp}")

--- a/vera/wasm/closures.py
+++ b/vera/wasm/closures.py
@@ -141,18 +141,26 @@ class ClosuresMixin:
             instructions.extend(arg_instrs)
             # Infer WASM type for call_indirect type signature.
             # Pair types (String, Array) push two i32 values onto the stack.
-            # Unit args push nothing — `_infer_expr_wasm_type` returns None
-            # for them — so they must NOT contribute a phantom param to
-            # the call_indirect sig.  The closure-lift side already
-            # skips Unit params (vera/codegen/closures.py:85), and a
-            # mismatch here makes WASM validation reject the call with
-            # "type mismatch: expected i64, found i32" because the
-            # closure's func_table_idx ends up where the phantom value
-            # arg was expected.
             wt = self._infer_expr_wasm_type(arg)
             if wt == "i32_pair":
                 arg_wasm_types.extend(["i32", "i32"])
-            elif wt is not None:
+            elif wt is None:
+                # Unit arg: `_infer_expr_wasm_type` returns None and
+                # `translate_expr` pushed nothing onto the stack
+                # above, so this entry must NOT contribute a phantom
+                # param to the call_indirect sig.  The closure-lift
+                # side at `vera/codegen/closures.py:85` likewise skips
+                # Unit params, so the two sides agree on omitting
+                # them (#586).  Per the type-checker invariant, the
+                # only well-typed expression for which
+                # `_infer_expr_wasm_type` returns None is a Unit-typed
+                # one — anything else would have failed type-check
+                # before reaching codegen, so an explicit branch here
+                # documents the intent without needing a runtime
+                # assert (which would have to re-run type inference
+                # to verify Unit-typedness, defeating the purpose).
+                pass
+            else:
                 arg_wasm_types.append(wt)
 
         # Load func_table_idx from closure struct


### PR DESCRIPTION
## Summary

Closes #586.

`apply_fn(closure, ())` on a `(Unit -> X)` closure tripped a WASM type-mismatch at compile time:

```
type mismatch: expected i64, found i32
```

`vera check` passed (the program is well-typed at the source level); the failure was purely in codegen.

Discovered while smoke-testing the v0.0.119 closure-capture bugs (#514 / #535) on v0.0.135 to confirm they were closed. Both ARE closed; this is a separate adjacent codegen bug — same class as #584 (falsy-pitfall: `None` overloaded between "Unit" and "unknown").

## Root cause

`_translate_apply_fn` in `vera/wasm/closures.py` (~line 148) defaulted the value-arg's WASM type to `i64` when `_infer_expr_wasm_type` returned `None`:

```python
wt = self._infer_expr_wasm_type(arg)
if wt == "i32_pair":
    arg_wasm_types.extend(["i32", "i32"])
else:
    arg_wasm_types.append(wt or "i64")  # bug: None means Unit OR unknown
```

For a `UnitLit` argument:
- `translate_expr(UnitLit, env)` returned `[]` (no WASM value pushed — correct)
- `_infer_expr_wasm_type(UnitLit)` returned `None` (correct — Unit has no representation)
- `wt or "i64"` evaluated to `"i64"` — registered a phantom param in the call_indirect sig

The closure-lift side (`vera/codegen/closures.py:85`) correctly skips Unit params. The closure was registered with `(param i32) (result i64)` (env-only); apply_fn emitted a `call_indirect (type $closure_sig_1)` where `$closure_sig_1` was `(param i32) (param i64) (result i64)`. The validator saw the closure's `func_table_idx` (an `i32`) where the phantom i64 value-arg was expected.

## Fix

Three-line change in `vera/wasm/closures.py::_translate_apply_fn`. Unit args now contribute zero entries to the call_indirect sig, matching the closure-lift side.

## Test plan

- [x] Issue reproducer compiles + runs cleanly (prints `42`).
- [x] New conformance test `tests/conformance/ch05_unit_arg_closure.vera` covers three positions:
  - **No-capture Unit-arg closure** — minimal reproducer
  - **Int-capture Unit-arg closure** — exercises capture path
  - **Array<Bool>-capture Unit-arg closure** — exercises heap-pointer capture (#514's fix) plus #586's fix together
- [x] Existing `ch05_closures.vera` and `ch05_nested_closures.vera` still pass.
- [x] All 85 conformance programs pass (was 84; +1 new).
- [x] All 33 examples pass `check` + `verify`.
- [x] `pytest tests/` — 3,719 passed, 14 skipped.
- [x] `mypy vera/` clean.
- [x] All pre-commit hooks pass (doc-counts, version-sync, limitations-sync, site assets all consistent).

## Doc updates

- `CHANGELOG.md` — new `[0.0.136]` entry under Fixed.
- `HISTORY.md` — Stage 11 row for v0.0.136 + footer release count 135 -> 136.
- Version files bumped 0.0.135 -> 0.0.136.
- Conformance + test count surfaces updated 84 -> 85 / 3,728 -> 3,733.
- Site assets regenerated.
- `uv.lock` regenerated for the version bump.

## Notes for follow-up

The conformance-test-writer agent flagged a separate pre-existing bug while writing the Array<Bool>-capture test: `@Array<Bool>.0[index]` Bool-element indexing inside a closure body trips a WASM codegen issue unrelated to #586. Worked around in the conformance test by using `array_length(...)` instead. Worth filing as a follow-up once a clean reproducer is isolated; not blocking this PR.

Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a conformance test covering unit-argument closures, expanding the suite to 85 programs.

* **Bug Fixes**
  * Fixed closure WASM code generation to ignore unit-typed arguments, removing phantom parameters.

* **Documentation**
  * Updated CHANGELOG, README, ROADMAP, FAQ, HISTORY and other docs to reflect v0.0.136 and the 85-program suite.

* **Chores**
  * Bumped package version to v0.0.136.

* **Tests**
  * Updated test manifest and testing guidance for the expanded conformance suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->