### PR TITLE
feat: LSP transport skeleton + coordinate layer (#222 Phase C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.163] - 2026-06-10
+
+### Added
+
+- **[#222](https://github.com/aallan/vera/issues/222) Phase C** — `vera lsp` serves the Language Server Protocol over stdio: handshake with `serverInfo`, full-text document sync into an in-memory `DocumentStore` (the source of truth for open files — features never read disk), and the coordinate-conversion layer in `vera/lsp/convert.py` where the three coordinate systems meet (Vera `Span`: 1-based line + 1-based code-point column with exclusive end; `SourceLocation`: 1-based line but 0-based column; LSP: 0-based line + UTF-16 code units, with astral-plane transcoding and surrogate-pair snapping per the spec).  Deliberately featureless — Phase D wires diagnostics/hover/completion onto this transport so the advertised capability surface never promises something unimplemented.  The transport dependencies live in a new optional `[lsp]` extra (`pygls>=2.0`, `lsprotocol`; both pure-Python, mirrored into `[dev]` for CI) so the base install is unchanged; `vera lsp` without the extra prints an actionable install message.
+
 ## [0.0.162] - 2026-06-10
 
 ### Added
@@ -2421,7 +2427,8 @@ Small docs sweep — closes six aging documentation issues in one PR.  No code c
 - Grammar: handler body simplified to avoid LALR reduce/reduce conflict
 - `pyproject.toml`: corrected build backend, package discovery, PEP 639 compliance
 
-[Unreleased]: https://github.com/aallan/vera/compare/v0.0.162...HEAD
+[Unreleased]: https://github.com/aallan/vera/compare/v0.0.163...HEAD
+[0.0.163]: https://github.com/aallan/vera/compare/v0.0.162...v0.0.163
 [0.0.162]: https://github.com/aallan/vera/compare/v0.0.161...v0.0.162
 [0.0.161]: https://github.com/aallan/vera/compare/v0.0.160...v0.0.161
 [0.0.160]: https://github.com/aallan/vera/compare/v0.0.159...v0.0.160

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -307,6 +307,7 @@ Stage 12 opens on the morning v0.0.138 shipped: the residual GC-rooting bug in #
 | v0.0.160 | 29 May | Centralized Ctrl-C-during-host-import handling on `wasmtime>=45.0.0`, removing the four per-import `_VeraExit(130)` workaround guards ([#599](https://github.com/aallan/vera/issues/599)). |
 | v0.0.161 | 10 Jun | Proof obligations reified as first-class records with a warm-Z3 `VerificationSession`, the semantic core for the LSP server ([#222](https://github.com/aallan/vera/issues/222) Phase A). |
 | v0.0.162 | 10 Jun | Incremental verification — unchanged functions replay cached obligations instead of re-entering Z3 ([#222](https://github.com/aallan/vera/issues/222) Phase B). |
+| v0.0.163 | 10 Jun | `vera lsp` serves LSP over stdio — transport skeleton, document sync, and the coordinate-conversion layer ([#222](https://github.com/aallan/vera/issues/222) Phase C). |
 
 ---
 
@@ -347,4 +348,4 @@ Alongside the compiler, editor support and AI discoverability infrastructure wer
 | Spec chapters | 7 | 10 | 11 | 12 | 13 | 13 | 13 |
 | Code coverage | — | — | — | 90% | 91% | 96% | 96% |
 
-Total: **810+ commits, 162 tagged releases, 61 active development days.**
+Total: **810+ commits, 163 tagged releases, 61 active development days.**

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ cp /path/to/vera/SKILL.md ~/.claude/skills/vera-language/SKILL.md
 
 ## Project status
 
-Vera is in **active development** at v0.0.162 — 810+ commits, 162 releases, 4,250 tests, 96% code coverage, 89 conformance programs, 35 examples, and a 13-chapter specification. See **[HISTORY.md](HISTORY.md)** for how the compiler was built.
+Vera is in **active development** at v0.0.163 — 810+ commits, 163 releases, 4,250 tests, 96% code coverage, 89 conformance programs, 35 examples, and a 13-chapter specification. See **[HISTORY.md](HISTORY.md)** for how the compiler was built.
 
 The reference compiler — parser, AST, type checker, contract verifier (Z3), WASM code generator, module system, browser runtime, and runtime contract insertion — is working. The language specification is in draft across [13 chapters](spec/).
 

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ cp /path/to/vera/SKILL.md ~/.claude/skills/vera-language/SKILL.md
 
 ## Project status
 
-Vera is in **active development** at v0.0.162 — 810+ commits, 162 releases, 4,220 tests, 96% code coverage, 89 conformance programs, 35 examples, and a 13-chapter specification. See **[HISTORY.md](HISTORY.md)** for how the compiler was built.
+Vera is in **active development** at v0.0.162 — 810+ commits, 162 releases, 4,250 tests, 96% code coverage, 89 conformance programs, 35 examples, and a 13-chapter specification. See **[HISTORY.md](HISTORY.md)** for how the compiler was built.
 
 The reference compiler — parser, AST, type checker, contract verifier (Z3), WASM code generator, module system, browser runtime, and runtime contract insertion — is working. The language specification is in draft across [13 chapters](spec/).
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ Where the project is going.  See [HISTORY.md](HISTORY.md) for what's been built 
 
 ## Where we are
 
-4,220 tests, 89 conformance programs, 35 examples, 13 spec chapters.
+4,250 tests, 89 conformance programs, 35 examples, 13 spec chapters.
 
 ## What's next
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,7 +6,7 @@ This is the single source of truth for Vera's testing infrastructure, coverage d
 
 | Metric | Value |
 |--------|-------|
-| **Tests** | 4,250 across 34 files (~54,625 lines of test code; 4,219 passed + 16 stress, 15 skipped) |
+| **Tests** | 4,250 across 34 files (~54,639 lines of test code; 4,219 passed + 16 stress, 15 skipped) |
 | **Compiler code coverage** | 96% of 15,149 statements (CI minimum: 80%) |
 | **Conformance programs** | 89 programs across 9 spec chapters, validating every language feature |
 | **Example programs** | 35, all validated through `vera check` + `vera verify` |
@@ -80,7 +80,7 @@ python scripts/fix_allowlists.py --fix               # auto-fix stale allowlists
 | `test_tester.py` | 17 | 445 | Contract-driven testing: tier classification, input generation, test execution, skip message content |
 | `test_tester_coverage.py` | 34 | 903 | Tester coverage gaps: String/Float64/ADT parameter input generation, Bool/Byte parameters, unsatisfiable preconditions, type expression edge cases |
 | `test_markdown.py` | 59 | 394 | Markdown parser: block/inline parsing, rendering, round-trips, edge cases |
-| `test_lsp.py` | 30 | 255 | LSP transport skeleton + coordinate layer (#222 Phase C): parametrized code-point↔UTF-16 goldens incl. astral-plane fixtures and surrogate-pair snapping, Span (1-based, exclusive-end) and SourceLocation (0-based col) → LSP Range conversions, point→token-range widening, DocumentStore open/change/close + index invalidation, an in-process handler-drive test, and one stdio end-to-end round-trip against the real `vera lsp` subprocess (initialize → didOpen → shutdown → exit) pinning serverInfo + textDocumentSync capabilities |
+| `test_lsp.py` | 30 | 269 | LSP transport skeleton + coordinate layer (#222 Phase C): parametrized code-point↔UTF-16 goldens incl. astral-plane fixtures and surrogate-pair snapping, Span (1-based, exclusive-end) and SourceLocation (0-based col) → LSP Range conversions, point→token-range widening, DocumentStore open/change/close + index invalidation, an in-process handler-drive test, and one stdio end-to-end round-trip against the real `vera lsp` subprocess (initialize → didOpen → shutdown → exit) pinning serverInfo + textDocumentSync capabilities |
 | `test_browser.py` | 102 | 1,990 | Browser parity: Python/wasmtime vs Node.js/JS-runtime output equivalence across IO, State, contracts, Markdown, Regex, and all compilable examples |
 | `test_conformance.py` | 445 | 102 | Parametrized conformance suite: parse, check, verify, run, format idempotency across 89 programs |
 | `test_prelude.py` | 24 | 422 | Prelude injection: Option/Result/array operation detection, combinator shadowing, type aliases, end-to-end compilation |

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,7 +6,7 @@ This is the single source of truth for Vera's testing infrastructure, coverage d
 
 | Metric | Value |
 |--------|-------|
-| **Tests** | 4,220 across 33 files (~54,370 lines of test code; 4,189 passed + 16 stress, 15 skipped) |
+| **Tests** | 4,250 across 34 files (~54,625 lines of test code; 4,219 passed + 16 stress, 15 skipped) |
 | **Compiler code coverage** | 96% of 15,149 statements (CI minimum: 80%) |
 | **Conformance programs** | 89 programs across 9 spec chapters, validating every language feature |
 | **Example programs** | 35, all validated through `vera check` + `vera verify` |
@@ -80,6 +80,7 @@ python scripts/fix_allowlists.py --fix               # auto-fix stale allowlists
 | `test_tester.py` | 17 | 445 | Contract-driven testing: tier classification, input generation, test execution, skip message content |
 | `test_tester_coverage.py` | 34 | 903 | Tester coverage gaps: String/Float64/ADT parameter input generation, Bool/Byte parameters, unsatisfiable preconditions, type expression edge cases |
 | `test_markdown.py` | 59 | 394 | Markdown parser: block/inline parsing, rendering, round-trips, edge cases |
+| `test_lsp.py` | 30 | 255 | LSP transport skeleton + coordinate layer (#222 Phase C): parametrized code-point↔UTF-16 goldens incl. astral-plane fixtures and surrogate-pair snapping, Span (1-based, exclusive-end) and SourceLocation (0-based col) → LSP Range conversions, point→token-range widening, DocumentStore open/change/close + index invalidation, an in-process handler-drive test, and one stdio end-to-end round-trip against the real `vera lsp` subprocess (initialize → didOpen → shutdown → exit) pinning serverInfo + textDocumentSync capabilities |
 | `test_browser.py` | 102 | 1,990 | Browser parity: Python/wasmtime vs Node.js/JS-runtime output equivalence across IO, State, contracts, Markdown, Regex, and all compilable examples |
 | `test_conformance.py` | 445 | 102 | Parametrized conformance suite: parse, check, verify, run, format idempotency across 89 programs |
 | `test_prelude.py` | 24 | 422 | Prelude injection: Option/Result/array operation detection, combinator shadowing, type aliases, end-to-end compilation |

--- a/docs/index.html
+++ b/docs/index.html
@@ -265,7 +265,7 @@
         <a href="/SKILL.md" rel="agent-instructions" type="text/markdown" class="btn btn-ghost">For Agents → SKILL.md</a>
       </div>
       <p class="version">
-        <span>v<a href="https://github.com/aallan/vera/releases/tag/v0.0.162">0.0.162</a></span>
+        <span>v<a href="https://github.com/aallan/vera/releases/tag/v0.0.163">0.0.163</a></span>
         <a href="https://github.com/aallan/vera/actions/workflows/ci.yml" aria-label="CI status"><img src="https://github.com/aallan/vera/actions/workflows/ci.yml/badge.svg" alt="CI" style="height:18px"></a>
       </p>
     </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@
 
 From the Latin *veritas* — truth. In Vera, verification is a first-class citizen.
 
-**Current version:** [0.0.162](https://github.com/aallan/vera/releases/tag/v0.0.162)  ·  [GitHub](https://github.com/aallan/vera)  ·  [SKILL.md](https://veralang.dev/SKILL.md) (agent language reference)
+**Current version:** [0.0.163](https://github.com/aallan/vera/releases/tag/v0.0.163)  ·  [GitHub](https://github.com/aallan/vera)  ·  [SKILL.md](https://veralang.dev/SKILL.md) (agent language reference)
 
 ## Why?
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2,7 +2,7 @@
 
 > Vera is a statically typed, purely functional programming language designed for large language models to write. It uses typed slot references (@T.n) instead of variable names, requires contracts on every function, and compiles to WebAssembly.
 
-This file contains the core Vera language documentation — language reference, agent instructions, FAQ, error codes, and formal grammar — compiled into a single document. Version 0.0.162. For the full documentation index including the 13-chapter specification and supplementary docs, see llms.txt.
+This file contains the core Vera language documentation — language reference, agent instructions, FAQ, error codes, and formal grammar — compiled into a single document. Version 0.0.163. For the full documentation index including the 13-chapter specification and supplementary docs, see llms.txt.
 
 
 ========================================================================

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -4,7 +4,7 @@
 
 Vera uses De Bruijn indexing for bindings: `@Int.0` is the most recent `Int` binding, `@Int.1` the one before. There are no variable names. Contracts are mandatory — every function must declare `requires(...)`, `ensures(...)`, and `effects(...)`. The Z3 SMT solver verifies contracts statically where possible; remaining contracts become runtime assertions. All side effects (IO, Http, State, Exceptions, Async, Inference, Random) are tracked in the type system via algebraic effects.
 
-Current version: 0.0.162. The reference compiler is written in Python. Install with `pip install -e .` from the repository.
+Current version: 0.0.163. The reference compiler is written in Python. Install with `pip install -e .` from the repository.
 
 ## Homepage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vera"
-version = "0.0.162"
+version = "0.0.163"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,13 @@ Issues = "https://github.com/aallan/vera/issues"
 Changelog = "https://github.com/aallan/vera/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
+# Both pure-Python; not gated by check_wheel_availability.py (which
+# reads project.dependencies only — optional extras are exempt by
+# design, see README §Supported platforms).
+lsp = [
+    "pygls>=2.0",
+    "lsprotocol>=2023.0",
+]
 dev = [
     "pytest>=9.0.3",
     "pytest-cov>=7.1.0",
@@ -54,6 +61,10 @@ dev = [
     "ruff>=0.15.16",
     "pre-commit>=4.6.0",
     "pip-licenses>=5.5.5",
+    # Mirror of the [lsp] extra so CI's `pip install -e ".[dev]"` can
+    # run tests/test_lsp.py.  Keep these two pins in sync with [lsp].
+    "pygls>=2.0",
+    "lsprotocol>=2023.0",
 ]
 
 [project.scripts]
@@ -105,6 +116,19 @@ ignore_missing_imports = true
 # wasmtime does not ship complete type stubs.
 module = "wasmtime.*"
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+# pygls ships partial typing; lsprotocol is typed but the override is
+# defensive for transitive attrs.  CI runs mypy strict over vera/lsp/.
+module = ["pygls.*", "lsprotocol.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+# pygls' @server.feature(...) decorator is untyped, which strict mode
+# rejects on every handler registration.  Same narrow-exception shape
+# as the vera.transform override above.
+module = "vera.lsp.server"
+disallow_untyped_decorators = false
 
 [[tool.mypy.overrides]]
 # Checker mixin classes reference attributes (self.env, self._error, etc.)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,10 +61,11 @@ dev = [
     "ruff>=0.15.16",
     "pre-commit>=4.6.0",
     "pip-licenses>=5.5.5",
-    # Mirror of the [lsp] extra so CI's `pip install -e ".[dev]"` can
-    # run tests/test_lsp.py.  Keep these two pins in sync with [lsp].
-    "pygls>=2.0",
-    "lsprotocol>=2023.0",
+    # Self-referential extra: dev pulls in [lsp] so CI's single
+    # `pip install -e ".[dev]"` can run tests/test_lsp.py without a
+    # second pin list to keep in sync (PEP 508 extras self-reference;
+    # supported by pip >= 21.2 and uv).
+    "vera[lsp]",
 ]
 
 [project.scripts]

--- a/tests/test_lsp.py
+++ b/tests/test_lsp.py
@@ -1,0 +1,255 @@
+"""Tests for vera/lsp/ — transport skeleton + coordinate layer (#222 Phase C).
+
+Three layers, matching the #222 plan's testing strategy:
+
+1. **Coordinate conversion** (the substance): parametrized goldens for
+   the three coordinate systems — ``ast.Span`` (1-based line, 1-based
+   code-point column, exclusive end), ``SourceLocation`` (1-based
+   line, 0-based column), LSP (0-based line, UTF-16 column) — with
+   multi-byte and astral-plane fixtures, plus round-trips.
+2. **Document store**: open/change/close semantics, version tracking,
+   index invalidation on change.
+3. **End-to-end**: one stdio round-trip against the real ``vera lsp``
+   subprocess (initialize → didOpen → shutdown → exit), pinning the
+   advertised capabilities.  Transport logic beyond the wire round-trip
+   is pygls' responsibility, not ours, so one e2e test suffices.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+import pytest
+
+from lsprotocol import types as lsp
+
+from vera.ast import Span
+from vera.errors import SourceLocation
+from vera.lsp.convert import (
+    LineIndex,
+    location_to_position,
+    location_to_range,
+    position_to_cp,
+    span_to_range,
+)
+from vera.lsp.documents import DocumentStore
+
+# A line with an astral-plane char: "ab🎉cd" — 🎉 (U+1F389) is ONE
+# code point but TWO UTF-16 code units, so LSP columns after it shift
+# by one relative to Python string indices.
+ASTRAL_LINE = "ab\U0001f389cd"
+
+
+class TestLineIndex:
+    @pytest.mark.parametrize(
+        ("cp_col", "utf16_col"),
+        [(0, 0), (1, 1), (2, 2), (3, 4), (4, 5), (5, 6)],
+    )
+    def test_cp_to_utf16_astral(self, cp_col: int, utf16_col: int) -> None:
+        index = LineIndex(ASTRAL_LINE)
+        assert index.cp_to_utf16(0, cp_col) == utf16_col
+
+    @pytest.mark.parametrize(
+        ("utf16_col", "cp_col"),
+        [(0, 0), (1, 1), (2, 2), (4, 3), (5, 4), (6, 5)],
+    )
+    def test_utf16_to_cp_astral(self, utf16_col: int, cp_col: int) -> None:
+        index = LineIndex(ASTRAL_LINE)
+        assert index.utf16_to_cp(0, utf16_col) == cp_col
+
+    def test_utf16_inside_surrogate_pair_snaps_to_char_start(self) -> None:
+        # UTF-16 offset 3 lands inside 🎉's surrogate pair; the LSP
+        # spec says invalid positions degrade gracefully — we snap to
+        # the character's start (code point 2).
+        index = LineIndex(ASTRAL_LINE)
+        assert index.utf16_to_cp(0, 3) == 2
+
+    def test_ascii_is_identity(self) -> None:
+        index = LineIndex("plain ascii\nsecond line")
+        assert index.cp_to_utf16(1, 6) == 6
+        assert index.utf16_to_cp(1, 6) == 6
+
+    def test_out_of_range_line_degrades_to_identity(self) -> None:
+        index = LineIndex("one line")
+        assert index.cp_to_utf16(99, 5) == 0  # empty virtual line
+        assert index.utf16_to_cp(99, 5) == 0
+
+    def test_column_clamped_to_line_length(self) -> None:
+        index = LineIndex("abc")
+        assert index.cp_to_utf16(0, 99) == 3
+
+    def test_bmp_multibyte_is_one_unit(self) -> None:
+        # é and → are multi-byte in UTF-8 but single UTF-16 units;
+        # only astral chars shift LSP columns.
+        index = LineIndex("é→x")
+        assert index.cp_to_utf16(0, 3) == 3
+
+
+class TestSpanConversion:
+    def test_span_is_one_based_inclusive_to_lsp_zero_based(self) -> None:
+        # Span line 2, cols 3..6 (1-based, exclusive end) on ASCII →
+        # LSP line 1, chars 2..5.
+        index = LineIndex("first\nabcdefgh")
+        span = Span(line=2, column=3, end_line=2, end_column=6)
+        r = span_to_range(span, index)
+        assert (r.start.line, r.start.character) == (1, 2)
+        assert (r.end.line, r.end.character) == (1, 5)
+
+    def test_span_after_astral_char_shifts_utf16(self) -> None:
+        # Span covering "cd" in "ab🎉cd": code points 3..5 → 1-based
+        # cols 4..6; UTF-16 chars 4..6 (the 🎉 occupies units 2-3).
+        index = LineIndex(ASTRAL_LINE)
+        span = Span(line=1, column=4, end_line=1, end_column=6)
+        r = span_to_range(span, index)
+        assert (r.start.character, r.end.character) == (4, 6)
+
+
+class TestLocationConversion:
+    def test_location_column_is_zero_based(self) -> None:
+        # SourceLocation col is 0-based (unlike Span) — col 4 on ASCII
+        # maps straight to LSP char 4.
+        index = LineIndex("abcdefgh")
+        loc = SourceLocation(file=None, line=1, column=4)
+        pos = location_to_position(loc, index)
+        assert (pos.line, pos.character) == (0, 4)
+
+    def test_location_range_widens_over_slot_token(self) -> None:
+        # Point at the @ of "@Int.0" widens across the slot token.
+        index = LineIndex("  @Int.0 + 1")
+        loc = SourceLocation(file=None, line=1, column=2)
+        r = location_to_range(loc, index)
+        assert r.start.character == 2
+        assert r.end.character == 8  # past "@Int.0"
+
+    def test_location_range_on_non_token_is_one_char(self) -> None:
+        index = LineIndex("a (b)")
+        loc = SourceLocation(file=None, line=1, column=2)  # the "("
+        r = location_to_range(loc, index)
+        assert (r.start.character, r.end.character) == (2, 3)
+
+    def test_location_range_at_eol_is_empty_not_crashing(self) -> None:
+        index = LineIndex("ab")
+        loc = SourceLocation(file=None, line=1, column=2)
+        r = location_to_range(loc, index)
+        assert r.start.character == 2
+        assert r.end.character == 2
+
+    def test_position_to_cp_round_trip(self) -> None:
+        index = LineIndex(ASTRAL_LINE)
+        pos = lsp.Position(line=0, character=4)  # after 🎉
+        line1, cp = position_to_cp(pos, index)
+        assert (line1, cp) == (1, 3)
+
+
+class TestDocumentStore:
+    def test_open_get_close(self) -> None:
+        store = DocumentStore()
+        store.open("file:///a.vera", "text", version=1)
+        doc = store.get("file:///a.vera")
+        assert doc is not None and doc.text == "text" and doc.version == 1
+        store.close("file:///a.vera")
+        assert store.get("file:///a.vera") is None
+        assert len(store) == 0
+
+    def test_change_replaces_text_and_invalidates_index(self) -> None:
+        store = DocumentStore()
+        doc = store.open("file:///a.vera", "old", version=1)
+        first_index = doc.index
+        store.change("file:///a.vera", "new text", version=2)
+        assert doc.text == "new text" and doc.version == 2
+        assert doc.index is not first_index  # rebuilt lazily
+
+    def test_change_without_open_creates_document(self) -> None:
+        store = DocumentStore()
+        doc = store.change("file:///b.vera", "hello", version=3)
+        assert store.get("file:///b.vera") is doc
+        assert doc.version == 3
+
+    def test_close_unknown_uri_is_noop(self) -> None:
+        DocumentStore().close("file:///never-opened.vera")
+
+
+def _lsp_msg(payload: dict[str, object]) -> bytes:
+    body = json.dumps(payload).encode("utf-8")
+    return f"Content-Length: {len(body)}\r\n\r\n".encode() + body
+
+
+class TestServerEndToEnd:
+    def test_stdio_handshake_round_trip(self) -> None:
+        """initialize → didOpen → shutdown → exit against the real
+        ``vera lsp`` subprocess, over raw JSON-RPC stdio framing."""
+        proc = subprocess.Popen(
+            [sys.executable, "-m", "vera.cli", "lsp"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        requests = (
+            _lsp_msg({
+                "jsonrpc": "2.0", "id": 1, "method": "initialize",
+                "params": {
+                    "processId": None, "rootUri": None,
+                    "capabilities": {},
+                },
+            })
+            + _lsp_msg({
+                "jsonrpc": "2.0", "method": "initialized", "params": {},
+            })
+            + _lsp_msg({
+                "jsonrpc": "2.0", "method": "textDocument/didOpen",
+                "params": {"textDocument": {
+                    "uri": "file:///t.vera", "languageId": "vera",
+                    "version": 1, "text": "-- comment\n",
+                }},
+            })
+            + _lsp_msg({
+                "jsonrpc": "2.0", "id": 2, "method": "shutdown",
+                "params": None,
+            })
+            + _lsp_msg({"jsonrpc": "2.0", "method": "exit", "params": None})
+        )
+        out, err = proc.communicate(requests, timeout=60)
+        text = out.decode("utf-8", errors="replace")
+        assert '"serverInfo"' in text, (text[:300], err.decode()[:300])
+        assert "vera-lsp" in text
+        assert '"textDocumentSync"' in text
+        assert proc.returncode == 0
+
+    def test_create_server_handlers_update_store(self) -> None:
+        """Document-sync handlers drive the store (in-process, no IO)."""
+        from vera.lsp.server import create_server
+
+        server = create_server()
+        protocol = server.protocol
+        # Drive the registered feature handlers directly through the
+        # feature manager — transport-free.
+        fm = protocol.fm if hasattr(protocol, "fm") else server.feature_manager
+        open_handler = fm.features[lsp.TEXT_DOCUMENT_DID_OPEN]
+        change_handler = fm.features[lsp.TEXT_DOCUMENT_DID_CHANGE]
+        close_handler = fm.features[lsp.TEXT_DOCUMENT_DID_CLOSE]
+
+        open_handler(lsp.DidOpenTextDocumentParams(
+            text_document=lsp.TextDocumentItem(
+                uri="file:///x.vera", language_id="vera",
+                version=1, text="one",
+            ),
+        ))
+        assert server.store.get("file:///x.vera").text == "one"
+
+        change_handler(lsp.DidChangeTextDocumentParams(
+            text_document=lsp.VersionedTextDocumentIdentifier(
+                uri="file:///x.vera", version=2,
+            ),
+            content_changes=[
+                lsp.TextDocumentContentChangeWholeDocument(text="two"),
+            ],
+        ))
+        assert server.store.get("file:///x.vera").text == "two"
+        assert server.store.get("file:///x.vera").version == 2
+
+        close_handler(lsp.DidCloseTextDocumentParams(
+            text_document=lsp.TextDocumentIdentifier(uri="file:///x.vera"),
+        ))
+        assert server.store.get("file:///x.vera") is None

--- a/tests/test_lsp.py
+++ b/tests/test_lsp.py
@@ -168,7 +168,13 @@ class TestDocumentStore:
         assert doc.version == 3
 
     def test_close_unknown_uri_is_noop(self) -> None:
-        DocumentStore().close("file:///never-opened.vera")
+        store = DocumentStore()
+        store.open("file:///kept.vera", "text")
+        store.close("file:///never-opened.vera")
+        # Observable postcondition: nothing raised AND unrelated
+        # documents are untouched.
+        assert len(store) == 1
+        assert store.get("file:///kept.vera") is not None
 
 
 def _lsp_msg(payload: dict[str, object]) -> bytes:
@@ -210,7 +216,15 @@ class TestServerEndToEnd:
             })
             + _lsp_msg({"jsonrpc": "2.0", "method": "exit", "params": None})
         )
-        out, err = proc.communicate(requests, timeout=60)
+        try:
+            out, err = proc.communicate(requests, timeout=60)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            out, err = proc.communicate()
+            pytest.fail(
+                "vera lsp subprocess timed out; killed to avoid an "
+                f"orphan. stdout={out[:300]!r} stderr={err[:300]!r}"
+            )
         text = out.decode("utf-8", errors="replace")
         assert '"serverInfo"' in text, (text[:300], err.decode()[:300])
         assert "vera-lsp" in text

--- a/uv.lock
+++ b/uv.lock
@@ -45,6 +45,28 @@ wheels = [
 ]
 
 [[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "cattrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a0/ec/ba18945e7d6e55a58364d9fb2e46049c1c2998b3d805f19b703f14e81057/cattrs-26.1.0.tar.gz", hash = "sha256:fa239e0f0ec0715ba34852ce813986dfed1e12117e209b816ab87401271cdd40", size = 495672, upload-time = "2026-02-18T22:15:19.406Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/56/60547f7801b97c67e97491dc3d9ade9fbccbd0325058fd3dfcb2f5d98d90/cattrs-26.1.0-py3-none-any.whl", hash = "sha256:d1e0804c42639494d469d08d4f26d6b9de9b8ab26b446db7b5f8c2e97f7c3096", size = 73054, upload-time = "2026-02-18T22:15:17.958Z" },
+]
+
+[[package]]
 name = "cfgv"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -294,6 +316,19 @@ wheels = [
 ]
 
 [[package]]
+name = "lsprotocol"
+version = "2025.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "cattrs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/26/67b84e6ec1402f0e6764ef3d2a0aaf9a79522cc1d37738f4e5bb0b21521a/lsprotocol-2025.0.0.tar.gz", hash = "sha256:e879da2b9301e82cfc3e60d805630487ac2f7ab17492f4f5ba5aaba94fe56c29", size = 74896, upload-time = "2025-06-17T21:30:18.156Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/f0/92f2d609d6642b5f30cb50a885d2bf1483301c69d5786286500d15651ef2/lsprotocol-2025.0.0-py3-none-any.whl", hash = "sha256:f9d78f25221f2a60eaa4a96d3b4ffae011b107537facee61d3da3313880995c7", size = 76250, upload-time = "2025-06-17T21:30:19.455Z" },
+]
+
+[[package]]
 name = "mypy"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -436,6 +471,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/79/45/b0847d88d6cfeb4413566738c8bbf1e1995fad3d42515327ff32cc1eb578/prettytable-3.17.0.tar.gz", hash = "sha256:59f2590776527f3c9e8cf9fe7b66dd215837cca96a9c39567414cbc632e8ddb0", size = 67892, upload-time = "2025-11-14T17:33:20.212Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/8c/83087ebc47ab0396ce092363001fa37c17153119ee282700c0713a195853/prettytable-3.17.0-py3-none-any.whl", hash = "sha256:aad69b294ddbe3e1f95ef8886a060ed1666a0b83018bbf56295f6f226c43d287", size = 34433, upload-time = "2025-11-14T17:33:19.093Z" },
+]
+
+[[package]]
+name = "pygls"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "cattrs" },
+    { name = "lsprotocol" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/2e/7bbe061d175c0baddde8fc9edb908a4c31ba5d9165b8c68e3439c3a9f138/pygls-2.1.1.tar.gz", hash = "sha256:1da03ba9053201bb337dcdd8d121df70feb2a91e1a0dcc74de5da79755b1a201", size = 55091, upload-time = "2026-03-25T11:19:10.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/1a/208293b6c350f5abea6941d5606080d4a492644052504f5312e5de30a902/pygls-2.1.1-py3-none-any.whl", hash = "sha256:510a6dea2476177230c7d851125e5948efdf3fdb9ebfd8543fc434972f8faed4", size = 68975, upload-time = "2026-03-25T11:19:11.374Z" },
 ]
 
 [[package]]
@@ -635,7 +684,7 @@ wheels = [
 
 [[package]]
 name = "vera"
-version = "0.0.162"
+version = "0.0.163"
 source = { editable = "." }
 dependencies = [
     { name = "lark" },
@@ -645,21 +694,31 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "lsprotocol" },
     { name = "mypy" },
     { name = "pip-licenses" },
     { name = "pre-commit" },
+    { name = "pygls" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
     { name = "ruff" },
 ]
+lsp = [
+    { name = "lsprotocol" },
+    { name = "pygls" },
+]
 
 [package.metadata]
 requires-dist = [
     { name = "lark", specifier = ">=1.3.1" },
+    { name = "lsprotocol", marker = "extra == 'dev'", specifier = ">=2023.0" },
+    { name = "lsprotocol", marker = "extra == 'lsp'", specifier = ">=2023.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=2.1.0" },
     { name = "pip-licenses", marker = "extra == 'dev'", specifier = ">=5.5.5" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.6.0" },
+    { name = "pygls", marker = "extra == 'dev'", specifier = ">=2.0" },
+    { name = "pygls", marker = "extra == 'lsp'", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.1.0" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.6" },
@@ -667,7 +726,7 @@ requires-dist = [
     { name = "wasmtime", specifier = ">=45.0.0" },
     { name = "z3-solver", specifier = ">=4.15.5" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["lsp", "dev"]
 
 [[package]]
 name = "virtualenv"

--- a/uv.lock
+++ b/uv.lock
@@ -712,17 +712,16 @@ lsp = [
 [package.metadata]
 requires-dist = [
     { name = "lark", specifier = ">=1.3.1" },
-    { name = "lsprotocol", marker = "extra == 'dev'", specifier = ">=2023.0" },
     { name = "lsprotocol", marker = "extra == 'lsp'", specifier = ">=2023.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=2.1.0" },
     { name = "pip-licenses", marker = "extra == 'dev'", specifier = ">=5.5.5" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.6.0" },
-    { name = "pygls", marker = "extra == 'dev'", specifier = ">=2.0" },
     { name = "pygls", marker = "extra == 'lsp'", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.1.0" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.6" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.16" },
+    { name = "vera", extras = ["lsp"], marker = "extra == 'dev'" },
     { name = "wasmtime", specifier = ">=45.0.0" },
     { name = "z3-solver", specifier = ">=4.15.5" },
 ]

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,4 +1,4 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.0.162"
-version = "0.0.162"
+__version__ = "0.0.163"
+version = "0.0.163"

--- a/vera/cli.py
+++ b/vera/cli.py
@@ -1159,7 +1159,14 @@ def cmd_lsp() -> int:
     """
     try:
         from vera.lsp.server import main as lsp_main
-    except ImportError:
+    except ModuleNotFoundError as exc:
+        # Only a missing transport dependency means "extra not
+        # installed" — any other import failure inside vera.lsp is a
+        # real bug and must surface as its traceback, not be
+        # misreported as a packaging problem.
+        missing = (exc.name or "").split(".")[0]
+        if missing not in {"pygls", "lsprotocol"}:
+            raise
         print(
             "Error: the LSP server needs the optional [lsp] extra.\n"
             '  Install it with: pip install -e ".[lsp]"',

--- a/vera/cli.py
+++ b/vera/cli.py
@@ -1125,6 +1125,8 @@ Commands:
     run [--fn name]      Compile and execute a .vera file
     ast [--json]         Parse a .vera file and print the AST
     fmt [--write|--check] Format a .vera file to canonical form
+    lsp                  Serve the Language Server Protocol over stdio
+                         (needs the [lsp] extra: pip install -e ".[lsp]")
 
 Options:
     --json               Output machine-readable JSON diagnostics
@@ -1148,6 +1150,26 @@ def cmd_version() -> int:
     return 0
 
 
+def cmd_lsp() -> int:
+    """Serve the Language Server Protocol over stdio (#222).
+
+    The transport dependencies live in the optional ``[lsp]`` extra so
+    the base install stays pure-wheel-minimal; the guard below turns a
+    missing extra into an actionable message instead of a traceback.
+    """
+    try:
+        from vera.lsp.server import main as lsp_main
+    except ImportError:
+        print(
+            "Error: the LSP server needs the optional [lsp] extra.\n"
+            '  Install it with: pip install -e ".[lsp]"',
+            file=sys.stderr,
+        )
+        return 1
+    lsp_main()
+    return 0
+
+
 def main() -> None:
     args = sys.argv[1:]
 
@@ -1157,6 +1179,11 @@ def main() -> None:
             print(USAGE, file=sys.stderr)
             sys.exit(1)
         sys.exit(cmd_version())
+
+    # `lsp` also takes no file argument — it serves LSP over stdio
+    # until the client disconnects (#222 Phase C).
+    if args[0] == "lsp":
+        sys.exit(cmd_lsp())
 
     if len(args) < 2:
         print(USAGE, file=sys.stderr)

--- a/vera/lsp/__init__.py
+++ b/vera/lsp/__init__.py
@@ -1,0 +1,9 @@
+"""Vera Language Server (#222) — transport layer.
+
+``vera lsp`` serves LSP 3.17 over stdio.  Phase C: handshake +
+document sync + the coordinate-conversion layer (``convert``).
+Language features arrive in Phase D on top of the obligation core
+(``vera.obligations``); the heavy imports (pygls) live in ``server``
+and are deliberately NOT imported here, so ``import vera.lsp.convert``
+works on a base install without the [lsp] extra.
+"""

--- a/vera/lsp/convert.py
+++ b/vera/lsp/convert.py
@@ -1,0 +1,144 @@
+"""Coordinate conversion between Vera and LSP positions (#222 Phase C).
+
+Three coordinate systems meet at the LSP boundary, and every feature
+must convert through this module — nobody hand-rolls the arithmetic:
+
+1. **``ast.Span``** — raw Lark positions: 1-based line, 1-based
+   *code-point* column, exclusive 1-based end column
+   (``transform._span_from_meta`` copies Lark's meta verbatim).
+2. **``errors.SourceLocation``** — diagnostics: 1-based line but
+   **0-based** code-point column (the historical convention of
+   ``ContractVerifier._error`` / the checker; note the base differs
+   from ``Span``, which is why every converter here takes its source
+   type explicitly rather than guessing).
+3. **LSP ``Position``** — 0-based line, 0-based **UTF-16 code unit**
+   column (the protocol's mandatory default encoding).
+
+The UTF-16 wrinkle: Python string indices count code points, LSP
+columns count UTF-16 code units, so any astral-plane character (emoji,
+mathematical alphanumerics — anything above U+FFFF) occupies *two* LSP
+columns.  :class:`LineIndex` does the transcoding per line against the
+document text.
+"""
+
+from __future__ import annotations
+
+from lsprotocol import types as lsp
+
+from vera.ast import Span
+from vera.errors import SourceLocation
+
+
+class LineIndex:
+    """Code-point ↔ UTF-16 column transcoding for one document text.
+
+    Built once per document version (the store caches it; see
+    ``documents.py``) and queried per conversion.  Lines are split with
+    ``splitlines()`` so all Unicode line boundaries Lark could have
+    counted are covered; out-of-range lines degrade to identity
+    transcoding rather than raising, because diagnostics can point at
+    a virtual line just past EOF (e.g. unexpected-end-of-input).
+    """
+
+    def __init__(self, text: str) -> None:
+        self._lines = text.splitlines()
+
+    def _line_text(self, line0: int) -> str:
+        if 0 <= line0 < len(self._lines):
+            return self._lines[line0]
+        return ""
+
+    def cp_to_utf16(self, line0: int, cp_col: int) -> int:
+        """Code-point column → UTF-16 column on 0-based line *line0*."""
+        text = self._line_text(line0)
+        clamped = max(0, min(cp_col, len(text)))
+        return sum(
+            2 if ord(ch) > 0xFFFF else 1 for ch in text[:clamped]
+        )
+
+    def utf16_to_cp(self, line0: int, utf16_col: int) -> int:
+        """UTF-16 column → code-point column on 0-based line *line0*.
+
+        A UTF-16 offset landing *inside* a surrogate pair snaps back to
+        the character's start, per the LSP spec's guidance for invalid
+        positions.
+        """
+        text = self._line_text(line0)
+        units = 0
+        for i, ch in enumerate(text):
+            width = 2 if ord(ch) > 0xFFFF else 1
+            if units + width > utf16_col:
+                return i
+            units += width
+        return len(text)
+
+
+def span_to_range(span: Span, index: LineIndex) -> lsp.Range:
+    """``ast.Span`` (1-based line, 1-based cp col, exclusive end) →
+    LSP ``Range`` (0-based line, UTF-16 col, exclusive end)."""
+    return lsp.Range(
+        start=lsp.Position(
+            line=span.line - 1,
+            character=index.cp_to_utf16(span.line - 1, span.column - 1),
+        ),
+        end=lsp.Position(
+            line=span.end_line - 1,
+            character=index.cp_to_utf16(
+                span.end_line - 1, span.end_column - 1,
+            ),
+        ),
+    )
+
+
+def location_to_position(
+    loc: SourceLocation, index: LineIndex,
+) -> lsp.Position:
+    """``SourceLocation`` (1-based line, 0-based cp col) → LSP
+    ``Position``.  Note the column base differs from ``Span``."""
+    return lsp.Position(
+        line=max(0, loc.line - 1),
+        character=index.cp_to_utf16(max(0, loc.line - 1), loc.column),
+    )
+
+
+def location_to_range(
+    loc: SourceLocation, index: LineIndex,
+) -> lsp.Range:
+    """Point diagnostic location → a usable squiggle range.
+
+    Diagnostics carry a point, not a span (the verifier copies only
+    ``span.line``/``span.column``).  Widen point → end-of-token using
+    a conservative token heuristic: extend across identifier-ish
+    characters (``@`` slot sigils, alphanumerics, ``_``, ``.``); if
+    the position is not on such a token, fall back to a single
+    character so the squiggle is at least visible.
+    """
+    line0 = max(0, loc.line - 1)
+    text = index._line_text(line0)
+    start_cp = min(loc.column, len(text))
+    end_cp = start_cp
+    while end_cp < len(text) and (
+        text[end_cp].isalnum() or text[end_cp] in "@_."
+    ):
+        end_cp += 1
+    if end_cp == start_cp and start_cp < len(text):
+        end_cp = start_cp + 1
+    return lsp.Range(
+        start=lsp.Position(
+            line=line0, character=index.cp_to_utf16(line0, start_cp),
+        ),
+        end=lsp.Position(
+            line=line0, character=index.cp_to_utf16(line0, end_cp),
+        ),
+    )
+
+
+def position_to_cp(
+    pos: lsp.Position, index: LineIndex,
+) -> tuple[int, int]:
+    """LSP ``Position`` → (1-based line, 0-based code-point column),
+    the shape lookups against ``Span``-carrying AST nodes want."""
+    return (
+        pos.line + 1,
+        index.utf16_to_cp(pos.line, pos.character),
+    )

--- a/vera/lsp/documents.py
+++ b/vera/lsp/documents.py
@@ -1,0 +1,69 @@
+"""In-memory document store for the LSP server (#222 Phase C).
+
+The store is the source of truth for open files: every feature reads
+document text from here, never from disk, so unsaved editor buffers
+are what get verified.  (Imported modules still resolve from disk in
+the single-file project model — making the *resolver* buffer-aware is
+deferred until the multi-file model matters, per the plan's risk
+notes.)
+
+Sync model: full-text (``TextDocumentSyncKind.Full``).  Incremental
+sync is a transport optimisation the obligation core cannot exploit
+yet — its invalidation operates on whole-function hashes — so the
+skeleton keeps the simplest correct thing.  Each change bumps
+``version`` and invalidates the cached :class:`LineIndex`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from vera.lsp.convert import LineIndex
+
+
+@dataclass
+class Document:
+    """One open document: URI, current text, version, lazy line index."""
+
+    uri: str
+    text: str
+    version: int = 0
+    _index: LineIndex | None = field(default=None, repr=False)
+
+    @property
+    def index(self) -> LineIndex:
+        if self._index is None:
+            self._index = LineIndex(self.text)
+        return self._index
+
+
+class DocumentStore:
+    """URI-keyed map of open documents."""
+
+    def __init__(self) -> None:
+        self._docs: dict[str, Document] = {}
+
+    def open(self, uri: str, text: str, version: int = 0) -> Document:
+        doc = Document(uri=uri, text=text, version=version)
+        self._docs[uri] = doc
+        return doc
+
+    def change(self, uri: str, text: str, version: int) -> Document:
+        """Full-text replacement; creates the document if the client
+        sent didChange without didOpen (defensive — some clients do)."""
+        doc = self._docs.get(uri)
+        if doc is None:
+            return self.open(uri, text, version)
+        doc.text = text
+        doc.version = version
+        doc._index = None
+        return doc
+
+    def close(self, uri: str) -> None:
+        self._docs.pop(uri, None)
+
+    def get(self, uri: str) -> Document | None:
+        return self._docs.get(uri)
+
+    def __len__(self) -> int:
+        return len(self._docs)

--- a/vera/lsp/server.py
+++ b/vera/lsp/server.py
@@ -1,0 +1,85 @@
+"""The ``vera lsp`` language server — transport skeleton (#222 Phase C).
+
+Phase C is deliberately featureless: the server completes the LSP
+handshake, advertises full-text document sync, and maintains the
+in-memory :class:`~vera.lsp.documents.DocumentStore`.  Phase D wires
+the obligation core in behind this transport (publishDiagnostics,
+hover, slot goto, typed-hole completion); Phase E adds the
+``vera/speculativeEdit`` extension.  Keeping the skeleton free of
+language features means the capability surface advertised at
+``initialize`` never promises something unimplemented.
+
+Structure note: ``VeraLanguageServer`` subclasses pygls 2.x's typed
+``pygls.lsp.server.LanguageServer`` (the 1.x ``pygls.server`` path no
+longer exists) and carries the document store as a declared attribute.
+
+Threading note (Phase D forward-reference): Z3 contexts are not
+thread-safe, so all verification will be serialised through a single
+session-owning worker; the pygls event loop itself never touches the
+``VerificationSession``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from lsprotocol import types as lsp
+from pygls.lsp.server import LanguageServer
+
+from vera import __version__
+from vera.lsp.documents import DocumentStore
+
+
+class VeraLanguageServer(LanguageServer):
+    """LanguageServer carrying the in-memory document store."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            name="vera-lsp",
+            version=__version__,
+            text_document_sync_kind=lsp.TextDocumentSyncKind.Full,
+        )
+        self.store = DocumentStore()
+
+
+def create_server() -> VeraLanguageServer:
+    """Build a fresh server with document-sync handlers registered.
+
+    Factory (rather than a module-level singleton) so each test gets
+    an isolated instance with its own store.
+    """
+    server = VeraLanguageServer()
+    store = server.store
+
+    @server.feature(lsp.TEXT_DOCUMENT_DID_OPEN)
+    def did_open(
+        ls: Any, params: lsp.DidOpenTextDocumentParams,
+    ) -> None:
+        doc = params.text_document
+        store.open(doc.uri, doc.text, doc.version)
+
+    @server.feature(lsp.TEXT_DOCUMENT_DID_CHANGE)
+    def did_change(
+        ls: Any, params: lsp.DidChangeTextDocumentParams,
+    ) -> None:
+        # Full sync: the last content change carries the whole text.
+        if params.content_changes:
+            text = params.content_changes[-1].text
+            store.change(
+                params.text_document.uri,
+                text,
+                params.text_document.version,
+            )
+
+    @server.feature(lsp.TEXT_DOCUMENT_DID_CLOSE)
+    def did_close(
+        ls: Any, params: lsp.DidCloseTextDocumentParams,
+    ) -> None:
+        store.close(params.text_document.uri)
+
+    return server
+
+
+def main() -> None:
+    """Entry point for ``vera lsp``: serve LSP over stdio."""
+    create_server().start_io()


### PR DESCRIPTION
## Summary

Phase C of the #222 plan: the **LSP transport skeleton** — `vera lsp` serves LSP 3.17 over stdio with handshake, full-text document sync, and the coordinate-conversion layer every later feature converts through. Deliberately featureless: Phase D wires the obligation core (diagnostics, hover, slot goto, typed-hole completion) onto this transport, so the capability surface advertised at `initialize` never promises something unimplemented. This PR does **not** finish #222 (Phases D–E follow; the issue stays open).

## What's in it

**New `vera/lsp/` package**
- `convert.py` — the load-bearing piece. Three coordinate systems meet at the LSP boundary: `ast.Span` (raw Lark — 1-based line, 1-based *code-point* column, exclusive end), `errors.SourceLocation` (1-based line but **0-based** column — the bases differ, so every converter takes its source type explicitly rather than guessing), and LSP `Position` (0-based line, **UTF-16 code units**). `LineIndex` transcodes code-point ↔ UTF-16 per line (astral-plane chars occupy two LSP columns); offsets landing inside a surrogate pair snap to the character start per the spec's invalid-position guidance. Includes point→token-range widening for diagnostics, which carry a point rather than a span.
- `documents.py` — URI-keyed `DocumentStore`, full-text sync, version tracking, lazy `LineIndex` invalidated on change. The store is the source of truth for open files; features never read disk for open documents.
- `server.py` — pygls 2.x skeleton: `VeraLanguageServer` subclassing the typed `pygls.lsp.server.LanguageServer`, didOpen/didChange/didClose wired to the store, `create_server()` factory for test isolation.

**CLI**: `vera lsp` dispatches before the path-argument guard (same shape as `version`); a missing `[lsp]` extra prints an actionable install message instead of a traceback. USAGE updated.

**Packaging**: new optional `[lsp]` extra — `pygls>=2.0` (pinned to the 2.x API line: the 1.x `pygls.server` import path no longer exists) + `lsprotocol>=2023.0`, mirrored into `[dev]` so CI runs the tests. Both pure-Python; the wheel-availability gate reads `project.dependencies` only and is unaffected. mypy strict overrides: `pygls.*`/`lsprotocol.*` missing-imports + an untyped-decorator exemption for `vera.lsp.server` (pygls' `@server.feature` is untyped), matching the established `vera.transform` narrow-exception shape.

## Verification

- **Live transport proof**: one end-to-end test drives the real `vera lsp` subprocess over raw JSON-RPC stdio framing — initialize → didOpen → shutdown → exit — and pins `serverInfo`, `textDocumentSync`, and exit code 0.
- **Coordinate goldens** (the substance, 30 tests total): parametrized code-point↔UTF-16 tables including astral fixtures (`ab🎉cd`) and surrogate-pair snapping; `Span` vs `SourceLocation` conversions pinning the differing column bases; BMP-multibyte (é, →) confirmed as single UTF-16 units; point→token widening over slot tokens, punctuation, and EOL; `DocumentStore` semantics including index invalidation; an in-process handler-drive test.
- `mypy vera/` strict clean (67 files); ruff S clean; obligation + verifier suites green (496 — Phases A/B untouched); full non-stress suite green via pre-commit on both commits; doc counts consistent (4,250 tests / 34 files).

## Release prep (in this PR per workflow)

v0.0.163 across all tracked sites, CHANGELOG cut, HISTORY.md single-sentence row, `uv.lock` regenerated for the new extra, site assets, tag on branch.

Part of #222 (Phase C of the phased plan — D–E follow in their own PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * LSP served over stdio with full-text document sync and a coordinate-conversion layer handling UTF-16 code-units
  * New CLI command to run the language server (with guidance if optional LSP extras are missing)

* **Tests**
  * Comprehensive LSP test suite including coordinate-mapping, document lifecycle and end-to-end stdio handshake

* **Chores**
  * Version bumped to v0.0.163; added optional [lsp] dependency extra

* **Documentation**
  * Updated changelog, history, README, roadmap and testing totals
<!-- end of auto-generated comment: release notes by coderabbit.ai -->