### PR TITLE
Remove unavailable VS Code distribution claims

### DIFF
--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 Language server integration.
 
-- First VS Code Marketplace release as `veralang.vera-language`
 - Bundles the extension runtime instead of shipping raw `node_modules`
 - The extension now starts Vera's language server (`vera lsp`) for
   `.vera` files: proof-aware diagnostics with verification-tier hints,

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -72,20 +72,6 @@ The **Vera: Restart Language Server** command restarts the server
 
 ## Installation
 
-### VS Code Marketplace
-
-Install **Vera Language** from the Extensions view, or run:
-
-```bash
-code --install-extension veralang.vera-language
-```
-
-### From VSIX
-
-```bash
-code --install-extension vera-language-0.2.0.vsix
-```
-
 ### From source
 
 **Fresh clone:**


### PR DESCRIPTION
## Summary

- remove the VS Code Marketplace and VSIX installation sections from the extension README
- remove the changelog claim that `0.2.0` is the first Marketplace release

Installation from source remains the only documented method.

## Why

Neither removed distribution method is currently available to users:

- `veralang.vera-language` has not been published because Marketplace upload is blocked by the issue tracked in #1106.
- The VSIX is a private GitHub Actions artifact, not a public end-user distribution.

These statements were added prematurely during release preparation. User-facing documentation and release notes must describe the current verified release state, not an anticipated state dependent on third-party publication.

Marketplace instructions and release notes should be added in a separate follow-up only after the listing is live and the exact installation flow has been tested. VSIX instructions should be added only if a public VSIX download is made available and tested.

## Validation

- `git diff --check`
- repository-wide search confirms there are no remaining `veralang.vera-language`, `vera-language-0.2.0.vsix`, `VS Code Marketplace`, `From VSIX`, or `code --install-extension` claims
- `npm run package:list`
