### PR TITLE
typo CST -> AST

### DIFF
--- a/spec/01-lexical-structure.md
+++ b/spec/01-lexical-structure.md
@@ -32,7 +32,7 @@ Vera supports three comment forms:
 
 **Block comments** begin with `{-` and end with `-}`. They nest: a `{-` inside a block comment begins a nested block comment that must be closed by its own `-}`.
 
-**Annotation comments** begin with `/*` and end with `*/`. They do not nest. Annotation comments are semantically ignored by the compiler but are preserved in the CST. They serve as optional human-readable labels for bindings:
+**Annotation comments** begin with `/*` and end with `*/`. They do not nest. Annotation comments are semantically ignored by the compiler but are preserved in the AST. They serve as optional human-readable labels for bindings:
 
 ```
 fn(@Int /* width */, @Int /* height */ -> @Int)


### PR DESCRIPTION
In this part of the spec:

>  -**Annotation comments** begin with `/*` and end with `*/`. They do
>  not nest. Annotation comments are semantically ignored by the
>  compiler but are preserved in the CST.

I assume AST was meant rather than CST as CST is not referenced anywhere
else in the codebase.

## Type of Change

- [ ] Specification change
- [ ] Compiler implementation
- [ ] Bug fix
- [ ] Tests
- [x] Documentation

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My changes follow the project's coding standards
- [x] I have added/updated tests as appropriate
- [x] I have updated relevant documentation
- [x] All tests pass locally
