### PR TITLE
Release v0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.1.8] - 2026-07-27
+
 ### Added
 
 - **Vim and Neovim support** ([#1155](https://github.com/aallan/vera/pull/1155), contributed by [@chromy](https://github.com/chromy)). A Vim 8+/Neovim package under `editors/vim-veralang/` — `ftdetect`, `ftplugin` and `syntax` — ported from the VS Code TextMate grammar. It registers the filetype as **`veralang`**, not `vera`: Vim has shipped an unrelated `vera` filetype since 2005 for the Synopsys hardware verification language, and because `$VIMRUNTIME` precedes `pack/*/start` in `runtimepath`, claiming that name would let the built-in syntax set `b:current_syntax` first and this plugin's own files would then exit silently through their own guard. It is the most current of the three editor integrations: it knows all ten effects in `vera effects --json`, where the VS Code and TextMate grammars are four behind. The remaining drift — those two grammars, and the `Eq`/`Hash`/`Ord`/`Show` abilities that no grammar knows — is tracked in [#1156](https://github.com/aallan/vera/issues/1156).
@@ -3137,7 +3139,8 @@ Small docs sweep — closes six aging documentation issues in one PR.  No code c
 - Grammar: handler body simplified to avoid LALR reduce/reduce conflict
 - `pyproject.toml`: corrected build backend, package discovery, PEP 639 compliance
 
-[Unreleased]: https://github.com/aallan/vera/compare/v0.1.7...HEAD
+[Unreleased]: https://github.com/aallan/vera/compare/v0.1.8...HEAD
+[0.1.8]: https://github.com/aallan/vera/compare/v0.1.7...v0.1.8
 [0.1.7]: https://github.com/aallan/vera/compare/v0.1.6...v0.1.7
 [0.1.6]: https://github.com/aallan/vera/compare/v0.1.5...v0.1.6
 [0.1.5]: https://github.com/aallan/vera/compare/v0.1.4...v0.1.5

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -473,6 +473,7 @@ Stages 19 and 20 run dual-threaded: community PRs against the single-source spri
 | v0.1.5 | 17 Jul | **The third burndown and the first PyPI release** — 29 bug-labelled issues fixed across the checker, codegen, and diagnostics, published to PyPI as `veralang` ([#737](https://github.com/aallan/vera/issues/737)). |
 | v0.1.6 | 20 Jul | **The comment system** — block comments nest, malformed ones get their own `E02x` diagnostics, annotation labels reach the AST, and `vera fmt` stops deleting comments it had silently dropped since the formatter was written ([#1112](https://github.com/aallan/vera/issues/1112)). |
 | v0.1.7 | 24 Jul | **SQL injection won't compile** — the built-in `<DB>` effect and a literal-provenance checker that makes SQL injection a compile-time error ([#309](https://github.com/aallan/vera/issues/309): `E207`/`E208`/`E209`), plus the bare-effect-op routing check (`E217`) and a Float64 rounding-assertion CI-flake fix. |
+| v0.1.8 | 27 Jul | **Editors and toolchain hygiene** — the VS Code extension reaches the Marketplace, Vim and Neovim gain a package, the ruff rule set is declared rather than inherited with five defect-class rules adopted, and the SQL checker's `E208` follows a `let` chain as `E207` already did ([#1106](https://github.com/aallan/vera/issues/1106)). |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ cp /path/to/vera/SKILL.md ~/.claude/skills/vera-language/SKILL.md
 
 ## Project status
 
-Vera is in **active development** at v0.1.7: 2,000+ commits, 204 releases, 8,568 tests, 95% code coverage, 169 conformance programs, 42 examples, and a 14-chapter specification. Known bugs and limitations are tracked in **[KNOWN_ISSUES.md](KNOWN_ISSUES.md)**. See **[HISTORY.md](HISTORY.md)** for how the compiler was built.
+Vera is in **active development** at v0.1.8: 2,000+ commits, 204 releases, 8,568 tests, 95% code coverage, 169 conformance programs, 42 examples, and a 14-chapter specification. Known bugs and limitations are tracked in **[KNOWN_ISSUES.md](KNOWN_ISSUES.md)**. See **[HISTORY.md](HISTORY.md)** for how the compiler was built.
 
 The reference compiler — parser, AST, type checker, contract verifier (Z3), WASM code generator, module system, browser runtime, and runtime contract insertion — is working. The language specification is in draft across [14 chapters](spec/).
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -262,7 +262,7 @@
         <a href="/SKILL.md" rel="agent-instructions" type="text/markdown" class="btn btn-ghost">For Agents → SKILL.md</a>
       </div>
       <p class="version">
-        <span>v<a href="https://github.com/aallan/vera/releases/tag/v0.1.7">0.1.7</a></span>
+        <span>v<a href="https://github.com/aallan/vera/releases/tag/v0.1.8">0.1.8</a></span>
         <a href="https://github.com/aallan/vera/actions/workflows/ci.yml" aria-label="CI status"><img src="https://github.com/aallan/vera/actions/workflows/ci.yml/badge.svg" alt="CI" style="height:18px"></a>
       </p>
     </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@
 
 From the Latin *veritas* — truth. In Vera, verification is a first-class citizen.
 
-**Current version:** [0.1.7](https://github.com/aallan/vera/releases/tag/v0.1.7)  ·  [GitHub](https://github.com/aallan/vera)  ·  [SKILL.md](https://veralang.dev/SKILL.md) (agent language reference)
+**Current version:** [0.1.8](https://github.com/aallan/vera/releases/tag/v0.1.8)  ·  [GitHub](https://github.com/aallan/vera)  ·  [SKILL.md](https://veralang.dev/SKILL.md) (agent language reference)
 
 ## Why?
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2,7 +2,7 @@
 
 > Vera is a statically typed, purely functional programming language designed for large language models to write. It uses typed slot references (@T.n) instead of variable names, requires contracts on every function, and compiles to WebAssembly.
 
-This file contains the core Vera language documentation — language reference, agent instructions, FAQ, error codes, and formal grammar — compiled into a single document. Version 0.1.7. For the full documentation index including the 14-chapter specification and supplementary docs, see llms.txt.
+This file contains the core Vera language documentation — language reference, agent instructions, FAQ, error codes, and formal grammar — compiled into a single document. Version 0.1.8. For the full documentation index including the 14-chapter specification and supplementary docs, see llms.txt.
 
 
 ========================================================================

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -4,7 +4,7 @@
 
 Vera uses De Bruijn indexing for bindings: `@Int.0` is the most recent `Int` binding, `@Int.1` the one before. There are no variable names. Contracts are mandatory — every function must declare `requires(...)`, `ensures(...)`, and `effects(...)`. The Z3 SMT solver verifies contracts statically where possible; remaining contracts become runtime assertions. All side effects (IO, Http, HttpServer, State, Exceptions, Async, Inference, DB, Random, Diverge) are tracked in the type system via algebraic effects.
 
-Current version: 0.1.7. The reference compiler is written in Python. Install the `veralang` distribution from PyPI or use `pip install -e ".[dev]"` from the repository.
+Current version: 0.1.8. The reference compiler is written in Python. Install the `veralang` distribution from PyPI or use `pip install -e ".[dev]"` from the repository.
 
 ## Homepage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "veralang"
-version = "0.1.7"
+version = "0.1.8"
 description = "Vera: a programming language designed for LLMs, with full contracts, algebraic effects, and typed slot references"
 readme = "PYPI_README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -1544,7 +1544,7 @@ wheels = [
 
 [[package]]
 name = "veralang"
-version = "0.1.7"
+version = "0.1.8"
 source = { editable = "." }
 dependencies = [
     { name = "lark" },

--- a/vera/__init__.py
+++ b/vera/__init__.py
@@ -1,4 +1,4 @@
 """Vera: a programming language designed for LLMs."""
 
-__version__ = "0.1.7"
+__version__ = "0.1.8"
 version = __version__


### PR DESCRIPTION
Cuts **v0.1.8** so tonight's VeraBench sweep — all 60 problems rather than 36 — runs against an anchored, published release rather than a moving `main`.

## Release machinery

- **Version** bumped across the six files `scripts/check_version_sync.py` binds: `pyproject.toml`, `vera/__init__.py`, `README.md`, both values in the `docs/index.html` badge, and `uv.lock`. Gate reports *"Version 0.1.8 is consistent across 6 files."*
- **CHANGELOG** `[Unreleased]` → `[0.1.8] - 2026-07-27`, a fresh empty `[Unreleased]` opened above it, `[Unreleased]` compare link retargeted to `v0.1.8...HEAD`, and a new `[0.1.8]: v0.1.7...v0.1.8` reference added.
- **HISTORY** gains its row in the Stage 19/20 table.
- Site assets regenerated.

Deliberately **not** changed: the benchmark caveat on the landing page still reads *"against Vera v0.1.7"*. That line records which release the currently-published VeraBench figures were measured on, not which release is current. It moves when a sweep against v0.1.8 has actually run — which is the point of cutting this tag first.

## What v0.1.8 contains

59 commits since v0.1.7. No compiler behaviour changes beyond two checker fixes; this is largely a hygiene and tooling release.

| | |
|---|---|
| **Added** | Vim and Neovim support ([#1155](https://github.com/aallan/vera/pull/1155), contributed by [@chromy](https://github.com/chromy)) — the only one of the three editor grammars that knows all ten effects |
| **Changed** | The ruff rule set is declared rather than inherited, with five defect-class rules adopted ([#1166](https://github.com/aallan/vera/issues/1166)) |
| **Security** | `brace-expansion` 5.0.7 → 5.0.8 in the VS Code extension, closing [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) (high, DoS) |
| **Fixed** | `E208` follows a `let` chain as `E207` already did ([#1160](https://github.com/aallan/vera/issues/1160)); the `Binding` provenance invariant is enforced rather than documented ([#1164](https://github.com/aallan/vera/issues/1164)) |
| **Documentation** | The VS Code extension reaches the Marketplace ([#1106](https://github.com/aallan/vera/issues/1106)); landing-page facts, the `vera/README.md` module map, and diagnostic `since` fields all gated against live sources |

## Gate

`check_version_sync`, `check_doc_counts`, `check_site_assets`, `check_limitations_sync`, `check_conformance`, `check_examples`, `check_corpus_canonical`, `check_walker_coverage`, `check_diagnostic_fields`, `check_explicit_encoding`, `check_licenses` — all pass. `ruff check .` and `ruff check --select S vera/` clean, `mypy vera/` clean, `tests/test_release.py` 47 passed, and the full suite via pre-commit.

`check_doc_counts` earned its place here: the first draft of the HISTORY row carried five issue links and the gate rejected it, since a version row takes one and secondary links belong in the CHANGELOG.

## After merge

`release.yml` detects the version increase, builds, and **pauses at the `pypi` environment for your approval**; it then publishes, verifies the registry hashes, and creates the `v0.1.8` tag and GitHub Release at the merge SHA. No manual tag, upload, or release command is part of this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Released version **0.1.8**.
  * Updated project version information and release references across public documentation.
  * Documented editor tooling, rule-set updates, and improved SQL checking behaviour in the release history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->