### PR TITLE
security: bump brace-expansion to 2.1.2 (GHSA-3jxr-9vmj-r5cp)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Security
+
+- **`brace-expansion` raised to `2.1.2` in the VS Code extension lockfile, off the range affected by [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp)** (CVE-2026-13149; GitHub severity high, CVSS 3.1 base 5.3 — availability only, `AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L`).  The advisory is exponential-time expansion of consecutive non-expanding `{}` groups, reachable only by whoever supplies the glob pattern.  It arrived as a runtime transitive of the language client — `vscode-languageclient@9.0.1` → `minimatch@5.1.9` → `brace-expansion@2.1.1` — so it ships inside the VSIX, but every pattern reaching that `minimatch` is a document selector written in the extension's own source rather than anything a workspace or document can influence; practical exposure is correspondingly low.  `minimatch@5.1.9` already declares `brace-expansion: ^2.0.1`, which admits the patched `2.1.2`, so the fix is a three-field lockfile bump that leaves `package.json`, the language-client major, and the packaged file inventory untouched.
+
 ## [0.1.6] - 2026-07-20
 
 ### Fixed

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1419,9 +1419,9 @@
 			"license": "BSD-2-Clause"
 		},
 		"node_modules/brace-expansion": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-			"integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+			"integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0"


### PR DESCRIPTION
Clears the one open Dependabot alert — [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp) / CVE-2026-13149, DoS via exponential-time expansion of consecutive non-expanding `{}` groups in `brace-expansion`.

## The chain

The vulnerable copy is a **runtime** transitive of the language client, so it ships inside the VSIX:

```
vscode-languageclient@9.0.1  ->  minimatch@5.1.9  ->  brace-expansion@2.1.1   (vulnerable: >=2.0.0 <2.1.2)
```

`minimatch@5.1.9` already declares `brace-expansion: ^2.0.1`, which admits the patched `2.1.2`. So the fix is three fields in one lockfile hunk — `version`, `resolved`, `integrity`. `package.json` is untouched, the language-client major is untouched, and the packaged file inventory is unchanged.

## Why not the grouped Dependabot PR

Dependabot proposed this fix bundled with a `vscode-languageclient` 9 -> 10 major bump ([#1127](https://github.com/aallan/vera/pull/1127)). That half is **not mergeable today**: v10 removes `./lib/node/terminateProcess.sh` from its `exports` map, and `editors/vscode/esbuild.js:9` resolves exactly that subpath, so `Package VSIX` fails at `require.resolve` before esbuild runs.

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './lib/node/terminateProcess.sh'
is not defined by "exports" in .../node_modules/vscode-languageclient/package.json
    at Object.<anonymous> (.../editors/vscode/esbuild.js:9:34)
```

Splitting the security fix out means it does not wait on that, and the v10 upgrade can be decided on its own terms rather than as a side effect of patching a CVE.

## Verification

Against the patched lockfile, from a clean `node_modules`:

| Check | Result |
|---|---|
| `npm ci` | clean |
| `npm audit` | **0 vulnerabilities** (was 1 high) |
| `node esbuild.js` | builds — the step that fails on #1127 |
| `dist/` | `extension.js` + `terminateProcess.sh` (0755), same as before |

## Severity, stated honestly

GitHub labels the advisory **high**; the CVSS 3.1 base score is **5.3**, availability-only (`AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L`). Every pattern reaching this `minimatch` is a document selector written in the extension's own source — not something a workspace, document, or remote can influence — so practical exposure is low. Patched regardless: the fix costs three lines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Fixed a vulnerability in brace expansion that could cause excessive processing time with certain glob patterns.
  - Updated the affected dependency to version 2.1.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->