### PR TITLE
Fix vera test verifier error handling (#674)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - **[#675](https://github.com/aallan/vera/issues/675)** — E500 (`Postcondition does not hold`) `fix=` text now names all three repair classes neutrally, with implementation-repair first.  Pre-fix the text named only two classes (strengthen `requires(...)`, weaken `ensures(...)`) — implicitly biasing the user away from the most common repair when E500 catches a typo in the function body.  External report from @rzyns.  Tightened `tests/test_verifier.py::TestCounterexamples::test_violation_has_fix_suggestion` to pin all three classes (pre-existing assertion would have survived the rewrite without catching a regression dropping "implementation").
 
+- **[#674](https://github.com/aallan/vera/issues/674)** — `vera test` now fails closed when the verifier reports E500/E501/E502 diagnostics instead of treating verifier-refuted contracts as successful Tier 1 results.  JSON output now sets `ok: false`, preserves the verifier diagnostics, and exits non-zero; human output displays failed functions and a diagnostics section so verifier failures cannot be hidden behind green rows.
+  - `E501` call-site precondition failures are attributed to the caller rather than the callee, while `E500` postcondition failures and `E502` `@Nat` subtraction underflow diagnostics are attributed to their responsible function.
+  - `--fn` keeps function rows filtered to the selected target, but whole-file verifier errors still fail closed and remain visible in diagnostics; private/non-displayed verifier failures likewise surface as unlisted verifier errors instead of disappearing.
+  - Human summaries distinguish static verifier failures from Tier 3 runtime trial failures, keep E700 runtime contract violations out of verifier-error counts, and avoid double-counting multiple verifier diagnostics already represented by a displayed failed function.
+
+### Tests
+
+- Added regression coverage for `vera test` verifier-error handling across JSON and human output, private helper failures, `--fn` filtering, E501 caller attribution, E502 underflow attribution, mixed static/Tier 3 summaries, E700 runtime failures, multiple diagnostics on one failed function, and CLI dispatch return codes.
+
 ### Documentation
 
 - **Docs sweep addressing 2026-05-18 compiler-review findings** ([PR #684](https://github.com/aallan/vera/pull/684)) —
   - `README.md` "Contracts the compiler proves" section reworded — the previous unqualified claim ("Division by zero is not a runtime error — it is a type error.  The compiler checks every call site to prove the divisor is non-zero.") overclaimed; the verifier checks contracts the programmer wrote, not auto-synthesised obligations on primitives.  New wording correctly describes static-vs-runtime split with forward reference to [#680](https://github.com/aallan/vera/issues/680) (auto-injection follow-up).
   - `FAQ.md` — new Q&A "Does the compiler prove division-by-zero, out-of-bounds indexing, etc. can't happen?" walking through the static/runtime split.
   - `spec/06-contracts.md` — new §6.4.3 "Primitive Operation Safety" between Call Site Verification and SMT Solver Integration.  Subsequent sections renumbered.  States explicitly that obligations on `a / b`, `a % b`, `arr[i]`, `string_at(s, i)` are not auto-synthesised; `@Nat` subtraction ([#520](https://github.com/aallan/vera/issues/520)) is the one exception today.
-  - `KNOWN_ISSUES.md` — Bugs section restored with [#674](https://github.com/aallan/vera/issues/674) (`vera test --json` reports refuted functions as `verified` — external report from @rzyns; I filed a duplicate as #681 which is closed in favour of #674).
+  - `KNOWN_ISSUES.md` — PR #684 restored the [#674](https://github.com/aallan/vera/issues/674) bug row with the external report from @rzyns and duplicate #681 provenance; this fixing PR removes that row because `vera test` now fails closed on verifier-refuted contracts.
   - `ROADMAP.md` — four new tracking items: [#679](https://github.com/aallan/vera/issues/679) (Ch 8 conformance gap), [#680](https://github.com/aallan/vera/issues/680) (auto-inject primitive obligations, cross-referenced from #427), [#682](https://github.com/aallan/vera/issues/682) (diagnostic-tagging discipline), [#683](https://github.com/aallan/vera/issues/683) (spec/Lark grammar nominal drift).
 
 ## [0.0.155] - 2026-05-13

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -6,7 +6,6 @@ Bugs and limitations tracked against the [issue tracker](https://github.com/aall
 
 | Bug | Issue |
 |-----|-------|
-| `vera test` reports functions as `VERIFIED (Tier 1)` when the verifier has refuted them with an `E500` counterexample.  The classifier only harvests `severity == "warning"` Tier 3 codes (`E520`–`E525`); `severity == "error"` codes (`E500`, `E501`, `E502`) flow past untouched and the function falls through to the default `"verified"` branch.  Reproducer: a function with `requires(true) ensures(@Int.result == @Int.0 + @Int.0)` and body `@Int.0 + @Int.0 + 1` is flagged by `vera verify` (E500 with counterexample `@Int.0 = 0`) but reported as `VERIFIED (Tier 1)` with exit code 0 by `vera test --json`.  This is a problem for CI: downstream tooling consuming `test --json` would silently accept a contract-incorrect program even though `verify --json` correctly rejects it.  Workaround: run `vera verify` before trusting `vera test` results.  Severity: correctness, unsafe direction. | [#674](https://github.com/aallan/vera/issues/674) |
 
 ## Limitations
 

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -4,8 +4,7 @@ Bugs and limitations tracked against the [issue tracker](https://github.com/aall
 
 ## Bugs
 
-| Bug | Issue |
-|-----|-------|
+No known bugs.
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ cp /path/to/vera/SKILL.md ~/.claude/skills/vera-language/SKILL.md
 
 ## Project status
 
-Vera is in **active development** at v0.0.155 — 810+ commits, 155 releases, 3,916 tests, 96% code coverage, 86 conformance programs, 34 examples, and a 13-chapter specification. See **[HISTORY.md](HISTORY.md)** for how the compiler was built.
+Vera is in **active development** at v0.0.155 — 810+ commits, 155 releases, 3,917 tests, 96% code coverage, 86 conformance programs, 34 examples, and a 13-chapter specification. See **[HISTORY.md](HISTORY.md)** for how the compiler was built.
 
 The reference compiler — parser, AST, type checker, contract verifier (Z3), WASM code generator, module system, browser runtime, and runtime contract insertion — is working. The language specification is in draft across [13 chapters](spec/).
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ cp /path/to/vera/SKILL.md ~/.claude/skills/vera-language/SKILL.md
 
 ## Project status
 
-Vera is in **active development** at v0.0.155 — 810+ commits, 155 releases, 3,905 tests, 96% code coverage, 86 conformance programs, 34 examples, and a 13-chapter specification. See **[HISTORY.md](HISTORY.md)** for how the compiler was built.
+Vera is in **active development** at v0.0.155 — 810+ commits, 155 releases, 3,916 tests, 96% code coverage, 86 conformance programs, 34 examples, and a 13-chapter specification. See **[HISTORY.md](HISTORY.md)** for how the compiler was built.
 
 The reference compiler — parser, AST, type checker, contract verifier (Z3), WASM code generator, module system, browser runtime, and runtime contract insertion — is working. The language specification is in draft across [13 chapters](spec/).
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ Where the project is going.  See [HISTORY.md](HISTORY.md) for what's been built 
 
 ## Where we are
 
-3,905 tests, 86 conformance programs, 34 examples, 13 spec chapters.
+3,916 tests, 86 conformance programs, 34 examples, 13 spec chapters.
 
 ## What's next
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ Where the project is going.  See [HISTORY.md](HISTORY.md) for what's been built 
 
 ## Where we are
 
-3,916 tests, 86 conformance programs, 34 examples, 13 spec chapters.
+3,917 tests, 86 conformance programs, 34 examples, 13 spec chapters.
 
 ## What's next
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,7 +6,7 @@ This is the single source of truth for Vera's testing infrastructure, coverage d
 
 | Metric | Value |
 |--------|-------|
-| **Tests** | 3,905 across 32 files (~53,284 lines of test code; 3,875 passed + 16 stress, 14 skipped) |
+| **Tests** | 3,916 across 32 files (~53,524 lines of test code; 3,886 passed + 16 stress, 14 skipped) |
 | **Compiler code coverage** | 96% of 15,149 statements (CI minimum: 80%) |
 | **Conformance programs** | 86 programs across 9 spec chapters, validating every language feature |
 | **Example programs** | 34, all validated through `vera check` + `vera verify` |
@@ -69,14 +69,14 @@ python scripts/fix_allowlists.py --fix               # auto-fix stale allowlists
 | `test_stress.py` | 16 | 553 | Scale-dependent regression tests (#596) — `@pytest.mark.stress`, skipped by default.  9 logical tests × eager-GC lane parametrisation = 16 test instances.  10K `array_map`, 5K nested-array `array_map`, 1K-deep tail recursion with allocating arg, 1M-deep tail recursion with allocating arg (#549 GC-aware TCO), 20×20 nested array-fold-of-array-fold, 100K `array_fold`, 10K String allocations, 1K `State<Int>` get/put cycles, 10K `IO.print` calls.  Pins #570 / #515 / #593 / #549 / #487 / #348 / #573 regression coverage |
 | `test_errors.py` | 52 | 525 | Error code registry, diagnostic formatting, serialisation, SourceLocation, error display sync (README/HTML/spec) |
 | `test_formatter.py` | 122 | 1,075 | Comment extraction, interior comment positioning, expression/declaration formatting, match arm block bodies, idempotency, parenthesization, spec rules, ability declarations |
-| `test_cli.py` | 217 | 3,021 | CLI commands (check, verify, compile, run, test, fmt, version, quiet), subprocess integration, JSON error paths, runtime traps, arg validation, multi-file resolution, IO exit codes, --explain-slots |
+| `test_cli.py` | 225 | 3,250 | CLI commands (check, verify, compile, run, test, fmt, version, quiet), subprocess integration, JSON error paths, runtime traps, arg validation, multi-file resolution, IO exit codes, --explain-slots |
 | `test_resolver.py` | 15 | 412 | Module resolution, path lookup, parse caching, circular import detection |
 | `test_types.py` | 73 | 390 | Type operations: subtyping, effect subtyping, equality, substitution, pretty-printing, canonical names |
 | `test_wasm.py` | 24 | 346 | WASM internals: StringPool, WasmSlotEnv, translation edge cases via full pipeline |
 | `test_verifier_coverage.py` | 91 | 1,590 | Verifier/SMT coverage gaps: SMT encoding paths, verifier edge cases, defensive branches, **#667 SMT translator coverage for `FloatLit` / `IndexExpr` / `ArrayLit`** (Tier 1 verification of float/array literal/index contract predicates) |
 | `test_wasm_coverage.py` | 226 | 3,978 | WASM coverage gaps: helpers unit tests, inference branches, closure free-var walking, operator/data/context edge cases |
-| `test_tester.py` | 14 | 369 | Contract-driven testing: tier classification, input generation, test execution, skip message content |
-| `test_tester_coverage.py` | 34 | 901 | Tester coverage gaps: String/Float64/ADT parameter input generation, Bool/Byte parameters, unsatisfiable preconditions, type expression edge cases |
+| `test_tester.py` | 17 | 445 | Contract-driven testing: tier classification, input generation, test execution, skip message content |
+| `test_tester_coverage.py` | 34 | 903 | Tester coverage gaps: String/Float64/ADT parameter input generation, Bool/Byte parameters, unsatisfiable preconditions, type expression edge cases |
 | `test_markdown.py` | 59 | 394 | Markdown parser: block/inline parsing, rendering, round-trips, edge cases |
 | `test_browser.py` | 99 | 1,821 | Browser parity: Python/wasmtime vs Node.js/JS-runtime output equivalence across IO, State, contracts, Markdown, Regex, and all compilable examples |
 | `test_conformance.py` | 430 | 102 | Parametrized conformance suite: parse, check, verify, run, format idempotency across 86 programs |

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,7 +6,7 @@ This is the single source of truth for Vera's testing infrastructure, coverage d
 
 | Metric | Value |
 |--------|-------|
-| **Tests** | 3,916 across 32 files (~53,524 lines of test code; 3,886 passed + 16 stress, 14 skipped) |
+| **Tests** | 3,917 across 32 files (~53,574 lines of test code; 3,887 passed + 16 stress, 14 skipped) |
 | **Compiler code coverage** | 96% of 15,149 statements (CI minimum: 80%) |
 | **Conformance programs** | 86 programs across 9 spec chapters, validating every language feature |
 | **Example programs** | 34, all validated through `vera check` + `vera verify` |
@@ -69,7 +69,7 @@ python scripts/fix_allowlists.py --fix               # auto-fix stale allowlists
 | `test_stress.py` | 16 | 553 | Scale-dependent regression tests (#596) — `@pytest.mark.stress`, skipped by default.  9 logical tests × eager-GC lane parametrisation = 16 test instances.  10K `array_map`, 5K nested-array `array_map`, 1K-deep tail recursion with allocating arg, 1M-deep tail recursion with allocating arg (#549 GC-aware TCO), 20×20 nested array-fold-of-array-fold, 100K `array_fold`, 10K String allocations, 1K `State<Int>` get/put cycles, 10K `IO.print` calls.  Pins #570 / #515 / #593 / #549 / #487 / #348 / #573 regression coverage |
 | `test_errors.py` | 52 | 525 | Error code registry, diagnostic formatting, serialisation, SourceLocation, error display sync (README/HTML/spec) |
 | `test_formatter.py` | 122 | 1,075 | Comment extraction, interior comment positioning, expression/declaration formatting, match arm block bodies, idempotency, parenthesization, spec rules, ability declarations |
-| `test_cli.py` | 225 | 3,250 | CLI commands (check, verify, compile, run, test, fmt, version, quiet), subprocess integration, JSON error paths, runtime traps, arg validation, multi-file resolution, IO exit codes, --explain-slots |
+| `test_cli.py` | 226 | 3,300 | CLI commands (check, verify, compile, run, test, fmt, version, quiet), subprocess integration, JSON error paths, runtime traps, arg validation, multi-file resolution, IO exit codes, --explain-slots |
 | `test_resolver.py` | 15 | 412 | Module resolution, path lookup, parse caching, circular import detection |
 | `test_types.py` | 73 | 390 | Type operations: subtyping, effect subtyping, equality, substitution, pretty-printing, canonical names |
 | `test_wasm.py` | 24 | 346 | WASM internals: StringPool, WasmSlotEnv, translation edge cases via full pipeline |

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1376,6 +1376,200 @@ class TestCmdTest:
         assert "functions" in data
         assert "summary" in data
 
+    def test_json_verifier_error_is_failed(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """--json must not report verifier-refuted contracts as verified."""
+        path = Path(_bad_vera(tmp_path, """\
+public fn double(@Int -> @Int)
+  requires(true)
+  ensures(@Int.result == @Int.0 + @Int.0)
+  effects(pure)
+{
+  @Int.0 + @Int.0 + 1
+}
+
+public fn main(@Unit -> @Int)
+  requires(true)
+  ensures(@Int.result == 42)
+  effects(pure)
+{
+  double(21)
+}
+"""))
+        rc = cmd_test(str(path), as_json=True)
+        assert rc == 1
+        data = json.loads(capsys.readouterr().out)
+        assert data["ok"] is False
+        assert data["summary"]["failed"] == 1
+        double = next(f for f in data["functions"] if f["name"] == "double")
+        assert double["category"] == "failed"
+        assert double["reason"] == "verification error (E500)"
+        assert any(d["error_code"] == "E500" for d in data["diagnostics"])
+
+    def test_human_verifier_error_is_failed(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Human output must also fail when verifier diagnostics contain errors."""
+        path = Path(_bad_vera(tmp_path, """\
+public fn double(@Int -> @Int)
+  requires(true)
+  ensures(@Int.result == @Int.0 + @Int.0)
+  effects(pure)
+{
+  @Int.0 + @Int.0 + 1
+}
+
+public fn main(@Unit -> @Int)
+  requires(true)
+  ensures(@Int.result == 42)
+  effects(pure)
+{
+  double(21)
+}
+"""))
+        rc = cmd_test(str(path))
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "FAILED" in out
+        assert "verification error (E500)" in out
+        assert "Results: 1 failed" in out
+
+    def test_private_verifier_error_is_reported(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Private verifier failures must not disappear from vera test."""
+        path = Path(_bad_vera(tmp_path, """\
+private fn bad(@Int -> @Int)
+  requires(true)
+  ensures(@Int.result == @Int.0 + @Int.0)
+  effects(pure)
+{
+  @Int.0 + @Int.0 + 1
+}
+
+public fn expose(@Int -> @Int)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  bad(@Int.0)
+}
+"""))
+        rc = cmd_test(str(path), as_json=True)
+        assert rc == 1
+        data = json.loads(capsys.readouterr().out)
+        assert data["ok"] is False
+        assert any(d["error_code"] == "E500" for d in data["diagnostics"])
+
+        rc = cmd_test(str(path))
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "Diagnostics:" in out
+        assert "E500" in out
+        assert "1 verifier error" in out
+
+    def test_fn_filter_surfaces_unselected_verifier_error(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """--fn still fails closed when the whole-file verifier reports errors."""
+        path = Path(_bad_vera(tmp_path, """\
+public fn broken(@Int -> @Int)
+  requires(true)
+  ensures(@Int.result == @Int.0 + @Int.0)
+  effects(pure)
+{
+  @Int.0 + @Int.0 + 1
+}
+
+public fn identity(@Int -> @Int)
+  requires(true)
+  ensures(@Int.result == @Int.0)
+  effects(pure)
+{
+  @Int.0
+}
+"""))
+        rc = cmd_test(str(path), as_json=True, fn_name="identity")
+        assert rc == 1
+        data = json.loads(capsys.readouterr().out)
+        assert data["ok"] is False
+        assert data["summary"]["failed"] == 0
+        assert any(d["error_code"] == "E500" for d in data["diagnostics"])
+        assert [f["name"] for f in data["functions"]] == ["identity"]
+        assert data["functions"][0]["category"] == "verified"
+
+    def test_mixed_static_failure_and_tier3_summary(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Static failures are summarized separately from Tier 3 runtime trials."""
+        path = Path(_bad_vera(tmp_path, """\
+public fn broken(@Int -> @Int)
+  requires(true)
+  ensures(@Int.result == @Int.0 + @Int.0)
+  effects(pure)
+{
+  @Int.0 + @Int.0 + 1
+}
+
+public fn tier3_ok(@Nat -> @Nat)
+  requires(true)
+  ensures(true)
+  decreases(0)
+  effects(pure)
+{
+  @Nat.0
+}
+"""))
+        rc = cmd_test(str(path), trials=5)
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "Results: 1 tested (1 passed), 1 failed" in out
+        assert "Trials:" in out
+        assert "0 failed" in out
+
+    def test_tier3_runtime_failures_are_not_verifier_errors(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """E700 runtime contract failures are not summarized as verifier errors."""
+        path = Path(_bad_vera(tmp_path, """\
+public fn tricky(@Int -> @Int)
+  requires(true)
+  ensures(exists(@Int, 1, fn(@Int -> @Bool) effects(pure) { false }))
+  effects(pure)
+{
+  @Int.0
+}
+"""))
+        rc = cmd_test(str(path), trials=3)
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "Results: 1 tested (0 passed, 1 failed)" in out
+        assert "verifier error" not in out
+        assert "E700" in out
+
+    def test_displayed_failed_function_does_not_double_count_verifier_errors(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Multiple verifier diagnostics on a displayed failed function are not extra errors."""
+        path = Path(_bad_vera(tmp_path, """\
+public fn multi(@Nat, @Nat -> @Nat)
+  requires(true)
+  ensures(false)
+  ensures(@Nat.result == @Nat.0)
+  effects(pure)
+{
+  @Nat.1 - @Nat.0
+}
+"""))
+        rc = cmd_test(str(path))
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "Results: 1 failed" in out
+        assert "verifier error" not in out
+        assert "E502" in out
+        assert "E500" in out
+
     def test_trials_flag(self, capsys: pytest.CaptureFixture[str]) -> None:
         """--trials should limit trial count."""
         rc = cmd_test(SAFE_DIVIDE, trials=5)
@@ -1427,6 +1621,34 @@ class TestCmdTestMain:
         assert result.returncode == 0
         data = json.loads(result.stdout)
         assert data["ok"] is True
+
+    def test_dispatch_test_json_verifier_error_nonzero(self, tmp_path: Path) -> None:
+        prog = tmp_path / "wrong_double.vera"
+        prog.write_text("""\
+public fn double(@Int -> @Int)
+  requires(true)
+  ensures(@Int.result == @Int.0 + @Int.0)
+  effects(pure)
+{
+  @Int.0 + @Int.0 + 1
+}
+
+public fn main(@Unit -> @Int)
+  requires(true)
+  ensures(@Int.result == 42)
+  effects(pure)
+{
+  double(21)
+}
+""", encoding="utf-8")
+        result = subprocess.run(
+            [sys.executable, "-m", "vera.cli", "test", "--json", str(prog)],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 1
+        data = json.loads(result.stdout)
+        assert data["ok"] is False
+        assert data["summary"]["failed"] == 1
 
     def test_dispatch_test_trials(self) -> None:
         result = subprocess.run(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1502,9 +1502,59 @@ public fn identity(@Int -> @Int)
         data = json.loads(capsys.readouterr().out)
         assert data["ok"] is False
         assert data["summary"]["failed"] == 0
+        # `broken` is filtered out of the displayed list but its
+        # verifier error still surfaces here.  Pinning the
+        # structured field (rather than re-running attribution
+        # in the test) keeps the test aligned with how downstream
+        # CI consumers should read the JSON.
+        assert data["summary"]["unlisted_errors"] == 1
         assert any(d["error_code"] == "E500" for d in data["diagnostics"])
         assert [f["name"] for f in data["functions"]] == ["identity"]
         assert data["functions"][0]["category"] == "verified"
+
+    def test_fn_filter_surfaces_unselected_verifier_error_text(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Text-output sibling of test_fn_filter_surfaces_unselected_verifier_error.
+
+        Pins the same fail-closed invariant against the human output
+        path: the displayed function list stays filtered to
+        ``identity`` (per ``--fn``), but the whole-file verifier
+        error on ``broken`` must still appear in the Diagnostics
+        section, drive the exit code to 1, and surface as an
+        unlisted verifier error in the summary (since ``broken``
+        isn't in the displayed list).
+        """
+        path = Path(_bad_vera(tmp_path, """\
+public fn broken(@Int -> @Int)
+  requires(true)
+  ensures(@Int.result == @Int.0 + @Int.0)
+  effects(pure)
+{
+  @Int.0 + @Int.0 + 1
+}
+
+public fn identity(@Int -> @Int)
+  requires(true)
+  ensures(@Int.result == @Int.0)
+  effects(pure)
+{
+  @Int.0
+}
+"""))
+        rc = cmd_test(str(path), fn_name="identity")
+        assert rc == 1
+        out = capsys.readouterr().out
+        # Only the selected function appears in the displayed list.
+        assert "identity" in out
+        assert "VERIFIED (Tier 1)" in out
+        assert "broken" not in out.split("Diagnostics:")[0]
+        # Diagnostics section surfaces the unselected E500.
+        assert "Diagnostics:" in out
+        assert "E500" in out
+        # Summary names the unlisted verifier error so the user
+        # sees that the exit-code-1 isn't from the displayed function.
+        assert "verifier error" in out
 
     def test_mixed_static_failure_and_tier3_summary(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,9 +27,16 @@ ABS_VALUE = str(EXAMPLES_DIR / "absolute_value.vera")
 
 
 def _bad_vera(tmp_path: Path, content: str) -> str:
-    """Write a bad .vera file and return its path."""
+    """Write a bad .vera file and return its path.
+
+    Uses ``encoding="utf-8"`` explicitly so Windows runs don't fall
+    back to cp1252.  CLAUDE.md (Cross-platform pitfalls) flags this
+    as a required convention for test fixtures: Vera sources can
+    contain UTF-8 sequences (string literals, conformance fixtures)
+    and the default text-mode encoding on Windows would corrupt them.
+    """
     p = tmp_path / "bad.vera"
-    p.write_text(content)
+    p.write_text(content, encoding="utf-8")
     return str(p)
 
 

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -89,7 +89,11 @@ public fn caller(@Int -> @Int)
         result = _test(source)
         needs_pos = _fn_result(result, "needs_pos")
         caller = _fn_result(result, "caller")
-        assert needs_pos.category != "failed"
+        # Positive assertion (vs the weaker `!= "failed"`) so we pin
+        # that the callee is correctly proven, not just that it
+        # avoided the failed bucket — `"skipped"` or any other
+        # category would also be a regression here.
+        assert needs_pos.category == "verified"
         assert caller.category == "failed"
         assert caller.reason == "verification error (E501)"
         assert result.summary.failed == 1

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -41,6 +41,78 @@ def _fn_result(result: TestResult, name: str) -> FunctionTestResult:
 class TestTier1:
     """Functions whose contracts are fully proved should be reported as verified."""
 
+    def test_verifier_error_is_failed_not_verified(self) -> None:
+        """A verifier-refuted postcondition must not be classified as Tier 1."""
+        source = """\
+public fn double(@Int -> @Int)
+  requires(true)
+  ensures(@Int.result == @Int.0 + @Int.0)
+  effects(pure)
+{
+  @Int.0 + @Int.0 + 1
+}
+
+public fn main(@Unit -> @Int)
+  requires(true)
+  ensures(@Int.result == 42)
+  effects(pure)
+{
+  double(21)
+}
+"""
+        result = _test(source)
+        f = _fn_result(result, "double")
+        assert f.category == "failed"
+        assert f.reason == "verification error (E500)"
+        assert result.summary.failed == 1
+        assert any(d.error_code == "E500" for d in result.diagnostics)
+
+    def test_call_precondition_error_fails_caller_not_callee(self) -> None:
+        """E501 is a failed caller obligation, not a callee failure."""
+        source = """\
+public fn needs_pos(@Int -> @Int)
+  requires(@Int.0 > 0)
+  ensures(true)
+  effects(pure)
+{
+  @Int.0
+}
+
+public fn caller(@Int -> @Int)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  needs_pos(@Int.0)
+}
+"""
+        result = _test(source)
+        needs_pos = _fn_result(result, "needs_pos")
+        caller = _fn_result(result, "caller")
+        assert needs_pos.category != "failed"
+        assert caller.category == "failed"
+        assert caller.reason == "verification error (E501)"
+        assert result.summary.failed == 1
+        assert any(d.error_code == "E501" for d in result.diagnostics)
+
+    def test_nat_underflow_error_is_failed(self) -> None:
+        """E502 Nat underflow obligations are classified as failed."""
+        source = """\
+public fn subtract(@Nat, @Nat -> @Nat)
+  requires(true)
+  ensures(true)
+  effects(pure)
+{
+  @Nat.1 - @Nat.0
+}
+"""
+        result = _test(source)
+        f = _fn_result(result, "subtract")
+        assert f.category == "failed"
+        assert f.reason == "verification error (E502)"
+        assert result.summary.failed == 1
+        assert any(d.error_code == "E502" for d in result.diagnostics)
+
     def test_simple_verified(self) -> None:
         """An absolute_value-like function with provable contracts."""
         source = """\
@@ -107,10 +179,8 @@ public fn identity(@Nat -> @Nat)
         assert result.summary.tested == 1
         assert result.summary.passed == 1
 
-    def test_tier3_failing(self) -> None:
-        """A function whose contract is violated for some inputs."""
-        # This function claims result >= 0, but for negative inputs
-        # it returns the input itself (which is negative).
+    def test_verifier_error_takes_precedence_over_tier3_testing(self) -> None:
+        """A verifier error is reported as failed before runtime testing."""
         source = """\
 public fn buggy(@Int -> @Int)
   requires(true)
@@ -123,9 +193,11 @@ public fn buggy(@Int -> @Int)
 """
         result = _test(source, trials=20)
         f = _fn_result(result, "buggy")
-        assert f.category == "tested"
-        assert f.trials_failed > 0
+        assert f.category == "failed"
+        assert f.reason == "verification error (E500)"
+        assert f.trials_run == 0
         assert result.summary.failed == 1
+        assert any(d.error_code == "E500" for d in result.diagnostics)
 
 
 # =====================================================================

--- a/tests/test_tester_coverage.py
+++ b/tests/test_tester_coverage.py
@@ -315,10 +315,12 @@ public fn double_pos(@PosInt -> @Int)
 """
         path = _write_vera(tmp_path, source)
         rc = cmd_test(path, trials=10)
-        assert rc == 0
+        assert rc == 1
         out = capsys.readouterr().out
-        # Should be tested or verified (refinement narrows input)
+        # Verifier errors are now classified as failed, not silently verified.
         assert "Testing:" in out
+        assert "FAILED" in out
+        assert "verification error (E500)" in out
 
 
 # =====================================================================

--- a/vera/cli.py
+++ b/vera/cli.py
@@ -886,6 +886,7 @@ def cmd_test(
     """Parse, type-check, and test a .vera file via contract-driven testing."""
     from vera.checker import typecheck
     from vera.resolver import ModuleResolver
+    from vera.tester import _failed_function_name
     from vera.tester import test as run_test
 
     try:
@@ -926,12 +927,12 @@ def cmd_test(
             resolved_modules=resolved,
         )
 
+        has_errors = any(d.severity == "error" for d in result.diagnostics)
+
         if as_json:
             s = result.summary
             result_dict = {
-                "ok": s.failed == 0 and not any(
-                    d.severity == "error" for d in result.diagnostics
-                ),
+                "ok": s.failed == 0 and not has_errors,
                 "file": path,
                 "functions": [
                     {
@@ -965,7 +966,7 @@ def cmd_test(
                 "diagnostics": [d.to_dict() for d in result.diagnostics],
             }
             print(json.dumps(result_dict, indent=2))
-            return 1 if s.failed > 0 else 0
+            return 1 if s.failed > 0 or has_errors else 0
 
         # Human-readable output
         print(f"\nTesting: {path}\n")
@@ -988,6 +989,11 @@ def cmd_test(
                     f"  {f.fn_name} {'.' * max(1, 40 - len(f.fn_name))} "
                     f"VERIFIED (Tier 1)"
                 )
+            elif f.category == "failed":
+                line = (
+                    f"  {f.fn_name} {'.' * max(1, 40 - len(f.fn_name))} "
+                    f"FAILED  ({f.reason})"
+                )
             else:
                 line = (
                     f"  {f.fn_name} {'.' * max(1, 40 - len(f.fn_name))} "
@@ -1003,13 +1009,42 @@ def cmd_test(
                     )
                     print(f"    {args_str} -> {trial.message}")
 
+        if result.diagnostics:
+            print("\nDiagnostics:")
+            for d in result.diagnostics:
+                code = f"{d.error_code}: " if d.error_code else ""
+                first_line = d.description.splitlines()[0]
+                print(f"  {code}{first_line}")
+
         # Summary
         s = result.summary
+        static_failed = sum(1 for f in result.functions if f.category == "failed")
+        tested_failed = sum(
+            1 for f in result.functions
+            if f.category == "tested" and f.trials_failed > 0
+        )
+        verifier_error_codes = {"E500", "E501", "E502"}
+        displayed_failed = {
+            f.fn_name for f in result.functions if f.category == "failed"
+        }
+        unlisted_errors = sum(
+            1 for d in result.diagnostics
+            if d.severity == "error"
+            and d.error_code in verifier_error_codes
+            and _failed_function_name(d) not in displayed_failed
+        )
         parts = []
         if s.tested > 0:
             parts.append(
                 f"{s.tested} tested ({s.passed} passed"
-                + (f", {s.failed} failed)" if s.failed else ")")
+                + (f", {tested_failed} failed)" if tested_failed else ")")
+            )
+        if static_failed > 0:
+            parts.append(f"{static_failed} failed")
+        if unlisted_errors > 0:
+            parts.append(
+                f"{unlisted_errors} verifier "
+                f"error{'s' if unlisted_errors != 1 else ''}"
             )
         if s.verified > 0:
             parts.append(f"{s.verified} verified")
@@ -1025,7 +1060,7 @@ def cmd_test(
                 f"{s.total_failures} failed"
             )
 
-        return 1 if s.failed > 0 else 0
+        return 1 if s.failed > 0 or has_errors else 0
 
     except FileNotFoundError:
         if as_json:

--- a/vera/cli.py
+++ b/vera/cli.py
@@ -886,11 +886,7 @@ def cmd_test(
     """Parse, type-check, and test a .vera file via contract-driven testing."""
     from vera.checker import typecheck
     from vera.resolver import ModuleResolver
-    from vera.tester import (
-        VERIFICATION_ERROR_CODES,
-        failed_function_name,
-        test as run_test,
-    )
+    from vera.tester import test as run_test
 
     try:
         p, source, tree = _load_and_parse(path)
@@ -965,6 +961,7 @@ def cmd_test(
                     "total_trials": s.total_trials,
                     "total_passes": s.total_passes,
                     "total_failures": s.total_failures,
+                    "unlisted_errors": s.unlisted_errors,
                 },
                 "diagnostics": [d.to_dict() for d in result.diagnostics],
             }
@@ -1026,15 +1023,7 @@ def cmd_test(
             1 for f in result.functions
             if f.category == "tested" and f.trials_failed > 0
         )
-        displayed_failed = {
-            f.fn_name for f in result.functions if f.category == "failed"
-        }
-        unlisted_errors = sum(
-            1 for d in result.diagnostics
-            if d.severity == "error"
-            and d.error_code in VERIFICATION_ERROR_CODES
-            and failed_function_name(d) not in displayed_failed
-        )
+        unlisted_errors = s.unlisted_errors
         parts = []
         if s.tested > 0:
             parts.append(

--- a/vera/cli.py
+++ b/vera/cli.py
@@ -886,8 +886,11 @@ def cmd_test(
     """Parse, type-check, and test a .vera file via contract-driven testing."""
     from vera.checker import typecheck
     from vera.resolver import ModuleResolver
-    from vera.tester import _failed_function_name
-    from vera.tester import test as run_test
+    from vera.tester import (
+        VERIFICATION_ERROR_CODES,
+        failed_function_name,
+        test as run_test,
+    )
 
     try:
         p, source, tree = _load_and_parse(path)
@@ -1023,15 +1026,14 @@ def cmd_test(
             1 for f in result.functions
             if f.category == "tested" and f.trials_failed > 0
         )
-        verifier_error_codes = {"E500", "E501", "E502"}
         displayed_failed = {
             f.fn_name for f in result.functions if f.category == "failed"
         }
         unlisted_errors = sum(
             1 for d in result.diagnostics
             if d.severity == "error"
-            and d.error_code in verifier_error_codes
-            and _failed_function_name(d) not in displayed_failed
+            and d.error_code in VERIFICATION_ERROR_CODES
+            and failed_function_name(d) not in displayed_failed
         )
         parts = []
         if s.tested > 0:

--- a/vera/tester.py
+++ b/vera/tester.py
@@ -44,7 +44,7 @@ class FunctionTestResult:
     """Test result for a single function."""
 
     fn_name: str
-    category: str  # "verified" | "tested" | "skipped"
+    category: str  # "verified" | "tested" | "failed" | "skipped"
     reason: str
     trials_run: int
     trials_passed: int
@@ -59,7 +59,7 @@ class TestSummary:
     verified: int = 0  # Tier 1 (proved)
     tested: int = 0  # Tier 3 exercised
     passed: int = 0  # tested + all trials OK
-    failed: int = 0  # tested + at least one trial failed
+    failed: int = 0  # verifier-refuted or tested + at least one trial failed
     skipped: int = 0  # can't generate inputs
     total_trials: int = 0
     total_passes: int = 0
@@ -189,6 +189,9 @@ class _TestEngine:
 
         # 2. Filter to target functions
         targets = self._get_targets(classification)
+        verifier_errors = [
+            d for d in verify_result.diagnostics if d.severity == "error"
+        ]
 
         # 3. Compile (needed for execution)
         compile_result = codegen_compile(
@@ -204,7 +207,7 @@ class _TestEngine:
 
         summary = TestSummary()
         results: list[FunctionTestResult] = []
-        diagnostics: list[Diagnostic] = []
+        diagnostics: list[Diagnostic] = verifier_errors
 
         for fn_name, category, reason, decl in targets:
             if category == "verified":
@@ -212,6 +215,19 @@ class _TestEngine:
                 results.append(FunctionTestResult(
                     fn_name=fn_name,
                     category="verified",
+                    reason=reason,
+                    trials_run=0,
+                    trials_passed=0,
+                    trials_failed=0,
+                    failures=[],
+                ))
+                continue
+
+            if category == "failed":
+                summary.failed += 1
+                results.append(FunctionTestResult(
+                    fn_name=fn_name,
+                    category="failed",
                     reason=reason,
                     trials_run=0,
                     trials_passed=0,
@@ -398,15 +414,21 @@ def _classify_functions(
 
     Returns {name: (category, reason, decl)}.
     """
-    # Collect function names mentioned in Tier 3 warnings
+    # Collect function names mentioned in verifier diagnostics.
     tier3_fns: set[str] = set()
     tier3_codes = {"E520", "E521", "E522", "E523", "E524", "E525"}
+    failed_fns: dict[str, str] = {}
+    verification_error_codes = {"E500", "E501", "E502"}
     for diag in verify_diagnostics:
         if diag.severity == "warning" and diag.error_code in tier3_codes:
             # Extract fn name from description: '...'
             m = re.search(r"'(\w+)'", diag.description)
             if m:
                 tier3_fns.add(m.group(1))
+        elif diag.severity == "error" and diag.error_code in verification_error_codes:
+            name = _failed_function_name(diag)
+            if name:
+                failed_fns[name] = diag.error_code or "verification error"
 
     result: dict[str, tuple[str, str, ast.FnDecl]] = {}
 
@@ -429,6 +451,13 @@ def _classify_functions(
         has_unsupported = any(
             base_type(pt) not in _Z3_SUPPORTED for pt in param_types
         )
+
+        # Verifier-refuted contracts fail before any verified/tier3/skipped result.
+        if decl.name in failed_fns:
+            result[decl.name] = (
+                "failed", f"verification error ({failed_fns[decl.name]})", decl,
+            )
+            continue
 
         # Unit-only params (no real params to test)
         if all(base_type(pt) == UNIT for pt in param_types):
@@ -474,6 +503,28 @@ def _classify_functions(
         result[decl.name] = ("verified", "Tier 1 (proved)", decl)
 
     return result
+
+
+def _failed_function_name(diag: Diagnostic) -> str | None:
+    """Extract the function responsible for a verifier error diagnostic."""
+    if diag.error_code == "E501":
+        # E501 text mentions both callee and caller:
+        # "Call to 'callee' in function 'caller' may violate...".
+        m = re.search(r"in function '(\w+)'", diag.description)
+        if m:
+            return m.group(1)
+
+    # E500: "Postcondition does not hold in function 'fn'."
+    m = re.search(r"in function '(\w+)'", diag.description)
+    if m:
+        return m.group(1)
+
+    # E502: "@Nat subtraction in 'fn' may underflow."
+    m = re.search(r"in '(\w+)'", diag.description)
+    if m:
+        return m.group(1)
+
+    return None
 
 
 def _has_nontrivial_contracts(decl: ast.FnDecl) -> bool:

--- a/vera/tester.py
+++ b/vera/tester.py
@@ -87,6 +87,12 @@ _Z3_SUPPORTED = {INT, NAT, BOOL, BYTE, STRING, FLOAT64}
 # Types that require the raw_args calling convention (String uses i32_pair ABI)
 _NEEDS_RAW = {STRING, FLOAT64}
 
+# Verifier-error codes that cause a function to be classified as
+# ``"failed"`` rather than ``"verified"`` / ``"tier3"`` / ``"skipped"``.
+# Exported (no underscore) because ``vera/cli.py`` also uses this set
+# in its summary-line de-duplication logic.
+VERIFICATION_ERROR_CODES = frozenset({"E500", "E501", "E502"})
+
 
 def _unsupported_type_names(param_types: list[Type]) -> list[str]:
     """Return a sorted list of type names that cannot be Z3-encoded."""
@@ -418,16 +424,24 @@ def _classify_functions(
     tier3_fns: set[str] = set()
     tier3_codes = {"E520", "E521", "E522", "E523", "E524", "E525"}
     failed_fns: dict[str, str] = {}
-    verification_error_codes = {"E500", "E501", "E502"}
     for diag in verify_diagnostics:
         if diag.severity == "warning" and diag.error_code in tier3_codes:
             # Extract fn name from description: '...'
             m = re.search(r"'(\w+)'", diag.description)
             if m:
                 tier3_fns.add(m.group(1))
-        elif diag.severity == "error" and diag.error_code in verification_error_codes:
-            name = _failed_function_name(diag)
-            if name:
+        elif (
+            diag.severity == "error"
+            and diag.error_code in VERIFICATION_ERROR_CODES
+        ):
+            name = failed_function_name(diag)
+            # First-hit wins: if a single function attracts multiple
+            # verifier errors (e.g. ``ensures(false)`` produces E500
+            # AND `@Nat - @Nat` produces E502 on the same body), the
+            # displayed ``reason`` would otherwise depend on
+            # diagnostic iteration order.  ``setdefault`` pins it to
+            # whichever diagnostic the verifier emitted first.
+            if name and name not in failed_fns:
                 failed_fns[name] = diag.error_code or "verification error"
 
     result: dict[str, tuple[str, str, ast.FnDecl]] = {}
@@ -505,8 +519,15 @@ def _classify_functions(
     return result
 
 
-def _failed_function_name(diag: Diagnostic) -> str | None:
-    """Extract the function responsible for a verifier error diagnostic."""
+def failed_function_name(diag: Diagnostic) -> str | None:
+    """Extract the function responsible for a verifier error diagnostic.
+
+    Public (no underscore) because ``vera/cli.py`` calls it from its
+    summary-line de-duplication logic.  Returns ``None`` when the
+    diagnostic's description doesn't include an attributable function
+    name (defensive — the verifier always emits these in the expected
+    shape, but the regex match is checked).
+    """
     if diag.error_code == "E501":
         # E501 text mentions both callee and caller:
         # "Call to 'callee' in function 'caller' may violate...".

--- a/vera/tester.py
+++ b/vera/tester.py
@@ -64,6 +64,14 @@ class TestSummary:
     total_trials: int = 0
     total_passes: int = 0
     total_failures: int = 0
+    # Verifier errors whose target function isn't in ``functions``
+    # (e.g. when ``--fn`` filters to a subset, or for private
+    # functions excluded from the displayed list).  Without this
+    # field a CLI consumer would have to re-run the regex
+    # attribution itself to spot fail-closed cases; exposing it as
+    # structured data on the summary keeps ``vera.tester``'s public
+    # API surface small and ``vera/cli.py`` purely presentational.
+    unlisted_errors: int = 0
 
 
 @dataclass
@@ -89,9 +97,11 @@ _NEEDS_RAW = {STRING, FLOAT64}
 
 # Verifier-error codes that cause a function to be classified as
 # ``"failed"`` rather than ``"verified"`` / ``"tier3"`` / ``"skipped"``.
-# Exported (no underscore) because ``vera/cli.py`` also uses this set
-# in its summary-line de-duplication logic.
-VERIFICATION_ERROR_CODES = frozenset({"E500", "E501", "E502"})
+# Private — ``vera/cli.py`` no longer needs this set directly; the
+# engine attributes errors to functions internally and exposes the
+# count of unattributable / filtered-out errors as
+# ``TestSummary.unlisted_errors``.
+_VERIFICATION_ERROR_CODES = frozenset({"E500", "E501", "E502"})
 
 
 def _unsupported_type_names(param_types: list[Type]) -> list[str]:
@@ -371,6 +381,22 @@ class _TestEngine:
                 failures=failures,
             ))
 
+        # Count verifier errors whose target function isn't in the
+        # displayed ``results`` list — happens when ``--fn`` filters
+        # to a subset, or when a private helper fails verification
+        # (private functions aren't displayed).  Exposing this as
+        # structured data on the summary saves CLI consumers from
+        # re-running the regex attribution.
+        displayed_failed = {
+            f.fn_name for f in results if f.category == "failed"
+        }
+        summary.unlisted_errors = sum(
+            1 for d in diagnostics
+            if d.severity == "error"
+            and d.error_code in _VERIFICATION_ERROR_CODES
+            and _failed_function_name(d) not in displayed_failed
+        )
+
         return TestResult(
             functions=results,
             summary=summary,
@@ -432,9 +458,9 @@ def _classify_functions(
                 tier3_fns.add(m.group(1))
         elif (
             diag.severity == "error"
-            and diag.error_code in VERIFICATION_ERROR_CODES
+            and diag.error_code in _VERIFICATION_ERROR_CODES
         ):
-            name = failed_function_name(diag)
+            name = _failed_function_name(diag)
             # First-hit wins: if a single function attracts multiple
             # verifier errors (e.g. ``ensures(false)`` produces E500
             # AND `@Nat - @Nat` produces E502 on the same body), the
@@ -519,14 +545,16 @@ def _classify_functions(
     return result
 
 
-def failed_function_name(diag: Diagnostic) -> str | None:
+def _failed_function_name(diag: Diagnostic) -> str | None:
     """Extract the function responsible for a verifier error diagnostic.
 
-    Public (no underscore) because ``vera/cli.py`` calls it from its
-    summary-line de-duplication logic.  Returns ``None`` when the
-    diagnostic's description doesn't include an attributable function
-    name (defensive — the verifier always emits these in the expected
-    shape, but the regex match is checked).
+    Private — used internally by ``_classify_functions`` and by the
+    engine's ``unlisted_errors`` computation.  ``vera/cli.py`` reads
+    the resulting structured count via ``TestSummary.unlisted_errors``
+    rather than calling this helper directly.  Returns ``None`` when
+    the diagnostic's description doesn't include an attributable
+    function name (defensive — the verifier always emits these in
+    the expected shape, but the regex match is checked).
     """
     if diag.error_code == "E501":
         # E501 text mentions both callee and caller:


### PR DESCRIPTION
## Summary

Fixes #674.

`vera test` now fails closed when the verifier reports E500/E501/E502 diagnostics instead of letting verifier-refuted functions fall through as `"verified" / "Tier 1 (proved)"`.

This makes `vera test --json` safe as a green contract gate again for the verifier-error cases discussed in #674.

## Behavior changes

- Preserve verifier error diagnostics in `TestResult.diagnostics`.
- Add/handle a `"failed"` function category for verifier-refuted public functions.
- Surface `TestSummary.failed` in JSON and human output.
- Return non-zero from `vera test` / `vera test --json` when result diagnostics contain errors.
- Set JSON `"ok": false` when verifier errors are present.
- Attribute:
  - E500 postcondition failures to the function named in `in function '...'`
  - E501 call-site precondition failures to the caller, not the callee
  - E502 `@Nat` subtraction underflow to the function named in `in '...'`
- Keep `--fn` rows filtered to the selected function while still failing closed on whole-file verifier errors.
- Surface private/non-displayed verifier failures in diagnostics and human summaries instead of silently dropping them.
- Keep Tier 3 E700 runtime contract failures distinct from static verifier errors in human summaries.
- Avoid double-counting multiple verifier diagnostics that are already represented by a displayed failed function.

## Tests added / updated

Regression coverage now includes:

- `vera test --json` returns nonzero and `ok: false` for E500 verifier errors.
- Human output shows verifier-refuted functions as `FAILED`.
- Private verifier failures are reported even when no private function row is displayed.
- `--fn` keeps function rows filtered but still fails closed on unselected whole-file verifier errors.
- E501 is attributed to the caller rather than the callee.
- E502 `@Nat` underflow is classified as a failed verifier error.
- Static verifier failures are summarized separately from Tier 3 runtime trial failures.
- Tier 3 E700 runtime failures are not summarized as verifier errors.
- Multiple verifier diagnostics on one displayed failed function are not double-counted as unlisted verifier errors.
- CLI dispatch for `vera test --json` returns nonzero for verifier errors.

## Verification

Ran locally:

```text
pytest tests/test_tester.py tests/test_tester_coverage.py tests/test_cli.py -q
276 passed
```

```text
pytest tests/ -q
3886 passed, 14 skipped, 16 deselected
```

```text
mypy vera/
Success: no issues found in 59 source files
```

```text
python scripts/check_conformance.py
All 86 conformance programs pass.
```

```text
python scripts/check_examples.py
All 34 examples pass (check + verify).
```

```text
pytest tests/test_conformance.py -q
416 passed, 14 skipped
```

Also checked:

```text
git diff --check
```

and a staged added-line secret scan; both were clean.

## Notes

This follows the intended direction from the maintainer comment on #674:

- harvest E500/E501/E502 verifier errors,
- introduce `"failed"`,
- make failed status take precedence over verified/Tier 3 classification,
- surface `TestSummary.failed`,
- return non-zero,
- and add regression coverage.

I kept the displayed `--fn` function list scoped to the selected function, but made diagnostics/exit status reflect whole-file verifier errors so `--fn` cannot false-green a file with verifier-refuted contracts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Verifier failures (E500, E501, E502) now cause tests to fail with non‑zero exit codes, JSON ok:false and preserved diagnostics, and human output shows failed functions plus a Diagnostics section; --fn filtering still surfaces whole‑file verifier errors.

* **New Features**
  * Improved error attribution and separate counts for static verifier failures vs runtime (Tier‑3) failures; avoids double‑counting multiple diagnostics; E700 remains distinct.

* **Tests**
  * Expanded regression and integration coverage for JSON/human output, filtering, attribution and exit codes.

* **Documentation**
  * CHANGELOG, KNOWN_ISSUES, README, ROADMAP and TESTING updated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aallan/vera/pull/685?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->