### PR TITLE
docs: add inference handler mock example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Vera Examples
 
-33 example programs demonstrating Vera's features. All examples pass `vera check` and `vera verify`.
+36 example programs demonstrating Vera's features. All examples pass `vera check` and `vera verify`.
 
 ## Running Examples
 
@@ -48,6 +48,8 @@ vera run examples/factorial.vera --fn factorial -- 10
 | `file_io.vera` | `vera run examples/file_io.vera` | File read/write with error handling |
 | `async_futures.vera` | `vera run examples/async_futures.vera` | Async effect, Future type, concurrent composition |
 | `http.vera` | `vera run examples/http.vera` | Http.get, JSON parsing, network I/O (requires network) |
+| `inference.vera` | `vera run examples/inference.vera` | Inference.complete, Result matching, API-key-backed LLM calls |
+| `inference_mock.vera` | `vera check examples/inference_mock.vera` | Inference effect handlers, deterministic mock responses, API-key-free check/verify workflows |
 
 ### Data Structures
 

--- a/examples/inference_mock.vera
+++ b/examples/inference_mock.vera
@@ -1,0 +1,28 @@
+-- Inference handler mock example: deterministic LLM responses for tests.
+-- Demonstrates: Inference.complete, algebraic effect handlers, resume.
+--
+-- `classify_sentiment` normally requires the Inference host effect. The
+-- wrapper below handles that effect locally and resumes the computation with a
+-- fixed response, making the classifier deterministic and API-key-free for
+-- check/verify workflows.
+
+private fn classify_sentiment(@String -> @Result<String, String>)
+  requires(string_length(@String.0) > 0)
+  ensures(true)
+  effects(<Inference>)
+{
+  let @String = string_concat("Classify the sentiment of this text as Positive, Negative, or Neutral. Respond with one word only.\n\n", @String.0);
+  Inference.complete(@String.0)
+}
+
+public fn with_mock_inference(@String -> @Result<String, String>)
+  requires(string_length(@String.0) > 0)
+  ensures(true)
+  effects(pure)
+{
+  handle[Inference] {
+    complete(@String) -> { resume(Ok("Positive")) }
+  } in {
+    classify_sentiment(@String.0)
+  }
+}


### PR DESCRIPTION
## Summary
- Adds an `inference_mock.vera` example showing `handle[Inference]` with a deterministic `Inference.complete` response
- Documents the example in `examples/README.md` and lists the existing inference example in the Effects table
- Refreshes the examples count to match the current top-level example set

## Test Plan
- [x] `uv run --project . vera check examples/inference_mock.vera`
- [x] `uv run --project . vera verify examples/inference_mock.vera`
- [x] `uv run --project . python scripts/check_examples.py`

Closes #380


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Expanded available examples collection with two new inference-related demonstrations, bringing the total example count from 33 to 36.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aallan/vera/pull/700?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->