### PR TITLE
ci: fix the release tag-probe (404-on-stdout) + post-release doc cleanups

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -300,6 +300,12 @@ jobs:
           tag_sha="$(gh api \
             "repos/$GITHUB_REPOSITORY/git/ref/tags/v${VERSION}" \
             --jq .object.sha 2>/dev/null || true)"
+          # gh api prints the 404 error body on stdout, so an absent tag
+          # captures error JSON rather than an empty string — treat anything
+          # that is not a 40-hex SHA as "tag does not exist".
+          if ! printf '%s' "$tag_sha" | grep -qE '^[0-9a-f]{40}$'; then
+            tag_sha=""
+          fi
           if [ -z "$tag_sha" ]; then
             gh api --method POST \
               "repos/$GITHUB_REPOSITORY/git/refs" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **The release workflow's tag-existence probe treats a 404 as "tag absent"** instead of capturing the error body. `gh api` prints the 404 JSON on stdout, so the first production run of the tag/Release job compared `{"message":"Not Found"...}` against the merge SHA, tripped the immutability guard, and failed after PyPI had already accepted the v0.1.5 files; the probe result is now shape-validated to a 40-hex SHA. The v0.1.5 tag and GitHub Release were completed manually from the run's registry-verified artifact per the RELEASING.md recovery runbook.
+
 ## [0.1.5] - 2026-07-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **The install section's language-server note names both routes** — the source `.[dev]` install already includes the server, while the PyPI route needs the `veralang[lsp]` extra — instead of an ambiguous "the `[lsp]` extra shown above."
 - **The install section's source-route explanation spans the full column** on veralang.dev. The paragraph carried a `max-width:56ch` cap that left a two-sentence block crammed into the left half beside the full-width code blocks; the cap is removed so it fills the column like the blocks it sits between.
 - **The release workflow's tag-existence probe treats a 404 as "tag absent"** instead of capturing the error body. `gh api` prints the 404 JSON on stdout, so the first production run of the tag/Release job compared `{"message":"Not Found"...}` against the merge SHA, tripped the immutability guard, and failed after PyPI had already accepted the v0.1.5 files; the probe result is now shape-validated to a 40-hex SHA. The v0.1.5 tag and GitHub Release were completed manually from the run's registry-verified artifact per the RELEASING.md recovery runbook.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **The install section's source-route explanation spans the full column** on veralang.dev. The paragraph carried a `max-width:56ch` cap that left a two-sentence block crammed into the left half beside the full-width code blocks; the cap is removed so it fills the column like the blocks it sits between.
 - **The release workflow's tag-existence probe treats a 404 as "tag absent"** instead of capturing the error body. `gh api` prints the 404 JSON on stdout, so the first production run of the tag/Release job compared `{"message":"Not Found"...}` against the merge SHA, tripped the immutability guard, and failed after PyPI had already accepted the v0.1.5 files; the probe result is now shape-validated to a 40-hex SHA. The v0.1.5 tag and GitHub Release were completed manually from the run's registry-verified artifact per the RELEASING.md recovery runbook.
 
 ## [0.1.5] - 2026-07-17

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -8,6 +8,7 @@ Defects in shipped compiler, runtime, or tooling behaviour — this table matche
 
 | Bug | Issue |
 |-----|-------|
