### PR TITLE
chore(ci): harden CodeRabbit config — Pro+ pre-merge checks, CI-ingest timeout, vera-bench link

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -22,8 +22,21 @@ knowledge_base:
     filePatterns:
       - "SKILL.md"
       - "CLAUDE.md"
+      - "AGENTS.md"
       - "CONTRIBUTING.md"
       - "FAQ.md"
+  # ── Cross-repo context ────────────────────────────────────────────
+  #
+  # Vera is upstream of vera-bench, which consumes the compiler purely as
+  # a black-box CLI. Linking lets CodeRabbit flag a CLI-flag / exit-code /
+  # diagnostic-format change here that would silently break the harness,
+  # during review of the vera PR rather than after vera-bench's own CI.
+  linked_repositories:
+    - repository: "aallan/vera-bench"
+      instructions: |
+        Black-box benchmark harness; consumes the compiler only as a CLI.
+        Flag changes to CLI flags, exit codes, or diagnostic output format
+        that could break the harness.
 
 chat:
   auto_reply: true
@@ -123,6 +136,11 @@ reviews:
         - Tests that don't assert anything meaningful
         - Duplicated test names (pytest silently shadows these)
         - Missing edge cases for new compiler features
+        - Missing coverage of the commutative-operations slot-ordering
+          trap: swapping @Int.0 and @Int.1 is invisible for + and *, but
+          wrong for - / division / comparison / recursive calls. A test
+          for a non-commutative op that only checks a commutative case
+          (or whose inputs are symmetric) cannot catch a slot-order bug.
 
     - path: "tests/conformance/**"
       instructions: |
@@ -224,6 +242,14 @@ reviews:
     gitleaks:
       enabled: true
 
+    # GitHub Checks ingestion — wait for the long multi-OS test matrix
+    # (4 OS × 3 Python) plus the lint job (~12 min) so CodeRabbit ingests
+    # CI failures instead of commenting before they land. 900000 ms = the
+    # 15-minute maximum; if a run exceeds it, re-trigger with
+    # `@coderabbitai review` after CI completes.
+    github-checks:
+      timeout_ms: 900000
+
     # Not applicable to this project
     eslint:
       enabled: false
@@ -263,3 +289,50 @@ reviews:
       enabled: true
     simplify:
       enabled: false
