### PR TITLE
Fix skipped-callee codegen diagnostics

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -739,10 +739,11 @@ class TestCmdCompile:
         err = capsys.readouterr().err
         assert len(err) > 0
 
-    # A CodegenSkip drops a function with an explanatory E602 warning; if that
-    # function has a CALLER, the caller's `call $f` then dangles and WAT
-    # assembly fails with an opaque `unknown func`.  `h` skips (`hash(@Decimal)`
-    # is unsupported in codegen), `main` calls it.  The program is check-green,
+    # A CodegenSkip drops a function with an explanatory E602 warning. If that
+    # function has a CALLER, the caller must now fail at the call site with a
+    # second E602 instead of emitting a dangling `call $f` and letting WAT
+    # assembly fail with an opaque `unknown func`. `h` skips (`hash(@Decimal)`
+    # is unsupported in codegen), `main` calls it. The program is check-green,
     # so this exercises the codegen-error branch that type/syntax errors return
     # before reaching.
     _SKIP_WITH_CALLER = (
@@ -752,25 +753,25 @@ class TestCmdCompile:
         "requires(true) ensures(true) effects(pure) { h(decimal_from_int(1)) }\n"
     )
 
-    def test_compile_skip_warning_shown_on_error_path_1004(
+    def test_compile_skipped_callee_reports_clean_call_site_diagnostic_1100(
         self,
         tmp_path: Path,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        """#1004: the E602 skip warning prints on the text error path.
+        """#1100: a caller of an E602-skipped function reports cleanly.
 
-        Before the fix, ``cmd_compile`` returned after printing only the
-        errors, dropping the E602 "function skipped" warning that explains
-        *why* ``$h`` is missing — the user saw the opaque ``unknown func``
-        alone.  The warning is in ``result.diagnostics`` (the JSON path
-        already emitted it); only the text presentation dropped it.
+        The callee's skip still prints, but the caller now emits a second E602
+        at the call site and codegen stops before WAT assembly. Users should
+        see the source-level unsupported callee, never a backend
+        ``unknown func``.
         """
         path = _bad_vera(tmp_path, self._SKIP_WITH_CALLER)
         rc = cmd_compile(path)
         assert rc == 1
         err = capsys.readouterr().err
-        assert "unknown func" in err  # the downstream error still shows
-        assert "[E602]" in err  # the E602 skip warning that explains it (#1004)
+        assert "unknown func" not in err
+        assert "[E602]" in err
+        assert "call target 'h' was skipped during code generation" in err
 
     def test_compile_skip_warning_in_json_error_output_1004(
         self,
@@ -787,7 +788,19 @@ class TestCmdCompile:
         assert rc == 1
         data = json.loads(capsys.readouterr().out)
         assert data["ok"] is False
-        assert any(w.get("error_code") == "E602" for w in data["warnings"])
+        e602_warnings = [
+            w for w in data["warnings"] if w.get("error_code") == "E602"
+        ]
+        assert e602_warnings
+        e602_errors = [
+            d for d in data["diagnostics"] if d.get("error_code") == "E602"
+        ]
+        assert e602_errors
+        assert any(
+            "call target 'h' was skipped during code generation"
+            in d.get("description", "")
+            for d in e602_errors
+        )
 
     _TYPE_ERROR_WITH_WARNING = (
         "public fn bad(@Int -> @Int) "

--- a/vera/codegen/core.py
+++ b/vera/codegen/core.py
@@ -139,6 +139,10 @@ class CodeGenerator(
 
         # Registered function signatures: name -> (param_types, return_type)
         self._fn_sigs: dict[str, tuple[list[str | None], str | None]] = {}
+        # Function bodies that were registered but did not emit WAT. Later
+        # callers use this to produce a source-located E602 instead of a
+        # dangling call that fails during WAT assembly.
+        self._skipped_fns: set[str] = set()
         # Registered function return Vera-type expressions (#614).
         # Carries the full NamedType (with type_args) alongside the WAT
         # type kept in `_fn_sigs`, so inference paths that need to
@@ -613,6 +617,8 @@ class CodeGenerator(
 
     def compile_program(self, program: ast.Program) -> CompileResult:
         """Compile a complete Vera program to WebAssembly."""
+        self._skipped_fns.clear()
+
         # Pass 0a: reject programs with typed holes
         holes = _find_holes(program)
         if holes:
@@ -884,6 +890,10 @@ class CodeGenerator(
                                     and wfn.name in mono_base_names):
                                 continue
                             functions_wat.append(wfn_wat)
+                        else:
+                            self._skipped_fns.add(wfn.name)
+                else:
+                    self._skipped_fns.add(decl.name)
 
         # Compile monomorphized functions.
         #
@@ -925,6 +935,8 @@ class CodeGenerator(
                 compiled_mono_bases.add(orig_name)
                 if is_public:
                     exports.append(mdecl.name)
+            else:
+                self._skipped_fns.add(mdecl.name)
 
         # Pass 2.5: compile imported function bodies (C7e)
         imported_seen: set[str] = set()
@@ -955,6 +967,8 @@ class CodeGenerator(
             )
             if fn_wat is not None:
                 functions_wat.append(fn_wat)
+            else:
+                self._skipped_fns.add(idecl.name)
 
         # Pass 2.6: emit shadowed module functions under their qualified
         # ('mod$…') WASM name (#814 §8.5.3).  The plain Pass 2.5 above skips
@@ -982,6 +996,8 @@ class CodeGenerator(
             )
             if fn_wat is not None:
                 functions_wat.append(fn_wat)
+            else:
+                self._skipped_fns.add(mangled)
 
         # #851 — all function compilation is done; any diagnostic
         # emitted from here on is module-level, not prelude-origin.

--- a/vera/codegen/functions.py
+++ b/vera/codegen/functions.py
@@ -238,6 +238,7 @@ class FunctionCompilationMixin:
             generic_fn_info=getattr(self, "_generic_fn_info", None),
             generic_constrained_vars=getattr(
                 self, "_generic_constrained_vars", None),
+            skipped_fns=getattr(self, "_skipped_fns", set()),
             ctor_to_adt=ctor_to_adt,
             known_fns=set(self._fn_sigs.keys()),
             ctor_adt_tp_indices=getattr(self, "_ctor_adt_tp_indices", None),
@@ -600,16 +601,30 @@ class FunctionCompilationMixin:
         except CodegenSkip as skip:
             # #626 Layer 3 — structured skip with node-level span.
             self._harvest_interp_inference_failures(ctx)
-            self._warning(
-                skip.node if getattr(skip.node, "span", None) else decl,
+            diag_node = skip.node if getattr(skip.node, "span", None) else decl
+            description = (
                 f"Function '{decl.name}' body contains unsupported "
                 f"{type(skip.node).__name__}: {skip.reason} — "
-                f"function skipped.",
-                rationale="The WASM backend does not yet support all "
-                "Vera expression types. This function will not appear "
-                "in the compiled output.",
-                error_code="E602",
+                f"function skipped."
             )
+            rationale = (
+                "The WASM backend does not yet support all Vera expression "
+                "types. This function will not appear in the compiled output."
+            )
+            if "was skipped during code generation" in skip.reason:
+                self._error(
+                    diag_node,
+                    description,
+                    rationale=rationale,
+                    error_code="E602",
+                )
+            else:
+                self._warning(
+                    diag_node,
+                    description,
+                    rationale=rationale,
+                    error_code="E602",
+                )
             return None
         except RecursionError:
             # #933 belt-and-suspenders: the structural derived-helper

--- a/vera/wasm/calls.py
+++ b/vera/wasm/calls.py
@@ -482,6 +482,12 @@ class CallsMixin:
         if call_target in self._intra_module_renames:
             call_target = self._intra_module_renames[call_target]
 
+        if call_target in self._skipped_fns:
+            raise CodegenSkip(
+                call,
+                f"call target {call_target!r} was skipped during code generation",
+            )
+
         # Guard rail: reject calls to functions not defined in this module.
         # In practice the cross-module check upstream has already emitted
         # a diagnostic for genuine unknown-fn cases.  This path also fires

--- a/vera/wasm/context.py
+++ b/vera/wasm/context.py
@@ -91,6 +91,7 @@ class WasmContext(
             dict[str, tuple[tuple[str, ...], tuple[ast.TypeExpr, ...]]] | None
         ) = None,
         generic_constrained_vars: dict[str, frozenset[str]] | None = None,
+        skipped_fns: set[str] | None = None,
         ctor_to_adt: dict[str, str] | None = None,
         known_fns: set[str] | None = None,
         ctor_adt_tp_indices: dict[str, tuple[int | None, ...]] | None = None,
@@ -163,6 +164,9 @@ class WasmContext(
         self._ctor_to_adt: dict[str, str] = ctor_to_adt or {}
         # Known locally-defined function names (for cross-module guard rail)
         self._known_fns: set[str] = known_fns or set()
+        # Locally-defined functions already dropped by codegen. Calls to these
+        # targets must stay source-located instead of dangling into WAT assembly.
+        self._skipped_fns: set[str] = skipped_fns or set()
         # Per-field ADT type-param indices for sparse constructors (e.g. Err → (1,))
         self._ctor_adt_tp_indices: dict[str, tuple[int | None, ...]] = (
             ctor_adt_tp_indices or {}


### PR DESCRIPTION
## Summary

- track functions that codegen registers but later skips before emitting WAT
- turn later calls to those skipped callees into a source-located E602 diagnostic
- update the CLI regression so skipped-callee callers no longer surface raw `unknown func` WAT errors

Fixes #1100.

## Validation

- `uv run pytest tests/test_cli.py -q`
- `uv run pytest tests/test_codegen_calls.py tests/test_codegen_infrastructure.py tests/test_codegen_monomorphize.py -q`
- `uv run pytest tests/test_codegen_effects.py tests/test_codegen_host_effects.py -q`
- `uv run ruff check vera/codegen/core.py vera/codegen/functions.py vera/wasm/calls.py vera/wasm/context.py tests/test_cli.py`
- `uv run mypy vera/codegen/core.py vera/codegen/functions.py vera/wasm/calls.py vera/wasm/context.py`
- `git diff --check`
- direct #1100 repro now exits with source-level E602 diagnostics and no `unknown func`
- `rg -n "Karim13014|claude-code@anthropic.com" .git .`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compiler diagnostics when a function is skipped during code generation.
  * Errors now identify the original call site with a clear E602 message.
  * Prevented confusing backend “unknown func” failures in affected compilation scenarios.
  * Standardised E602 reporting across text and JSON error output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->