+| A codegen `[E602]` skip drops the function from the emitted module but leaves its callers' `call`/`return_call` in place, so a check- and verify-clean program whose skipped construct sits in a *called helper* fails at `run`/`compile` with a raw wasmtime `unknown func` error instead of a source-located diagnostic. Loud, not silent (never a wrong answer); the fix propagates the skip to callers or diagnoses the dropped callee at the call site. | [#1100](https://github.com/aallan/vera/issues/1100) |
 | `ch05_closure_nat_return` (a run-level conformance program in the pre-commit + CI gate) trapped **once** in a full `check_conformance.py` run (`unreachable` in `main` — the sentinel `assert` or a GC shadow-stack guard) and has not reproduced in ~960 attempts across isolated, parallel, eager-GC, and hash-seed-swept executions; the emitted WAT is deterministic and correct. Suspected rare runtime/GC/wasmtime interaction, tracked so a future intermittent CI red resolves here instead of starting fresh. | [#996](https://github.com/aallan/vera/issues/996) |
 
 ## Limitations

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -48,7 +48,6 @@ Exit criterion: each listed drift class has a generator or a gate, and a release
 | [#653](https://github.com/aallan/vera/issues/653) | Spec audit for §0.2 / §0.3 design-principle violations — the spec held to its own principles. |
 | [#528](https://github.com/aallan/vera/issues/528) | Gate the hand-edited numbers on the veralang.dev homepage against live counts (the Stage 18 landing-page audit found this class live). |
 | [#540](https://github.com/aallan/vera/issues/540) | lychee + markdownlint MD051 cross-doc anchor validation. |
-| [#737](https://github.com/aallan/vera/issues/737) | Complete the first live PyPI `veralang` release and verify both documented installation routes. |
 | [#1095](https://github.com/aallan/vera/issues/1095) | Verify the concurrent-await alias-Future limitation with a genuinely concurrent repro — spec §9.5.4's prose and the KNOWN_ISSUES row update (or fall away) with the verdict. |
 
 ## Stage 21 — The effect hardening sprint

--- a/docs/index.html
+++ b/docs/index.html
@@ -565,7 +565,7 @@ vera version
 python -m pip install "veralang[lsp]"</pre>
       </div>
 
-      <p style="color:var(--ink-500);max-width:56ch;margin-top:1.25rem">The wheel ships the compiler and the <code>vera</code> command. For the full environment &mdash; the bundled examples, conformance suite, and specification the agent docs teach from &mdash; or for compiler development and unreleased changes, install from source.</p>
+      <p style="color:var(--ink-500);margin-top:1.25rem">The wheel ships the compiler and the <code>vera</code> command. For the full environment &mdash; the bundled examples, conformance suite, and specification the agent docs teach from &mdash; or for compiler development and unreleased changes, install from source.</p>
 
       <div class="code-block">
 <pre><span class="cm"># Clone and install from source</span>

--- a/docs/index.html
+++ b/docs/index.html
@@ -593,7 +593,7 @@ vera compile --target browser examples/hello_world.vera</pre>
       </div>
       </div>
 
-      <p style="color:var(--ink-500);margin-top:1.25rem">Live proof-aware diagnostics, hover, slot go-to-definition, and typed-hole completion come from the <a href="https://github.com/aallan/vera/blob/main/LSP_SERVER.md">language server</a>, installed with the <code>[lsp]</code> extra shown above (source checkout: <code>pip install -e ".[lsp]"</code>). Any editor with a generic LSP client can point at <code>vera lsp</code> directly.</p>
+      <p style="color:var(--ink-500);margin-top:1.25rem">Live proof-aware diagnostics, hover, slot go-to-definition, and typed-hole completion come from the <a href="https://github.com/aallan/vera/blob/main/LSP_SERVER.md">language server</a>. The source install above (<code>.[dev]</code>) already includes it; on the PyPI route add it with <code>python -m pip install "veralang[lsp]"</code>, or use <code>pip install -e ".[lsp]"</code> for a lighter source checkout. Any editor with a generic LSP client can point at <code>vera lsp</code> directly.</p>
     </div>
   </section>
 


### PR DESCRIPTION
Post-release fixes for the v0.1.5 cut — the workflow bug that stopped the tag/Release step, plus the install-documentation issues surfaced afterward.

## Release workflow

The first production run of the tag/Release job failed **after PyPI had accepted the v0.1.5 files**: the tag-existence probe captures `gh api` output, and `gh` prints the 404 error body to **stdout**, so an absent tag yielded `{"message":"Not Found",...}` instead of an empty string — the immutability guard then compared that JSON against the merge SHA and exited 1 (run [29586934288](https://github.com/aallan/vera/actions/runs/29586934288); reproduced locally, deterministic on rerun). The probe result is now shape-validated: anything that is not a 40-hex SHA is treated as tag-absent, so the create path runs; a real existing-but-mismatched SHA still trips the guard. Validated both directions against the captured 404 body and the v0.1.5 merge SHA.

The v0.1.5 tag and GitHub Release themselves were completed manually from the run's registry-verified artifact per the RELEASING.md recovery runbook; this fix is for every future release.

## Install-section documentation (docs/index.html)

- The source-route explanation carried a `max-width:56ch` cap, so a two-sentence paragraph wrapped into a narrow block hugging the left half beside the full-width code blocks. Cap removed — it now fills the column.
- The language-server note was ambiguous about which route installs the server. It now says the source `.[dev]` install already includes it and the PyPI route needs the `veralang[lsp]` extra.

## Tracking

- `KNOWN_ISSUES.md` gains the [#1100](https://github.com/aallan/vera/issues/1100) Bugs row: a codegen `[E602]` skip drops the callee but leaves its callers dangling, so a check/verify-clean program whose skipped construct is in a called helper fails with a raw wasmtime `unknown func` error (found in the #1098 adversarial review; loud, not silent).

## First PyPI release complete

`veralang 0.1.5` is live on production PyPI with matching digests across the registry, the built artifact, and the GitHub Release; both documented install routes are verified (details on #737). The stale Stage 20 ROADMAP row is retired here.

Closes #737

🤖 Generated with [Claude Code](https://claude.com/claude-code)
