### PR TITLE
Fix VS Code Marketplace README links

### DIFF
--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -5,7 +5,7 @@ Language server integration and syntax highlighting for the [Vera programming la
 ## Features
 
 **Language server integration** — the extension starts Vera's own
-language server ([`vera lsp`](../../LSP_SERVER.md)) for `.vera` files,
+language server ([`vera lsp`](https://github.com/aallan/vera/blob/main/LSP_SERVER.md)) for `.vera` files,
 which runs the full pipeline — parse, type-check, **verify** — on every
 edit and provides:
 
@@ -20,7 +20,7 @@ edit and provides:
 
 Requires the `vera` binary with the `[lsp]` extra from PyPI (see
 [Requirements](#requirements)); without it the extension stays in
-syntax-highlighting-only mode. See [LSP_SERVER.md](../../LSP_SERVER.md)
+syntax-highlighting-only mode. See [LSP_SERVER.md](https://github.com/aallan/vera/blob/main/LSP_SERVER.md)
 for everything the server can do, including the custom methods for
 coding agents.
 
@@ -80,8 +80,6 @@ Install **Vera Language** from the Extensions view, or run:
 code --install-extension veralang.vera-language
 ```
 
-[Open Vera Language in the VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=veralang.vera-language).
-
 ### From VSIX
 
 ```bash
@@ -136,7 +134,6 @@ The grammar uses standard TextMate scope conventions, so it works with any colou
 
 - [Vera language](https://veralang.dev/)
 - [Vera on GitHub](https://github.com/aallan/vera)
-- [Vera Language on the VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=veralang.vera-language)
 - [TextMate bundle](https://github.com/aallan/vera/tree/main/editors/textmate) (same grammar, TextMate 2 packaging)
 
 ## Licence


### PR DESCRIPTION
## Summary

- replace the VS Code extension README's repository-relative LSP documentation links with stable absolute GitHub URLs
- remove Marketplace hyperlinks that cannot resolve until the extension has completed its first publication

## Why

`vsce` rewrites repository-relative links while packaging. Because the extension lives below the repository root, the two `../../LSP_SERVER.md` links became malformed `HEAD/../../` URLs in the packaged README and returned HTTP 404. The README also linked to the extension's Marketplace page before that page existed, producing two more 404s.

This removes known-bad metadata from the VSIX before retrying the Marketplace upload. Broken ordinary links are not documented by Microsoft as a definitive cause of the opaque "suspicious content" rejection, so this is a focused corrective step rather than a claim that the scanner's root cause is proven.

## Validation

- `npm ci`
- `npm run check`
- `npm run package:list`
- `npm run package -- --out /tmp/vera-language-0.2.0-readme-fix.vsix`
- inspected `extension/readme.md` inside the resulting VSIX
- confirmed the replacement LSP documentation URL returns HTTP 200
- confirmed the VSIX remains 11 files / 99.74 KB with no `node_modules`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the VS Code extension README with a direct link to the Vera language server setup guide.
  - Simplified installation instructions by retaining the command-line installation option.
  - Refreshed the links section with the Vera language website and GitHub repository.
  - Retained the TextMate bundle link for continued access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->