### PR TITLE
chore: annotate the pypi-publish pin with its tag, not a review date

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,7 +197,7 @@ jobs:
           path: artifact
 
       - name: Publish package distributions to TestPyPI
-        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # release/v1, 2026-07-15
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1 (release/v1), 2026-05-21
         with:
           packages-dir: artifact/dist/
           repository-url: https://test.pypi.org/legacy/
@@ -247,7 +247,7 @@ jobs:
           path: artifact
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # release/v1, 2026-07-15
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1 (release/v1), 2026-05-21
         with:
           packages-dir: artifact/dist/
           print-hash: true


### PR DESCRIPTION
Dependabot updates a pinned SHA but never the hand-written comment beside it, so #1117 left both `gh-action-pypi-publish` pins reading `# release/v1, 2026-07-15` against a commit from **2026-05-21** — a date matching neither the new pin nor the one it replaced (2026-02-18).

```diff
-  uses: pypa/gh-action-pypi-publish@ba38be9e… # release/v1, 2026-07-15
+  uses: pypa/gh-action-pypi-publish@ba38be9e… # v1.14.1 (release/v1), 2026-05-21
```

Both sites (`release.yml:200` publish-testpypi, `:250` publish-pypi).

## Why the tag rather than a date

The old annotation recorded roughly "when someone last looked at `release/v1`". That is unverifiable after the fact and goes stale silently on **every** future dependabot bump — which is the defect being fixed, not a one-off.

`v1.14.1` is checkable against upstream:

```bash
gh api repos/pypa/gh-action-pypi-publish/tags --paginate \
  --jq '.[] | select(.commit.sha=="ba38be9e461d3875417946c167d0b5f3d385a247") | .name'
```

The date now means the pinned commit's own date, so both halves of the annotation can be verified from the pin itself rather than trusted.

It will still go stale on the next bump — dependabot does not know about the comment — but a wrong tag is *detectable* by the command above, where a wrong "date we looked" is not.

## Scope

Comment-only. No SHA change, no behavioural change; `release.yml` parses to the same 7 jobs. Carries a `Skip-changelog:` trailer since it touches neither `vera/` nor `spec/` and does not merit a release note.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow metadata for TestPyPI and PyPI publishing.
  * No changes to publishing behaviour, permissions, or release configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->