### PR TITLE
Fix #628: cross-module _fn_ret_type_exprs propagation + release v0.0.147

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.147] - 2026-05-12
+
+### Fixed
+
+- **[#628](https://github.com/aallan/vera/issues/628)** — cross-module imports now propagate `_fn_ret_type_exprs` alongside `_fn_sigs`.  Pre-fix `vera/codegen/modules.py`'s cross-module harvest only populated `_fn_sigs` (carrying WASM type info — sufficient for call-validation), but the `_fn_ret_type_exprs` registry (added in #614, re-used by #602) was never harvested across modules.  A `String`- or `Array<T>`-returning fn defined in module A and called from module B then hit `_fn_ret_type_exprs.get(name) → None` and fell through to the silent-skip path that #602 / #614 had already closed in-module.  Two failure shapes: (1) `make_arr(())[0]` where `make_arr` is cross-module — IndexExpr element-type inference returned None, enclosing function dropped via `[E602]`; (2) `IO.print("\(make_str(()))\n")` where `make_str` is cross-module — interpolation segment fell through to the `to_string(...)` silent wrapper, tripping `expected i64, found i32` at WASM validation.  Post-fix the cross-module harvest in `vera/codegen/modules.py` populates `_fn_ret_type_exprs` with the same `setdefault` shape as `_fn_sigs`.  Closes `#628`.
+
 ## [0.0.146] - 2026-05-12
 
 ### Fixed
@@ -2155,7 +2161,8 @@ Small docs sweep — closes six aging documentation issues in one PR.  No code c
 - Grammar: handler body simplified to avoid LALR reduce/reduce conflict
 - `pyproject.toml`: corrected build backend, package discovery, PEP 639 compliance
 
-[Unreleased]: https://github.com/aallan/vera/compare/v0.0.146...HEAD
+[Unreleased]: https://github.com/aallan/vera/compare/v0.0.147...HEAD
+[0.0.147]: https://github.com/aallan/vera/compare/v0.0.146...v0.0.147
 [0.0.146]: https://github.com/aallan/vera/compare/v0.0.145...v0.0.146
 [0.0.145]: https://github.com/aallan/vera/compare/v0.0.144...v0.0.145
 [0.0.144]: https://github.com/aallan/vera/compare/v0.0.143...v0.0.144

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -291,6 +291,7 @@ Stage 12 opens on the morning v0.0.138 shipped: the residual GC-rooting bug in #
 | v0.0.144 | 11 May | Tier A bug burn-down — closes [#633](https://github.com/aallan/vera/issues/633), [#634](https://github.com/aallan/vera/issues/634), [#556](https://github.com/aallan/vera/issues/556), [#591](https://github.com/aallan/vera/issues/591). |
 | v0.0.145 | 11 May | Mono-suffix bug + template-warning suppression — closes [#604](https://github.com/aallan/vera/issues/604) and [#655](https://github.com/aallan/vera/issues/655) Shape A. |
 | v0.0.146 | 12 May | Refinement-of-Array element inference — closes [#655](https://github.com/aallan/vera/issues/655) Shape B. |
+| v0.0.147 | 12 May | Cross-module `_fn_ret_type_exprs` propagation — closes [#628](https://github.com/aallan/vera/issues/628). |
 
 ---
 
@@ -331,4 +332,4 @@ Alongside the compiler, editor support and AI discoverability infrastructure wer
 | Spec chapters | 7 | 10 | 11 | 12 | 13 | 13 | 13 |
 | Code coverage | — | — | — | 90% | 91% | 96% | 96% |
 
-Total: **810+ commits, 146 tagged releases, 58 active development days.**
+Total: **810+ commits, 147 tagged releases, 58 active development days.**

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ cp /path/to/vera/SKILL.md ~/.claude/skills/vera-language/SKILL.md
 
 ## Project status
 
-Vera is in **active development** at v0.0.146 — 810+ commits, 146 releases, 3,813 tests, 96% code coverage, 86 conformance programs, 34 examples, and a 13-chapter specification. See **[HISTORY.md](HISTORY.md)** for how the compiler was built.
+Vera is in **active development** at v0.0.147 — 810+ commits, 147 releases, 3,815 tests, 96% code coverage, 86 conformance programs, 34 examples, and a 13-chapter specification. See **[HISTORY.md](HISTORY.md)** for how the compiler was built.
 
 The reference compiler — parser, AST, type checker, contract verifier (Z3), WASM code generator, module system, browser runtime, and runtime contract insertion — is working. The language specification is in draft across [13 chapters](spec/).
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ Where the project is going.  See [HISTORY.md](HISTORY.md) for what's been built 
 
 ## Where we are
 
-3,813 tests, 86 conformance programs, 34 examples, 13 spec chapters.
+3,815 tests, 86 conformance programs, 34 examples, 13 spec chapters.
 
 ## What's next
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,7 +6,7 @@ This is the single source of truth for Vera's testing infrastructure, coverage d
 
 | Metric | Value |
 |--------|-------|
-| **Tests** | 3,813 across 29 files (~50,858 lines of test code; 3,799 passed, 14 skipped) |
+| **Tests** | 3,815 across 29 files (~50,932 lines of test code; 3,801 passed, 14 skipped) |
 | **Compiler code coverage** | 96% of 15,149 statements (CI minimum: 80%) |
 | **Conformance programs** | 86 programs across 9 spec chapters, validating every language feature |
 | **Example programs** | 34, all validated through `vera check` + `vera verify` |
@@ -62,7 +62,7 @@ python scripts/fix_allowlists.py --fix               # auto-fix stale allowlists
 | `test_codegen_contracts.py` | 32 | 576 | Runtime pre/postconditions, contract fail messages, old/new state postconditions |
 | `test_codegen_monomorphize.py` | 71 | 1,326 | Generic instantiation, type inference, monomorphization edge cases, ability constraint satisfaction (Eq/Ord/Hash/Show), operation rewriting (eq/compare), show/hash dispatch, ADT auto-derivation, array operations (slice/map/filter/fold) |
 | `test_codegen_closures.py` | 50 | 1,624 | Closure lifting, captured variables, higher-order functions, iterative-builder shadow-stack regressions (#570), closure return-value shadow-push balance for both i32-pair and i32-ADT branches across array_map and array_mapi, plus VERA_EAGER_GC injection self-test (#593), IndexExpr-of-FnCall element-type inference (#614), non-contiguous capture and walker-order miscompiles (#615) |
-| `test_codegen_modules.py` | 19 | 565 | Cross-module guard rail, cross-module codegen, name collision detection (E608/E609/E610) |
+| `test_codegen_modules.py` | 21 | 639 | Cross-module guard rail, cross-module codegen, name collision detection (E608/E609/E610) |
 | `test_codegen_coverage.py` | 5 | 250 | Defensive error paths: E600, E601, E605, E606, unknown module calls  |
 | `test_errors.py` | 52 | 525 | Error code registry, diagnostic formatting, serialisation, SourceLocation, error display sync (README/HTML/spec) |
 | `test_formatter.py` | 122 | 1,075 | Comment extraction, interior comment positioning, expression/declaration formatting, match arm block bodies, idempotency, parenthesization, spec rules, ability declarations |

--- a/docs/index.html
+++ b/docs/index.html
@@ -265,7 +265,7 @@
         <a href="/SKILL.md" rel="agent-instructions" type="text/markdown" class="btn btn-ghost">For Agents → SKILL.md</a>
       </div>
       <p class="version">
-        <span>v<a href="https://github.com/aallan/vera/releases/tag/v0.0.146">0.0.146</a></span>
+        <span>v<a href="https://github.com/aallan/vera/releases/tag/v0.0.147">0.0.147</a></span>
         <a href="https://github.com/aallan/vera/actions/workflows/ci.yml" aria-label="CI status"><img src="https://github.com/aallan/vera/actions/workflows/ci.yml/badge.svg" alt="CI" style="height:18px"></a>
       </p>
     </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@
 
 From the Latin *veritas* — truth. In Vera, verification is a first-class citizen.
 
-**Current version:** [0.0.146](https://github.com/aallan/vera/releases/tag/v0.0.146)  ·  [GitHub](https://github.com/aallan/vera)  ·  [SKILL.md](https://veralang.dev/SKILL.md) (agent language reference)
+**Current version:** [0.0.147](https://github.com/aallan/vera/releases/tag/v0.0.147)  ·  [GitHub](https://github.com/aallan/vera)  ·  [SKILL.md](https://veralang.dev/SKILL.md) (agent language reference)
 
 ## Why?
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2,7 +2,7 @@
 
 > Vera is a statically typed, purely functional programming language designed for large language models to write. It uses typed slot references (@T.n) instead of variable names, requires contracts on every function, and compiles to WebAssembly.
 
-This file contains the core Vera language documentation — language reference, agent instructions, FAQ, error codes, and formal grammar — compiled into a single document. Version 0.0.146. For the full documentation index including the 13-chapter specification and supplementary docs, see llms.txt.
+This file contains the core Vera language documentation — language reference, agent instructions, FAQ, error codes, and formal grammar — compiled into a single document. Version 0.0.147. For the full documentation index including the 13-chapter specification and supplementary docs, see llms.txt.
 
 
 ========================================================================

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -4,7 +4,7 @@
 
 Vera uses De Bruijn indexing for bindings: `@Int.0` is the most recent `Int` binding, `@Int.1` the one before. There are no variable names. Contracts are mandatory — every function must declare `requires(...)`, `ensures(...)`, and `effects(...)`. The Z3 SMT solver verifies contracts statically where possible; remaining contracts become runtime assertions. All side effects (IO, Http, State, Exceptions, Async, Inference, Random) are tracked in the type system via algebraic effects.
 
-Current version: 0.0.146. The reference compiler is written in Python. Install with `pip install -e .` from the repository.
+Current version: 0.0.147. The reference compiler is written in Python. Install with `pip install -e .` from the repository.
 
 ## Homepage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.146"
+version = "0.0.147"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_codegen_modules.py
+++ b/tests/test_codegen_modules.py
@@ -348,6 +348,80 @@ public fn main(-> @Int)
 """, [mod], fn="main")
         assert val == 42
 
+    # -- #628 cross-module return-type-expression harvest -----------------
+
+    def test_cross_module_index_of_fncall(self) -> None:
+        """`make_arr(())[0]` where `make_arr` is defined in another
+        module compiles and returns the first element.
+
+        `#628` regression: pre-fix `_fn_ret_type_exprs` was populated
+        only for in-module functions, so the IndexExpr translator's
+        element-type inference returned None for `make_arr(())[0]`,
+        the enclosing `main` got dropped via `[E602]`, and `vera run`
+        reported "No exported functions to call".  Post-fix the
+        cross-module harvest in `vera/codegen/modules.py` populates
+        `_fn_ret_type_exprs` alongside `_fn_sigs`.
+        """
+        arr_mod_source = """\
+public fn make_arr(@Unit -> @Array<Int>)
+  requires(true) ensures(true) effects(pure)
+{
+  [1, 2, 3]
+}
+"""
+        mod = self._resolved(("arr",), arr_mod_source)
+        val = self._run_mod("""\
+import arr(make_arr);
+
+public fn main(@Unit -> @Int)
+  requires(true) ensures(true) effects(pure)
+{
+  make_arr(())[0]
+}
+""", [mod], fn="main")
+        assert val == 1, (
+            f"Expected make_arr(())[0] == 1 cross-module; got {val!r}.  "
+            "Pre-#628-fix this would have failed with main dropped via "
+            "[E602] and no exported function to call."
+        )
+
+    def test_cross_module_string_interpolation_of_fncall(self) -> None:
+        """Interpolating a `String`-returning cross-module call inside
+        a string literal compiles and prints correctly.
+
+        Pre-fix: `_fn_ret_type_exprs` lookup returned None for
+        cross-module `make_str`, the interpolation segment fell through
+        to the `to_string(...)` silent wrapper, the i32_pair value
+        tripped `expected i64, found i32` at WASM validation, and
+        the enclosing function was dropped.
+        """
+        str_mod_source = """\
+public fn make_str(@Unit -> @String)
+  requires(true) ensures(true) effects(pure)
+{
+  "hello"
+}
+"""
+        mod = self._resolved(("strs",), str_mod_source)
+        result = self._compile_mod("""\
+import strs(make_str);
+
+public fn main(@Unit -> @Unit)
+  requires(true) ensures(true) effects(<IO>)
+{
+  IO.print("\\(make_str(()))!\\n")
+}
+""", [mod])
+        errors = [d for d in result.diagnostics if d.severity == "error"]
+        assert not errors, (
+            f"Expected no errors after #628 fix; got: "
+            f"{[d.description for d in errors]}"
+        )
+        exec_result = execute(result, fn_name="main")
+        assert exec_result.stdout == "hello!\n", (
+            f"Expected 'hello!\\n'; got {exec_result.stdout!r}"
+        )
+
 
 # =====================================================================
 # Name collision detection (#110)

--- a/uv.lock
+++ b/uv.lock
@@ -635,7 +635,7 @@ wheels = [
 
 [[package]]
 name = "vera"
-version = "0.0.146"
+version = "0.0.147"
 source = { editable = "." }
 dependencies = [
     { name = "lark" },

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,4 +1,4 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.146"
-version = "0.0.146"
+__version__ = "0.0.147"
+version = "0.0.147"

--- a/vera/codegen/modules.py
+++ b/vera/codegen/modules.py
@@ -90,6 +90,24 @@ class CrossModuleMixin:
                 # registered so the guard rail sees them as known
                 self._fn_sigs.setdefault(fn_name, sig)
 
+            # Harvest return-type expressions alongside _fn_sigs.
+            # #628 — _fn_ret_type_exprs (added in #614 / re-used by
+            # #602) stores each FnDecl's full Vera return-type AST so
+            # inference walkers can extract element types from
+            # `Array<T>`-returning calls and element types from
+            # `String`-returning calls used inside interpolation
+            # segments.  Pre-fix the registry was populated only for
+            # functions defined in the current module; cross-module
+            # calls hit `_fn_ret_type_exprs.get(name) → None` and
+            # fell through to the silent-skip path that #602 / #614
+            # had already closed in-module.  Same harvest shape as
+            # `_fn_sigs` above — `setdefault` so first-seen wins (no
+            # collision detection needed; if `fn_sigs` collision
+            # detection above caught a name clash, the offending
+            # decl was rejected before we reach this loop).
+            for fn_name, ret_te in temp._fn_ret_type_exprs.items():
+                self._fn_ret_type_exprs.setdefault(fn_name, ret_te)
+
             # Harvest ADT layouts
             for adt_name, layouts in temp._adt_layouts.items():
                 # Builtin ADTs (Option, Result, Ordering, etc.) appear in


### PR DESCRIPTION
## Summary

- Closes #628: cross-module imports now propagate `_fn_ret_type_exprs` alongside `_fn_sigs`. Fixes two failure shapes (`make_arr(())[0]` IndexExpr-of-FnCall + `IO.print("\(make_str(()))\n")` String interpolation) for cross-module callees that worked in-module since #614 / #602.
- Bundle v0.0.147 release prep (per the ABSOLUTE RULE — no separate cleanup PR).

Closes #628.

## Root cause

`vera/codegen/modules.py`'s cross-module harvest loop populated `_fn_sigs` via `setdefault` but never touched `_fn_ret_type_exprs`. That registry (added in #614, re-used by #602) stores each FnDecl's full Vera return-type AST so inference walkers can extract `Array<T>` element types and recognise `String`-returning calls. Cross-module callees hit `_fn_ret_type_exprs.get(name) → None` and fell through to the silent-skip path that #602 / #614 had closed in-module.

## Fix

One harvest block added in the cross-module loop, alongside the existing `_fn_sigs` harvest:

```python
for fn_name, ret_te in temp._fn_ret_type_exprs.items():
    self._fn_ret_type_exprs.setdefault(fn_name, ret_te)
```

Same shape as the `_fn_sigs` harvest. No collision detection needed — the existing `_fn_sigs` collision loop above already rejects name clashes.

## Regression tests

Two new tests in `tests/test_codegen_modules.py::TestCrossModuleCodegen`:

1. **`test_cross_module_index_of_fncall`** — `make_arr(())[0]` returns 1 cross-module
2. **`test_cross_module_string_interpolation_of_fncall`** — `IO.print("\(make_str(()))!\n")` produces `"hello!\n"` cross-module

Both fail against the pre-fix code path; both pass post-fix.

## Release prep (v0.0.147)

- `vera/__init__.py` + `pyproject.toml` + `uv.lock`: 0.0.146 → 0.0.147
- `CHANGELOG.md`: dated `[0.0.147] - 2026-05-12` heading + link refs
- `HISTORY.md` Stage 12 row + roll-up counter 146 → 147
- `docs/index.html`: version tag
- `README.md` / `TESTING.md` / `ROADMAP.md`: count refreshes

## Test plan

- [x] mypy clean
- [x] pytest passes (3,801 passed, 14 skipped — was 3,799 + 2 new regression tests)
- [x] All 86 conformance programs pass
- [x] All 34 examples pass `vera check` + `vera verify`
- [x] e602 gate: 116 files clean, 5 allowlist matched, 0 stale
- [x] version-sync, doc-counts: consistent
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cross-module return-type inference for imported functions, enabling array indexing and string interpolation to work correctly across modules.

* **Tests**
  * Added regression tests validating cross-module function calls with array indexing and string interpolation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aallan/vera/pull/663)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->