+
+# ── Pre-merge checks (Pro+) ──────────────────────────────────────────
+#
+# Agentic, natural-language checks that run per-PR against the diff, git
+# history, and linked issues, returning pass / fail / inconclusive with
+# reasoning. They COMPLEMENT — never replace — the deterministic floor
+# (mypy, scripts/check_*.py, pre-commit, the conformance suite).
+#
+# All three start in "warning" (advisory: surfaced in review, blocks
+# nothing). Promote an individual check to "error" only after ~a week of
+# low false positives, and only once the Pro+ custom-check tier/cap is
+# confirmed in the dashboard and reviews.request_changes_workflow +
+# branch-protection required-checks are updated. Dry-run before relying:
+#   @coderabbitai evaluate custom pre-merge check --name <name> --instructions <text> --mode warning
+pre_merge_checks:
+  # Once a check is a blocking gate, only requested reviewers (not the
+  # author/bot) may override a failure.
+  override_requested_reviewers_only: true
+  custom_checks:
+    - name: "Changelog covers public-surface changes"
+      mode: "warning"        # promote to "error" once stable
+      instructions: |
+        Fail if a change to the public surface is not DESCRIBED (not
+        merely "touched") in CHANGELOG.md. Public surface includes: CLI
+        subcommands/flags (vera/cli.py), diagnostics and error codes
+        (vera/errors.py), the formal specification (spec/), the language
+        server surface (vera/lsp/), and the WASM ABI / execute() result
+        shape (vera/codegen/api.py). The deterministic gate
+        (scripts/check_changelog_updated.py) only checks that a bullet
+        exists; this verifies the actual change is covered.
+    - name: "Spec and implementation move together"
+      mode: "warning"
+      instructions: |
+        Fail if language semantics changed in the compiler (parser,
+        checker, verifier, codegen under vera/) without a matching update
+        to the formal spec (spec/), or if the spec changed without the
+        implementation following. scripts/check_spec_examples.py only
+        validates that spec code blocks still parse/check/verify — it does
+        NOT catch silent prose-vs-behaviour drift, which this targets.
+    - name: "Diagnostics carry full metadata"
+      mode: "warning"
+      instructions: |
+        Fail if a new or changed error-severity diagnostic lacks any of:
+        a stable error_code (E###), a rationale, a concrete fix, or a
+        spec_ref. Vera's diagnostics-as-instructions philosophy is
+        load-bearing. INTERIM advisory layer until the deterministic hook
+        in issue #682 lands; relax or retire once #682 gates this.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -290,49 +290,49 @@ reviews:
     simplify:
       enabled: false
 
-# ── Pre-merge checks (Pro+) ──────────────────────────────────────────
-#
-# Agentic, natural-language checks that run per-PR against the diff, git
-# history, and linked issues, returning pass / fail / inconclusive with
-# reasoning. They COMPLEMENT — never replace — the deterministic floor
-# (mypy, scripts/check_*.py, pre-commit, the conformance suite).
-#
-# All three start in "warning" (advisory: surfaced in review, blocks
-# nothing). Promote an individual check to "error" only after ~a week of
-# low false positives, and only once the Pro+ custom-check tier/cap is
-# confirmed in the dashboard and reviews.request_changes_workflow +
-# branch-protection required-checks are updated. Dry-run before relying:
-#   @coderabbitai evaluate custom pre-merge check --name <name> --instructions <text> --mode warning
-pre_merge_checks:
-  # Once a check is a blocking gate, only requested reviewers (not the
-  # author/bot) may override a failure.
-  override_requested_reviewers_only: true
-  custom_checks:
-    - name: "Changelog covers public-surface changes"
-      mode: "warning"        # promote to "error" once stable
-      instructions: |
-        Fail if a change to the public surface is not DESCRIBED (not
-        merely "touched") in CHANGELOG.md. Public surface includes: CLI
-        subcommands/flags (vera/cli.py), diagnostics and error codes
-        (vera/errors.py), the formal specification (spec/), the language
-        server surface (vera/lsp/), and the WASM ABI / execute() result
-        shape (vera/codegen/api.py). The deterministic gate
-        (scripts/check_changelog_updated.py) only checks that a bullet
-        exists; this verifies the actual change is covered.
-    - name: "Spec and implementation move together"
-      mode: "warning"
-      instructions: |
-        Fail if language semantics changed in the compiler (parser,
-        checker, verifier, codegen under vera/) without a matching update
-        to the formal spec (spec/), or if the spec changed without the
-        implementation following. scripts/check_spec_examples.py only
-        validates that spec code blocks still parse/check/verify — it does
-        NOT catch silent prose-vs-behaviour drift, which this targets.
-    - name: "Diagnostics carry full metadata"
-      mode: "warning"
-      instructions: |
-        Fail if a new or changed error-severity diagnostic lacks any of:
-        a stable error_code (E###), a rationale, a concrete fix, or a
-        spec_ref. Vera's diagnostics-as-instructions philosophy is
-        load-bearing. INTERIM advisory layer until the deterministic hook
-        in issue #682 lands; relax or retire once #682 gates this.
+  # ── Pre-merge checks (Pro+) ──────────────────────────────────────────
+  #
+  # Agentic, natural-language checks that run per-PR against the diff, git
+  # history, and linked issues, returning pass / fail / inconclusive with
+  # reasoning. They COMPLEMENT — never replace — the deterministic floor
+  # (mypy, scripts/check_*.py, pre-commit, the conformance suite).
+  #
+  # All three start in "warning" (advisory: surfaced in review, blocks
+  # nothing). Promote an individual check to "error" only after ~a week of
+  # low false positives, and only once the Pro+ custom-check tier/cap is
+  # confirmed in the dashboard and reviews.request_changes_workflow +
+  # branch-protection required-checks are updated. Dry-run before relying:
+  #   @coderabbitai evaluate custom pre-merge check --name <name> --instructions <text> --mode warning
+  pre_merge_checks:
+    # Once a check is a blocking gate, only requested reviewers (not the
+    # author/bot) may override a failure.
+    override_requested_reviewers_only: true
+    custom_checks:
+      - name: "Changelog covers public-surface changes"
+        mode: "warning"        # promote to "error" once stable
+        instructions: |
+          Fail if a change to the public surface is not DESCRIBED (not
+          merely "touched") in CHANGELOG.md. Public surface includes: CLI
+          subcommands/flags (vera/cli.py), diagnostics and error codes
+          (vera/errors.py), the formal specification (spec/), the language
+          server surface (vera/lsp/), and the WASM ABI / execute() result
+          shape (vera/codegen/api.py). The deterministic gate
+          (scripts/check_changelog_updated.py) only checks that a bullet
+          exists; this verifies the actual change is covered.
+      - name: "Spec and implementation move together"
+        mode: "warning"
+        instructions: |
+          Fail if language semantics changed in the compiler (parser,
+          checker, verifier, codegen under vera/) without a matching update
+          to the formal spec (spec/), or if the spec changed without the
+          implementation following. scripts/check_spec_examples.py only
+          validates that spec code blocks still parse/check/verify — it does
+          NOT catch silent prose-vs-behaviour drift, which this targets.
+      - name: "Diagnostics carry full metadata"
+        mode: "warning"
+        instructions: |
+          Fail if a new or changed error-severity diagnostic lacks any of:
+          a stable error_code (E###), a rationale, a concrete fix, or a
+          spec_ref. Vera's diagnostics-as-instructions philosophy is
+          load-bearing. INTERIM advisory layer until the deterministic hook
+          in issue #682 lands; relax or retire once #682 gates this.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- **CI hardening — CodeRabbit Pro+ configuration** (no compiler or runtime change).  `.coderabbit.yaml` gains three agentic pre-merge checks — *changelog covers public-surface changes*, *spec and implementation move together*, and *diagnostics carry full metadata* — all in `warning` (advisory) mode, so they surface drift during review without blocking merge.  The deterministic floor (mypy, `scripts/check_*.py`, pre-commit, the conformance suite) remains the only hard gate; these checks complement it and target judgment-gaps it cannot cheaply cover (e.g. "the changelog *describes* the change", not merely "a bullet exists").  Also raised the GitHub-Checks ingestion timeout to 15 min so CodeRabbit waits for the full multi-OS test matrix before commenting; added `AGENTS.md` to the Code Guidelines set; linked `aallan/vera-bench` so a downstream-breaking CLI / exit-code / diagnostic-format change here is flagged during review; and extended the `tests/**` review guidance to call out the commutative-operations slot-ordering trap.  The deterministic counterparts surfaced by this round — a diagnostic-metadata gate ([#682](https://github.com/aallan/vera/issues/682)) and ruff `flake8-bandit` for assert-as-guard ([#657](https://github.com/aallan/vera/issues/657)) — are tracked as follow-ups.
+
 ## [0.0.187] - 2026-06-30
 
 ### Fixed


### PR DESCRIPTION
## Summary

Track A of the CodeRabbit Pro+ CI-hardening plan — **config only** (`.coderabbit.yaml` + a CHANGELOG note). No compiler or runtime change, **not a release** (no version bump). Everything here **complements** the deterministic floor (mypy, `scripts/check_*.py`, pre-commit, conformance) — it does not replace or relax any existing gate.

## What changed (`.coderabbit.yaml`)

- **Three custom pre-merge checks, all `warning` (advisory) mode** — `Changelog covers public-surface changes`, `Spec and implementation move together`, `Diagnostics carry full metadata`. They surface drift during review but **block nothing**. Each targets a judgment-gap the deterministic floor can't cheaply cover (e.g. the changelog gate checks a bullet *exists*; this checks the change is *described*). `override_requested_reviewers_only: true` is set for when/if they become gates.
- **`reviews.tools.github-checks.timeout_ms: 900000`** (15 min) — the 90 s default times out long before the 4-OS × 3-Python matrix + lint (~12 min), so CR was commenting without CI context.
- **`AGENTS.md` added to `code_guidelines.filePatterns`** (it was missing; CLAUDE/SKILL/CONTRIBUTING/FAQ were already there).
- **Linked `aallan/vera-bench`** (`knowledge_base.linked_repositories`) — it consumes the compiler as a black-box CLI, so a CLI-flag / exit-code / diagnostic-format change here is now flagged during review of the `vera` PR.
- **`tests/**` review guidance** now calls out the commutative-operations slot-ordering trap.

## What this is *not*

- Not a hard gate yet. Checks stay `warning` until: (a) the Pro+ custom-check tier/cap is confirmed in the dashboard, (b) ~a week of low false positives, (c) `request_changes_workflow` + branch-protection are updated. Each promotes individually.
- Not the deterministic fixes. The two real deterministic gaps this round surfaced are tracked as follow-ups, not done here: a diagnostic-metadata gate ([#682](https://github.com/aallan/vera/issues/682), enriched with this round's findings) and ruff `flake8-bandit` for assert-as-guard ([#657](https://github.com/aallan/vera/issues/657)).

## Verification

- `.coderabbit.yaml` parses (Python `yaml.safe_load`); `check-yaml` runs in pre-commit. The **schema key names** follow the CR briefing and are validated by CodeRabbit at PR time — if CR flags an unknown key, I'll correct it.
- The three custom checks should be **dry-run** before any promotion to a gate: `@coderabbitai evaluate custom pre-merge check --name <name> --instructions <text> --mode warning`.
- Full deterministic floor unchanged and green (pre-commit ran mypy + pytest + conformance + examples on commit).

Per the plan, **do not merge** until you've eyeballed the config and (optionally) dry-run the checks; the merge and any future check-override are yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Hardened CI and automated review checks to reduce noise and avoid premature review comments during longer multi-OS runs.
  * Added stronger advisory pre-merge checks for changelog coverage on public changes, spec/compiler semantic synchronisation, and complete diagnostic metadata (including stable error codes).
  * Expanded review guidance to better catch harness-evading test gaps and updated the release notes to document the new safeguards and follow-up work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->