### PR TITLE
deps: bump qs from 6.15.3 to 6.16.0 in /editors/vscode

### DIFF
--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -3345,9 +3345,9 @@
 			}
 		},
 		"node_modules/qs": {
-			"version": "6.15.3",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-			"integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+			"version": "6.16.0",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+			"integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {


### PR DESCRIPTION
Lockfile-only bump of `qs` 6.15.3 → 6.16.0 in `editors/vscode/package-lock.json`, produced with `npm update qs --package-lock-only`; the diff is the entry's `version`, `resolved` and `integrity` fields and nothing else (6.16.0 declares the same dependency set as 6.15.3, and `typed-rest-client`'s range `^6.9.1` admits it).

Closes the tree's last vulnerable npm entry: Dependabot alert 29 ([GHSA-x5fp-wj9c-mxmx](https://github.com/advisories/GHSA-x5fp-wj9c-mxmx), medium, array-limit bypass via bracket-key comma parsing) was auto-dismissed rather than fixed, and 6.16.0 is its first patched version. `qs` is a **development** transitive — `typed-rest-client` under `@vscode/vsce` / `azure-devops-node-api` — and `esbuild.js` bundles only what the extension source imports, so the shipped VSIX never contained it. Following the js-yaml / esbuild lockfile-bump precedent rather than the brace-expansion one: no extension version bump and no CHANGELOG entry.

Targets `release/v0.2.0` so the fix reaches `main` with the release; the four open fast-uri alerts close the same way via #1392, already on this branch.
